### PR TITLE
Add LEARNINGS.md knowledge base and session startup hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "echo '📋 Review LEARNINGS.md for accumulated project knowledge before starting work. Update it with new discoveries when you encounter non-obvious issues.' && echo '' && tail -50 LEARNINGS.md"
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,28 @@ feat: Add VM snapshot support
 
 The `Co-Authored-By` trailer is automatically appended by Claude Code and should not be duplicated in the commit message body.
 
+## Self-Improvement Loop
+
+This project maintains a **[LEARNINGS.md](LEARNINGS.md)** file — an append-only knowledge base of non-obvious discoveries, resolved pitfalls, and codebase-specific patterns accumulated across development sessions.
+
+### How it works
+1. **At session start:** The `.claude/settings.json` SessionStart hook surfaces recent learnings. Read the full file if working on an area covered by existing entries.
+2. **During work:** When you encounter a non-obvious issue (e.g., a build failure with a misleading error, a concurrency gotcha, a testing pattern that doesn't work as expected), note it mentally.
+3. **After resolving:** Append a concise, actionable entry to the appropriate category in LEARNINGS.md. Entries should be specific to this codebase — not general programming advice.
+4. **Keep it lean:** Each entry should be 1-2 sentences. Remove entries that become obsolete (e.g., if the underlying code changes). The file should stay under ~100 entries.
+
+### What to capture
+- Build/environment gotchas with non-obvious root causes
+- Concurrency and actor isolation pitfalls specific to the VZ integration
+- Testing patterns that work (or don't) with the mock/protocol setup
+- Architecture constraints that aren't obvious from reading the code
+- Common mistakes when modifying specific components
+
+### What NOT to capture
+- General Swift/SwiftUI knowledge
+- Information already documented in CLAUDE.md or ARCHITECTURE.md
+- Obvious patterns that any experienced developer would know
+
 ## Architecture Change Protocol
 
 After completing any task that hits one or more of the following triggers, suggest follow-up updates before considering the task complete.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -1,0 +1,29 @@
+# Learnings
+
+This file is an append-only knowledge base maintained by Claude Code. Each entry captures a non-obvious discovery, resolved pitfall, or codebase-specific pattern learned during a development session. Future sessions read this file to avoid repeating mistakes and to apply proven approaches.
+
+**Format:** Each entry is a concise, actionable item under a category heading. Entries should be specific to this codebase — not general Swift/programming knowledge.
+
+---
+
+## Build & Environment
+
+- The project requires macOS 26 and Xcode 26. Builds will fail on earlier versions with no clear error message — check the environment first if xcodebuild fails unexpectedly.
+- This is an Xcode project, not SPM. Do not attempt `swift build` or `swift test` — use `xcodebuild` commands from CLAUDE.md.
+
+## Concurrency & Actor Isolation
+
+- All `VZVirtualMachine` interactions must be `@MainActor`. Forgetting this causes Swift 6 strict concurrency errors that can be confusing — the compiler error points to the call site, not the missing annotation.
+- VZ delegate callbacks require `nonisolated(unsafe)` with `MainActor.assumeIsolated` to bridge back. This pattern is intentional and used in VirtualizationService — don't try to refactor it away.
+
+## Testing
+
+- Tests use Swift Testing (`@Suite`, `@Test`, `#expect`), not XCTest. Mixing frameworks in the same file causes compilation errors.
+- Mock services use `throwError` properties for error injection. Set `mockService.throwError = SomeError()` before calling the method under test, not after.
+- Test factories like `makeInstance()` and `makeViewModel()` exist in test files — check existing tests before writing new setup code.
+
+## Architecture Patterns
+
+- `VMConfiguration` is `Codable` and `Sendable` — any new properties must also be `Codable` and `Sendable` or the project won't compile under Swift 6.
+- Services are protocol-backed (see `Services/Protocols/`). New services should follow the same pattern: define a protocol, implement it, create a mock for tests.
+- The app uses `os.Logger` with `com.kernova.app` subsystem. Never use `print()` — it won't show in production logs and violates the codebase convention.


### PR DESCRIPTION
## Summary
Introduces a self-improvement loop for the project by adding a LEARNINGS.md file — an append-only knowledge base for capturing non-obvious discoveries, resolved pitfalls, and codebase-specific patterns. Includes a SessionStart hook in `.claude/settings.json` to surface recent learnings at the beginning of each development session.

## Key Changes
- **LEARNINGS.md** (new): Append-only knowledge base with initial entries covering:
  - Build & Environment (macOS/Xcode version requirements, Xcode vs SPM)
  - Concurrency & Actor Isolation (VZVirtualMachine @MainActor requirements, delegate callback patterns)
  - Testing (Swift Testing framework, mock error injection, test factories)
  - Architecture Patterns (Codable/Sendable constraints, protocol-backed services, logging conventions)

- **.claude/settings.json** (new): SessionStart hook that displays a reminder and the last 50 lines of LEARNINGS.md at session start

- **CLAUDE.md** (updated): Added "Self-Improvement Loop" section documenting:
  - How the LEARNINGS.md workflow operates across sessions
  - Guidelines for what to capture (build gotchas, concurrency pitfalls, testing patterns, architecture constraints)
  - What NOT to capture (general knowledge, existing documentation, obvious patterns)
  - Maintenance guidance (keep entries lean, remove obsolete entries, target ~100 entries max)

## Implementation Details
- Entries are concise and actionable, specific to this codebase rather than general programming knowledge
- The SessionStart hook uses `tail -50` to surface recent learnings without overwhelming output
- Format is category-based for easy navigation and discovery
- The system is designed to be lightweight and maintainable across multiple development sessions

https://claude.ai/code/session_01MC6A786sTqJ5Kv2szTmPJM