### PR TITLE
fix: Validate Serial Console menu item in Window menu

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 @main
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenuDelegate {
 
     private var mainWindowController: MainWindowController?
     private var viewModel: VMLibraryViewModel!
@@ -12,6 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     private var serialConsoleObservers: [UUID: Any] = [:]
     private var fullscreenWindows: [UUID: FullscreenWindowController] = [:]
     private var fullscreenObservers: [UUID: Any] = [:]
+    private var serialConsoleMenuItem: NSMenuItem?
 
     // MARK: - Entry Point
 
@@ -261,6 +262,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         }
     }
 
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        if menu === NSApp.windowsMenu {
+            serialConsoleMenuItem?.isEnabled = viewModel.selectedInstance?.canShowSerialConsole ?? false
+        }
+    }
+
     // MARK: - Main Menu
 
     private func setupMainMenu() {
@@ -344,6 +351,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             keyEquivalent: "t"
         )
         serialItem.keyEquivalentModifierMask = [.command, .shift]
+        self.serialConsoleMenuItem = serialItem
         windowMenu.addItem(serialItem)
         windowMenu.addItem(.separator())
         windowMenu.addItem(withTitle: "Minimize", action: #selector(NSWindow.performMiniaturize(_:)), keyEquivalent: "m")
@@ -352,6 +360,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         windowMenu.addItem(withTitle: "Bring All to Front", action: #selector(NSApplication.arrangeInFront(_:)), keyEquivalent: "")
         windowMenuItem.submenu = windowMenu
         NSApp.windowsMenu = windowMenu
+        windowMenu.delegate = self
         mainMenu.addItem(windowMenuItem)
 
         // Help menu

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -12,7 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private var serialConsoleObservers: [UUID: Any] = [:]
     private var fullscreenWindows: [UUID: FullscreenWindowController] = [:]
     private var fullscreenObservers: [UUID: Any] = [:]
-    private var serialConsoleMenuItem: NSMenuItem?
+    private var serialConsoleMenuItem: NSMenuItem!
 
     // MARK: - Entry Point
 
@@ -244,6 +244,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             return instance.status.canEditSettings && !viewModel.isCloning
         case #selector(deleteVM(_:)):
             return viewModel.selectedInstance?.status.canEditSettings ?? false
+        // AppKit bypasses NSMenuItemValidation for windowsMenu items, so
+        // menuNeedsUpdate(_:) handles visual state. This case covers keyboard
+        // shortcut validation, which still routes through validateMenuItem(_:).
         case #selector(showSerialConsole(_:)):
             return viewModel.selectedInstance?.canShowSerialConsole ?? false
         case #selector(toggleFullscreenDisplay(_:)):
@@ -264,7 +267,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     func menuNeedsUpdate(_ menu: NSMenu) {
         if menu === NSApp.windowsMenu {
-            serialConsoleMenuItem?.isEnabled = viewModel.selectedInstance?.canShowSerialConsole ?? false
+            serialConsoleMenuItem.isEnabled = viewModel.selectedInstance?.canShowSerialConsole ?? false
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix Serial Console menu item staying enabled for non-running VMs — AppKit bypasses `NSMenuItemValidation` for items in the managed windows menu (`NSApp.windowsMenu`)
- Use `NSMenuDelegate.menuNeedsUpdate(_:)` to manually validate the item before the menu opens

## Changes
- Add `NSMenuDelegate` conformance to `AppDelegate`
- Store a reference to the Serial Console `NSMenuItem`
- Set `AppDelegate` as the Window menu's delegate
- Implement `menuNeedsUpdate(_:)` to set `isEnabled` based on `canShowSerialConsole`

## Test plan
- [ ] Running VM selected → Serial Console enabled, opens console window
- [ ] Stopped VM selected → Serial Console grayed out
- [ ] No VM selected → Serial Console grayed out
- [ ] Cmd+Shift+T shortcut respects the same enabled state
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)