### PR TITLE
fix: Close fullscreen window on suspend and pre-create on resume

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -30,6 +30,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         viewModel = VMLibraryViewModel()
+        viewModel.onEnterFullscreen = { [weak self] instance in
+            self?.enterFullscreen(for: instance)
+        }
         setupMainMenu()
 
         let windowController = MainWindowController(viewModel: viewModel)
@@ -171,12 +174,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     @objc func startVM(_ sender: Any?) {
         guard let instance = viewModel.selectedInstance else { return }
-        Task {
-            await viewModel.start(instance)
-            if instance.status == .running && instance.configuration.prefersFullscreen {
-                enterFullscreen(for: instance)
-            }
-        }
+        Task { await viewModel.start(instance) }
     }
 
     @objc func pauseVM(_ sender: Any?) {
@@ -186,12 +184,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     @objc func resumeVM(_ sender: Any?) {
         guard let instance = viewModel.selectedInstance else { return }
-        Task {
-            await viewModel.resume(instance)
-            if instance.status == .running && instance.configuration.prefersFullscreen {
-                enterFullscreen(for: instance)
-            }
-        }
+        Task { await viewModel.resume(instance) }
     }
 
     @objc func stopVM(_ sender: Any?) {
@@ -300,7 +293,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                     NotificationCenter.default.removeObserver(token)
                 }
                 if let controller = self.fullscreenWindows.removeValue(forKey: vmID),
-                   !controller.closedByVMStop {
+                   !controller.closedProgrammatically {
                     instance.configuration.prefersFullscreen = false
                     self.viewModel.saveConfiguration(for: instance)
                 }

--- a/Kernova/App/FullscreenWindowController.swift
+++ b/Kernova/App/FullscreenWindowController.swift
@@ -12,7 +12,7 @@ import Virtualization
 final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
 
     let vmID: UUID
-    private(set) var closedByVMStop = false
+    private(set) var closedProgrammatically = false
     private let instance: VMInstance
     private var observingStatus = false
 
@@ -67,17 +67,18 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
 
     // MARK: - Status Observation
 
-    /// Automatically closes the fullscreen window when the VM stops or errors out.
+    /// Automatically closes the fullscreen window when the VM stops, errors, or is cold-paused (save state).
     private func observeStatus() {
         observingStatus = true
         withObservationTracking {
             _ = self.instance.status
+            _ = self.instance.virtualMachine
         } onChange: {
             Task { @MainActor [weak self] in
                 guard let self, self.observingStatus else { return }
                 let status = self.instance.status
-                if status == .stopped || status == .error {
-                    self.closedByVMStop = true
+                if status == .stopped || status == .error || self.instance.isColdPaused {
+                    self.closedProgrammatically = true
                     self.window?.close()
                 } else {
                     self.observeStatus()
@@ -98,6 +99,16 @@ private struct FullscreenVMView: View {
         if let vm = instance.virtualMachine {
             VMDisplayView(virtualMachine: vm)
                 .ignoresSafeArea()
+        } else if instance.status.isTransitioning || instance.isColdPaused {
+            VStack(spacing: 12) {
+                ProgressView()
+                    .controlSize(.large)
+                Text(instance.isColdPaused ? "Restoring" : instance.status.displayName)
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.black)
         } else {
             ContentUnavailableView(
                 "No Display",

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -35,6 +35,10 @@ final class VMLibraryViewModel {
     /// `true` when any instance is mid-clone or mid-import.
     var hasPreparing: Bool { instances.contains(where: \.isPreparing) }
 
+    /// Called when a VM with `prefersFullscreen` is about to start or resume,
+    /// allowing the app delegate to pre-create the fullscreen window with a spinner.
+    @ObservationIgnored var onEnterFullscreen: ((VMInstance) -> Void)?
+
     // MARK: - Directory Watcher
 
     private var directoryWatcher: VMDirectoryWatcher?
@@ -201,6 +205,9 @@ final class VMLibraryViewModel {
     // MARK: - Lifecycle
 
     func start(_ instance: VMInstance) async {
+        if instance.configuration.prefersFullscreen {
+            onEnterFullscreen?(instance)
+        }
         do {
             try await lifecycle.start(instance)
         } catch {
@@ -267,6 +274,9 @@ final class VMLibraryViewModel {
     }
 
     func resume(_ instance: VMInstance) async {
+        if instance.configuration.prefersFullscreen {
+            onEnterFullscreen?(instance)
+        }
         do {
             try await lifecycle.resume(instance)
         } catch {


### PR DESCRIPTION
## Summary
- Fullscreen window now closes when a VM is suspended (Save State) instead of staying open with a "No Display" placeholder
- Fullscreen window is pre-created with a spinner before start/resume begins, eliminating the resize flash when transitioning from library view to fullscreen
- Observation tracking hardened to detect cold-pause regardless of mutation ordering

## Changes
- Rename `closedByVMStop` → `closedProgrammatically` in `FullscreenWindowController` to cover both stop and suspend close triggers
- Add `isColdPaused` as a close trigger in `observeStatus()` alongside `.stopped`/`.error`
- Track both `instance.status` and `instance.virtualMachine` in `withObservationTracking` to ensure cold-pause detection fires reliably
- Update `FullscreenVMView` to show a spinner with status text during transitioning/cold-paused states instead of "No Display"
- Add `@ObservationIgnored onEnterFullscreen` callback on `VMLibraryViewModel`, invoked before `start()`/`resume()` when `prefersFullscreen` is true
- Register callback in `AppDelegate` to pre-create fullscreen window; remove post-operation fullscreen entry from `startVM()`/`resumeVM()`

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Suspend (Save State) a fullscreen VM → window closes, library shows "Suspended"
- [ ] Resume the suspended VM → fullscreen window opens with spinner, then display appears at full size (no resize flash)
- [ ] Start a stopped VM with `prefersFullscreen` → fullscreen opens with spinner, then display appears
- [ ] Hot pause (Pause, not Save) while in fullscreen → window stays open with frozen display (no change)
- [ ] Resume from sidebar context menu with `prefersFullscreen` → enters fullscreen
- [ ] Resume from sidebar without `prefersFullscreen` → stays in library window
- [ ] VM error during start/resume → fullscreen window closes automatically
- [ ] Esc to exit fullscreen manually → `prefersFullscreen` reset to false (existing behavior preserved)
- [ ] All 312 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)