### PR TITLE
Add operation serialization to VMLifecycleCoordinator

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -153,7 +153,7 @@ All service implementations conform to protocols defined in `Services/Protocols/
 
 - **`VMLibraryViewModel`** is the central `@Observable` view model. It owns the array of `VMInstance`s and handles list-level operations: add, remove, rename, selection tracking. For lifecycle operations (start, stop, install), it delegates to `VMLifecycleCoordinator`.
 
-- **`VMLifecycleCoordinator`** is an `@MainActor` coordinator that owns the lifecycle services (`VirtualizationService`, `MacOSInstallService`, `IPSWService`). It orchestrates multi-step operations like macOS installation (which involves IPSW download → platform file creation → VM configuration → installation). This separation keeps `VMLibraryViewModel` focused on list management. The coordinator enforces **per-VM operation serialization** — at most one lifecycle operation can be in flight for a given VM at any time; concurrent requests are rejected with `VMLifecycleCoordinator.Error.operationInProgress`. `stop` and `forceStop` are interruption-aware and bypass serialization so users can always cancel hung operations.
+- **`VMLifecycleCoordinator`** is an `@MainActor` coordinator that owns the lifecycle services (`VirtualizationService`, `MacOSInstallService`, `IPSWService`). It orchestrates multi-step operations like macOS installation (which involves IPSW download → platform file creation → VM configuration → installation). This separation keeps `VMLibraryViewModel` focused on list management. The coordinator enforces **per-VM operation serialization** — at most one lifecycle operation can be in flight for a given VM at any time; concurrent requests are rejected with `VMLifecycleCoordinator.LifecycleError.operationInProgress`. `stop` and `forceStop` bypass serialization entirely (clearing the active-operation token before calling the service) so users can always cancel hung operations.
 
 - **`VMCreationViewModel`** drives the multi-step creation wizard. It tracks the current step, validates inputs at each stage, and produces a `VMConfiguration` + disk image on completion.
 
@@ -265,7 +265,7 @@ SystemSleepWatcher ──sleep/wake──→ VMLibraryViewModel ──pause/resu
 
 ### 6. VMLifecycleCoordinator separation
 
-**What:** `VMLifecycleCoordinator` sits between `VMLibraryViewModel` and the services, orchestrating multi-step operations. It also enforces per-VM operation serialization — a `Set<UUID>` tracks in-flight operations and rejects concurrent requests for the same VM with `VMLifecycleCoordinator.Error.operationInProgress`. `stop`/`forceStop` bypass serialization (interruption-aware) and clear the active-operation flag on success.
+**What:** `VMLifecycleCoordinator` sits between `VMLibraryViewModel` and the services, orchestrating multi-step operations. It also enforces per-VM operation serialization — a token-based `[UUID: UUID]` dictionary maps each VM to its current operation token and rejects concurrent requests with `VMLifecycleCoordinator.LifecycleError.operationInProgress`. `stop`/`forceStop` bypass serialization entirely — they clear the token *before* calling the service, which invalidates any in-flight operation's `defer` guard and prevents stale removals.
 
 **Why:** macOS VM installation is a multi-step process (download IPSW → create platform files → configure VM → install). Putting this in `VMLibraryViewModel` would bloat it with orchestration logic. The coordinator keeps the view model focused on list management and selection, while the coordinator handles operational complexity. Operation serialization prevents undefined behavior from concurrent `VZVirtualMachine` calls (e.g., double-start or pause-during-start).
 
@@ -301,7 +301,7 @@ No external package dependencies. No Swift Package Manager, CocoaPods, or Cartha
 | `VMConfiguration` | 43 tests + clone suite | Encoding/decoding, defaults, validation, all fields |
 | `VMLibraryViewModel` | 47 tests | Add/remove/rename VMs, selection, delegation to coordinator, sleep/wake |
 | `VMCreationViewModel` | 44 tests | All wizard steps, validation, OS-specific paths |
-| `VMLifecycleCoordinator` | Yes | Multi-step orchestration, error handling, service delegation, operation serialization |
+| `VMLifecycleCoordinator` | Yes | Multi-step orchestration, error handling, service delegation, token-based operation serialization, stop/forceStop bypass, stale-token race condition coverage |
 | `VMInstance` | Yes | Status transitions, configuration updates, bundle layout |
 | `ConfigurationBuilder` | Yes | All three boot paths, device configuration |
 | `VirtualizationService` | Yes | Start/stop/pause/resume via mock VZ objects |
@@ -336,6 +336,6 @@ These services interact with system processes, the network, or VZ installer inte
 ### Test Patterns
 
 - **Framework:** Swift Testing (`@Suite`, `@Test`, `#expect`) — not XCTest
