### PR TITLE
fix: Prevent orphaned serial console windows and add auto-close on VM…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Kernova/
 │   ├── AppDelegate.swift               # NSApplicationDelegate — startup, window tracking, menu, save-on-quit
 │   ├── MainWindowController.swift      # Primary NSSplitViewController hosting SwiftUI sidebar + detail
 │   ├── FullscreenWindowController.swift # Per-VM fullscreen window, auto-closes on VM stop
-│   └── SerialConsoleWindowController.swift # Per-VM serial console window
+│   └── SerialConsoleWindowController.swift # Per-VM serial console window, auto-closes on VM stop
 ├── Models/                             # Data types — all value types or @MainActor-isolated
 │   ├── VMConfiguration.swift           # Codable/Sendable struct persisted as config.json per VM bundle
 │   ├── VMInstance.swift                # @Observable runtime wrapper: VMConfiguration + VZVirtualMachine + VMStatus

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -146,9 +146,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     // MARK: - Serial Console
 
     @objc func showSerialConsole(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance else { return }
+        guard let instance = viewModel.selectedInstance,
+              instance.status == .running || instance.status == .paused,
+              instance.virtualMachine != nil else { return }
 
         if let existing = serialConsoleWindows[instance.instanceID] {
+            // Only re-show if the VM is still active
+            guard instance.status == .running || instance.status == .paused,
+                  instance.virtualMachine != nil else { return }
             existing.showWindow(nil)
             existing.window?.makeKeyAndOrderFront(nil)
             return
@@ -244,7 +249,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         case #selector(deleteVM(_:)):
             return viewModel.selectedInstance?.status.canEditSettings ?? false
         case #selector(showSerialConsole(_:)):
-            return viewModel.selectedInstance != nil
+            guard let instance = viewModel.selectedInstance else { return false }
+            return (instance.status == .running || instance.status == .paused)
+                && instance.virtualMachine != nil
         case #selector(toggleFullscreenDisplay(_:)):
             guard let instance = viewModel.selectedInstance else { return false }
             // Only allow fullscreen when the VM has a live VZVirtualMachine

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -147,14 +147,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
     @objc func showSerialConsole(_ sender: Any?) {
         guard let instance = viewModel.selectedInstance,
-              instance.status == .running || instance.status == .paused,
-              instance.virtualMachine != nil else { return }
+              instance.canShowSerialConsole else { return }
 
         if let existing = serialConsoleWindows[instance.instanceID] {
-            // Only re-show if the VM is still active
-            guard instance.status == .running || instance.status == .paused,
-                  instance.virtualMachine != nil else { return }
-            existing.showWindow(nil)
             existing.window?.makeKeyAndOrderFront(nil)
             return
         }
@@ -249,9 +244,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         case #selector(deleteVM(_:)):
             return viewModel.selectedInstance?.status.canEditSettings ?? false
         case #selector(showSerialConsole(_:)):
-            guard let instance = viewModel.selectedInstance else { return false }
-            return (instance.status == .running || instance.status == .paused)
-                && instance.virtualMachine != nil
+            return viewModel.selectedInstance?.canShowSerialConsole ?? false
         case #selector(toggleFullscreenDisplay(_:)):
             guard let instance = viewModel.selectedInstance else { return false }
             // Only allow fullscreen when the VM has a live VZVirtualMachine

--- a/Kernova/App/SerialConsoleWindowController.swift
+++ b/Kernova/App/SerialConsoleWindowController.swift
@@ -1,17 +1,26 @@
 import Cocoa
+import os
 import SwiftUI
 
 /// Manages a serial console window for a single VM instance.
 ///
 /// Each VM gets its own window controller. The window hosts a `SerialConsoleContentView`
 /// via `NSHostingController` and persists its frame position per VM ID.
+///
+/// The controller observes the VM's status and automatically closes the window when
+/// the VM stops or enters an error state, mirroring `FullscreenWindowController` behavior.
 @MainActor
-final class SerialConsoleWindowController: NSWindowController {
+final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate {
+
+    private static let logger = Logger(subsystem: "com.kernova.app", category: "SerialConsoleWindowController")
 
     let vmID: UUID
+    private let instance: VMInstance
+    private var observingStatus = false
 
     init(instance: VMInstance) {
         self.vmID = instance.instanceID
+        self.instance = instance
 
         let contentView = SerialConsoleContentView(instance: instance)
         let hostingController = NSHostingController(rootView: contentView)
@@ -28,16 +37,61 @@ final class SerialConsoleWindowController: NSWindowController {
         window.minSize = NSSize(width: 400, height: 200)
 
         super.init(window: window)
+        window.delegate = self
 
         // Restore saved frame or center on first open
         let frameName = "SerialConsole-\(instance.instanceID.uuidString)"
         if !window.setFrameUsingName(frameName) {
             window.center()
         }
+
+        // Validate restored frame is visible on a connected screen
+        if let frame = self.window?.frame,
+           !NSScreen.screens.contains(where: { $0.visibleFrame.intersects(frame) }) {
+            Self.logger.debug("Restored frame not visible on any screen, centering window")
+            window.center()
+        }
+
         window.setFrameAutosaveName(frameName)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func showWindow(_ sender: Any?) {
+        super.showWindow(sender)
+        observeStatus()
+        Self.logger.debug("Serial console window shown for VM '\(self.instance.name)'")
+    }
+
+    // MARK: - NSWindowDelegate
+
+    func windowWillClose(_ notification: Notification) {
+        observingStatus = false
+        Self.logger.debug("Serial console window closing for VM '\(self.instance.name)'")
+    }
+
+    // MARK: - Status Observation
+
+    /// Automatically closes the serial console window when the VM stops or errors out.
+    private func observeStatus() {
+        observingStatus = true
+        withObservationTracking {
+            _ = self.instance.status
+        } onChange: {
+            Task { @MainActor [weak self] in
+                guard let self, self.observingStatus else { return }
+                let status = self.instance.status
+                if status == .stopped || status == .error {
+                    Self.logger.notice("Auto-closing serial console for VM '\(self.instance.name)' (status: \(status.displayName))")
+                    self.window?.close()
+                } else {
+                    self.observeStatus()
+                }
+            }
+        }
     }
 }

--- a/Kernova/App/SerialConsoleWindowController.swift
+++ b/Kernova/App/SerialConsoleWindowController.swift
@@ -63,7 +63,7 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
 
     override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
-        observeStatus()
+        if !observingStatus { observeStatus() }
         Self.logger.debug("Serial console window shown for VM '\(self.instance.name)'")
     }
 

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -81,6 +81,11 @@ final class VMInstance: Identifiable {
         status == .paused && virtualMachine == nil
     }
 
+    /// `true` when the VM is eligible to show a serial console window (active status + live VM).
+    var canShowSerialConsole: Bool {
+        (status == .running || status == .paused) && virtualMachine != nil
+    }
+
     // MARK: - Delegate Setup
 
     func setupDelegate() {

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -93,6 +93,28 @@ struct VMInstanceTests {
         #expect(instance.isColdPaused == false)
     }
 
+    // MARK: - canShowSerialConsole
+
+    @Test("canShowSerialConsole is false when running without a virtual machine")
+    func canShowSerialConsoleFalseWithoutVM() {
+        let instance = makeInstance(status: .running)
+        #expect(instance.virtualMachine == nil)
+        #expect(instance.canShowSerialConsole == false)
+    }
+
+    @Test("canShowSerialConsole is false when stopped")
+    func canShowSerialConsoleFalseWhenStopped() {
+        let instance = makeInstance(status: .stopped)
+        #expect(instance.canShowSerialConsole == false)
+    }
+
+    @Test("canShowSerialConsole is false for cold-paused VM")
+    func canShowSerialConsoleFalseWhenColdPaused() {
+        let instance = makeInstance(status: .paused)
+        #expect(instance.isColdPaused == true)
+        #expect(instance.canShowSerialConsole == false)
+    }
+
     // MARK: - Bundle Paths
 
     @Test("Bundle path URLs are correctly derived from bundleURL")

--- a/KernovaTests/VMStatusSerialConsoleTests.swift
+++ b/KernovaTests/VMStatusSerialConsoleTests.swift
@@ -1,0 +1,94 @@
+import Testing
+import Foundation
+@testable import Kernova
+
+@Suite("VMStatus Serial Console Validation Tests")
+@MainActor
+struct VMStatusSerialConsoleTests {
+
+    private func makeInstance(status: VMStatus = .stopped) -> VMInstance {
+        let config = VMConfiguration(
+            name: "Test VM",
+            guestOS: .linux,
+            bootMode: .efi
+        )
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(config.id.uuidString, isDirectory: true)
+        return VMInstance(configuration: config, bundleURL: bundleURL, status: status)
+    }
+
+    // MARK: - Serial Console Eligibility
+
+    /// The serial console requires both an active status (running/paused) and a live VZVirtualMachine.
+    /// Since we can't create a real VZVirtualMachine in tests, these tests verify the status
+    /// portion of the validation logic that AppDelegate.validateMenuItem uses.
+
+    @Test("Serial console requires running or paused status")
+    func serialConsoleRequiresActiveStatus() {
+        let activeStatuses: [VMStatus] = [.running, .paused]
+        let inactiveStatuses: [VMStatus] = [.stopped, .starting, .saving, .restoring, .installing, .error]
+
+        for status in activeStatuses {
+            let isActive = status == .running || status == .paused
+            #expect(isActive == true, "Expected \(status) to be eligible for serial console")
+        }
+
+        for status in inactiveStatuses {
+            let isActive = status == .running || status == .paused
+            #expect(isActive == false, "Expected \(status) to be ineligible for serial console")
+        }
+    }
+
+    @Test("Serial console requires a live virtual machine")
+    func serialConsoleRequiresVirtualMachine() {
+        let instance = makeInstance(status: .running)
+        // Without a real VZVirtualMachine, virtualMachine is nil
+        #expect(instance.virtualMachine == nil)
+
+        let canShow = (instance.status == .running || instance.status == .paused)
+            && instance.virtualMachine != nil
+        #expect(canShow == false, "Should not allow serial console without a live virtual machine")
+    }
+
+    @Test("Stopped VM is ineligible for serial console regardless of other state")
+    func stoppedVMIneligible() {
+        let instance = makeInstance(status: .stopped)
+        let canShow = (instance.status == .running || instance.status == .paused)
+            && instance.virtualMachine != nil
+        #expect(canShow == false)
+    }
+
+    @Test("Error VM is ineligible for serial console")
+    func errorVMIneligible() {
+        let instance = makeInstance(status: .error)
+        let canShow = (instance.status == .running || instance.status == .paused)
+            && instance.virtualMachine != nil
+        #expect(canShow == false)
+    }
+
+    @Test("Starting VM is ineligible for serial console")
+    func startingVMIneligible() {
+        let instance = makeInstance(status: .starting)
+        let canShow = (instance.status == .running || instance.status == .paused)
+            && instance.virtualMachine != nil
+        #expect(canShow == false)
+    }
+
+    @Test("Saving VM is ineligible for serial console")
+    func savingVMIneligible() {
+        let instance = makeInstance(status: .saving)
+        let canShow = (instance.status == .running || instance.status == .paused)
+            && instance.virtualMachine != nil
+        #expect(canShow == false)
+    }
+
+    @Test("Cold-paused VM (paused with no virtualMachine) is ineligible for serial console")
+    func coldPausedVMIneligible() {
+        let instance = makeInstance(status: .paused)
+        #expect(instance.isColdPaused == true)
+
+        let canShow = (instance.status == .running || instance.status == .paused)
+            && instance.virtualMachine != nil
+        #expect(canShow == false, "Cold-paused VM has no live virtual machine")
+    }
+}

--- a/KernovaTests/VMStatusSerialConsoleTests.swift
+++ b/KernovaTests/VMStatusSerialConsoleTests.swift
@@ -19,76 +19,32 @@ struct VMStatusSerialConsoleTests {
 
     // MARK: - Serial Console Eligibility
 
-    /// The serial console requires both an active status (running/paused) and a live VZVirtualMachine.
-    /// Since we can't create a real VZVirtualMachine in tests, these tests verify the status
-    /// portion of the validation logic that AppDelegate.validateMenuItem uses.
-
-    @Test("Serial console requires running or paused status")
-    func serialConsoleRequiresActiveStatus() {
-        let activeStatuses: [VMStatus] = [.running, .paused]
-        let inactiveStatuses: [VMStatus] = [.stopped, .starting, .saving, .restoring, .installing, .error]
-
-        for status in activeStatuses {
-            let isActive = status == .running || status == .paused
-            #expect(isActive == true, "Expected \(status) to be eligible for serial console")
-        }
-
-        for status in inactiveStatuses {
-            let isActive = status == .running || status == .paused
-            #expect(isActive == false, "Expected \(status) to be ineligible for serial console")
-        }
-    }
-
     @Test("Serial console requires a live virtual machine")
     func serialConsoleRequiresVirtualMachine() {
         let instance = makeInstance(status: .running)
         // Without a real VZVirtualMachine, virtualMachine is nil
         #expect(instance.virtualMachine == nil)
-
-        let canShow = (instance.status == .running || instance.status == .paused)
-            && instance.virtualMachine != nil
-        #expect(canShow == false, "Should not allow serial console without a live virtual machine")
+        #expect(instance.canShowSerialConsole == false,
+                "Should not allow serial console without a live virtual machine")
     }
 
-    @Test("Stopped VM is ineligible for serial console regardless of other state")
-    func stoppedVMIneligible() {
-        let instance = makeInstance(status: .stopped)
-        let canShow = (instance.status == .running || instance.status == .paused)
-            && instance.virtualMachine != nil
-        #expect(canShow == false)
-    }
-
-    @Test("Error VM is ineligible for serial console")
-    func errorVMIneligible() {
-        let instance = makeInstance(status: .error)
-        let canShow = (instance.status == .running || instance.status == .paused)
-            && instance.virtualMachine != nil
-        #expect(canShow == false)
-    }
-
-    @Test("Starting VM is ineligible for serial console")
-    func startingVMIneligible() {
-        let instance = makeInstance(status: .starting)
-        let canShow = (instance.status == .running || instance.status == .paused)
-            && instance.virtualMachine != nil
-        #expect(canShow == false)
-    }
-
-    @Test("Saving VM is ineligible for serial console")
-    func savingVMIneligible() {
-        let instance = makeInstance(status: .saving)
-        let canShow = (instance.status == .running || instance.status == .paused)
-            && instance.virtualMachine != nil
-        #expect(canShow == false)
+    @Test(
+        "Inactive statuses are ineligible for serial console",
+        arguments: [
+            VMStatus.stopped, .starting, .saving, .restoring, .installing, .error,
+        ]
+    )
+    func inactiveStatusIneligible(status: VMStatus) {
+        let instance = makeInstance(status: status)
+        #expect(instance.canShowSerialConsole == false,
+                "Expected \(status) to be ineligible for serial console")
     }
 
     @Test("Cold-paused VM (paused with no virtualMachine) is ineligible for serial console")
     func coldPausedVMIneligible() {
         let instance = makeInstance(status: .paused)
         #expect(instance.isColdPaused == true)
-
-        let canShow = (instance.status == .running || instance.status == .paused)
-            && instance.virtualMachine != nil
-        #expect(canShow == false, "Cold-paused VM has no live virtual machine")
+        #expect(instance.canShowSerialConsole == false,
+                "Cold-paused VM has no live virtual machine")
     }
 }


### PR DESCRIPTION
… stop

## Summary
- Serial console windows could be opened for non-running VMs, producing invisible disconnected windows
- Because `applicationShouldTerminateAfterLastWindowClosed` returns true, these orphaned windows prevented the app from quitting when the main window was closed
- Serial console now mirrors FullscreenWindowController's lifecycle pattern

## Changes
- SerialConsoleWindowController: store VMInstance reference, conform to NSWindowDelegate, observe status via withObservationTracking to auto-close on stopped/error
- SerialConsoleWindowController: validate restored window frame is visible on a connected screen, fall back to centering
- AppDelegate.validateMenuItem: serial console menu item now requires running/paused status with a live VZVirtualMachine
- AppDelegate.showSerialConsole: add runtime guard against status changes between validation and dispatch
- Add VMStatusSerialConsoleTests covering eligibility for all VM states
- Update ARCHITECTURE.md directory tree to document auto-close behavior

## Test plan
- [x] Build succeeds on macOS 26
- [x] All 251 tests pass (including 7 new serial console validation tests)