### PR TITLE
fix: Prevent app termination on fullscreen exit and add main window reopen

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,7 +17,7 @@ Kernova/
 │   ├── VMConfiguration.swift           # Codable/Sendable struct persisted as config.json per VM bundle
 │   ├── VMInstance.swift                # @Observable runtime wrapper: VMConfiguration + VZVirtualMachine + VMStatus
 │   ├── VMBundleLayout.swift            # Sendable struct centralizing file paths within a .kernova bundle
-│   ├── VMStatus.swift                  # Enum: stopped, starting, running, pausing, paused, stopping, error
+│   ├── VMStatus.swift                  # Enum: stopped, starting, running, paused, saving, restoring, installing, error
 │   ├── VMBootMode.swift                # Enum: macOS, efi, linuxKernel
 │   ├── VMGuestOS.swift                 # Enum: macOS, linux
 │   ├── MacOSInstallState.swift         # Tracks two-phase macOS installation progress (download + install)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,9 +104,11 @@ KernovaTests/
 **Files:** `AppDelegate.swift`, `MainWindowController.swift`, `FullscreenWindowController.swift`, `SerialConsoleWindowController.swift`
 
 `AppDelegate` is the entry point. It creates the `VMLibraryViewModel` and `VMLifecycleCoordinator`, opens the main window, and manages the lifecycle of all windows. It tracks window controllers in dictionaries keyed by VM UUID, enabling one-to-many relationships (a VM can have a main view, a fullscreen window, and a serial console open simultaneously). `AppDelegate` also handles:
-- The application menu (including VM-specific actions)
+- The application menu (including VM-specific actions and Window > Show Library with Cmd+0)
 - Save-on-quit behavior (saving VM state before termination)
-- Window restoration
+- Conditional termination: `applicationShouldTerminateAfterLastWindowClosed` returns `false` when VMs are active or fullscreen windows exist, preventing premature exit on fullscreen-to-inline transitions
+- Dock icon reopen: `applicationShouldHandleReopen` restores the main window when clicked with no visible windows
+- Fullscreen exit recovery: closing a fullscreen window automatically re-shows the main library window via `showLibrary(_:)`
 
 `MainWindowController` hosts an `NSSplitViewController` where each pane is an `NSHostingController` wrapping SwiftUI views. This is the AppKit/SwiftUI bridge point.
 
@@ -122,7 +124,7 @@ The model layer has two key types:
 
 `VMBundleLayout` is a `Sendable` struct that takes a bundle root path and provides all derived file paths (disk image, aux storage, save file, serial log, etc.), keeping path logic centralized.
 