-- **Mocks:** 6 mock implementations conforming to service protocols, supporting call counting and error injection via `throwError` properties. Includes `SuspendingMockVirtualizationService` for testing operation serialization (suspends mid-operation to verify concurrent rejection)
+- **Mocks:** 6 mock implementations conforming to service protocols, supporting call counting and error injection via `throwError` properties. Includes `SuspendingMockVirtualizationService` for testing operation serialization — suspends mid-operation to verify concurrent rejection and token-based race conditions. Relies on `@MainActor` cooperative scheduling (documented in the mock) and enforces single-suspension via `precondition`
 - **Factories:** Shared helpers like `makeInstance()`, `makeViewModel()`, `makeCoordinator()` reduce setup duplication
 - **Error paths:** Mocks support setting `throwError` to inject failures and verify error handling

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -153,7 +153,7 @@ All service implementations conform to protocols defined in `Services/Protocols/
 
 - **`VMLibraryViewModel`** is the central `@Observable` view model. It owns the array of `VMInstance`s and handles list-level operations: add, remove, rename, selection tracking. For lifecycle operations (start, stop, install), it delegates to `VMLifecycleCoordinator`.
 
-- **`VMLifecycleCoordinator`** is an `@MainActor` coordinator that owns the lifecycle services (`VirtualizationService`, `MacOSInstallService`, `IPSWService`). It orchestrates multi-step operations like macOS installation (which involves IPSW download → platform file creation → VM configuration → installation). This separation keeps `VMLibraryViewModel` focused on list management.
+- **`VMLifecycleCoordinator`** is an `@MainActor` coordinator that owns the lifecycle services (`VirtualizationService`, `MacOSInstallService`, `IPSWService`). It orchestrates multi-step operations like macOS installation (which involves IPSW download → platform file creation → VM configuration → installation). This separation keeps `VMLibraryViewModel` focused on list management. The coordinator enforces **per-VM operation serialization** — at most one lifecycle operation can be in flight for a given VM at any time; concurrent requests are rejected with `VMLifecycleCoordinator.Error.operationInProgress`. `stop` and `forceStop` are interruption-aware and bypass serialization so users can always cancel hung operations.
 
 - **`VMCreationViewModel`** drives the multi-step creation wizard. It tracks the current step, validates inputs at each stage, and produces a `VMConfiguration` + disk image on completion.
 
@@ -265,9 +265,9 @@ SystemSleepWatcher ──sleep/wake──→ VMLibraryViewModel ──pause/resu
 
 ### 6. VMLifecycleCoordinator separation
 
-**What:** `VMLifecycleCoordinator` sits between `VMLibraryViewModel` and the services, orchestrating multi-step operations.
+**What:** `VMLifecycleCoordinator` sits between `VMLibraryViewModel` and the services, orchestrating multi-step operations. It also enforces per-VM operation serialization — a `Set<UUID>` tracks in-flight operations and rejects concurrent requests for the same VM with `VMLifecycleCoordinator.Error.operationInProgress`. `stop`/`forceStop` bypass serialization (interruption-aware) and clear the active-operation flag on success.
 
-**Why:** macOS VM installation is a multi-step process (download IPSW → create platform files → configure VM → install). Putting this in `VMLibraryViewModel` would bloat it with orchestration logic. The coordinator keeps the view model focused on list management and selection, while the coordinator handles operational complexity.
+**Why:** macOS VM installation is a multi-step process (download IPSW → create platform files → configure VM → install). Putting this in `VMLibraryViewModel` would bloat it with orchestration logic. The coordinator keeps the view model focused on list management and selection, while the coordinator handles operational complexity. Operation serialization prevents undefined behavior from concurrent `VZVirtualMachine` calls (e.g., double-start or pause-during-start).
 
 **Alternatives:** Fat view model (simpler structure but harder to test and maintain), or individual operation objects (more granular but more types to manage).
 
@@ -301,7 +301,7 @@ No external package dependencies. No Swift Package Manager, CocoaPods, or Cartha
 | `VMConfiguration` | 43 tests + clone suite | Encoding/decoding, defaults, validation, all fields |
 | `VMLibraryViewModel` | 47 tests | Add/remove/rename VMs, selection, delegation to coordinator, sleep/wake |
 | `VMCreationViewModel` | 44 tests | All wizard steps, validation, OS-specific paths |
-| `VMLifecycleCoordinator` | Yes | Multi-step orchestration, error handling, service delegation |
+| `VMLifecycleCoordinator` | Yes | Multi-step orchestration, error handling, service delegation, operation serialization |
 | `VMInstance` | Yes | Status transitions, configuration updates, bundle layout |
 | `ConfigurationBuilder` | Yes | All three boot paths, device configuration |
 | `VirtualizationService` | Yes | Start/stop/pause/resume via mock VZ objects |
@@ -336,6 +336,6 @@ These services interact with system processes, the network, or VZ installer inte
 ### Test Patterns
 
 - **Framework:** Swift Testing (`@Suite`, `@Test`, `#expect`) — not XCTest
-- **Mocks:** 5 mock implementations conforming to service protocols, supporting call counting and error injection via `throwError` properties
+- **Mocks:** 6 mock implementations conforming to service protocols, supporting call counting and error injection via `throwError` properties. Includes `SuspendingMockVirtualizationService` for testing operation serialization (suspends mid-operation to verify concurrent rejection)
 - **Factories:** Shared helpers like `makeInstance()`, `makeViewModel()`, `makeCoordinator()` reduce setup duplication
 - **Error paths:** Mocks support setting `throwError` to inject failures and verify error handling

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -6,6 +6,15 @@ import os
 /// Groups all state-changing VM operations into a single type, keeping
 /// `VMLibraryViewModel` focused on list management and UI state.
 /// All methods re-throw errors — the caller is responsible for presentation.
