### PR TITLE
feat: Update VM icons and centralize icon names in VMGuestOS

### DIFF
--- a/Kernova/Models/VMGuestOS.swift
+++ b/Kernova/Models/VMGuestOS.swift
@@ -12,6 +12,13 @@ enum VMGuestOS: String, Codable, CaseIterable, Sendable {
         }
     }
 
+    var iconName: String {
+        switch self {
+        case .macOS: "apple.logo"
+        case .linux: "terminal.fill"
+        }
+    }
+
     var defaultCPUCount: Int {
         switch self {
         case .macOS: 4

--- a/Kernova/Views/Creation/OSSelectionStep.swift
+++ b/Kernova/Views/Creation/OSSelectionStep.swift
@@ -16,19 +16,19 @@ struct OSSelectionStep: View {
                 .multilineTextAlignment(.center)
 
             HStack(spacing: 20) {
-                osCard(for: .macOS, icon: "macwindow", description: "Run macOS in a virtual machine on Apple Silicon.")
-                osCard(for: .linux, icon: "terminal", description: "Run Linux distributions using EFI or direct kernel boot.")
+                osCard(for: .macOS, description: "Run macOS in a virtual machine on Apple Silicon.")
+                osCard(for: .linux, description: "Run Linux distributions using EFI or direct kernel boot.")
             }
             .padding(.top, 8)
         }
     }
 
-    private func osCard(for os: VMGuestOS, icon: String, description: String) -> some View {
+    private func osCard(for os: VMGuestOS, description: String) -> some View {
         Button {
             creationVM.selectedOS = os
         } label: {
             VStack(spacing: 12) {
-                Image(systemName: icon)
+                Image(systemName: os.iconName)
                     .font(.system(size: 36))
                     .foregroundStyle(creationVM.selectedOS == os ? Color.accentColor : .secondary)
 

--- a/Kernova/Views/Sidebar/VMRowView.swift
+++ b/Kernova/Views/Sidebar/VMRowView.swift
@@ -12,7 +12,7 @@ struct VMRowView: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: iconName)
+            Image(systemName: instance.configuration.guestOS.iconName)
                 .foregroundStyle(.secondary)
                 .frame(width: 20)
 
@@ -56,13 +56,6 @@ struct VMRowView: View {
             if !focused && isRenaming {
                 onCommitRename(editingName)
             }
-        }
-    }
-
-    private var iconName: String {
-        switch instance.configuration.guestOS {
-        case .macOS: "macwindow"
-        case .linux: "terminal"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace generic SF Symbols with more recognizable OS-specific icons (apple.logo for macOS, terminal.fill for Linux)
- Centralize icon name mapping in `VMGuestOS` enum to eliminate duplication across views

## Changes
- Add `iconName` property to `VMGuestOS` enum
- Update `VMRowView` to use `guestOS.iconName` instead of local computed property
- Update `OSSelectionStep` to use `os.iconName`, removing the `icon` parameter from `osCard`

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Verify apple.logo and terminal.fill render correctly in sidebar VM rows
- [ ] Verify icons render correctly in OS selection wizard
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)