### PR TITLE
fix: Harden resource cleanup in cancel-installation and delete paths

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -177,8 +177,8 @@ final class VMLibraryViewModel {
         instance.installTask?.cancel()
         instance.installTask = nil
 
-        // 2. Release VZ resources
-        instance.virtualMachine = nil
+        // 2. Release VZ resources (tearDownSession clears VM, pipes, delegate adapter)
+        instance.tearDownSession()
         instance.installState = nil
 
         // 3. Remove bundle from disk (moves to Trash)
@@ -300,9 +300,12 @@ final class VMLibraryViewModel {
     }
 
     func deleteConfirmed(_ instance: VMInstance) {
+        instance.tearDownSession()
         do {
             try storageService.deleteVMBundle(at: instance.bundleURL)
             lifecycle.clearActiveOperation(for: instance.id)
+            lastStopRequestTimes.removeValue(forKey: instance.id)
+            sleepPausedInstanceIDs.remove(instance.id)
             instances.removeAll { $0.id == instance.id }
             if selectedID == instance.id {
                 selectedID = instances.first?.id


### PR DESCRIPTION
## Summary
- Defensive improvements from memory leak audit to ensure VZ resources, serial pipes, and tracking dictionaries are properly cleaned up
- `cancelInstallation`: use `tearDownSession()` instead of bare `virtualMachine = nil` so pipes and delegate adapter are also released
- `deleteConfirmed`: call `tearDownSession()` before trashing the bundle, and clean up `lastStopRequestTimes` / `sleepPausedInstanceIDs`

## Test plan
- [x] Built successfully on macOS 26
- [x] Full test suite passes
- [ ] Verify cancel-installation flow (create macOS VM, cancel during install)
- [ ] Verify delete flow (create VM, delete it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)