-The remaining models are enums: `VMStatus` (stopped/starting/running/pausing/paused/stopping/error), `VMBootMode` (macOS/efi/linuxKernel), `VMGuestOS` (macOS/linux), and `MacOSInstallState` (tracking download and install phases with progress).
+The remaining models are enums: `VMStatus` (stopped/starting/running/paused/saving/restoring/installing/error), `VMBootMode` (macOS/efi/linuxKernel), `VMGuestOS` (macOS/linux), and `MacOSInstallState` (tracking download and install phases with progress). `VMStatus` provides computed properties for state checks (`canStart`, `canStop`, `canPause`, `canResume`, `canSave`, `canEditSettings`, `isTransitioning`, `isActive`).
 
 ### Services
 

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -119,21 +119,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     }
 
     private func showLibraryWindow(bringToFront: Bool) {
-        if mainWindowController?.window == nil {
+        if let existingWindow = mainWindowController?.window {
+            if bringToFront {
+                Self.logger.debug("showLibrary: focusing existing window")
+                existingWindow.makeKeyAndOrderFront(nil)
+            } else {
+                Self.logger.debug("showLibrary: showing existing window in background")
+                existingWindow.orderBack(nil)
+            }
+        } else {
             Self.logger.notice("showLibrary: recreating main window controller")
             let windowController = MainWindowController(viewModel: viewModel)
-            windowController.showWindow(nil)
-            mainWindowController = windowController
-        }
-
-        if let window = mainWindowController?.window {
             if bringToFront {
-                Self.logger.debug("showLibrary: focusing window")
-                window.makeKeyAndOrderFront(nil)
+                windowController.showWindow(nil)
             } else {
-                Self.logger.debug("showLibrary: showing window in background")
-                window.orderBack(nil)
+                windowController.showWindowInBackground()
             }
+            mainWindowController = windowController
         }
     }
 

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -133,6 +133,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             if bringToFront {
                 windowController.showWindow(nil)
             } else {
+                windowController.showWindow(nil)
                 windowController.window?.orderBack(nil)
             }
             mainWindowController = windowController

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -45,10 +45,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         let hasActiveVMs = viewModel.instances.contains { instance in
-            if instance.status.isActive { return true }
-            // Live-paused VMs (not cold-paused to disk) should keep the app alive
-            if instance.status == .paused && instance.virtualMachine != nil { return true }
-            return false
+            // Live-paused VMs (not cold-paused to disk) should also keep the app alive
+            instance.status.isActive || (instance.status == .paused && instance.virtualMachine != nil)
         }
 
         // Stay alive if VMs are active or fullscreen windows still exist
@@ -117,13 +115,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     }
 
     @objc func showLibrary(_ sender: Any?) {
+        showLibraryWindow(bringToFront: true)
+    }
+
+    private func showLibraryWindow(bringToFront: Bool) {
         if let existingWindow = mainWindowController?.window {
-            Self.logger.debug("showLibrary: focusing existing window")
-            existingWindow.makeKeyAndOrderFront(nil)
+            if bringToFront {
+                Self.logger.debug("showLibrary: focusing existing window")
+                existingWindow.makeKeyAndOrderFront(nil)
+            } else {
+                Self.logger.debug("showLibrary: showing existing window in background")
+                existingWindow.orderBack(nil)
+            }
         } else {
             Self.logger.notice("showLibrary: recreating main window controller")
             let windowController = MainWindowController(viewModel: viewModel)
-            windowController.showWindow(nil)
+            if bringToFront {
+                windowController.showWindow(nil)
+            } else {
+                windowController.window?.orderBack(nil)
+            }
             mainWindowController = windowController
         }
     }
@@ -241,7 +252,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             forName: NSWindow.willCloseNotification,
             object: controller.window,
             queue: .main
