### PR TITLE
feat: Update VM icons to apple.logo and terminal.fill

### DIFF
--- a/Kernova/Views/Creation/OSSelectionStep.swift
+++ b/Kernova/Views/Creation/OSSelectionStep.swift
@@ -16,8 +16,8 @@ struct OSSelectionStep: View {
                 .multilineTextAlignment(.center)
 
             HStack(spacing: 20) {
-                osCard(for: .macOS, icon: "macwindow", description: "Run macOS in a virtual machine on Apple Silicon.")
-                osCard(for: .linux, icon: "terminal", description: "Run Linux distributions using EFI or direct kernel boot.")
+                osCard(for: .macOS, icon: "apple.logo", description: "Run macOS in a virtual machine on Apple Silicon.")
+                osCard(for: .linux, icon: "terminal.fill", description: "Run Linux distributions using EFI or direct kernel boot.")
             }
             .padding(.top, 8)
         }

--- a/Kernova/Views/Sidebar/VMRowView.swift
+++ b/Kernova/Views/Sidebar/VMRowView.swift
@@ -61,8 +61,8 @@ struct VMRowView: View {
 
     private var iconName: String {
         switch instance.configuration.guestOS {
-        case .macOS: "macwindow"
-        case .linux: "terminal"
+        case .macOS: "apple.logo"
+        case .linux: "terminal.fill"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace generic SF Symbols with more recognizable OS-specific icons in the sidebar and creation wizard

## Changes
- Update VMRowView sidebar icon from macwindow to apple.logo for macOS, terminal to terminal.fill for Linux
- Update OSSelectionStep wizard icons to match

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Verify apple.logo and terminal.fill render correctly in sidebar VM rows
- [ ] Verify icons render correctly in OS selection wizard

https://claude.ai/code/session_015F9uqXsbUgbsPQrvmHjuZq