### PR TITLE
fix: Replace deprecated APIs with modern equivalents

### DIFF
--- a/Kernova/Models/VMBundleLayout.swift
+++ b/Kernova/Models/VMBundleLayout.swift
@@ -37,7 +37,7 @@ struct VMBundleLayout: Sendable {
     }
 
     var hasSaveFile: Bool {
-        FileManager.default.fileExists(atPath: saveFileURL.path)
+        FileManager.default.fileExists(atPath: saveFileURL.path(percentEncoded: false))
     }
 
     /// Actual bytes consumed on disk by the sparse disk image, or `nil` if the file doesn't exist.

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -137,18 +137,27 @@ final class VMInstance: Identifiable {
             FileManager.default.createFile(atPath: logURL.path(percentEncoded: false), contents: nil)
         }
         let logHandle = try? FileHandle(forWritingTo: logURL)
-        _ = try? logHandle?.seekToEnd()
+        do {
+            _ = try logHandle?.seekToEnd()
+        } catch {
+            Self.logger.warning("Could not seek to end of serial log: \(error.localizedDescription)")
+        }
         serialLogFileHandle = logHandle
 
         // Capture for the readability handler closure (runs on a background GCD queue)
         let logFileHandle = logHandle
+        let logger = Self.logger
 
         outputPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
             guard !data.isEmpty else { return }
 
             // Write to disk log (background-safe — FileHandle is thread-safe for sequential writes)
