### PR TITLE
feat: Add progress feedback for clone and import operations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -120,7 +120,7 @@ The model layer has two key types:
 
 - **`VMConfiguration`** is the persisted identity of a VM. It's a `Codable` + `Sendable` struct written as `config.json` inside each VM bundle. It holds: name, UUID, guest OS type, boot mode, CPU/memory/disk settings, display configuration, network settings, and OS-specific fields (macOS hardware model data, Linux kernel/initrd/cmdline paths).
 
-- **`VMInstance`** is the runtime representation. It's an `@Observable` `@MainActor` class that wraps a `VMConfiguration`, an optional `VZVirtualMachine`, and a `VMStatus`. It references the VM's bundle path and provides computed properties for disk image, aux storage, and save file locations via `VMBundleLayout`. A view-layer extension (`VMInstance+Display.swift`) provides display properties (`statusDisplayName`, `statusDisplayColor`, `statusToolTip`) that distinguish cold-paused VMs (state saved to disk, shown as "Suspended" in orange) from live-paused VMs (in memory, shown as "Paused" in yellow).
+- **`VMInstance`** is the runtime representation. It's an `@Observable` `@MainActor` class that wraps a `VMConfiguration`, an optional `VZVirtualMachine`, and a `VMStatus`. It references the VM's bundle path and provides computed properties for disk image, aux storage, and save file locations via `VMBundleLayout`. A view-layer extension (`VMInstance+Display.swift`) provides display properties (`statusDisplayName`, `statusDisplayColor`, `statusToolTip`) that distinguish preparing VMs (shown as "Cloning…"/"Importing…" in orange with a spinner), cold-paused VMs (state saved to disk, shown as "Suspended" in orange), and live-paused VMs (in memory, shown as "Paused" in yellow). The `PreparingOperation` enum (`.cloning`, `.importing`) provides display labels, cancel labels, and alert titles for preparing states. The `PreparingState` struct bundles the operation and its cancellable task into a single optional (`preparingState`) — when non-nil the instance is preparing, and `isPreparing` is a computed convenience.
 
 `VMBundleLayout` is a `Sendable` struct that takes a bundle root path and provides all derived file paths (disk image, aux storage, save file, serial log, etc.), keeping path logic centralized.
 
