### PR TITLE
feat: Expose force stop UI for unresponsive VMs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,13 +104,13 @@ KernovaTests/
 **Files:** `AppDelegate.swift`, `MainWindowController.swift`, `FullscreenWindowController.swift`, `SerialConsoleWindowController.swift`
 
 `AppDelegate` is the entry point. It creates the `VMLibraryViewModel` and `VMLifecycleCoordinator`, opens the main window, and manages the lifecycle of all windows. It tracks window controllers in dictionaries keyed by VM UUID, enabling one-to-many relationships (a VM can have a main view, a fullscreen window, and a serial console open simultaneously). `AppDelegate` also handles:
-- The application menu (including VM-specific actions and Window > Show Library with Cmd+0)
+- The application menu (including VM-specific actions, Force Stop with `canForceStop` validation, and Window > Show Library with Cmd+0)
 - Save-on-quit behavior (saving VM state before termination)
 - Conditional termination: `applicationShouldTerminateAfterLastWindowClosed` returns `false` when VMs are active or fullscreen windows exist, preventing premature exit on fullscreen-to-inline transitions
 - Dock icon reopen: `applicationShouldHandleReopen` restores the main window when clicked with no visible windows
 - Fullscreen exit recovery: closing a fullscreen window automatically re-shows the main library window via `showLibrary(_:)`
 
-`MainWindowController` hosts an `NSSplitViewController` where each pane is an `NSHostingController` wrapping SwiftUI views. This is the AppKit/SwiftUI bridge point.
+`MainWindowController` hosts an `NSSplitViewController` where each pane is an `NSHostingController` wrapping SwiftUI views. This is the AppKit/SwiftUI bridge point. The Stop toolbar item uses a custom `NSButton` with `bezelStyle = .toolbar` (instead of the image-based approach used by other items) to support an `NSPressGestureRecognizer` for long-press force-stop.
 
 ### Models
 
@@ -124,7 +124,7 @@ The model layer has two key types:
 
 `VMBundleLayout` is a `Sendable` struct that takes a bundle root path and provides all derived file paths (disk image, aux storage, save file, serial log, etc.), keeping path logic centralized.
 
-The remaining models are enums: `VMStatus` (stopped/starting/running/paused/saving/restoring/installing/error), `VMBootMode` (macOS/efi/linuxKernel), `VMGuestOS` (macOS/linux), and `MacOSInstallState` (tracking download and install phases with progress). `VMStatus` provides computed properties for state checks (`canStart`, `canStop`, `canPause`, `canResume`, `canSave`, `canEditSettings`, `isTransitioning`, `isActive`).
+The remaining models are enums: `VMStatus` (stopped/starting/running/paused/saving/restoring/installing/error), `VMBootMode` (macOS/efi/linuxKernel), `VMGuestOS` (macOS/linux), and `MacOSInstallState` (tracking download and install phases with progress). `VMStatus` provides computed properties for state checks (`canStart`, `canStop`, `canForceStop`, `canPause`, `canResume`, `canSave`, `canEditSettings`, `isTransitioning`, `isActive`). `canForceStop` covers all states where a `VZVirtualMachine` may exist and need forceful termination (running, paused, starting, saving, restoring).
 
 ### Services
 