+///
+/// **Operation serialization:** Each VM can have at most one in-flight lifecycle
+/// operation at a time. Concurrent requests for the same VM are rejected with
+/// ``VMLifecycleCoordinator/Error/operationInProgress``. Since the coordinator
+/// is `@MainActor`, a simple `Set<UUID>` is sufficient — no locks required.
+///
+/// **Interruption-aware:** `stop` and `forceStop` bypass serialization so users
+/// can always interrupt a hung or in-progress operation. On success they also
+/// clear the active-operation flag for that VM.
 @MainActor
 final class VMLifecycleCoordinator {
 
@@ -14,6 +23,9 @@ final class VMLifecycleCoordinator {
     let virtualizationService: any VirtualizationProviding
     let installService: any MacOSInstallProviding
     let ipswService: any IPSWProviding
+
+    /// Tracks VMs that currently have a lifecycle operation in flight.
+    private var activeOperations: Set<UUID> = []
 
     init(
         virtualizationService: any VirtualizationProviding,
@@ -25,30 +37,72 @@ final class VMLifecycleCoordinator {
         self.ipswService = ipswService
     }
 
+    // MARK: - Operation Serialization
+
+    /// Returns `true` if the given VM currently has a lifecycle operation in progress.
+    func hasActiveOperation(for instanceID: UUID) -> Bool {
+        activeOperations.contains(instanceID)
+    }
+
+    /// Executes `body` only if no other operation is already in flight for this VM.
+    /// Inserts the VM's ID before running and removes it on completion (success or failure).
+    private func serialized<T>(
+        _ instance: VMInstance,
+        action: String,
+        body: () async throws -> T
+    ) async throws -> T {
+        guard !activeOperations.contains(instance.id) else {
+            Self.logger.warning("Rejected \(action) for '\(instance.name)': operation already in progress")
+            throw Error.operationInProgress(vmName: instance.name)
+        }
+
+        activeOperations.insert(instance.id)
+        defer { activeOperations.remove(instance.id) }
+
+        Self.logger.debug("Acquired operation lock for '\(instance.name)' (action: \(action))")
+        return try await body()
+    }
+
     // MARK: - Lifecycle
 
     func start(_ instance: VMInstance) async throws {
-        try await virtualizationService.start(instance)
+        try await serialized(instance, action: "start") {
+            try await virtualizationService.start(instance)
+        }
     }
 
+    /// Requests a graceful stop. Bypasses serialization so users can always
+    /// interrupt an in-progress operation (e.g. a hung start). On success,
+    /// clears the active-operation flag for this VM.
     func stop(_ instance: VMInstance) throws {
         try virtualizationService.stop(instance)
+        activeOperations.remove(instance.id)
     }
 
+    /// Immediately terminates the VM. Bypasses serialization so users can
+    /// always force-kill, even during another in-flight operation. On success,
+    /// clears the active-operation flag for this VM.
     func forceStop(_ instance: VMInstance) async throws {
         try await virtualizationService.forceStop(instance)
+        activeOperations.remove(instance.id)
     }
 
     func pause(_ instance: VMInstance) async throws {
-        try await virtualizationService.pause(instance)
+        try await serialized(instance, action: "pause") {
+            try await virtualizationService.pause(instance)
+        }
     }
 
     func resume(_ instance: VMInstance) async throws {
-        try await virtualizationService.resume(instance)
+        try await serialized(instance, action: "resume") {
+            try await virtualizationService.resume(instance)
+        }
     }
 
     func save(_ instance: VMInstance) async throws {
-        try await virtualizationService.save(instance)
+        try await serialized(instance, action: "save") {
+            try await virtualizationService.save(instance)
+        }
     }
 
     // MARK: - macOS Installation
@@ -59,74 +113,92 @@ final class VMLifecycleCoordinator {
         wizard: VMCreationViewModel,
         storageService: any VMStorageProviding
     ) async throws {
-        Self.logger.debug("installMacOS: entering for '\(instance.name)', source=\(String(describing: wizard.ipswSource))")
-        do {
-            let ipswURL: URL
+        try await serialized(instance, action: "installMacOS") {
+            Self.logger.debug("installMacOS: entering for '\(instance.name)', source=\(String(describing: wizard.ipswSource))")
+            do {
+                let ipswURL: URL
 
-            switch wizard.ipswSource {
-            case .downloadLatest:
-                guard let downloadPath = wizard.ipswDownloadPath else {
-                    throw IPSWError.noDownloadURL
-                }
-                let downloadDestination = URL(fileURLWithPath: downloadPath)
+                switch wizard.ipswSource {
+                case .downloadLatest:
+                    guard let downloadPath = wizard.ipswDownloadPath else {
+                        throw IPSWError.noDownloadURL
+                    }
+                    let downloadDestination = URL(fileURLWithPath: downloadPath)
 
-                // Set up two-step install state before changing status
-                instance.installState = MacOSInstallState(
-                    hasDownloadStep: true,
-                    currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 0)
-                )
-                instance.status = .installing
-
-                // Download the latest IPSW to user-chosen location
-                let remoteURL = try await ipswService.fetchLatestRestoreImageURL()
-                try await ipswService.downloadRestoreImage(
-                    from: remoteURL,
-                    to: downloadDestination
-                ) { progress, bytesWritten, totalBytes in
-                    instance.installState?.currentPhase = .downloading(
-                        progress: progress,
-                        bytesWritten: bytesWritten,
-                        totalBytes: totalBytes
+                    // Set up two-step install state before changing status
+                    instance.installState = MacOSInstallState(
+                        hasDownloadStep: true,
+                        currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 0)
                     )
+                    instance.status = .installing
+
+                    // Download the latest IPSW to user-chosen location
+                    let remoteURL = try await ipswService.fetchLatestRestoreImageURL()
+                    try await ipswService.downloadRestoreImage(
+                        from: remoteURL,
+                        to: downloadDestination
+                    ) { progress, bytesWritten, totalBytes in
+                        instance.installState?.currentPhase = .downloading(
+                            progress: progress,
+                            bytesWritten: bytesWritten,
+                            totalBytes: totalBytes
+                        )
+                    }
+
+                    // Mark download complete, transition to install phase
+                    instance.installState?.downloadCompleted = true
+                    instance.installState?.currentPhase = .installing(progress: 0)
+                    ipswURL = downloadDestination
+
+                case .localFile:
+                    guard let path = wizard.ipswPath else {
+                        throw IPSWError.noDownloadURL
+                    }
+                    ipswURL = URL(fileURLWithPath: path)
+
+                    // Local file: single-step install (no download)
+                    instance.installState = MacOSInstallState(
+                        hasDownloadStep: false,
+                        currentPhase: .installing(progress: 0)
+                    )
+                    instance.status = .installing
                 }
 
-                // Mark download complete, transition to install phase
-                instance.installState?.downloadCompleted = true
-                instance.installState?.currentPhase = .installing(progress: 0)
-                ipswURL = downloadDestination
-
-            case .localFile:
-                guard let path = wizard.ipswPath else {
-                    throw IPSWError.noDownloadURL
+                // Run macOS installation
+                try await installService.install(
+                    into: instance,
+                    restoreImageURL: ipswURL
+                ) { @MainActor progress in
+                    instance.installState?.currentPhase = .installing(progress: progress)
                 }
-                ipswURL = URL(fileURLWithPath: path)
-
-                // Local file: single-step install (no download)
-                instance.installState = MacOSInstallState(
-                    hasDownloadStep: false,
-                    currentPhase: .installing(progress: 0)
-                )
-                instance.status = .installing
+            } catch is CancellationError {
+                Self.logger.info("macOS installation cancelled for '\(instance.name)'")
+            } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
+                Self.logger.info("IPSW download cancelled for '\(instance.name)'")
+            } catch {
+                instance.status = .error
+                instance.errorMessage = error.localizedDescription
+                throw error
             }
 
-            // Run macOS installation
-            try await installService.install(
-                into: instance,
-                restoreImageURL: ipswURL
-            ) { @MainActor progress in
-                instance.installState?.currentPhase = .installing(progress: progress)
-            }
-        } catch is CancellationError {
-            Self.logger.info("macOS installation cancelled for '\(instance.name)'")
-        } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
-            Self.logger.info("IPSW download cancelled for '\(instance.name)'")
-        } catch {
-            instance.status = .error
-            instance.errorMessage = error.localizedDescription
-            throw error
+            instance.installTask = nil
         }
-
-        instance.installTask = nil
     }
     #endif
+}
+
+// MARK: - VMLifecycleCoordinator.Error
+
+extension VMLifecycleCoordinator {
+
+    enum Error: LocalizedError {
+        case operationInProgress(vmName: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .operationInProgress(let vmName):
+                "An operation is already in progress for '\(vmName)'. Please wait for it to complete."
+            }
+        }
+    }
 }

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -9,12 +9,14 @@ import os
 ///
 /// **Operation serialization:** Each VM can have at most one in-flight lifecycle
 /// operation at a time. Concurrent requests for the same VM are rejected with
-/// ``VMLifecycleCoordinator/Error/operationInProgress``. Since the coordinator
-/// is `@MainActor`, a simple `Set<UUID>` is sufficient — no locks required.
+/// ``LifecycleError/operationInProgress``. A token-based `[UUID: UUID]` dictionary
+/// maps each VM to its current operation token. Since the coordinator is `@MainActor`,
+/// no locks are required.
 ///
-/// **Interruption-aware:** `stop` and `forceStop` bypass serialization so users
-/// can always interrupt a hung or in-progress operation. On success they also
-/// clear the active-operation flag for that VM.
+/// **Interruption-aware:** `stop` and `forceStop` bypass serialization entirely —
+/// they clear the active-operation token *before* calling the underlying service.
+/// This invalidates any in-flight operation's token so its `defer` cleanup won't
+/// clobber a subsequent operation's entry.
 @MainActor
 final class VMLifecycleCoordinator {
 
@@ -24,8 +26,9 @@ final class VMLifecycleCoordinator {
     let installService: any MacOSInstallProviding
     let ipswService: any IPSWProviding
 
-    /// Tracks VMs that currently have a lifecycle operation in flight.
-    private var activeOperations: Set<UUID> = []
+    /// Maps VM ID → operation token for VMs that currently have a lifecycle operation in flight.
+    /// The token allows `defer` blocks to avoid clobbering entries inserted by a later operation.
+    private var activeOperations: [UUID: UUID] = [:]
 
     init(
         virtualizationService: any VirtualizationProviding,
@@ -37,27 +40,48 @@ final class VMLifecycleCoordinator {
         self.ipswService = ipswService
     }
 
+    // MARK: - Errors
+
+    enum LifecycleError: LocalizedError {
+        case operationInProgress(vmName: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .operationInProgress(let vmName):
+                "An operation is already in progress for '\(vmName)'. Please wait for it to complete."
+            }
+        }
+    }
+
     // MARK: - Operation Serialization
 
     /// Returns `true` if the given VM currently has a lifecycle operation in progress.
     func hasActiveOperation(for instanceID: UUID) -> Bool {
-        activeOperations.contains(instanceID)
+        activeOperations[instanceID] != nil
     }
 
     /// Executes `body` only if no other operation is already in flight for this VM.
-    /// Inserts the VM's ID before running and removes it on completion (success or failure).
+    ///
+    /// Generates a unique token per invocation. The `defer` block only removes the
+    /// entry if its token still matches, preventing a stale removal from clobbering
+    /// a token written by `stop`/`forceStop` or a subsequent operation.
     private func serialized<T>(
         _ instance: VMInstance,
         action: String,
         body: () async throws -> T
     ) async throws -> T {
-        guard !activeOperations.contains(instance.id) else {
+        guard activeOperations[instance.id] == nil else {
             Self.logger.warning("Rejected \(action) for '\(instance.name)': operation already in progress")
-            throw Error.operationInProgress(vmName: instance.name)
+            throw LifecycleError.operationInProgress(vmName: instance.name)
         }
 
-        activeOperations.insert(instance.id)
-        defer { activeOperations.remove(instance.id) }
+        let token = UUID()
+        activeOperations[instance.id] = token
+        defer {
+            if activeOperations[instance.id] == token {
+                activeOperations.removeValue(forKey: instance.id)
+            }
+        }
 
         Self.logger.debug("Acquired operation lock for '\(instance.name)' (action: \(action))")
         return try await body()
@@ -72,19 +96,21 @@ final class VMLifecycleCoordinator {
     }
 
     /// Requests a graceful stop. Bypasses serialization so users can always
-    /// interrupt an in-progress operation (e.g. a hung start). On success,
-    /// clears the active-operation flag for this VM.
+    /// interrupt an in-progress operation (e.g. a hung start). Clears the
+    /// active-operation token *before* calling the service, invalidating any
+    /// in-flight operation's defer guard.
     func stop(_ instance: VMInstance) throws {
+        activeOperations.removeValue(forKey: instance.id)
         try virtualizationService.stop(instance)
-        activeOperations.remove(instance.id)
     }
 
     /// Immediately terminates the VM. Bypasses serialization so users can
-    /// always force-kill, even during another in-flight operation. On success,
-    /// clears the active-operation flag for this VM.
+    /// always force-kill, even during another in-flight operation. Clears the
+    /// active-operation token *before* calling the service, invalidating any
+    /// in-flight operation's defer guard.
     func forceStop(_ instance: VMInstance) async throws {
+        activeOperations.removeValue(forKey: instance.id)
         try await virtualizationService.forceStop(instance)
-        activeOperations.remove(instance.id)
     }
 
     func pause(_ instance: VMInstance) async throws {
@@ -185,20 +211,4 @@ final class VMLifecycleCoordinator {
         }
     }
     #endif
-}
-
-// MARK: - VMLifecycleCoordinator.Error
-
-extension VMLifecycleCoordinator {
-
-    enum Error: LocalizedError {
-        case operationInProgress(vmName: String)
-
-        var errorDescription: String? {
-            switch self {
-            case .operationInProgress(let vmName):
-                "An operation is already in progress for '\(vmName)'. Please wait for it to complete."
-            }
-        }
-    }
 }

--- a/KernovaTests/Mocks/SuspendingMockVirtualizationService.swift
+++ b/KernovaTests/Mocks/SuspendingMockVirtualizationService.swift
@@ -1,0 +1,94 @@
+import Foundation
+@testable import Kernova
+
+/// A mock virtualization service whose `start` and `pause` methods suspend until
+/// explicitly resumed. Used to test operation serialization in `VMLifecycleCoordinator`.
+///
+/// - Important: Only **one** operation can be suspended at a time. The mock stores a
+///   single `suspendedContinuation` slot; calling `suspendIfNeeded()` while another
+///   operation is already suspended will overwrite the first continuation, leaking it.
+@MainActor
+final class SuspendingMockVirtualizationService: VirtualizationProviding {
+
+    /// When `true`, `start` will suspend. Set to `false` to allow subsequent calls through immediately.
+    var shouldSuspendOnStart = true
+
+    /// When `true`, `pause` will suspend. Set to `false` to allow subsequent calls through immediately.
+    var shouldSuspendOnPause = true
+
+    // MARK: - Suspension Mechanism
+
+    /// Continuation that, when resumed, unblocks the suspended operation.
+    private var suspendedContinuation: CheckedContinuation<Void, Never>?
+
+    /// Continuation that signals the test that the mock has entered its suspended state.
+    private var suspendedNotification: CheckedContinuation<Void, Never>?
+
+    /// Waits until the mock is suspended inside an operation.
+    ///
+    /// This relies on `@MainActor` cooperative scheduling: the `Task { @MainActor in … }`
+    /// that drives the coordinator will suspend at `withCheckedContinuation` inside
+    /// `suspendIfNeeded()`, yielding back to the main actor run loop. That yield allows
+    /// this method's own `withCheckedContinuation` to execute and observe the stored
+    /// `suspendedContinuation`, confirming the mock has entered its suspended state.
+    func waitUntilSuspended() async {
+        // If already suspended, return immediately
+        if suspendedContinuation != nil { return }
+
+        await withCheckedContinuation { continuation in
+            suspendedNotification = continuation
+        }
+    }
+
+    /// Called by the test to let the suspended operation complete.
+    func resumeSuspended() {
+        suspendedContinuation?.resume()
+        suspendedContinuation = nil
+    }
+
+    private func suspendIfNeeded() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            suspendedContinuation = continuation
+
+            // Signal the test that we're now suspended
+            suspendedNotification?.resume()
+            suspendedNotification = nil
+        }
+    }
+
+    // MARK: - VirtualizationProviding
+
+    func start(_ instance: VMInstance) async throws {
+        if shouldSuspendOnStart {
+            await suspendIfNeeded()
+        }
+        instance.status = .running
+    }
+
+    func stop(_ instance: VMInstance) throws {
+        instance.resetToStopped()
+    }
+
+    func forceStop(_ instance: VMInstance) async throws {
+        instance.resetToStopped()
+    }
+
+    func pause(_ instance: VMInstance) async throws {
+        if shouldSuspendOnPause {
+            await suspendIfNeeded()
+        }
+        instance.status = .paused
+    }
+
+    func resume(_ instance: VMInstance) async throws {
+        instance.status = .running
+    }
+
+    func save(_ instance: VMInstance) async throws {
+        instance.status = .paused
+    }
+
+    func restore(_ instance: VMInstance) async throws {
+        instance.status = .running
+    }
+}

--- a/KernovaTests/Mocks/SuspendingMockVirtualizationService.swift
+++ b/KernovaTests/Mocks/SuspendingMockVirtualizationService.swift
@@ -47,6 +47,7 @@ final class SuspendingMockVirtualizationService: VirtualizationProviding {
     }
 
     private func suspendIfNeeded() async {
+        precondition(suspendedContinuation == nil, "Only one operation can be suspended at a time")
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             suspendedContinuation = continuation
 

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -125,6 +125,213 @@ struct VMLifecycleCoordinatorTests {
         }
     }
 
+    // MARK: - Operation Serialization
+
+    @Test("hasActiveOperation returns false when no operation is running")
+    func hasActiveOperationInitiallyFalse() {
+        let (coordinator, _, _, _) = makeCoordinator()
+        let instance = makeInstance()
+
+        #expect(!coordinator.hasActiveOperation(for: instance.id))
+    }
+
+    @Test("hasActiveOperation returns true during an in-flight operation")
+    func hasActiveOperationTrueDuringOperation() async throws {
+        let suspendingService = SuspendingMockVirtualizationService()
+        let coordinator = VMLifecycleCoordinator(
+            virtualizationService: suspendingService,
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService()
+        )
+        let instance = makeInstance()
+
+        // Start an operation that will suspend
+        let task = Task { @MainActor in
+            try await coordinator.start(instance)
+        }
+
+        // Wait for the operation to begin (the mock will signal via its continuation)
+        await suspendingService.waitUntilSuspended()
+
+        #expect(coordinator.hasActiveOperation(for: instance.id))
+
+        // Let the operation complete
+        suspendingService.resumeSuspended()
+        try await task.value
+    }
+
+    @Test("concurrent operation on the same VM throws operationInProgress")
+    func rejectsConcurrentOperationOnSameVM() async throws {
+        let suspendingService = SuspendingMockVirtualizationService()
+        let coordinator = VMLifecycleCoordinator(
+            virtualizationService: suspendingService,
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService()
+        )
+        let instance = makeInstance()
+
+        // Start an operation that will suspend
+        let task = Task { @MainActor in
+            try await coordinator.start(instance)
+        }
+
+        await suspendingService.waitUntilSuspended()
+
+        // A second operation on the same VM should be rejected
+        await #expect(throws: VMLifecycleCoordinator.Error.self) {
+            try await coordinator.pause(instance)
+        }
+
+        // Clean up
+        suspendingService.resumeSuspended()
+        try await task.value
+    }
+
+    @Test("operations on different VMs are allowed concurrently")
+    func allowsConcurrentOperationsOnDifferentVMs() async throws {
+        let suspendingService = SuspendingMockVirtualizationService()
+        let coordinator = VMLifecycleCoordinator(
+            virtualizationService: suspendingService,
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService()
+        )
+        let instance1 = makeInstance(name: "VM 1")
+        let instance2 = makeInstance(name: "VM 2")
+
+        // Start an operation on instance1 that suspends
+        let task = Task { @MainActor in
+            try await coordinator.start(instance1)
+        }
+
+        await suspendingService.waitUntilSuspended()
+
+        // A different VM should still be able to start (uses regular mock behavior for second call)
+        suspendingService.shouldSuspendOnStart = false
+        try await coordinator.start(instance2)
+
+        // Clean up
+        suspendingService.resumeSuspended()
+        try await task.value
+    }
+
+    @Test("lock is released after operation completes successfully")
+    func lockReleasedAfterSuccess() async throws {
+        let (coordinator, _, _, _) = makeCoordinator()
+        let instance = makeInstance()
+
+        try await coordinator.start(instance)
+        #expect(!coordinator.hasActiveOperation(for: instance.id))
+
+        // A second operation should succeed
+        instance.status = .running
+        try await coordinator.pause(instance)
+        #expect(!coordinator.hasActiveOperation(for: instance.id))
+    }
+
+    @Test("lock is released after operation fails")
+    func lockReleasedAfterError() async throws {
+        let (coordinator, virtService, _, _) = makeCoordinator()
+        virtService.startError = VirtualizationError.noVirtualMachine
+        let instance = makeInstance()
+
+        await #expect(throws: VirtualizationError.self) {
+            try await coordinator.start(instance)
+        }
+
+        #expect(!coordinator.hasActiveOperation(for: instance.id))
+
+        // Should be able to retry after failure
+        virtService.startError = nil
+        try await coordinator.start(instance)
+        #expect(virtService.startCallCount == 2)
+    }
+
+    @Test("stop bypasses serialization during an active operation")
+    func stopBypassesSerializationDuringActiveOperation() async throws {
+        let suspendingService = SuspendingMockVirtualizationService()
+        let coordinator = VMLifecycleCoordinator(
+            virtualizationService: suspendingService,
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService()
+        )
+        let instance = makeInstance()
+
+        // Start an operation that will suspend
+        let task = Task { @MainActor in
+            try await coordinator.start(instance)
+        }
+
+        await suspendingService.waitUntilSuspended()
+        #expect(coordinator.hasActiveOperation(for: instance.id))
+
+        // Stop should succeed even though start is in flight
+        try coordinator.stop(instance)
+
+        // Active operation flag should be cleared by stop
+        #expect(!coordinator.hasActiveOperation(for: instance.id))
+
+        // Clean up — let the suspended start complete
+        suspendingService.resumeSuspended()
+        _ = try? await task.value
+    }
+
+    @Test("forceStop bypasses serialization during an active operation")
+    func forceStopBypassesSerializationDuringActiveOperation() async throws {
+        let suspendingService = SuspendingMockVirtualizationService()
+        let coordinator = VMLifecycleCoordinator(
+            virtualizationService: suspendingService,
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService()
+        )
+        let instance = makeInstance()
+
+        // Start an operation that will suspend
+        let task = Task { @MainActor in
+            try await coordinator.start(instance)
+        }
+
+        await suspendingService.waitUntilSuspended()
+        #expect(coordinator.hasActiveOperation(for: instance.id))
+
+        // Force stop should succeed even though start is in flight
+        try await coordinator.forceStop(instance)
+
+        // Active operation flag should be cleared by forceStop
+        #expect(!coordinator.hasActiveOperation(for: instance.id))
+
+        // Clean up
+        suspendingService.resumeSuspended()
+        _ = try? await task.value
+    }
+
+    @Test("synchronous stop lock is released after completion")
+    func stopLockReleasedAfterCompletion() throws {
+        let (coordinator, virtService, _, _) = makeCoordinator()
+        let instance = makeInstance()
+        instance.status = .running
+
+        try coordinator.stop(instance)
+        #expect(!coordinator.hasActiveOperation(for: instance.id))
+        #expect(virtService.stopCallCount == 1)
+    }
+
+    @Test("synchronous stop lock is released after error")
+    func stopLockReleasedAfterError() async throws {
+        let (coordinator, virtService, _, _) = makeCoordinator()
+        virtService.stopError = VirtualizationError.noVirtualMachine
+        let instance = makeInstance()
+
+        #expect(throws: VirtualizationError.self) {
+            try coordinator.stop(instance)
+        }
+
+        #expect(!coordinator.hasActiveOperation(for: instance.id))
+
+        // Should be able to start after failed stop
+        try await coordinator.start(instance)
+        #expect(virtService.startCallCount == 1)
+    }
+
     // MARK: - macOS Installation
 
     #if arch(arm64)

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -178,7 +178,7 @@ struct VMLifecycleCoordinatorTests {
         await suspendingService.waitUntilSuspended()
 
         // A second operation on the same VM should be rejected
-        await #expect(throws: VMLifecycleCoordinator.Error.self) {
+        await #expect(throws: VMLifecycleCoordinator.LifecycleError.self) {
             try await coordinator.pause(instance)
         }
 