@@ -153,7 +153,7 @@ All service implementations conform to protocols defined in `Services/Protocols/
 
 **Files:** `VMLibraryViewModel.swift`, `VMLifecycleCoordinator.swift`, `VMCreationViewModel.swift`, `IPSWDownloadViewModel.swift`, `VMDirectoryWatcher.swift`
 
-- **`VMLibraryViewModel`** is the central `@Observable` view model. It owns the array of `VMInstance`s and handles list-level operations: add, remove, rename, selection tracking. For lifecycle operations (start, stop, install), it delegates to `VMLifecycleCoordinator`.
+- **`VMLibraryViewModel`** is the central `@Observable` view model. It owns the array of `VMInstance`s and handles list-level operations: add, remove, rename, selection tracking. For lifecycle operations (start, stop, install), it delegates to `VMLifecycleCoordinator`. Clone and import operations use a "phantom row" pattern: a `VMInstance` with `isPreparing = true` appears immediately in the sidebar with a spinner while the file copy runs asynchronously via `Task.detached`. The `hasPreparing` computed property enforces serialization — only one clone/import at a time. Cancellation removes the phantom row, cancels the task, and cleans up partial files on disk.
 
 - **`VMLifecycleCoordinator`** is an `@MainActor` coordinator that owns the lifecycle services (`VirtualizationService`, `MacOSInstallService`, `IPSWService`). It orchestrates multi-step operations like macOS installation (which involves IPSW download → platform file creation → VM configuration → installation). This separation keeps `VMLibraryViewModel` focused on list management. The coordinator enforces **per-VM operation serialization** — at most one lifecycle operation can be in flight for a given VM at any time; concurrent requests are rejected with `VMLifecycleCoordinator.LifecycleError.operationInProgress`. `stop` and `forceStop` bypass serialization entirely (clearing the active-operation token before calling the service) so users can always cancel hung operations.
 
@@ -300,10 +300,10 @@ No external package dependencies. No Swift Package Manager, CocoaPods, or Cartha
 | Component | Tests | Notes |
 |-----------|-------|-------|
 | `VMConfiguration` | 43 tests + clone suite | Encoding/decoding, defaults, validation, all fields |
-| `VMLibraryViewModel` | 47 tests | Add/remove/rename VMs, selection, delegation to coordinator, sleep/wake |
+| `VMLibraryViewModel` | 59 tests | Add/remove/rename VMs, selection, delegation to coordinator, sleep/wake, clone/import phantom rows, cancel preparing |
 | `VMCreationViewModel` | 44 tests | All wizard steps, validation, OS-specific paths |
 | `VMLifecycleCoordinator` | Yes | Multi-step orchestration, error handling, service delegation, token-based operation serialization, stop/forceStop bypass, stale-token race condition coverage |
-| `VMInstance` | Yes | Status transitions, configuration updates, bundle layout |
+| `VMInstance` | Yes | Status transitions, configuration updates, bundle layout, preparing state display properties |
 | `ConfigurationBuilder` | Yes | All three boot paths, device configuration, path validation (symlinks, missing kernel/initrd/ISO, directory rejection for file paths) |
 | `VirtualizationService` | Yes | Start/stop/pause/resume via mock VZ objects |
 | `VMStorageService` | Yes | CRUD operations, cloning, migration |

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -67,19 +67,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        // Cancel all preparing operations before terminating
-        for instance in viewModel.instances where instance.isPreparing {
+        // Cancel all preparing operations and remove phantom rows before terminating
+        viewModel.instances.removeAll { instance in
+            guard instance.isPreparing else { return false }
+
             Self.logger.notice("Terminating: cancelling preparing operation for '\(instance.name)'")
             instance.preparingState?.task.cancel()
-            instance.preparingState = nil
             // Best effort — in-flight copy may still be writing (FileManager.copyItem is not interruptible)
             do {
                 try FileManager.default.trashItem(at: instance.bundleURL, resultingItemURL: nil)
             } catch {
                 Self.logger.warning("Failed to clean up partial bundle for '\(instance.name)' during termination: \(error.localizedDescription)")
             }
+            return true
         }
-        viewModel.instances.removeAll { $0.isPreparing }
 
         // Save VMs that have a live virtual machine; cold-paused VMs already have state on disk
         let runningInstances = viewModel.instances.filter {

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -45,8 +45,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         let hasActiveVMs = viewModel.instances.contains { instance in
-            // Live-paused VMs (not cold-paused to disk) should also keep the app alive
-            instance.status.isActive || (instance.status == .paused && instance.virtualMachine != nil)
+            // Live-paused VMs (not cold-paused to disk) and preparing VMs should also keep the app alive
+            instance.isPreparing || instance.status.isActive || (instance.status == .paused && instance.virtualMachine != nil)
         }
 
         // Stay alive if VMs are active or fullscreen windows still exist
@@ -67,6 +67,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        // Cancel all preparing operations before terminating
+        for instance in viewModel.instances where instance.isPreparing {
+            Self.logger.notice("Terminating: cancelling preparing operation for '\(instance.name)'")
+            instance.preparingState?.task.cancel()
+            instance.preparingState = nil
+            // Best effort — in-flight copy may still be writing (FileManager.copyItem is not interruptible)
+            do {
+                try FileManager.default.trashItem(at: instance.bundleURL, resultingItemURL: nil)
+            } catch {
+                Self.logger.warning("Failed to clean up partial bundle for '\(instance.name)' during termination: \(error.localizedDescription)")
+            }
+        }
+        viewModel.instances.removeAll { $0.isPreparing }
+
         // Save VMs that have a live virtual machine; cold-paused VMs already have state on disk
         let runningInstances = viewModel.instances.filter {
             ($0.status == .running || $0.status == .paused) && $0.virtualMachine != nil
@@ -183,7 +197,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     @objc func cloneVM(_ sender: Any?) {
         guard let instance = viewModel.selectedInstance else { return }
-        Task { await viewModel.cloneVM(instance) }
+        viewModel.cloneVM(instance)
     }
 
     @objc func deleteVM(_ sender: Any?) {
@@ -286,6 +300,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     // MARK: - Menu Validation
 
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        // Preparing instances disable all VM menu bar actions (cancel is only available via sidebar context menu)
+        if let instance = viewModel.selectedInstance, instance.isPreparing {
+            switch menuItem.action {
+            case #selector(showLibrary(_:)), #selector(newVM(_:)):
+                return true
+            default:
+                return false
+            }
+        }
+
         switch menuItem.action {
         case #selector(startVM(_:)):
             return viewModel.selectedInstance?.status.canStart ?? false
@@ -301,7 +325,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             return viewModel.selectedInstance?.status.canEditSettings ?? false
         case #selector(cloneVM(_:)):
             guard let instance = viewModel.selectedInstance else { return false }
-            return instance.status.canEditSettings && !viewModel.isCloning
+            return instance.status.canEditSettings && !viewModel.hasPreparing
         case #selector(deleteVM(_:)):
             return viewModel.selectedInstance?.status.canEditSettings ?? false
         // AppKit bypasses NSMenuItemValidation for windowsMenu items, so

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -154,6 +154,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
             _ = self.viewModel.selectedInstance
             _ = self.viewModel.selectedInstance?.status
             _ = self.viewModel.selectedInstance?.virtualMachine
+            _ = self.viewModel.selectedInstance?.preparingState
         } onChange: {
             Task { @MainActor [weak self] in
                 guard let self else { return }
@@ -197,6 +198,8 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
 
     /// Returns the action identifiers that should be visible for a given VM instance.
     private func desiredActionIdentifiers(for instance: VMInstance) -> [NSToolbarItem.Identifier] {
+        if instance.isPreparing { return [] }
+
         switch instance.status {
         case .stopped:
             return [Self.startVMIdentifier, Self.deleteVMIdentifier]

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -21,6 +21,49 @@ final class VMInstance: Identifiable {
     /// Handle to the in-flight macOS installation task, enabling cooperative cancellation.
     var installTask: Task<Void, Never>?
 
+    // MARK: - Preparing State (Clone/Import)
+
+    /// Describes the kind of long-running preparation operation in progress
+    /// and provides all associated user-facing strings (display labels, cancel labels, alert titles).
+    enum PreparingOperation: Sendable {
+        case cloning
+        case importing
+
+        var displayLabel: String {
+            switch self {
+            case .cloning: "Cloning\u{2026}"
+            case .importing: "Importing\u{2026}"
+            }
+        }
+
+        var cancelLabel: String {
+            switch self {
+            case .cloning: "Cancel Clone"
+            case .importing: "Cancel Import"
+            }
+        }
+
+        var cancelAlertTitle: String {
+            switch self {
+            case .cloning: "Cancel Clone?"
+            case .importing: "Cancel Import?"
+            }
+        }
+    }
+
+    /// Tracks an in-flight clone or import operation. Non-nil when this instance is a
+    /// "phantom row" awaiting a file copy to finish (see `VMLibraryViewModel`).
+    struct PreparingState {
+        let operation: PreparingOperation
+        var task: Task<Void, Never>
+    }
+
+    /// Non-nil when this instance is a phantom row awaiting a clone or import to finish.
+    var preparingState: PreparingState?
+
+    /// Convenience: `true` when a preparing operation is in progress.
+    var isPreparing: Bool { preparingState != nil }
+
     /// Error message if the VM entered an error state.
     var errorMessage: String?
 

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -346,12 +346,7 @@ final class VMLibraryViewModel {
                     Self.logger.notice("Imported VM '\(config.name)' from \(sourceURL.lastPathComponent)")
                 } catch {
                     guard let self else { return }
-                    self.instances.removeAll { $0.id == phantom.id }
-                    if self.selectedID == phantom.id {
-                        self.selectedID = self.instances.first?.id
-                    }
-                    phantom.preparingState = nil
-                    Self.trashPartialBundle(at: destinationURL)
+                    self.cleanupPhantomInstance(phantom)
                     if !Task.isCancelled {
                         self.presentError(error)
                     }
@@ -468,12 +463,7 @@ final class VMLibraryViewModel {
                 Self.logger.notice("Cloned VM '\(instance.name)' as '\(config.name)'")
             } catch {
                 guard let self else { return }
-                self.instances.removeAll { $0.id == phantom.id }
-                if self.selectedID == phantom.id {
-                    self.selectedID = self.instances.first?.id
-                }
-                phantom.preparingState = nil
-                Self.trashPartialBundle(at: phantom.bundleURL)
+                self.cleanupPhantomInstance(phantom)
                 if !Task.isCancelled {
                     self.presentError(error)
                 }
@@ -629,19 +619,22 @@ final class VMLibraryViewModel {
         let operationLabel = instance.preparingState?.operation.displayLabel ?? "preparing"
 
         instance.preparingState?.task.cancel()
-        instance.preparingState = nil
-
-        let bundleURL = instance.bundleURL
-        instances.removeAll { $0.id == instance.id }
-        if selectedID == instance.id {
-            selectedID = instances.first?.id
-        }
+        cleanupPhantomInstance(instance)
 
         preparingInstanceToCancel = nil
         showCancelPreparingConfirmation = false
 
-        Self.trashPartialBundle(at: bundleURL)
         Self.logger.notice("Cancelled \(operationLabel) for '\(instance.name)'")
+    }
+
+    /// Removes a phantom instance from the library, clears its preparing state, and trashes its partial bundle.
+    private func cleanupPhantomInstance(_ phantom: VMInstance) {
+        instances.removeAll { $0.id == phantom.id }
+        if selectedID == phantom.id {
+            selectedID = instances.first?.id
+        }
+        phantom.preparingState = nil
+        Self.trashPartialBundle(at: phantom.bundleURL)
     }
 
     // MARK: - Error Handling

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -25,7 +25,11 @@ final class VMLibraryViewModel {
     var errorMessage: String?
     var instanceToDelete: VMInstance?
     var renamingInstanceID: UUID?
-    var isCloning = false
+    var showCancelPreparingConfirmation = false
+    var preparingInstanceToCancel: VMInstance?
+
+    /// `true` when any instance is mid-clone or mid-import.
+    var hasPreparing: Bool { instances.contains(where: \.isPreparing) }
 
     // MARK: - Directory Watcher
 
@@ -275,7 +279,7 @@ final class VMLibraryViewModel {
     ///
     /// If the bundle is already inside the VMs directory, it is simply selected.
     /// If a VM with the same UUID already exists in the library, that instance is selected.
-    /// Otherwise, the bundle is copied into the VMs directory and loaded.
+    /// Otherwise, the bundle is copied into the VMs directory asynchronously with a phantom row.
     func importVM(from sourceURL: URL) {
         do {
             let vmsDir = try storageService.vmsDirectory
@@ -298,18 +302,62 @@ final class VMLibraryViewModel {
                 return
             }
 
-            // Copy bundle into VMs directory
-            let destinationURL = vmsDir.appendingPathComponent(sourceURL.lastPathComponent, isDirectory: true)
-            try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+            // Serialize: only one preparing operation at a time
+            guard !hasPreparing else {
+                presentError(PreparingError.operationInProgress)
+                return
+            }
 
-            // Load and add to library
-            let layout = VMBundleLayout(bundleURL: destinationURL)
-            let initialStatus: VMStatus = layout.hasSaveFile ? .paused : .stopped
-            let instance = VMInstance(configuration: config, bundleURL: destinationURL, status: initialStatus)
-            instances.append(instance)
+            // Check save file from source bundle (destination doesn't exist yet)
+            let sourceLayout = VMBundleLayout(bundleURL: sourceURL)
+            let initialStatus: VMStatus = sourceLayout.hasSaveFile ? .paused : .stopped
+
+            // Determine destination, avoiding filename collisions
+            let destinationURL: URL = {
+                let candidate = vmsDir.appendingPathComponent(sourceURL.lastPathComponent, isDirectory: true)
+                guard FileManager.default.fileExists(atPath: candidate.path(percentEncoded: false)) else {
+                    return candidate
+                }
+                let stem = sourceURL.deletingPathExtension().lastPathComponent
+                let ext = sourceURL.pathExtension
+                var counter = 2
+                var url: URL
+                repeat {
+                    url = vmsDir.appendingPathComponent("\(stem) \(counter).\(ext)", isDirectory: true)
+                    counter += 1
+                } while FileManager.default.fileExists(atPath: url.path(percentEncoded: false))
+                return url
+            }()
+            // Create phantom row immediately
+            let phantom = VMInstance(configuration: config, bundleURL: destinationURL, status: initialStatus)
+            instances.append(phantom)
             instances.sort { $0.configuration.createdAt < $1.configuration.createdAt }
-            selectedID = instance.id
-            Self.logger.notice("Imported VM '\(config.name)' from \(sourceURL.lastPathComponent)")
+            selectedID = phantom.id
+
+            // Launch async file copy and assign preparing state atomically
+            let task = Task { [weak self] in
+                do {
+                    try await Task.detached {
+                        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+                    }.value
+
+                    guard let self else { return }
+                    phantom.preparingState = nil
+                    Self.logger.notice("Imported VM '\(config.name)' from \(sourceURL.lastPathComponent)")
+                } catch {
+                    guard let self else { return }
+                    self.instances.removeAll { $0.id == phantom.id }
+                    if self.selectedID == phantom.id {
+                        self.selectedID = self.instances.first?.id
+                    }
+                    phantom.preparingState = nil
+                    Self.trashPartialBundle(at: destinationURL)
+                    if !Task.isCancelled {
+                        self.presentError(error)
+                    }
+                }
+            }
+            phantom.preparingState = VMInstance.PreparingState(operation: .importing, task: task)
         } catch {
             presentError(error)
         }
@@ -348,65 +396,90 @@ final class VMLibraryViewModel {
 
     // MARK: - Clone
 
-    func cloneVM(_ instance: VMInstance) async {
+    func cloneVM(_ instance: VMInstance) {
         guard instance.status.canEditSettings else { return }
+        guard !hasPreparing else {
+            presentError(PreparingError.operationInProgress)
+            return
+        }
 
-        isCloning = true
-        defer { isCloning = false }
+        let existingNames = instances.map(\.configuration.name)
+        var clonedConfig = instance.configuration.clonedForNewInstance(existingNames: existingNames)
 
+        // Regenerate platform identity fields
+        clonedConfig.macAddress = VZMACAddress.randomLocallyAdministered().string
+
+        #if arch(arm64)
+        if clonedConfig.guestOS == .macOS {
+            clonedConfig.machineIdentifierData = VZMacMachineIdentifier().dataRepresentation
+        }
+        #endif
+
+        if clonedConfig.bootMode == .efi || clonedConfig.bootMode == .linuxKernel {
+            clonedConfig.genericMachineIdentifierData = VZGenericMachineIdentifier().dataRepresentation
+        }
+
+        // Determine which bundle files to copy
+        var filesToCopy = ["Disk.asif"]
+        switch clonedConfig.guestOS {
+        case .macOS:
+            filesToCopy.append(contentsOf: ["AuxiliaryStorage", "HardwareModel"])
+        case .linux:
+            if clonedConfig.bootMode == .efi {
+                filesToCopy.append("EFIVariableStore")
+            }
+        }
+
+        // Derive the destination bundle URL (may touch disk to ensure VMs directory exists)
+        let bundleURL: URL
         do {
-            let existingNames = instances.map(\.configuration.name)
-            var clonedConfig = instance.configuration.clonedForNewInstance(existingNames: existingNames)
-
-            // Regenerate platform identity fields
-            clonedConfig.macAddress = VZMACAddress.randomLocallyAdministered().string
-
-            #if arch(arm64)
-            if clonedConfig.guestOS == .macOS {
-                clonedConfig.machineIdentifierData = VZMacMachineIdentifier().dataRepresentation
-            }
-            #endif
-
-            if clonedConfig.bootMode == .efi || clonedConfig.bootMode == .linuxKernel {
-                clonedConfig.genericMachineIdentifierData = VZGenericMachineIdentifier().dataRepresentation
-            }
-
-            // Determine which bundle files to copy
-            var filesToCopy = ["Disk.asif"]
-            switch clonedConfig.guestOS {
-            case .macOS:
-                filesToCopy.append(contentsOf: ["AuxiliaryStorage", "HardwareModel"])
-            case .linux:
-                if clonedConfig.bootMode == .efi {
-                    filesToCopy.append("EFIVariableStore")
-                }
-            }
-
-            // Copy files off the main thread (disk images can be large)
-            let sourceBundleURL = instance.bundleURL
-            let config = clonedConfig
-            let storage = storageService
-            let bundleURL = try await Task.detached {
-                try storage.cloneVMBundle(from: sourceBundleURL, newConfiguration: config, filesToCopy: filesToCopy)
-            }.value
-
-            // Write regenerated MachineIdentifier file for macOS clones
-            #if arch(arm64)
-            if let machineIDData = clonedConfig.machineIdentifierData, clonedConfig.guestOS == .macOS {
-                let layout = VMBundleLayout(bundleURL: bundleURL)
-                try machineIDData.write(to: layout.machineIdentifierURL, options: .atomic)
-            }
-            #endif
-
-            let clonedInstance = VMInstance(configuration: clonedConfig, bundleURL: bundleURL)
-            instances.append(clonedInstance)
-            instances.sort { $0.configuration.createdAt < $1.configuration.createdAt }
-            selectedID = clonedInstance.id
-
-            Self.logger.notice("Cloned VM '\(instance.name)' as '\(clonedConfig.name)'")
+            bundleURL = try storageService.bundleURL(for: clonedConfig)
         } catch {
             presentError(error)
+            return
         }
+
+        // Create phantom row immediately
+        let phantom = VMInstance(configuration: clonedConfig, bundleURL: bundleURL)
+        instances.append(phantom)
+        instances.sort { $0.configuration.createdAt < $1.configuration.createdAt }
+        selectedID = phantom.id
+
+        // Launch async file copy and assign preparing state atomically
+        let sourceBundleURL = instance.bundleURL
+        let config = clonedConfig
+        let storage = storageService
+        let task = Task { [weak self] in
+            do {
+                try await Task.detached {
+                    let resultURL = try storage.cloneVMBundle(from: sourceBundleURL, newConfiguration: config, filesToCopy: filesToCopy)
+
+                    // Write regenerated MachineIdentifier file for macOS clones (off main thread)
+                    #if arch(arm64)
+                    if let machineIDData = config.machineIdentifierData, config.guestOS == .macOS {
+                        let layout = VMBundleLayout(bundleURL: resultURL)
+                        try machineIDData.write(to: layout.machineIdentifierURL, options: .atomic)
+                    }
+                    #endif
+                }.value
+
+                guard let self else { return }
+                phantom.preparingState = nil
+                Self.logger.notice("Cloned VM '\(instance.name)' as '\(config.name)'")
+            } catch {
+                guard let self else { return }
+                self.instances.removeAll { $0.id == phantom.id }
+                if self.selectedID == phantom.id {
+                    self.selectedID = self.instances.first?.id
+                }
+                phantom.preparingState = nil
+                Self.trashPartialBundle(at: phantom.bundleURL)
+                if !Task.isCancelled {
+                    self.presentError(error)
+                }
+            }
+        }
+        phantom.preparingState = VMInstance.PreparingState(operation: .cloning, task: task)
     }
 
     // MARK: - Sleep/Wake
@@ -487,7 +560,7 @@ final class VMLibraryViewModel {
 
     /// Diffs on-disk VM bundles against in-memory instances and adds/removes as needed.
     func reconcileWithDisk() {
-        guard !isCloning else { return }
+        guard !hasPreparing else { return }
         Self.logger.debug("reconcileWithDisk: starting")
         do {
             let diskBundles = try storageService.listVMBundles()
@@ -521,9 +594,10 @@ final class VMLibraryViewModel {
             }
 
             // Removals: instances in memory whose bundles no longer exist on disk
-            // Only remove stopped or errored VMs — never touch running/paused ones
+            // Only remove stopped or errored VMs — never touch running/paused/preparing ones
             let instancesToRemove = instances.filter { instance in
                 !diskIDs.contains(instance.id)
+                    && !instance.isPreparing
                     && (instance.status == .stopped || instance.status == .error)
             }
             for instance in instancesToRemove {
@@ -544,7 +618,57 @@ final class VMLibraryViewModel {
         }
     }
 
+    // MARK: - Cancel Preparing
+
+    func confirmCancelPreparing(_ instance: VMInstance) {
+        preparingInstanceToCancel = instance
+        showCancelPreparingConfirmation = true
+    }
+
+    func cancelPreparingConfirmed(_ instance: VMInstance) {
+        let operationLabel = instance.preparingState?.operation.displayLabel ?? "preparing"
+
+        instance.preparingState?.task.cancel()
+        instance.preparingState = nil
+
+        let bundleURL = instance.bundleURL
+        instances.removeAll { $0.id == instance.id }
+        if selectedID == instance.id {
+            selectedID = instances.first?.id
+        }
+
+        preparingInstanceToCancel = nil
+        showCancelPreparingConfirmation = false
+
+        Self.trashPartialBundle(at: bundleURL)
+        Self.logger.notice("Cancelled \(operationLabel) for '\(instance.name)'")
+    }
+
     // MARK: - Error Handling
+
+    /// Moves a partial VM bundle to the Trash in the background, logging on failure.
+    private static func trashPartialBundle(at url: URL) {
+        let log = logger
+        Task.detached {
+            do {
+                try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+            } catch {
+                log.warning("Failed to clean up partial bundle at \(url.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Error type for preparing-related validation failures.
+    private enum PreparingError: LocalizedError {
+        case operationInProgress
+
+        var errorDescription: String? {
+            switch self {
+            case .operationInProgress:
+                return "Another clone or import operation is already in progress. Please wait for it to finish."
+            }
+        }
+    }
 
     func presentError(_ error: Error) {
         errorMessage = error.localizedDescription

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -7,24 +7,35 @@ struct VMDetailView: View {
 
     var body: some View {
         Group {
-            switch instance.status {
-            case .stopped, .error:
-                VMSettingsView(instance: instance, viewModel: viewModel)
+            if let preparing = instance.preparingState {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .controlSize(.large)
+                    Text(preparing.operation.displayLabel)
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                switch instance.status {
+                case .stopped, .error:
+                    VMSettingsView(instance: instance, viewModel: viewModel)
 
-            case .installing:
-                if let installState = instance.installState {
-                    MacOSInstallProgressView(installState: installState) {
-                        viewModel.cancelInstallation(instance)
+                case .installing:
+                    if let installState = instance.installState {
+                        MacOSInstallProgressView(installState: installState) {
+                            viewModel.cancelInstallation(instance)
+                        }
+                    } else {
+                        transitionView
                     }
-                } else {
+
+                case .running, .paused:
+                    VMConsoleView(instance: instance)
+
+                default:
                     transitionView
                 }
-
-            case .running, .paused:
-                VMConsoleView(instance: instance)
-
-            default:
-                transitionView
             }
         }
         .navigationTitle(instance.name)
@@ -39,6 +50,18 @@ struct VMDetailView: View {
             Button("Cancel", role: .cancel) {}
         } message: { vm in
             Text("\"\(vm.name)\" will be moved to the Trash. You can restore it using Finder's Put Back command. Empty the Trash to permanently delete the VM and reclaim disk space.")
+        }
+        .alert(
+            viewModel.preparingInstanceToCancel?.preparingState?.operation.cancelAlertTitle ?? "",
+            isPresented: $viewModel.showCancelPreparingConfirmation,
+            presenting: viewModel.preparingInstanceToCancel
+        ) { instance in
+            Button(instance.preparingState?.operation.cancelLabel ?? "Cancel", role: .destructive) {
+                viewModel.cancelPreparingConfirmed(instance)
+            }
+            Button("Continue", role: .cancel) {}
+        } message: { _ in
+            Text("The operation will be stopped and any partially copied files will be removed.")
         }
     }
 

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -44,46 +44,55 @@ struct SidebarView: View {
 
     @ViewBuilder
     private func contextMenu(for instance: VMInstance) -> some View {
-        if instance.status.canStart {
-            Button("Start") {
-                Task { await viewModel.start(instance) }
+        if let preparing = instance.preparingState {
+            Button(preparing.operation.cancelLabel) {
+                viewModel.confirmCancelPreparing(instance)
             }
-        }
-        if instance.status.canPause {
-            Button("Pause") {
-                Task { await viewModel.pause(instance) }
+            Button("Show in Finder") {
+                NSWorkspace.shared.activateFileViewerSelecting([instance.bundleURL])
             }
-        }
-        if instance.status.canResume {
-            Button("Resume") {
-                Task { await viewModel.resume(instance) }
+        } else {
+            if instance.status.canStart {
+                Button("Start") {
+                    Task { await viewModel.start(instance) }
+                }
             }
-        }
-        if instance.status.canStop {
-            Button("Stop") {
-                viewModel.stop(instance)
+            if instance.status.canPause {
+                Button("Pause") {
+                    Task { await viewModel.pause(instance) }
+                }
             }
-        }
+            if instance.status.canResume {
+                Button("Resume") {
+                    Task { await viewModel.resume(instance) }
+                }
+            }
+            if instance.status.canStop {
+                Button("Stop") {
+                    viewModel.stop(instance)
+                }
+            }
 
-        Divider()
+            Divider()
 
-        Button("Rename") {
-            viewModel.renameVM(instance)
-        }
-        .disabled(!instance.status.canEditSettings)
+            Button("Rename") {
+                viewModel.renameVM(instance)
+            }
+            .disabled(!instance.status.canEditSettings)
 
-        Button("Clone") {
-            Task { await viewModel.cloneVM(instance) }
-        }
-        .disabled(!instance.status.canEditSettings || viewModel.isCloning)
+            Button("Clone") {
+                viewModel.cloneVM(instance)
+            }
+            .disabled(!instance.status.canEditSettings || viewModel.hasPreparing)
 
-        Button("Show in Finder") {
-            NSWorkspace.shared.activateFileViewerSelecting([instance.bundleURL])
-        }
+            Button("Show in Finder") {
+                NSWorkspace.shared.activateFileViewerSelecting([instance.bundleURL])
+            }
 
-        Button("Move to Trash", role: .destructive) {
-            viewModel.confirmDelete(instance)
+            Button("Move to Trash", role: .destructive) {
+                viewModel.confirmDelete(instance)
+            }
+            .disabled(instance.status != .stopped)
         }
-        .disabled(instance.status != .stopped)
     }
 }

--- a/Kernova/Views/Sidebar/VMRowView.swift
+++ b/Kernova/Views/Sidebar/VMRowView.swift
@@ -41,10 +41,16 @@ struct VMRowView: View {
 
             Spacer()
 
-            Circle()
-                .fill(instance.statusDisplayColor)
-                .frame(width: 8, height: 8)
-                .help(instance.statusToolTip ?? "")
+            if instance.isPreparing {
+                ProgressView()
+                    .controlSize(.mini)
+                    .frame(width: 8, height: 8)
+            } else {
+                Circle()
+                    .fill(instance.statusDisplayColor)
+                    .frame(width: 8, height: 8)
+                    .help(instance.statusToolTip ?? "")
+            }
         }
         .padding(.vertical, 2)
         .onChange(of: isRenaming) { _, renaming in

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -1,20 +1,23 @@
 import SwiftUI
 
-/// Display-layer properties that distinguish cold-paused ("Suspended") from live-paused ("Paused").
+/// Display-layer properties that distinguish preparing, cold-paused ("Suspended"), and live-paused ("Paused") states.
 extension VMInstance {
 
-    /// Display name that distinguishes cold-paused ("Suspended") from live-paused ("Paused").
+    /// Display name that distinguishes preparing, cold-paused ("Suspended"), and live-paused ("Paused").
     var statusDisplayName: String {
-        isColdPaused ? "Suspended" : status.displayName
+        if let state = preparingState { return state.operation.displayLabel }
+        return isColdPaused ? "Suspended" : status.displayName
     }
 
-    /// Display color that distinguishes cold-paused (orange) from live-paused (yellow).
+    /// Display color that distinguishes preparing (orange), cold-paused (orange), and live-paused (yellow).
     var statusDisplayColor: Color {
-        isColdPaused ? .orange : status.statusColor
+        if isPreparing { return .orange }
+        return isColdPaused ? .orange : status.statusColor
     }
 
-    /// Tooltip explaining the paused variant, or `nil` for non-paused states.
+    /// Tooltip explaining the VM state variant, or `nil` for standard states.
     var statusToolTip: String? {
+        if let state = preparingState { return state.operation.displayLabel }
         guard status == .paused else { return nil }
         return isColdPaused
             ? "VM state is saved to disk"

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -214,4 +214,64 @@ struct VMInstanceTests {
             #expect(instance.statusToolTip == nil)
         }
     }
+
+    // MARK: - Preparing State
+
+    @Test("preparingState defaults to nil and isPreparing to false")
+    func preparingStateDefaultsNil() {
+        let instance = makeInstance()
+        #expect(instance.preparingState == nil)
+        #expect(instance.isPreparing == false)
+    }
+
+    @Test("isPreparing is true when preparingState is set")
+    func isPreparingTrueWhenSet() {
+        let instance = makeInstance()
+        let task = Task {}
+        instance.preparingState = VMInstance.PreparingState(operation: .cloning, task: task)
+        #expect(instance.isPreparing == true)
+
+        instance.preparingState = nil
+        #expect(instance.isPreparing == false)
+        task.cancel()
+    }
+
+    @Test("statusDisplayName returns preparing label when isPreparing")
+    func statusDisplayNamePreparing() {
+        let instance = makeInstance()
+        let task = Task {}
+        defer { task.cancel() }
+
+        instance.preparingState = VMInstance.PreparingState(operation: .cloning, task: task)
+        #expect(instance.statusDisplayName == "Cloning\u{2026}")
+
+        instance.preparingState = VMInstance.PreparingState(operation: .importing, task: task)
+        #expect(instance.statusDisplayName == "Importing\u{2026}")
+    }
+
+    @Test("statusDisplayColor returns orange when isPreparing")
+    func statusDisplayColorPreparing() {
+        let instance = makeInstance()
+        let task = Task {}
+        defer { task.cancel() }
+        instance.preparingState = VMInstance.PreparingState(operation: .cloning, task: task)
+        #expect(instance.statusDisplayColor == .orange)
+    }
+
+    @Test("statusToolTip returns preparing label when isPreparing")
+    func statusToolTipPreparing() {
+        let instance = makeInstance()
+        let task = Task {}
+        defer { task.cancel() }
+        instance.preparingState = VMInstance.PreparingState(operation: .cloning, task: task)
+        #expect(instance.statusToolTip == "Cloning\u{2026}")
+    }
+
+    @Test("PreparingOperation cancelLabel and cancelAlertTitle")
+    func preparingOperationLabels() {
+        #expect(VMInstance.PreparingOperation.cloning.cancelLabel == "Cancel Clone")
+        #expect(VMInstance.PreparingOperation.cloning.cancelAlertTitle == "Cancel Clone?")
+        #expect(VMInstance.PreparingOperation.importing.cancelLabel == "Cancel Import")
+        #expect(VMInstance.PreparingOperation.importing.cancelAlertTitle == "Cancel Import?")
+    }
 }

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -702,68 +702,54 @@ struct VMLibraryViewModelTests {
 
     // MARK: - Clone
 
-    @Test("cloneVM creates a new instance with different ID and Copy name")
-    func cloneVMCreatesNewInstance() async {
+    /// Helper to mark an instance as preparing with a no-op task.
+    private func markPreparing(_ instance: VMInstance, operation: VMInstance.PreparingOperation = .cloning) {
+        instance.preparingState = VMInstance.PreparingState(operation: operation, task: Task {})
+    }
+
+    @Test("cloneVM creates phantom row immediately with preparingState")
+    func cloneVMCreatesPhantomRow() {
         let (viewModel, storage, _, _) = makeViewModel()
         let instance = makeInstance(name: "Original")
         instance.status = .stopped
         viewModel.instances.append(instance)
         storage.bundles[instance.bundleURL] = instance.configuration
 
-        await viewModel.cloneVM(instance)
+        viewModel.cloneVM(instance)
 
         #expect(viewModel.instances.count == 2)
-        let cloned = viewModel.instances.first { $0.id != instance.id }
-        #expect(cloned != nil)
-        #expect(cloned?.name == "Original Copy")
-        #expect(cloned?.id != instance.id)
+        let phantom = viewModel.instances.first { $0.id != instance.id }
+        #expect(phantom != nil)
+        #expect(phantom?.isPreparing == true)
+        #expect(phantom?.preparingState?.operation == .cloning)
+        #expect(phantom?.name == "Original Copy")
+        #expect(viewModel.selectedID == phantom?.id)
+    }
+
+    @Test("cloneVM transitions phantom to real on success")
+    func cloneVMTransitionsPhantom() async {
+        let (viewModel, storage, _, _) = makeViewModel()
+        let instance = makeInstance(name: "Original")
+        instance.status = .stopped
+        viewModel.instances.append(instance)
+        storage.bundles[instance.bundleURL] = instance.configuration
+
+        viewModel.cloneVM(instance)
+
+        let phantom = viewModel.instances.first { $0.id != instance.id }
+        #expect(phantom != nil)
+
+        // Wait for the preparing task to complete
+        await phantom?.preparingState?.task.value
+
+        #expect(phantom?.isPreparing == false)
+        #expect(phantom?.preparingState == nil)
+        #expect(viewModel.instances.count == 2)
         #expect(storage.cloneVMBundleCallCount == 1)
     }
 
-    @Test("cloneVM selects the cloned instance")
-    func cloneVMSelectsClone() async {
-        let (viewModel, storage, _, _) = makeViewModel()
-        let instance = makeInstance(name: "Source")
-        instance.status = .stopped
-        viewModel.instances.append(instance)
-        storage.bundles[instance.bundleURL] = instance.configuration
-
-        await viewModel.cloneVM(instance)
-
-        let cloned = viewModel.instances.first { $0.id != instance.id }
-        #expect(viewModel.selectedID == cloned?.id)
-    }
-
-    @Test("cloneVM increments name when Copy already exists")
-    func cloneVMIncrementsName() async {
-        let (viewModel, storage, _, _) = makeViewModel()
-        let instance = makeInstance(name: "VM")
-        instance.status = .stopped
-        let copyInstance = makeInstance(name: "VM Copy")
-        viewModel.instances = [instance, copyInstance]
-        storage.bundles[instance.bundleURL] = instance.configuration
-
-        await viewModel.cloneVM(instance)
-
-        let cloned = viewModel.instances.first { $0.id != instance.id && $0.id != copyInstance.id }
-        #expect(cloned?.name == "VM Copy 2")
-    }
-
-    @Test("cloneVM is skipped when VM is running")
-    func cloneVMSkippedWhenRunning() async {
-        let (viewModel, storage, _, _) = makeViewModel()
-        let instance = makeInstance(name: "Running VM")
-        instance.status = .running
-        viewModel.instances.append(instance)
-
-        await viewModel.cloneVM(instance)
-
-        #expect(viewModel.instances.count == 1)
-        #expect(storage.cloneVMBundleCallCount == 0)
-    }
-
-    @Test("cloneVM presents error on storage failure")
-    func cloneVMPresentsError() async {
+    @Test("cloneVM removes phantom on storage error and selects remaining instance")
+    func cloneVMRemovesPhantomOnError() async {
         let storage = MockVMStorageService()
         storage.cloneVMBundleError = VMStorageError.bundleAlreadyExists(UUID())
         let (viewModel, _, _, _) = makeViewModel(storageService: storage)
@@ -771,9 +757,171 @@ struct VMLibraryViewModelTests {
         instance.status = .stopped
         viewModel.instances.append(instance)
 
-        await viewModel.cloneVM(instance)
+        viewModel.cloneVM(instance)
 
+        // Phantom was created
+        let phantom = viewModel.instances.first { $0.id != instance.id }
+        #expect(phantom != nil)
+
+        // Wait for the task to complete (and fail)
+        await phantom?.preparingState?.task.value
+
+        #expect(viewModel.instances.count == 1)
+        #expect(viewModel.instances.first?.id == instance.id)
+        #expect(viewModel.selectedID == instance.id)
         #expect(viewModel.showError == true)
         #expect(viewModel.errorMessage != nil)
+    }
+
+    @Test("cloneVM is skipped when VM is running")
+    func cloneVMSkippedWhenRunning() {
+        let (viewModel, storage, _, _) = makeViewModel()
+        let instance = makeInstance(name: "Running VM")
+        instance.status = .running
+        viewModel.instances.append(instance)
+
+        viewModel.cloneVM(instance)
+
+        #expect(viewModel.instances.count == 1)
+        #expect(storage.cloneVMBundleCallCount == 0)
+    }
+
+    @Test("cloneVM shows error when hasPreparing is true")
+    func cloneVMShowsErrorWhenPreparing() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let existing = makeInstance(name: "Existing")
+        markPreparing(existing)
+        let instance = makeInstance(name: "Source")
+        instance.status = .stopped
+        viewModel.instances = [existing, instance]
+
+        viewModel.cloneVM(instance)
+
+        // No new instance added, error shown
+        #expect(viewModel.instances.count == 2)
+        #expect(viewModel.showError == true)
+    }
+
+    @Test("cloneVM increments name when Copy already exists")
+    func cloneVMIncrementsName() {
+        let (viewModel, storage, _, _) = makeViewModel()
+        let instance = makeInstance(name: "VM")
+        instance.status = .stopped
+        let copyInstance = makeInstance(name: "VM Copy")
+        viewModel.instances = [instance, copyInstance]
+        storage.bundles[instance.bundleURL] = instance.configuration
+
+        viewModel.cloneVM(instance)
+
+        let cloned = viewModel.instances.first { $0.id != instance.id && $0.id != copyInstance.id }
+        #expect(cloned?.name == "VM Copy 2")
+    }
+
+    // MARK: - Cancel Preparing
+
+    @Test("cancelPreparingConfirmed removes phantom instance and cancels task")
+    func cancelPreparingConfirmedRemovesPhantom() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let phantom = makeInstance(name: "Cloning VM")
+        markPreparing(phantom)
+        viewModel.instances.append(phantom)
+        viewModel.selectedID = phantom.id
+
+        viewModel.cancelPreparingConfirmed(phantom)
+
+        #expect(viewModel.instances.isEmpty)
+        #expect(phantom.preparingState == nil)
+        #expect(viewModel.showCancelPreparingConfirmation == false)
+        #expect(viewModel.preparingInstanceToCancel == nil)
+    }
+
+    @Test("cancelPreparingConfirmed selects remaining instance")
+    func cancelPreparingConfirmedSelectsRemaining() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let other = makeInstance(name: "Other VM")
+        let phantom = makeInstance(name: "Cloning VM")
+        markPreparing(phantom)
+        viewModel.instances = [other, phantom]
+        viewModel.selectedID = phantom.id
+
+        viewModel.cancelPreparingConfirmed(phantom)
+
+        #expect(viewModel.instances.count == 1)
+        #expect(viewModel.selectedID == other.id)
+    }
+
+    @Test("confirmCancelPreparing sets state for alert")
+    func confirmCancelPreparingSetsState() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let phantom = makeInstance(name: "Cloning VM")
+        markPreparing(phantom)
+        viewModel.instances.append(phantom)
+
+        viewModel.confirmCancelPreparing(phantom)
+
+        #expect(viewModel.showCancelPreparingConfirmation == true)
+        #expect(viewModel.preparingInstanceToCancel?.id == phantom.id)
+    }
+
+    // MARK: - hasPreparing
+
+    @Test("hasPreparing returns true when an instance is preparing")
+    func hasPreparingTrue() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        markPreparing(instance)
+        viewModel.instances.append(instance)
+
+        #expect(viewModel.hasPreparing == true)
+    }
+
+    @Test("hasPreparing returns false when no instances are preparing")
+    func hasPreparingFalse() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        viewModel.instances.append(instance)
+
+        #expect(viewModel.hasPreparing == false)
+    }
+
+    // MARK: - Reconcile With Disk (Preparing)
+
+    @Test("reconcileWithDisk skips when instances are preparing")
+    func reconcileSkipsWhenPreparing() {
+        let storage = MockVMStorageService()
+        let config = VMConfiguration(name: "New VM", guestOS: .linux, bootMode: .efi)
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+        storage.bundles[bundleURL] = config
+
+        let (viewModel, _, _, _) = makeViewModel(storageService: storage)
+        viewModel.instances.removeAll()
+
+        // Add a preparing instance
+        let preparing = makeInstance(name: "Preparing")
+        markPreparing(preparing)
+        viewModel.instances.append(preparing)
+
+        viewModel.reconcileWithDisk()
+
+        // Should not have added the disk bundle because hasPreparing is true
+        #expect(viewModel.instances.count == 1)
+        #expect(viewModel.instances.first?.name == "Preparing")
+    }
+
+    @Test("reconcileWithDisk preserves preparing instances from removal")
+    func reconcilePreservesPreparingInstances() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let preparing = makeInstance(name: "Preparing VM")
+        markPreparing(preparing)
+        preparing.status = .stopped
+        viewModel.instances.append(preparing)
+
+        // Storage has no bundles — normally this instance would be removed
+        // but hasPreparing guard should prevent reconcile from running
+        viewModel.reconcileWithDisk()
+
+        #expect(viewModel.instances.count == 1)
+        #expect(viewModel.instances.first?.name == "Preparing VM")
     }
 }


### PR DESCRIPTION
## Summary
- Clone and import operations now show immediate visual feedback via "phantom rows" — a new sidebar row appears instantly with a spinner while the file copy runs asynchronously
- Import no longer blocks the main thread, fixing UI freezes on large bundles
- Operations are cancellable with confirmation, and serialized (one at a time)

## Changes
- Add `PreparingOperation` enum and `PreparingState` struct on `VMInstance` to track in-flight clone/import operations
- Refactor `cloneVM` from async to synchronous with phantom row pattern
- Refactor `importVM` to copy files asynchronously via `Task.detached`
- Add cancellation flow: context menu → confirmation alert → cleanup partial files
- Replace `isCloning` with `hasPreparing` computed property for serialization
- Show spinner in sidebar, progress view in detail pane, hide toolbar for preparing instances
- Handle filename collisions during import; keep app alive during operations
- Add `trashPartialBundle(at:)` helper with `.warning`-level logging on cleanup failure
- Update ARCHITECTURE.md with preparing state documentation

## Test plan
- [x] Built successfully on macOS 26
- [x] All tests pass (18 new tests for preparing state lifecycle, cancellation, serialization, display properties)
- [ ] Manual: Clone a stopped VM → phantom row with spinner appears → completes to stopped
- [ ] Manual: Drag `.kernova` bundle onto sidebar → phantom row appears → UI never freezes
- [ ] Manual: Right-click phantom row → "Cancel Clone" → confirmation → row removed
- [ ] Manual: Try to clone while another clone is running → error message shown
- [ ] Manual: Quit app during clone → partial bundle cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)