-        ) { [weak self] _ in
+        ) { [weak self] notification in
+            // Capture window state synchronously — by the time the Task runs, it may have changed
+            let wasKeyWindow = (notification.object as? NSWindow)?.isKeyWindow ?? false
+            let appWasActive = NSApp.isActive
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 if let token = self.fullscreenObservers.removeValue(forKey: vmID) {
@@ -253,8 +267,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                     self.viewModel.saveConfiguration(for: instance)
                 }
 
-                // Ensure the main window is visible after fullscreen closes
-                self.showLibrary(nil)
+                // Restore library window based on context:
+                // - Key + active app: user deliberately left fullscreen → focus library
+                // - App not active: VM stopped while user is elsewhere → show library in background
+                // - Active but not key: user is in another Kernova window → no action needed
+                if wasKeyWindow && appWasActive {
+                    self.showLibrary(nil)
+                } else if !appWasActive {
+                    self.showLibraryWindow(bringToFront: false)
+                }
             }
         }
         fullscreenObservers[vmID] = token

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -119,24 +119,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     }
 
     private func showLibraryWindow(bringToFront: Bool) {
-        if let existingWindow = mainWindowController?.window {
-            if bringToFront {
-                Self.logger.debug("showLibrary: focusing existing window")
-                existingWindow.makeKeyAndOrderFront(nil)
-            } else {
-                Self.logger.debug("showLibrary: showing existing window in background")
-                existingWindow.orderBack(nil)
-            }
-        } else {
+        if mainWindowController?.window == nil {
             Self.logger.notice("showLibrary: recreating main window controller")
             let windowController = MainWindowController(viewModel: viewModel)
-            if bringToFront {
-                windowController.showWindow(nil)
-            } else {
-                windowController.showWindow(nil)
-                windowController.window?.orderBack(nil)
-            }
+            windowController.showWindow(nil)
             mainWindowController = windowController
+        }
+
+        if let window = mainWindowController?.window {
+            if bringToFront {
+                Self.logger.debug("showLibrary: focusing window")
+                window.makeKeyAndOrderFront(nil)
+            } else {
+                Self.logger.debug("showLibrary: showing window in background")
+                window.orderBack(nil)
+            }
         }
     }
 

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import os
 import SwiftUI
 
 @main
@@ -13,6 +14,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private var fullscreenWindows: [UUID: FullscreenWindowController] = [:]
     private var fullscreenObservers: [UUID: Any] = [:]
     private var serialConsoleMenuItem: NSMenuItem!
+
+    private static let logger = Logger(subsystem: "com.kernova.app", category: "AppDelegate")
 
     // MARK: - Entry Point
 
@@ -41,7 +44,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        true
+        let hasActiveVMs = viewModel.instances.contains { instance in
+            if instance.status.isActive { return true }
+            // Live-paused VMs (not cold-paused to disk) should keep the app alive
+            if instance.status == .paused && instance.virtualMachine != nil { return true }
+            return false
+        }
+
+        // Stay alive if VMs are active or fullscreen windows still exist
+        if hasActiveVMs || !fullscreenWindows.isEmpty {
+            Self.logger.debug("applicationShouldTerminateAfterLastWindowClosed: false (activeVMs=\(hasActiveVMs), fullscreenWindows=\(self.fullscreenWindows.count))")
+            return false
+        }
+
+        Self.logger.debug("applicationShouldTerminateAfterLastWindowClosed: true")
+        return true
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            showLibrary(nil)
+        }
+        return true
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -90,6 +114,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     @objc func newVM(_ sender: Any?) {
         viewModel.showCreationWizard = true
+    }
+
+    @objc func showLibrary(_ sender: Any?) {
+        if let existingWindow = mainWindowController?.window {
+            Self.logger.debug("showLibrary: focusing existing window")
+            existingWindow.makeKeyAndOrderFront(nil)
+        } else {
+            Self.logger.notice("showLibrary: recreating main window controller")
+            let windowController = MainWindowController(viewModel: viewModel)
+            windowController.showWindow(nil)
+            mainWindowController = windowController
+        }
     }
 
     // MARK: - VM Actions
@@ -216,6 +252,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                     instance.configuration.prefersFullscreen = false
                     self.viewModel.saveConfiguration(for: instance)
                 }
+
+                // Ensure the main window is visible after fullscreen closes
+                self.showLibrary(nil)
             }
         }
         fullscreenObservers[vmID] = token
@@ -348,6 +387,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // Window menu
         let windowMenuItem = NSMenuItem()
         let windowMenu = NSMenu(title: "Window")
+        let showLibraryItem = NSMenuItem(
+            title: "Show Library",
+            action: #selector(showLibrary(_:)),
+            keyEquivalent: "0"
+        )
+        windowMenu.addItem(showLibraryItem)
+        windowMenu.addItem(.separator())
         let serialItem = NSMenuItem(
             title: "Serial Console",
             action: #selector(showSerialConsole(_:)),

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -97,6 +97,15 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
         observeToolbarState()
     }
 