@@ -304,8 +304,8 @@ struct VMLifecycleCoordinatorTests {
         _ = try? await task.value
     }
 
-    @Test("synchronous stop lock is released after completion")
-    func stopLockReleasedAfterCompletion() throws {
+    @Test("stop does not affect active operation tracking")
+    func stopDoesNotAffectActiveOperationTracking() throws {
         let (coordinator, virtService, _, _) = makeCoordinator()
         let instance = makeInstance()
         instance.status = .running
@@ -315,8 +315,8 @@ struct VMLifecycleCoordinatorTests {
         #expect(virtService.stopCallCount == 1)
     }
 
-    @Test("synchronous stop lock is released after error")
-    func stopLockReleasedAfterError() async throws {
+    @Test("stop error does not affect active operation tracking")
+    func stopErrorDoesNotAffectActiveOperationTracking() async throws {
         let (coordinator, virtService, _, _) = makeCoordinator()
         virtService.stopError = VirtualizationError.noVirtualMachine
         let instance = makeInstance()
@@ -330,6 +330,40 @@ struct VMLifecycleCoordinatorTests {
         // Should be able to start after failed stop
         try await coordinator.start(instance)
         #expect(virtService.startCallCount == 1)
+    }
+
+    @Test("token prevents stale defer from clobbering after stop clears entry")
+    func tokenPreventsStaleRemoval() async throws {
+        let suspendingService = SuspendingMockVirtualizationService()
+        let coordinator = VMLifecycleCoordinator(
+            virtualizationService: suspendingService,
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService()
+        )
+        let instance = makeInstance()
+
+        // Start an operation that will suspend (acquires token A)
+        let task = Task { @MainActor in
+            try await coordinator.start(instance)
+        }
+
+        await suspendingService.waitUntilSuspended()
+        #expect(coordinator.hasActiveOperation(for: instance.id))
+
+        // Stop clears the active operation entry (invalidating token A)
+        try coordinator.stop(instance)
+        #expect(!coordinator.hasActiveOperation(for: instance.id))
+
+        // Resume the suspended start — its defer should NOT re-clear the entry
+        // because its token no longer matches
+        suspendingService.resumeSuspended()
+        _ = try? await task.value
+
+        // Now start a new operation — this should succeed because
+        // the stale defer didn't clobber anything
+        suspendingService.shouldSuspendOnStart = false
+        try await coordinator.start(instance)
+        #expect(!coordinator.hasActiveOperation(for: instance.id))
     }
 
     // MARK: - macOS Installation


### PR DESCRIPTION
## Summary
Implements operation serialization in `VMLifecycleCoordinator` to prevent concurrent lifecycle operations on the same VM. Each VM can have at most one in-flight operation at a time, with concurrent requests rejected via a new `LifecycleError.operationInProgress` error.

## Key Changes

- **Token-Based Operation Serialization**: Added `activeOperations: [UUID: UUID]` dictionary mapping VM IDs to unique operation tokens
  - `serialized()` method wraps async operations with token acquisition/release
  - Token-based `defer` guard only cleans up if its token still matches, preventing stale operations from clobbering new entries
  - `hasActiveOperation(for:)` public method allows checking operation status

- **Stop/ForceStop Bypass Serialization**: `stop` and `forceStop` are intentionally not wrapped in `serialized()` — they are interruption/emergency operations that must always succeed
  - They call `activeOperations.removeValue(forKey:)` *before* invoking the service, invalidating the in-flight operation's token so its `defer` guard becomes a no-op

- **Serialized Lifecycle Methods**: `start`, `pause`, `resume`, `save`, `installMacOS`

- **New Error Type**: Added `LifecycleError` enum (nested inside `VMLifecycleCoordinator`) with `operationInProgress` case providing user-friendly error messages

- **Comprehensive Test Coverage**: Tests covering:
  - Initial state verification and active operation detection during in-flight operations
  - Rejection of concurrent operations on the same VM
  - Allowance of concurrent operations on different VMs
  - Lock release after success and failure
  - Stop and forceStop bypass serialization even during active operations
  - Token prevents stale `defer` from clobbering after stop clears entry (the critical race condition test)
  - macOS installation forwarding and error handling

- **Test Infrastructure**: Created `SuspendingMockVirtualizationService` with precondition and scheduling assumption documentation, enabling tests to suspend operations mid-flight via `CheckedContinuation` and inspect state before resuming

## Implementation Details

- Since `VMLifecycleCoordinator` is `@MainActor`, no locks are required — a simple `[UUID: UUID]` dictionary is sufficient for tracking active operations
- Each operation generates a unique `UUID` token stored in the dictionary; the `defer` block only removes the entry if the token still matches, which prevents a stale operation's cleanup from wiping a subsequent operation's tracking
- `stop`/`forceStop` clear the token before calling the service, so they always succeed and any suspended operation's `defer` guard becomes a no-op
- Detailed logging at debug and warning levels for operation lifecycle tracking
- Architecture documentation updated to reflect serialization behavior

https://claude.ai/code/session_01YXkAZuJitdxMPL2NQPSn9j