-            try? logFileHandle?.write(contentsOf: data)
+            do {
+                try logFileHandle?.write(contentsOf: data)
+            } catch {
+                logger.error("Failed to write to serial log: \(error.localizedDescription)")
+            }
 
             // Update UI buffer on the main actor
             if let text = String(data: data, encoding: .utf8) {
@@ -176,13 +185,21 @@ final class VMInstance: Identifiable {
     func sendSerialInput(_ string: String) {
         guard let data = string.data(using: .utf8),
               let inputPipe = serialInputPipe else { return }
-        try? inputPipe.fileHandleForWriting.write(contentsOf: data)
+        do {
+            try inputPipe.fileHandleForWriting.write(contentsOf: data)
+        } catch {
+            Self.logger.error("Failed to send serial input to VM '\(self.name)': \(error.localizedDescription)")
+        }
     }
 
     /// Stops reading from the serial output pipe and closes the log file handle.
     func stopSerialReading() {
         serialOutputPipe?.fileHandleForReading.readabilityHandler = nil
-        try? serialLogFileHandle?.close()
+        do {
+            try serialLogFileHandle?.close()
+        } catch {
+            Self.logger.warning("Failed to close serial log file for VM '\(self.name)': \(error.localizedDescription)")
+        }
         serialLogFileHandle = nil
     }
 }

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -136,16 +136,18 @@ final class VMInstance: Identifiable {
         if !FileManager.default.fileExists(atPath: logURL.path(percentEncoded: false)) {
             FileManager.default.createFile(atPath: logURL.path(percentEncoded: false), contents: nil)
         }
-        let logHandle = try? FileHandle(forWritingTo: logURL)
         do {
-            _ = try logHandle?.seekToEnd()
+            let handle = try FileHandle(forWritingTo: logURL)
+            do { _ = try handle.seekToEnd() } catch {
+                Self.logger.warning("Could not seek to end of serial log: \(error.localizedDescription)")
+            }
+            serialLogFileHandle = handle
         } catch {
-            Self.logger.warning("Could not seek to end of serial log: \(error.localizedDescription)")
+            Self.logger.warning("Could not open serial log for writing: \(error.localizedDescription)")
         }
-        serialLogFileHandle = logHandle
 
         // Capture for the readability handler closure (runs on a background GCD queue)
-        let logFileHandle = logHandle
+        let logFileHandle = serialLogFileHandle
         let logger = Self.logger
 
         outputPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -133,11 +133,11 @@ final class VMInstance: Identifiable {
 
         // Open (or create) the log file for appending
         let logURL = serialLogURL
-        if !FileManager.default.fileExists(atPath: logURL.path) {
-            FileManager.default.createFile(atPath: logURL.path, contents: nil)
+        if !FileManager.default.fileExists(atPath: logURL.path(percentEncoded: false)) {
+            FileManager.default.createFile(atPath: logURL.path(percentEncoded: false), contents: nil)
         }
         let logHandle = try? FileHandle(forWritingTo: logURL)
-        logHandle?.seekToEndOfFile()
+        _ = try? logHandle?.seekToEnd()
         serialLogFileHandle = logHandle
 
         // Capture for the readability handler closure (runs on a background GCD queue)
@@ -148,7 +148,7 @@ final class VMInstance: Identifiable {
             guard !data.isEmpty else { return }
 
             // Write to disk log (background-safe — FileHandle is thread-safe for sequential writes)
-            logFileHandle?.write(data)
+            try? logFileHandle?.write(contentsOf: data)
 
             // Update UI buffer on the main actor
             if let text = String(data: data, encoding: .utf8) {
@@ -176,13 +176,13 @@ final class VMInstance: Identifiable {
     func sendSerialInput(_ string: String) {
         guard let data = string.data(using: .utf8),
               let inputPipe = serialInputPipe else { return }
-        inputPipe.fileHandleForWriting.write(data)
+        try? inputPipe.fileHandleForWriting.write(contentsOf: data)
     }
 
     /// Stops reading from the serial output pipe and closes the log file handle.
     func stopSerialReading() {
         serialOutputPipe?.fileHandleForReading.readabilityHandler = nil
-        serialLogFileHandle?.closeFile()
+        try? serialLogFileHandle?.close()
         serialLogFileHandle = nil
     }
 }

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -135,7 +135,7 @@ struct ConfigurationBuilder: Sendable {
 
         let layout = VMBundleLayout(bundleURL: bundleURL)
         let variableStore: VZEFIVariableStore
-        if FileManager.default.fileExists(atPath: layout.efiVariableStoreURL.path) {
+        if FileManager.default.fileExists(atPath: layout.efiVariableStoreURL.path(percentEncoded: false)) {
             variableStore = VZEFIVariableStore(url: layout.efiVariableStoreURL)
         } else {
             variableStore = try VZEFIVariableStore(creatingVariableStoreAt: layout.efiVariableStoreURL, options: [])
@@ -205,7 +205,7 @@ struct ConfigurationBuilder: Sendable {
         bundleURL: URL
     ) throws {
         let layout = VMBundleLayout(bundleURL: bundleURL)
-        guard FileManager.default.fileExists(atPath: layout.diskImageURL.path) else {
+        guard FileManager.default.fileExists(atPath: layout.diskImageURL.path(percentEncoded: false)) else {
             throw ConfigurationBuilderError.diskImageNotFound(layout.diskImageURL)
         }
 
@@ -216,7 +216,7 @@ struct ConfigurationBuilder: Sendable {
         // Attach ISO as USB mass storage device
         if let isoPath = config.isoPath {
             let isoURL = URL(fileURLWithPath: isoPath)
-            if FileManager.default.fileExists(atPath: isoURL.path) {
+            if FileManager.default.fileExists(atPath: isoURL.path(percentEncoded: false)) {
                 do {
                     let isoAttachment = try VZDiskImageStorageDeviceAttachment(url: isoURL, readOnly: true)
                     let usbStorage = VZUSBMassStorageDeviceConfiguration(attachment: isoAttachment)
@@ -386,7 +386,7 @@ enum ConfigurationBuilderError: LocalizedError {
         case .missingKernelPath:
             "A kernel path is required for Linux kernel boot mode."
         case .diskImageNotFound(let url):
-            "Disk image not found at \(url.path)."
+            "Disk image not found at \(url.path(percentEncoded: false))."
         case .sharedDirectoryNotFound(let path):
             "Shared directory not found at \(path)."
         case .sharedDirectoryNotADirectory(let path):

--- a/Kernova/Services/DiskImageService.swift
+++ b/Kernova/Services/DiskImageService.swift
@@ -46,8 +46,8 @@ struct DiskImageService: Sendable {
 
     /// Returns the physical (actual) size of a disk image on disk.
     func physicalSize(of url: URL) throws -> UInt64 {
-        let values = try url.resourceValues(forKeys: [.fileSizeKey])
-        return UInt64(values.fileSize ?? 0)
+        let values = try url.resourceValues(forKeys: [.totalFileAllocatedSizeKey])
+        return UInt64(values.totalFileAllocatedSize ?? 0)
     }
 }
 

--- a/Kernova/Services/DiskImageService.swift
+++ b/Kernova/Services/DiskImageService.swift
@@ -27,7 +27,7 @@ struct DiskImageService: Sendable {
             "--fs", "none",
             "--format", "ASIF",
             "--size", "\(sizeInGB)g",
-            url.path
+            url.path(percentEncoded: false)
         ]
         process.standardOutput = pipe
         process.standardError = pipe
@@ -46,8 +46,8 @@ struct DiskImageService: Sendable {
 
     /// Returns the physical (actual) size of a disk image on disk.
     func physicalSize(of url: URL) throws -> UInt64 {
-        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
-        return attributes[.size] as? UInt64 ?? 0
+        let values = try url.resourceValues(forKeys: [.fileSizeKey])
+        return UInt64(values.fileSize ?? 0)
     }
 }
 

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -26,7 +26,7 @@ struct IPSWService: Sendable {
         Self.logger.info("Downloading restore image from \(remoteURL)")
 
         // Create the destination file up-front so it's visible in Finder immediately.
-        FileManager.default.createFile(atPath: destinationURL.path, contents: nil)
+        FileManager.default.createFile(atPath: destinationURL.path(percentEncoded: false), contents: nil)
 
         var cleanUpPartial = true
         defer {
@@ -40,8 +40,11 @@ struct IPSWService: Sendable {
         let expectedBytes = response.expectedContentLength  // -1 if unknown
         let expected = expectedBytes > 0 ? expectedBytes : Int64.max
 
-        guard let fileHandle = FileHandle(forWritingAtPath: destinationURL.path) else {
-            throw IPSWError.downloadFailed("Could not open destination file for writing")
+        let fileHandle: FileHandle
+        do {
+            fileHandle = try FileHandle(forWritingTo: destinationURL)
+        } catch {
+            throw IPSWError.downloadFailed("Could not open destination file for writing: \(error.localizedDescription)")
         }
         defer { try? fileHandle.close() }
 

--- a/Kernova/Services/VMStorageService.swift
+++ b/Kernova/Services/VMStorageService.swift
@@ -29,7 +29,7 @@ struct VMStorageService: Sendable {
                 .appendingPathComponent("Kernova", isDirectory: true)
                 .appendingPathComponent("VMs", isDirectory: true)
 
-            if !FileManager.default.fileExists(atPath: vmsDir.path) {
+            if !FileManager.default.fileExists(atPath: vmsDir.path(percentEncoded: false)) {
                 try FileManager.default.createDirectory(at: vmsDir, withIntermediateDirectories: true)
             }
             return vmsDir
@@ -56,7 +56,7 @@ struct VMStorageService: Sendable {
         )
         return contents.filter { url in
             let configFile = url.appendingPathComponent("config.json")
-            return FileManager.default.fileExists(atPath: configFile.path)
+            return FileManager.default.fileExists(atPath: configFile.path(percentEncoded: false))
         }
     }
 
@@ -84,7 +84,7 @@ struct VMStorageService: Sendable {
     func createVMBundle(for configuration: VMConfiguration) throws -> URL {
         let bundle = try bundleURL(for: configuration)
 
-        if FileManager.default.fileExists(atPath: bundle.path) {
+        if FileManager.default.fileExists(atPath: bundle.path(percentEncoded: false)) {
             throw VMStorageError.bundleAlreadyExists(configuration.id)
         }
 
@@ -99,7 +99,7 @@ struct VMStorageService: Sendable {
     func cloneVMBundle(from sourceBundleURL: URL, newConfiguration: VMConfiguration, filesToCopy: [String]) throws -> URL {
         let destinationBundle = try bundleURL(for: newConfiguration)
 
-        if FileManager.default.fileExists(atPath: destinationBundle.path) {
+        if FileManager.default.fileExists(atPath: destinationBundle.path(percentEncoded: false)) {
             throw VMStorageError.bundleAlreadyExists(newConfiguration.id)
         }
 
@@ -109,7 +109,7 @@ struct VMStorageService: Sendable {
         for fileName in filesToCopy {
             let sourceFile = sourceBundleURL.appendingPathComponent(fileName)
             let destinationFile = destinationBundle.appendingPathComponent(fileName)
-            if fm.fileExists(atPath: sourceFile.path) {
+            if fm.fileExists(atPath: sourceFile.path(percentEncoded: false)) {
                 try fm.copyItem(at: sourceFile, to: destinationFile)
             }
         }
@@ -122,7 +122,7 @@ struct VMStorageService: Sendable {
 
     /// Deletes a VM bundle directory and all its contents.
     func deleteVMBundle(at bundleURL: URL) throws {
-        guard FileManager.default.fileExists(atPath: bundleURL.path) else {
+        guard FileManager.default.fileExists(atPath: bundleURL.path(percentEncoded: false)) else {
             throw VMStorageError.bundleNotFound(bundleURL)
         }
         try FileManager.default.trashItem(at: bundleURL, resultingItemURL: nil)
@@ -146,8 +146,8 @@ struct VMStorageService: Sendable {
             )
 
         let fm = FileManager.default
-        let legacyExists = fm.fileExists(atPath: bundleURL.path)
-        let migratedExists = fm.fileExists(atPath: migratedURL.path)
+        let legacyExists = fm.fileExists(atPath: bundleURL.path(percentEncoded: false))
+        let migratedExists = fm.fileExists(atPath: migratedURL.path(percentEncoded: false))
 
         if legacyExists && migratedExists {
             throw VMStorageError.migrationConflict(bundleURL)
@@ -178,7 +178,7 @@ enum VMStorageError: LocalizedError {
         case .bundleAlreadyExists(let id):
             "A VM bundle already exists for ID \(id.uuidString)."
         case .bundleNotFound(let url):
-            "VM bundle not found at \(url.path)."
+            "VM bundle not found at \(url.path(percentEncoded: false))."
         case .migrationConflict(let url):
             "Migration conflict: both legacy and .kernova bundles exist for \(url.lastPathComponent)."
         }

--- a/Kernova/Utilities/FileManagerExtensions.swift
+++ b/Kernova/Utilities/FileManagerExtensions.swift
@@ -13,7 +13,7 @@ extension FileManager {
             )
             let kernovaDir = appSupport.appendingPathComponent("Kernova", isDirectory: true)
 
-            if !fileExists(atPath: kernovaDir.path) {
+            if !fileExists(atPath: kernovaDir.path(percentEncoded: false)) {
                 try createDirectory(at: kernovaDir, withIntermediateDirectories: true)
             }
 
@@ -27,18 +27,12 @@ extension FileManager {
             let vmsDir = try kernovaAppSupportDirectory
                 .appendingPathComponent("VMs", isDirectory: true)
 
-            if !fileExists(atPath: vmsDir.path) {
+            if !fileExists(atPath: vmsDir.path(percentEncoded: false)) {
                 try createDirectory(at: vmsDir, withIntermediateDirectories: true)
             }
 
             return vmsDir
         }
-    }
-
-    /// Returns the size of a file or directory in bytes.
-    func sizeOfItem(atPath path: String) throws -> UInt64 {
-        let attributes = try attributesOfItem(atPath: path)
-        return attributes[.size] as? UInt64 ?? 0
     }
 
     /// Returns the total size of a directory and all its contents.

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -137,7 +137,7 @@ final class VMCreationViewModel {
     static var defaultIPSWDownloadPath: String {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Downloads/RestoreImage.ipsw")
-            .path
+            .path(percentEncoded: false)
     }
 
     // MARK: - Apply Defaults

--- a/Kernova/ViewModels/VMDirectoryWatcher.swift
+++ b/Kernova/ViewModels/VMDirectoryWatcher.swift
@@ -25,9 +25,9 @@ final class VMDirectoryWatcher {
 
     /// Starts watching the given directory for file system write events.
     func start(directory: URL) {
-        let fd = open(directory.path, O_EVTONLY)
+        let fd = open(directory.path(percentEncoded: false), O_EVTONLY)
         guard fd >= 0 else {
-            Self.logger.warning("Could not open VMs directory for monitoring: \(directory.path)")
+            Self.logger.warning("Could not open VMs directory for monitoring: \(directory.path(percentEncoded: false))")
             return
         }
 
@@ -48,7 +48,7 @@ final class VMDirectoryWatcher {
         source.resume()
         directorySource = source
 
-        Self.logger.info("Started directory watcher on \(directory.path)")
+        Self.logger.info("Started directory watcher on \(directory.path(percentEncoded: false))")
     }
 
     /// Debounces rapid FS events into a single reconciliation pass after 0.5 seconds of quiet.

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -281,7 +281,7 @@ final class VMLibraryViewModel {
             let vmsDir = try storageService.vmsDirectory
 
             // If the source is already inside our VMs directory, just select it
-            if sourceURL.path.hasPrefix(vmsDir.path) {
+            if sourceURL.path(percentEncoded: false).hasPrefix(vmsDir.path(percentEncoded: false)) {
                 let config = try storageService.loadConfiguration(from: sourceURL)
                 if let existing = instances.first(where: { $0.id == config.id }) {
                     selectedID = existing.id

--- a/Kernova/Views/Creation/IPSWSelectionStep.swift
+++ b/Kernova/Views/Creation/IPSWSelectionStep.swift
@@ -160,7 +160,7 @@ struct IPSWSelectionStep: View {
         panel.allowedContentTypes = [UTType(filenameExtension: "ipsw")!]
 
         if panel.runModal() == .OK, let url = panel.url {
-            creationVM.ipswDownloadPath = url.path
+            creationVM.ipswDownloadPath = url.path(percentEncoded: false)
         }
     }
 
@@ -173,12 +173,12 @@ struct IPSWSelectionStep: View {
 
         if panel.runModal() == .OK, let url = panel.url {
             creationVM.ipswSource = .localFile
-            creationVM.ipswPath = url.path
+            creationVM.ipswPath = url.path(percentEncoded: false)
         }
     }
 
     private func abbreviateWithTilde(_ path: String) -> String {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let home = FileManager.default.homeDirectoryForCurrentUser.path(percentEncoded: false)
         if path.hasPrefix(home) {
             return "~" + path.dropFirst(home.count)
         }

--- a/Kernova/Views/Creation/ReviewStep.swift
+++ b/Kernova/Views/Creation/ReviewStep.swift
@@ -62,7 +62,7 @@ struct ReviewStep: View {
     }
 
     private func abbreviateWithTilde(_ path: String) -> String {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let home = FileManager.default.homeDirectoryForCurrentUser.path(percentEncoded: false)
         if path.hasPrefix(home) {
             return "~" + path.dropFirst(home.count)
         }

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -101,7 +101,7 @@ struct VMSettingsView: View {
         panel.prompt = "Attach"
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
-        instance.configuration.isoPath = url.path
+        instance.configuration.isoPath = url.path(percentEncoded: false)
     }
 
     @ViewBuilder
@@ -238,7 +238,7 @@ struct VMSettingsView: View {
         let existingPaths = Set(current.map(\.path))
 
         for url in panel.urls {
-            let path = url.path
+            let path = url.path(percentEncoded: false)
             guard !existingPaths.contains(path) else { continue }
             current.append(SharedDirectory(path: path))
         }

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -89,7 +89,7 @@ struct ConfigurationBuilderTests {
         defer { try? FileManager.default.removeItem(at: bundleURL) }
 
         // Create a file (not a directory) to use as the shared path
-        let filePath = bundleURL.appendingPathComponent("not-a-directory").path
+        let filePath = bundleURL.appendingPathComponent("not-a-directory").path(percentEncoded: false)
         FileManager.default.createFile(atPath: filePath, contents: nil)
 
         let config = makeLinuxConfig(sharedDirectories: [
@@ -110,11 +110,11 @@ struct ConfigurationBuilderTests {
         // Create a read-only directory
         let shareDir = bundleURL.appendingPathComponent("readonly-share")
         try FileManager.default.createDirectory(at: shareDir, withIntermediateDirectories: true)
-        try FileManager.default.setAttributes([.posixPermissions: 0o444], ofItemAtPath: shareDir.path)
-        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: shareDir.path) }
+        try FileManager.default.setAttributes([.posixPermissions: 0o444], ofItemAtPath: shareDir.path(percentEncoded: false))
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: shareDir.path(percentEncoded: false)) }
 
         let config = makeLinuxConfig(sharedDirectories: [
-            SharedDirectory(path: shareDir.path, readOnly: false)
+            SharedDirectory(path: shareDir.path(percentEncoded: false), readOnly: false)
         ])
 
         let builder = ConfigurationBuilder()
@@ -131,11 +131,11 @@ struct ConfigurationBuilderTests {
         // Create a read-only directory
         let shareDir = bundleURL.appendingPathComponent("readonly-share")
         try FileManager.default.createDirectory(at: shareDir, withIntermediateDirectories: true)
-        try FileManager.default.setAttributes([.posixPermissions: 0o444], ofItemAtPath: shareDir.path)
-        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: shareDir.path) }
+        try FileManager.default.setAttributes([.posixPermissions: 0o444], ofItemAtPath: shareDir.path(percentEncoded: false))
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: shareDir.path(percentEncoded: false)) }
 
         let config = makeLinuxConfig(sharedDirectories: [
-            SharedDirectory(path: shareDir.path, readOnly: true)
+            SharedDirectory(path: shareDir.path(percentEncoded: false), readOnly: true)
         ])
 
         let builder = ConfigurationBuilder()

--- a/KernovaTests/VMBundleLayoutTests.swift
+++ b/KernovaTests/VMBundleLayoutTests.swift
@@ -76,7 +76,7 @@ struct VMBundleLayoutTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let layout = VMBundleLayout(bundleURL: tempDir)
-        FileManager.default.createFile(atPath: layout.saveFileURL.path, contents: Data([0x00]))
+        FileManager.default.createFile(atPath: layout.saveFileURL.path(percentEncoded: false), contents: Data([0x00]))
 
         #expect(layout.hasSaveFile == true)
     }
@@ -116,7 +116,7 @@ struct VMBundleLayoutTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let layout = VMBundleLayout(bundleURL: tempDir)
-        let path = layout.diskImageURL.path
+        let path = layout.diskImageURL.path(percentEncoded: false)
 
         // Create a sparse file via ftruncate: 10 MB logical size, 0 bytes physically allocated
         let logicalSize: UInt64 = 10 * 1024 * 1024

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -59,17 +59,17 @@ struct VMInstanceTests {
             withIntermediateDirectories: true
         )
         FileManager.default.createFile(
-            atPath: instance.saveFileURL.path,
+            atPath: instance.saveFileURL.path(percentEncoded: false),
             contents: Data("fake save".utf8)
         )
 
         defer { try? FileManager.default.removeItem(at: instance.bundleURL) }
 
-        #expect(FileManager.default.fileExists(atPath: instance.saveFileURL.path))
+        #expect(FileManager.default.fileExists(atPath: instance.saveFileURL.path(percentEncoded: false)))
 
         instance.removeSaveFile()
 
-        #expect(!FileManager.default.fileExists(atPath: instance.saveFileURL.path))
+        #expect(!FileManager.default.fileExists(atPath: instance.saveFileURL.path(percentEncoded: false)))
     }
 
     // MARK: - isColdPaused

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -380,7 +380,7 @@ struct VMLifecycleCoordinatorTests {
         wizard.selectedOS = .macOS
         wizard.ipswSource = .downloadLatest
         wizard.ipswDownloadPath = FileManager.default.temporaryDirectory
-            .appendingPathComponent("test-restore.ipsw").path
+            .appendingPathComponent("test-restore.ipsw").path(percentEncoded: false)
 
         let storageService = MockVMStorageService()
 

--- a/KernovaTests/VMStorageServiceTests.swift
+++ b/KernovaTests/VMStorageServiceTests.swift
@@ -16,15 +16,15 @@ struct VMStorageServiceTests {
         )
 
         let bundleURL = try service.createVMBundle(for: config)
-        #expect(FileManager.default.fileExists(atPath: bundleURL.path))
+        #expect(FileManager.default.fileExists(atPath: bundleURL.path(percentEncoded: false)))
 
         // Verify config.json exists
         let configURL = bundleURL.appendingPathComponent("config.json")
-        #expect(FileManager.default.fileExists(atPath: configURL.path))
+        #expect(FileManager.default.fileExists(atPath: configURL.path(percentEncoded: false)))
 
         // Clean up (use removeItem directly to avoid polluting Trash during tests)
         try FileManager.default.removeItem(at: bundleURL)
-        #expect(!FileManager.default.fileExists(atPath: bundleURL.path))
+        #expect(!FileManager.default.fileExists(atPath: bundleURL.path(percentEncoded: false)))
     }
 
     @Test("Load configuration from bundle")
@@ -148,8 +148,8 @@ struct VMStorageServiceTests {
         let result = try service.migrateBundleIfNeeded(at: legacyURL)
         #expect(result.pathExtension == "kernova")
         #expect(result.lastPathComponent == "\(uuid.uuidString).kernova")
-        #expect(FileManager.default.fileExists(atPath: result.path))
-        #expect(!FileManager.default.fileExists(atPath: legacyURL.path))
+        #expect(FileManager.default.fileExists(atPath: result.path(percentEncoded: false)))
+        #expect(!FileManager.default.fileExists(atPath: legacyURL.path(percentEncoded: false)))
     }
 
     @Test("Migrate already-migrated bundle is idempotent")


### PR DESCRIPTION
## Summary
- Replace all deprecated `URL.path` property usage with `.path(percentEncoded: false)` across the codebase
- Replace deprecated `FileHandle` methods (`seekToEndOfFile`, `write(_:)`, `closeFile`) with modern throwing variants
- Replace `FileHandle(forWritingAtPath:)` with URL-based `FileHandle(forWritingTo:)`
- Replace `FileManager.attributesOfItem(atPath:)` with `URL.resourceValues(forKeys:)`
- Remove unused `sizeOfItem(atPath:)` from `FileManagerExtensions.swift`

## Changes
- Update 35 occurrences of `URL.path` → `.path(percentEncoded: false)` across 18 files (13 source, 5 test)
- Replace `seekToEndOfFile()` → `seekToEnd()`, `write(_:)` → `write(contentsOf:)`, `closeFile()` → `close()` in `VMInstance.swift`
- Replace `FileHandle(forWritingAtPath:)` → `FileHandle(forWritingTo:)` in `IPSWService.swift`
- Replace `attributesOfItem(atPath:)` → `URL.resourceValues(forKeys:)` in `DiskImageService.swift`

## Test plan
- [x] Built successfully on macOS 26 with zero deprecation warnings
- [x] All existing tests pass
- [x] `SharedDirectory.path` (stored `String` property) references correctly preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)