@@ -153,7 +153,7 @@ All service implementations conform to protocols defined in `Services/Protocols/
 
 **Files:** `VMLibraryViewModel.swift`, `VMLifecycleCoordinator.swift`, `VMCreationViewModel.swift`, `IPSWDownloadViewModel.swift`, `VMDirectoryWatcher.swift`
 
-- **`VMLibraryViewModel`** is the central `@Observable` view model. It owns the array of `VMInstance`s and handles list-level operations: add, remove, rename, selection tracking. For lifecycle operations (start, stop, install), it delegates to `VMLifecycleCoordinator`. Clone and import operations use a "phantom row" pattern: a `VMInstance` with `isPreparing = true` appears immediately in the sidebar with a spinner while the file copy runs asynchronously via `Task.detached`. The `hasPreparing` computed property enforces serialization — only one clone/import at a time. Cancellation removes the phantom row, cancels the task, and cleans up partial files on disk.
+- **`VMLibraryViewModel`** is the central `@Observable` view model. It owns the array of `VMInstance`s and handles list-level operations: add, remove, rename, selection tracking. For lifecycle operations (start, stop, install), it delegates to `VMLifecycleCoordinator`. Clone and import operations use a "phantom row" pattern: a `VMInstance` with `isPreparing = true` appears immediately in the sidebar with a spinner while the file copy runs asynchronously via `Task.detached`. The `hasPreparing` computed property enforces serialization — only one clone/import at a time. Cancellation removes the phantom row, cancels the task, and cleans up partial files on disk. Force-stop is surfaced via `confirmForceStop()` (direct) and smart escalation in `stop()` — if a graceful stop was already requested 5+ seconds ago and the user clicks stop again, an escalation dialog offers force-stop. Per-VM timestamps in `lastStopRequestTimes` track this, cleared on successful force-stop, reconciliation, or via `clearStopTimestamp()`.
 
 - **`VMLifecycleCoordinator`** is an `@MainActor` coordinator that owns the lifecycle services (`VirtualizationService`, `MacOSInstallService`, `IPSWService`). It orchestrates multi-step operations like macOS installation (which involves IPSW download → platform file creation → VM configuration → installation). This separation keeps `VMLibraryViewModel` focused on list management. The coordinator enforces **per-VM operation serialization** — at most one lifecycle operation can be in flight for a given VM at any time; concurrent requests are rejected with `VMLifecycleCoordinator.LifecycleError.operationInProgress`. `stop` and `forceStop` bypass serialization entirely (clearing the active-operation token before calling the service) so users can always cancel hung operations.
 
@@ -300,7 +300,7 @@ No external package dependencies. No Swift Package Manager, CocoaPods, or Cartha
 | Component | Tests | Notes |
 |-----------|-------|-------|
 | `VMConfiguration` | 43 tests + clone suite | Encoding/decoding, defaults, validation, all fields |
-| `VMLibraryViewModel` | 59 tests | Add/remove/rename VMs, selection, delegation to coordinator, sleep/wake, clone/import phantom rows, cancel preparing |
+| `VMLibraryViewModel` | 66 tests | Add/remove/rename VMs, selection, delegation to coordinator, sleep/wake, clone/import phantom rows, cancel preparing, force-stop confirmation, stop escalation timing |
 | `VMCreationViewModel` | 44 tests | All wizard steps, validation, OS-specific paths |
 | `VMLifecycleCoordinator` | Yes | Multi-step orchestration, error handling, service delegation, token-based operation serialization, stop/forceStop bypass, stale-token race condition coverage |
 | `VMInstance` | Yes | Status transitions, configuration updates, bundle layout, preparing state display properties |
@@ -308,7 +308,7 @@ No external package dependencies. No Swift Package Manager, CocoaPods, or Cartha
 | `VirtualizationService` | Yes | Start/stop/pause/resume via mock VZ objects |
 | `VMStorageService` | Yes | CRUD operations, cloning, migration |
 | `VMBundleLayout` | Yes | Path derivation from bundle root |
-| `VMStatus` | Yes | Enum behavior and transitions |
+| `VMStatus` | Yes | Enum behavior, transitions, `canForceStop` |
 | `VMBootMode` | Yes | Enum cases and properties |
 | `VMGuestOS` | Yes | Enum cases and properties |
 | `MacOSInstallState` | Yes | Phase tracking, progress calculation |

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -199,6 +199,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         viewModel.stop(instance)
     }
 
+    @objc func forceStopVM(_ sender: Any?) {
+        guard let instance = viewModel.selectedInstance else { return }
+        viewModel.confirmForceStop(instance)
+    }
+
     @objc func saveVM(_ sender: Any?) {
         guard let instance = viewModel.selectedInstance else { return }
         Task { await viewModel.save(instance) }
@@ -333,6 +338,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             return viewModel.selectedInstance?.status.canResume ?? false
         case #selector(stopVM(_:)):
             return viewModel.selectedInstance?.status.canStop ?? false
+        case #selector(forceStopVM(_:)):
+            return viewModel.selectedInstance?.status.canForceStop ?? false
         case #selector(saveVM(_:)):
             return viewModel.selectedInstance?.status.canSave ?? false
         case #selector(renameVM(_:)):
@@ -425,6 +432,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         let resumeItem = vmMenu.addItem(withTitle: "Resume", action: #selector(resumeVM(_:)), keyEquivalent: "r")
         resumeItem.keyEquivalentModifierMask = [.command, .option]
         vmMenu.addItem(withTitle: "Stop", action: #selector(stopVM(_:)), keyEquivalent: "")
+        vmMenu.addItem(withTitle: "Force Stop", action: #selector(forceStopVM(_:)), keyEquivalent: "")
         vmMenu.addItem(.separator())
         let saveItem = vmMenu.addItem(withTitle: "Save State", action: #selector(saveVM(_:)), keyEquivalent: "s")
         saveItem.keyEquivalentModifierMask = [.command, .option]

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -301,10 +301,6 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
             return ActionButtonSpec(
                 symbolName: "play.fill", toolTip: "Resume the virtual machine",
                 accessibilityLabel: "Resume", action: #selector(AppDelegate.resumeVM(_:)))
-        case Self.stopVMIdentifier:
-            return ActionButtonSpec(
-                symbolName: "stop.fill", toolTip: "Stop the virtual machine",
-                accessibilityLabel: "Stop", action: #selector(AppDelegate.stopVM(_:)))
         case Self.saveVMIdentifier:
             return ActionButtonSpec(
                 symbolName: "square.and.arrow.down", toolTip: "Save the virtual machine state to disk",

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -255,6 +255,9 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
         if itemIdentifier == Self.newVMIdentifier {
             return makeNewVMItem()
         }
+        if itemIdentifier == Self.stopVMIdentifier {
+            return makeStopActionItem()
+        }
         if Self.allActionIdentifiers.contains(itemIdentifier) {
             return makeActionItem(for: itemIdentifier)
         }
@@ -317,6 +320,32 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
         default:
             return nil
         }
+    }
+
+    private func makeStopActionItem() -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: Self.stopVMIdentifier)
+        let button = NSButton(
+            image: NSImage(systemSymbolName: "stop.fill", accessibilityDescription: "Stop")!,
+            target: nil,
+            action: #selector(AppDelegate.stopVM(_:))
+        )
+        button.bezelStyle = .toolbar
+        let pressGesture = NSPressGestureRecognizer(
+            target: self, action: #selector(stopButtonLongPressed(_:))
+        )
+        pressGesture.minimumPressDuration = 0.5
+        button.addGestureRecognizer(pressGesture)
+        item.view = button
+        item.label = "Stop"
+        item.paletteLabel = "Stop"
+        item.toolTip = "Stop the virtual machine. Long-press to force stop."
+        return item
+    }
+
+    @objc private func stopButtonLongPressed(_ sender: NSPressGestureRecognizer) {
+        guard sender.state == .began,
+              let instance = viewModel.selectedInstance else { return }
+        viewModel.confirmForceStop(instance)
     }
 
     private func makeActionItem(for identifier: NSToolbarItem.Identifier) -> NSToolbarItem? {

--- a/Kernova/Models/VMStatus.swift
+++ b/Kernova/Models/VMStatus.swift
@@ -49,6 +49,13 @@ enum VMStatus: String, Codable, Sendable {
     var canSave: Bool { self == .running || self == .paused }
     var canEditSettings: Bool { self == .stopped || self == .error }
 
+    var canForceStop: Bool {
+        switch self {
+        case .running, .paused, .starting, .saving, .restoring: true
+        default: false
+        }
+    }
+
     /// Whether this status represents an active VM that should keep the app alive.
     /// Note: live-paused VMs (`.paused` with a non-nil `VZVirtualMachine`) should
     /// be handled separately by the caller.

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -211,6 +211,7 @@ final class VMLibraryViewModel {
     func stop(_ instance: VMInstance) {
         if let lastRequest = lastStopRequestTimes[instance.id],
            Date().timeIntervalSince(lastRequest) >= 5 {
+            Self.logger.debug("Stop escalation for '\(instance.name)': graceful stop sent \(Date().timeIntervalSince(lastRequest), format: .fixed(precision: 1))s ago")
             confirmForceStopAfterGraceful(instance)
             return
         }
@@ -226,6 +227,7 @@ final class VMLibraryViewModel {
         do {
             try await lifecycle.forceStop(instance)
             lastStopRequestTimes.removeValue(forKey: instance.id)
+            Self.logger.notice("Force-stopped VM '\(instance.name)'")
         } catch {
             presentError(error)
         }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -27,6 +27,10 @@ final class VMLibraryViewModel {
     var renamingInstanceID: UUID?
     var showCancelPreparingConfirmation = false
     var preparingInstanceToCancel: VMInstance?
+    var showForceStopConfirmation = false
+    var instanceToForceStop: VMInstance?
+    var showStopEscalation = false
+    var instanceToEscalate: VMInstance?
 
     /// `true` when any instance is mid-clone or mid-import.
     var hasPreparing: Bool { instances.contains(where: \.isPreparing) }
@@ -34,6 +38,10 @@ final class VMLibraryViewModel {
     // MARK: - Directory Watcher
 
     private var directoryWatcher: VMDirectoryWatcher?
+
+    // MARK: - Stop Escalation
+
+    private var lastStopRequestTimes: [UUID: Date] = [:]
 
     // MARK: - Sleep/Wake
 
@@ -201,8 +209,14 @@ final class VMLibraryViewModel {
     }
 
     func stop(_ instance: VMInstance) {
+        if let lastRequest = lastStopRequestTimes[instance.id],
+           Date().timeIntervalSince(lastRequest) >= 5 {
+            confirmForceStopAfterGraceful(instance)
+            return
+        }
         do {
             try lifecycle.stop(instance)
+            lastStopRequestTimes[instance.id] = Date()
         } catch {
             presentError(error)
         }
@@ -211,9 +225,35 @@ final class VMLibraryViewModel {
     func forceStop(_ instance: VMInstance) async {
         do {
             try await lifecycle.forceStop(instance)
+            lastStopRequestTimes.removeValue(forKey: instance.id)
         } catch {
             presentError(error)
         }
+    }
+
+    // MARK: - Force Stop Confirmation
+
+    func confirmForceStop(_ instance: VMInstance) {
+        instanceToForceStop = instance
+        showForceStopConfirmation = true
+    }
+
+    func forceStopConfirmed(_ instance: VMInstance) async {
+        await forceStop(instance)
+    }
+
+    private func confirmForceStopAfterGraceful(_ instance: VMInstance) {
+        instanceToEscalate = instance
+        showStopEscalation = true
+    }
+
+    func clearStopTimestamp(for instanceID: UUID) {
+        lastStopRequestTimes.removeValue(forKey: instanceID)
+    }
+
+    /// Sets a stop request timestamp for the given VM. Used by tests to simulate elapsed time.
+    func setLastStopRequestTime(_ date: Date, for instanceID: UUID) {
+        lastStopRequestTimes[instanceID] = date
     }
 
     func pause(_ instance: VMInstance) async {
@@ -602,6 +642,12 @@ final class VMLibraryViewModel {
             if didChange {
                 instances.sort { $0.configuration.createdAt < $1.configuration.createdAt }
             }
+
+            // Clean up stop escalation timestamps for VMs that have stopped
+            for instance in instances where instance.status == .stopped {
+                lastStopRequestTimes.removeValue(forKey: instance.id)
+            }
+
             Self.logger.debug("reconcileWithDisk: complete — \(self.instances.count) VM(s) in library")
         } catch {
             Self.logger.error("Directory reconciliation failed: \(error.localizedDescription)")

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -63,6 +63,35 @@ struct VMDetailView: View {
         } message: { _ in
             Text("The operation will be stopped and any partially copied files will be removed.")
         }
+        .alert(
+            "Force Stop Virtual Machine",
+            isPresented: $viewModel.showForceStopConfirmation,
+            presenting: viewModel.instanceToForceStop
+        ) { vm in
+            Button("Force Stop", role: .destructive) {
+                Task { await viewModel.forceStopConfirmed(vm) }
+            }
+            if vm.status.canStop {
+                Button("Shut Down") {
+                    viewModel.stop(vm)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { vm in
+            Text("\"\(vm.name)\" will be immediately terminated. Any unsaved data inside the guest will be lost.")
+        }
+        .alert(
+            "Shut Down Not Responding",
+            isPresented: $viewModel.showStopEscalation,
+            presenting: viewModel.instanceToEscalate
+        ) { vm in
+            Button("Force Stop", role: .destructive) {
+                Task { await viewModel.forceStopConfirmed(vm) }
+            }
+            Button("Keep Waiting", role: .cancel) {}
+        } message: { vm in
+            Text("A shut down request was already sent to \"\(vm.name)\". The virtual machine may need more time, or it may be unresponsive.")
+        }
     }
 
     private var transitionView: some View {

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -963,20 +963,31 @@ struct VMLibraryViewModelTests {
 
     @Test("reconcileWithDisk clears stop timestamps for stopped VMs")
     func reconcileClearsStopTimestamps() {
-        let (viewModel, _, _, _) = makeViewModel()
-        let instance = makeInstance()
-        instance.status = .stopped
-        viewModel.instances.append(instance)
+        let storage = MockVMStorageService()
+        let config = VMConfiguration(name: "Stopped VM", guestOS: .linux, bootMode: .efi)
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+        storage.bundles[bundleURL] = config
 
-        // Set a stale timestamp
-        viewModel.setLastStopRequestTime(Date(), for: instance.id)
+        let (viewModel, _, _, virtService) = makeViewModel(storageService: storage)
+
+        // The instance was loaded by init; mark it stopped and set a stale timestamp
+        guard let instance = viewModel.instances.first else {
+            Issue.record("Expected one loaded instance")
+            return
+        }
+        instance.status = .stopped
+        viewModel.setLastStopRequestTime(Date().addingTimeInterval(-10), for: instance.id)
 
         viewModel.reconcileWithDisk()
 
-        // After reconcile, calling stop on a running VM with the same ID should not escalate
-        // (timestamp was cleared for stopped VMs)
-        // Verify indirectly: the instance was removed (no bundle on disk), so the timestamp cleanup ran
-        #expect(viewModel.instances.isEmpty)
+        // Instance still exists (bundle is on disk), but timestamp should have been cleared.
+        // Verify by setting to running and calling stop — should NOT escalate.
+        instance.status = .running
+        viewModel.stop(instance)
+
+        #expect(virtService.stopCallCount == 1)
+        #expect(viewModel.showStopEscalation == false)
     }
 
     // MARK: - hasPreparing

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -863,6 +863,122 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.preparingInstanceToCancel?.id == phantom.id)
     }
 
+    // MARK: - Force Stop Confirmation
+
+    @Test("confirmForceStop sets instance and shows confirmation")
+    func confirmForceStop() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .running
+        viewModel.instances.append(instance)
+
+        viewModel.confirmForceStop(instance)
+
+        #expect(viewModel.instanceToForceStop?.id == instance.id)
+        #expect(viewModel.showForceStopConfirmation == true)
+    }
+
+    @Test("forceStopConfirmed delegates to lifecycle and clears timestamp")
+    func forceStopConfirmed() async {
+        let (viewModel, _, _, virtService) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .running
+        viewModel.instances.append(instance)
+
+        // Set a stop request timestamp first
+        viewModel.setLastStopRequestTime(Date(), for: instance.id)
+
+        await viewModel.forceStopConfirmed(instance)
+
+        #expect(virtService.forceStopCallCount == 1)
+        #expect(instance.status == .stopped)
+    }
+
+    // MARK: - Stop Escalation
+
+    @Test("stop records timestamp and delegates to lifecycle on first call")
+    func stopFirstCallRecordsTimestamp() {
+        let (viewModel, _, _, virtService) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .running
+        viewModel.instances.append(instance)
+
+        viewModel.stop(instance)
+
+        #expect(virtService.stopCallCount == 1)
+    }
+
+    @Test("stop within 5 seconds sends another graceful stop")
+    func stopWithin5SecondsNoEscalation() {
+        let (viewModel, _, _, virtService) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .running
+        viewModel.instances.append(instance)
+
+        // Simulate a recent stop request (1 second ago)
+        viewModel.setLastStopRequestTime(Date().addingTimeInterval(-1), for: instance.id)
+
+        viewModel.stop(instance)
+
+        // Should send another graceful stop, not escalate
+        #expect(virtService.stopCallCount == 1)
+        #expect(viewModel.showStopEscalation == false)
+    }
+
+    @Test("stop after 5+ seconds shows escalation dialog")
+    func stopAfter5SecondsShowsEscalation() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .running
+        viewModel.instances.append(instance)
+
+        // Simulate a stop request from 6 seconds ago
+        viewModel.setLastStopRequestTime(Date().addingTimeInterval(-6), for: instance.id)
+
+        viewModel.stop(instance)
+
+        #expect(viewModel.showStopEscalation == true)
+        #expect(viewModel.instanceToEscalate?.id == instance.id)
+    }
+
+    @Test("clearStopTimestamp allows fresh stop without escalation")
+    func clearStopTimestampAllowsFreshStop() {
+        let (viewModel, _, _, virtService) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .running
+        viewModel.instances.append(instance)
+
+        // Simulate an old stop request
+        viewModel.setLastStopRequestTime(Date().addingTimeInterval(-10), for: instance.id)
+
+        // Clear it
+        viewModel.clearStopTimestamp(for: instance.id)
+
+        // Next stop should be a fresh graceful stop
+        viewModel.stop(instance)
+
+        #expect(virtService.stopCallCount == 1)
+        #expect(viewModel.showStopEscalation == false)
+    }
+
+    @Test("reconcileWithDisk clears stop timestamps for stopped VMs")
+    func reconcileClearsStopTimestamps() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .stopped
+        viewModel.instances.append(instance)
+
+        // Set a stale timestamp
+        viewModel.setLastStopRequestTime(Date(), for: instance.id)
+
+        viewModel.reconcileWithDisk()
+
+        // After reconcile, calling stop on a running VM with the same ID should not escalate
+        // (timestamp was cleared for stopped VMs)
+        // Verify indirectly: the instance was removed (no bundle on disk), so the timestamp cleanup ran
+        #expect(viewModel.instances.isEmpty)
+    }
+
     // MARK: - hasPreparing
 
     @Test("hasPreparing returns true when an instance is preparing")

--- a/KernovaTests/VMStatusTests.swift
+++ b/KernovaTests/VMStatusTests.swift
@@ -79,6 +79,18 @@ struct VMStatusTests {
         #expect(VMStatus.installing.canEditSettings == false)
     }
 
+    @Test("canForceStop returns true for running, paused, starting, saving, restoring")
+    func canForceStop() {
+        #expect(VMStatus.running.canForceStop == true)
+        #expect(VMStatus.paused.canForceStop == true)
+        #expect(VMStatus.starting.canForceStop == true)
+        #expect(VMStatus.saving.canForceStop == true)
+        #expect(VMStatus.restoring.canForceStop == true)
+        #expect(VMStatus.stopped.canForceStop == false)
+        #expect(VMStatus.installing.canForceStop == false)
+        #expect(VMStatus.error.canForceStop == false)
+    }
+
     // MARK: - Active
 
     @Test("isActive returns true for running, starting, saving, restoring, installing")


### PR DESCRIPTION
## Summary
- Surface the existing force-stop capability through UI so users can terminate unresponsive VMs that ignore graceful ACPI shutdown requests
- Add smart escalation that detects repeated stop attempts and offers force-stop
- Add long-press gesture on toolbar Stop button and "Force Stop" menu item

## Changes
- Add `canForceStop` computed property to `VMStatus` (running, paused, starting, saving, restoring)
- Add force-stop confirmation dialog (Force Stop / Shut Down / Cancel) and stop escalation dialog ("Shut Down Not Responding") in `VMDetailView`
- Add "Force Stop" menu item to Virtual Machine menu with `canForceStop` validation
- Build Stop toolbar button as custom `NSButton` with `NSPressGestureRecognizer` (0.5s long-press → force-stop confirmation)
- Track per-VM stop request timestamps; escalate after 5+ seconds if user clicks Stop again
- Add 7 new tests covering `canForceStop`, confirmation state, escalation timing, and timestamp cleanup
- Update ARCHITECTURE.md

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Menu bar: "Force Stop" enabled only when VM `canForceStop`
- [ ] Click "Force Stop" in menu → confirmation dialog with Force Stop (red), Shut Down, Cancel
- [ ] Toolbar: Long-press Stop button (0.5s) → confirmation dialog
- [ ] Escalation: Start VM → Stop → wait 5s → Stop again → escalation dialog
- [ ] Stop within 5s → no escalation (normal graceful stop)
- [ ] After VM stops, timestamp cleared (next stop attempt is fresh)
- [ ] All existing and new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)