+    /// Makes the window visible behind other windows without stealing focus.
+    ///
+    /// Use instead of ``showWindow(_:)`` when the window should exist but not
+    /// interrupt the user. All controller setup happens in ``init(viewModel:)``,
+    /// so this is safe to call without going through `showWindow`.
+    func showWindowInBackground() {
+        window?.orderBack(nil)
+    }
+
     // MARK: - Sidebar Double-Click to Start/Resume
 
     @objc private func sidebarRowDoubleClicked(_ sender: Any?) {

--- a/Kernova/Models/VMStatus.swift
+++ b/Kernova/Models/VMStatus.swift
@@ -50,6 +50,8 @@ enum VMStatus: String, Codable, Sendable {
     var canEditSettings: Bool { self == .stopped || self == .error }
 
     /// Whether this status represents an active VM that should keep the app alive.
+    /// Note: live-paused VMs (`.paused` with a non-nil `VZVirtualMachine`) should
+    /// be handled separately by the caller.
     var isActive: Bool {
         switch self {
         case .running, .starting, .saving, .restoring, .installing:

--- a/Kernova/Models/VMStatus.swift
+++ b/Kernova/Models/VMStatus.swift
@@ -48,4 +48,14 @@ enum VMStatus: String, Codable, Sendable {
     var canResume: Bool { self == .paused }
     var canSave: Bool { self == .running || self == .paused }
     var canEditSettings: Bool { self == .stopped || self == .error }
+
+    /// Whether this status represents an active VM that should keep the app alive.
+    var isActive: Bool {
+        switch self {
+        case .running, .starting, .saving, .restoring, .installing:
+            true
+        case .paused, .stopped, .error:
+            false
+        }
+    }
 }

--- a/KernovaTests/VMStatusTests.swift
+++ b/KernovaTests/VMStatusTests.swift
@@ -79,6 +79,20 @@ struct VMStatusTests {
         #expect(VMStatus.installing.canEditSettings == false)
     }
 
+    // MARK: - Active
+
+    @Test("isActive returns true for running, starting, saving, restoring, installing")
+    func isActive() {
+        #expect(VMStatus.running.isActive == true)
+        #expect(VMStatus.starting.isActive == true)
+        #expect(VMStatus.saving.isActive == true)
+        #expect(VMStatus.restoring.isActive == true)
+        #expect(VMStatus.installing.isActive == true)
+        #expect(VMStatus.paused.isActive == false)
+        #expect(VMStatus.stopped.isActive == false)
+        #expect(VMStatus.error.isActive == false)
+    }
+
     // MARK: - Transitioning
 
     @Test("isTransitioning returns true for starting, saving, restoring, and installing")


### PR DESCRIPTION
## Summary
- Fix premature app termination when closing a fullscreen VM window (zero visible windows triggered auto-terminate)
- Add multiple ways to reopen the main library window: dock icon click, Window > Show Library (Cmd+0), and automatic restore on fullscreen exit
- Context-aware library window restore — focuses when user exits fullscreen deliberately, shows in background when a VM stops while the user is elsewhere

## Changes
- **AppDelegate.swift** — Make `applicationShouldTerminateAfterLastWindowClosed` conditional on active VMs and fullscreen windows; add `applicationShouldHandleReopen` for dock icon reopen; add `showLibrary` action and private `showLibraryWindow(bringToFront:)` helper; capture `isKeyWindow`/`isActive` synchronously in fullscreen close handler for context-aware restore; add "Show Library" (Cmd+0) to Window menu; add `os.Logger`
- **MainWindowController.swift** — Add `showWindowInBackground()` to centralize background window presentation, avoiding `AppDelegate` reaching past the controller to call `window?.orderBack` directly
- **VMStatus.swift** — Add `isActive` computed property for states that should keep the app alive
- **VMStatusTests.swift** — Add tests for `isActive` across all status cases
- **ARCHITECTURE.md** — Update App Shell and Models sections; fix stale enum states (pausing/stopping → saving/restoring/installing)

## Test plan
- [ ] Enter fullscreen on a running VM, exit fullscreen — app stays alive, library window focuses
- [ ] VM stops while user is in another app — library window appears in background
- [ ] Close all windows, click dock icon — main library window reappears
- [ ] Window > Show Library (Cmd+0) opens the library from any state
- [ ] Close all windows with no running VMs — app terminates normally
- [ ] All existing tests pass including new `isActive` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)