### PR TITLE
feat: Add pause overlay for live-paused VMs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,6 +55,7 @@ Kernova/
 │   ├── Console/
 │   │   ├── VMConsoleView.swift         # VM display container
 │   │   ├── VMDisplayView.swift         # NSViewRepresentable wrapping VZVirtualMachineView
+│   │   ├── VMPauseOverlay.swift         # Frosted overlay with play button for live-paused VMs
 │   │   ├── SerialConsoleContentView.swift # Serial console content wrapper
 │   │   └── SerialTerminalView.swift    # Terminal text view for serial output
 │   └── Creation/
@@ -167,7 +168,7 @@ All service implementations conform to protocols defined in `Services/Protocols/
 
 ### Views
 
-**Files:** 16 SwiftUI views across 4 subdirectories + root
+**Files:** 17 SwiftUI views across 4 subdirectories + root
 
 Views observe `VMLibraryViewModel` and individual `VMInstance`s via the Observation framework. The view hierarchy:
 
@@ -175,7 +176,7 @@ Views observe `VMLibraryViewModel` and individual `VMInstance`s via the Observat
 ContentView
 ├── SidebarView → VMRowView (per VM)
 └── VMDetailView
-    ├── VMConsoleView → VMDisplayView (NSViewRepresentable for VZVirtualMachineView)
+    ├── VMConsoleView → VMDisplayView (NSViewRepresentable for VZVirtualMachineView) + VMPauseOverlay
     ├── VMSettingsView
     └── MacOSInstallProgressView
 VMCreationWizardView (modal)

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -271,7 +271,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // Already showing fullscreen for this VM
         guard fullscreenWindows[vmID] == nil else { return }
 
-        let controller = FullscreenWindowController(instance: instance)
+        let controller = FullscreenWindowController(instance: instance) { [weak self] in
+            guard let self else { return }
+            Task { await self.viewModel.resume(instance) }
+        }
         fullscreenWindows[vmID] = controller
 
         let token = NotificationCenter.default.addObserver(

--- a/Kernova/App/FullscreenWindowController.swift
+++ b/Kernova/App/FullscreenWindowController.swift
@@ -16,11 +16,11 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
     private let instance: VMInstance
     private var observingStatus = false
 
-    init(instance: VMInstance) {
+    init(instance: VMInstance, onResume: @escaping () -> Void) {
         self.vmID = instance.instanceID
         self.instance = instance
 
-        let contentView = FullscreenVMView(instance: instance)
+        let contentView = FullscreenVMView(instance: instance, onResume: onResume)
         let hostingController = NSHostingController(rootView: contentView)
         hostingController.sizingOptions = []
 
@@ -94,11 +94,19 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
 /// `VZVirtualMachine` is available, or a placeholder otherwise.
 private struct FullscreenVMView: View {
     let instance: VMInstance
+    var onResume: () -> Void
 
     var body: some View {
         if let vm = instance.virtualMachine {
             VMDisplayView(virtualMachine: vm)
                 .ignoresSafeArea()
+                .overlay {
+                    if instance.status == .paused {
+                        VMPauseOverlay(onResume: onResume)
+                            .transition(.opacity)
+                    }
+                }
+                .animation(.easeInOut(duration: 0.25), value: instance.status == .paused)
         } else if instance.status.isTransitioning || instance.isColdPaused {
             VStack(spacing: 12) {
                 ProgressView()

--- a/Kernova/App/FullscreenWindowController.swift
+++ b/Kernova/App/FullscreenWindowController.swift
@@ -100,13 +100,7 @@ private struct FullscreenVMView: View {
         if let vm = instance.virtualMachine {
             VMDisplayView(virtualMachine: vm)
                 .ignoresSafeArea()
-                .overlay {
-                    if instance.status == .paused {
-                        VMPauseOverlay(onResume: onResume)
-                            .transition(.opacity)
-                    }
-                }
-                .animation(.easeInOut(duration: 0.25), value: instance.status == .paused)
+                .vmPauseOverlay(isPaused: instance.status == .paused, onResume: onResume)
         } else if instance.status.isTransitioning || instance.isColdPaused {
             VStack(spacing: 12) {
                 ProgressView()

--- a/Kernova/App/FullscreenWindowController.swift
+++ b/Kernova/App/FullscreenWindowController.swift
@@ -91,7 +91,7 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
 // MARK: - Fullscreen SwiftUI View
 
 /// SwiftUI view used inside the fullscreen window. Shows the VM display when a
-/// `VZVirtualMachine` is available, or a placeholder otherwise.
+/// `VZVirtualMachine` is available (with a pause overlay when live-paused), or a placeholder otherwise.
 private struct FullscreenVMView: View {
     let instance: VMInstance
     var onResume: () -> Void

--- a/Kernova/Views/Console/VMConsoleView.swift
+++ b/Kernova/Views/Console/VMConsoleView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Console view with the VM display and lifecycle control toolbar.
 struct VMConsoleView: View {
     @Bindable var instance: VMInstance
+    var onResume: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -20,6 +21,13 @@ struct VMConsoleView: View {
             } else if let vm = instance.virtualMachine {
                 VMDisplayView(virtualMachine: vm)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .overlay {
+                        if instance.status == .paused {
+                            VMPauseOverlay(onResume: onResume)
+                                .transition(.opacity)
+                        }
+                    }
+                    .animation(.easeInOut(duration: 0.25), value: instance.status == .paused)
             } else if instance.isColdPaused {
                 ContentUnavailableView(
                     "Suspended",

--- a/Kernova/Views/Console/VMConsoleView.swift
+++ b/Kernova/Views/Console/VMConsoleView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Console view with the VM display and lifecycle control toolbar.
+/// Console view that displays the VM screen, pause overlay, or a placeholder depending on VM state.
 struct VMConsoleView: View {
     @Bindable var instance: VMInstance
     var onResume: () -> Void

--- a/Kernova/Views/Console/VMConsoleView.swift
+++ b/Kernova/Views/Console/VMConsoleView.swift
@@ -21,13 +21,7 @@ struct VMConsoleView: View {
             } else if let vm = instance.virtualMachine {
                 VMDisplayView(virtualMachine: vm)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .overlay {
-                        if instance.status == .paused {
-                            VMPauseOverlay(onResume: onResume)
-                                .transition(.opacity)
-                        }
-                    }
-                    .animation(.easeInOut(duration: 0.25), value: instance.status == .paused)
+                    .vmPauseOverlay(isPaused: instance.status == .paused, onResume: onResume)
             } else if instance.isColdPaused {
                 ContentUnavailableView(
                     "Suspended",

--- a/Kernova/Views/Console/VMPauseOverlay.swift
+++ b/Kernova/Views/Console/VMPauseOverlay.swift
@@ -21,6 +21,7 @@ struct VMPauseOverlay: View {
                         .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Resume")
 
                 Text("Paused")
                     .font(.title2)

--- a/Kernova/Views/Console/VMPauseOverlay.swift
+++ b/Kernova/Views/Console/VMPauseOverlay.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Translucent overlay shown when a VM is live-paused (in memory but not running).
+/// Displays a play button and "Paused" label over the frozen display.
+struct VMPauseOverlay: View {
+    var onResume: () -> Void
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(.ultraThinMaterial)
+
+            VStack(spacing: 12) {
+                Button {
+                    onResume()
+                } label: {
+                    Image(systemName: "play.circle.fill")
+                        .font(.system(size: 64))
+                        .foregroundStyle(.white)
+                        .shadow(radius: 8)
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+
+                Text("Paused")
+                    .font(.title2)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.white)
+                    .shadow(radius: 4)
+            }
+        }
+        .allowsHitTesting(true)
+    }
+}

--- a/Kernova/Views/Console/VMPauseOverlay.swift
+++ b/Kernova/Views/Console/VMPauseOverlay.swift
@@ -6,37 +6,32 @@ struct VMPauseOverlay: View {
     var onResume: () -> Void
 
     var body: some View {
-        ZStack {
-            Rectangle()
-                .fill(.ultraThinMaterial)
-
-            VStack(spacing: 12) {
-                Button {
-                    onResume()
-                } label: {
-                    Image(systemName: "play.circle.fill")
-                        .font(.system(size: 64))
-                        .foregroundStyle(.white)
-                        .shadow(radius: 8)
-                        .contentShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Resume")
-
-                Text("Paused")
-                    .font(.title2)
-                    .fontWeight(.medium)
+        VStack(spacing: 12) {
+            Button(action: onResume) {
+                Image(systemName: "play.circle.fill")
+                    .font(.system(size: 64))
                     .foregroundStyle(.white)
-                    .shadow(radius: 4)
+                    .shadow(radius: 8)
+                    .contentShape(Circle())
             }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Resume")
+
+            Text("Paused")
+                .font(.title2)
+                .fontWeight(.medium)
+                .foregroundStyle(.white)
+                .shadow(radius: 4)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.ultraThinMaterial)
     }
 }
 
 extension View {
     /// Adds a pause overlay with animated opacity transition when `isPaused` is true.
     func vmPauseOverlay(isPaused: Bool, onResume: @escaping () -> Void) -> some View {
-        self.overlay {
+        overlay {
             if isPaused {
                 VMPauseOverlay(onResume: onResume)
                     .transition(.opacity)

--- a/Kernova/Views/Console/VMPauseOverlay.swift
+++ b/Kernova/Views/Console/VMPauseOverlay.swift
@@ -29,6 +29,18 @@ struct VMPauseOverlay: View {
                     .shadow(radius: 4)
             }
         }
-        .allowsHitTesting(true)
+    }
+}
+
+extension View {
+    /// Adds a pause overlay with animated opacity transition when `isPaused` is true.
+    func vmPauseOverlay(isPaused: Bool, onResume: @escaping () -> Void) -> some View {
+        self.overlay {
+            if isPaused {
+                VMPauseOverlay(onResume: onResume)
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: isPaused)
     }
 }

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -31,7 +31,9 @@ struct VMDetailView: View {
                     }
 
                 case .running, .paused:
-                    VMConsoleView(instance: instance)
+                    VMConsoleView(instance: instance) {
+                        Task { await viewModel.resume(instance) }
+                    }
 
                 default:
                     transitionView

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Detail area that switches between settings (when stopped) and console (when running).
+/// Detail area that switches between settings, console, install progress, and transition views based on VM status.
 struct VMDetailView: View {
     @Bindable var instance: VMInstance
     @Bindable var viewModel: VMLibraryViewModel


### PR DESCRIPTION
## Summary
- Show a translucent frosted-glass overlay with a play button when a VM is live-paused, making it immediately obvious the VM is paused and providing a quick way to resume
- The overlay appears in both the inline console view and the fullscreen display
- Instance-specific resume closures ensure the correct VM is always resumed, even when sidebar selection differs from the fullscreen display

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Run a VM, pause it → overlay appears with play button and smooth fade-in
- [ ] Click play button → VM resumes, overlay disappears with smooth fade-out
- [ ] Enter fullscreen, pause → overlay appears in fullscreen too
- [ ] Resume from fullscreen overlay → correct VM resumes
- [ ] Cold-paused (suspended) VMs still show existing ContentUnavailableView, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)