### PR TITLE
feat: Remember fullscreen display across VM lifecycle transitions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -119,7 +119,7 @@ KernovaTests/
 
 The model layer has two key types:
 
-- **`VMConfiguration`** is the persisted identity of a VM. It's a `Codable` + `Sendable` struct written as `config.json` inside each VM bundle. It holds: name, UUID, guest OS type, boot mode, CPU/memory/disk settings, display configuration, network settings, and OS-specific fields (macOS hardware model data, Linux kernel/initrd/cmdline paths).
+- **`VMConfiguration`** is the persisted identity of a VM. It's a `Codable` + `Sendable` struct written as `config.json` inside each VM bundle. It holds: name, UUID, guest OS type, boot mode, CPU/memory/disk settings, display configuration (including `lastFullscreenDisplayID` for remembering which display a VM was fullscreen on), network settings, and OS-specific fields (macOS hardware model data, Linux kernel/initrd/cmdline paths).
 
 - **`VMInstance`** is the runtime representation. It's an `@Observable` `@MainActor` class that wraps a `VMConfiguration`, an optional `VZVirtualMachine`, and a `VMStatus`. It references the VM's bundle path and provides computed properties for disk image, aux storage, and save file locations via `VMBundleLayout`. A view-layer extension (`VMInstance+Display.swift`) provides display properties (`statusDisplayName`, `statusDisplayColor`, `statusToolTip`) that distinguish preparing VMs (shown as "Cloning…"/"Importing…" in orange with a spinner), cold-paused VMs (state saved to disk, shown as "Suspended" in orange), and live-paused VMs (in memory, shown as "Paused" in yellow). The `PreparingOperation` enum (`.cloning`, `.importing`) provides display labels, cancel labels, and alert titles for preparing states. The `PreparingState` struct bundles the operation and its cancellable task into a single optional (`preparingState`) — when non-nil the instance is preparing, and `isPreparing` is a computed convenience.
 
@@ -300,7 +300,7 @@ No external package dependencies. No Swift Package Manager, CocoaPods, or Cartha
 
 | Component | Tests | Notes |
 |-----------|-------|-------|
-| `VMConfiguration` | 43 tests + clone suite | Encoding/decoding, defaults, validation, all fields |
+| `VMConfiguration` | 47 tests + clone suite | Encoding/decoding, defaults, validation, all fields |
 | `VMLibraryViewModel` | 66 tests | Add/remove/rename VMs, selection, delegation to coordinator, sleep/wake, clone/import phantom rows, cancel preparing, force-stop confirmation, stop escalation timing |
 | `VMCreationViewModel` | 44 tests | All wizard steps, validation, OS-specific paths |
 | `VMLifecycleCoordinator` | Yes | Multi-step orchestration, error handling, service delegation, token-based operation serialization, stop/forceStop bypass, stale-token race condition coverage |

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -295,9 +295,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                 if let token = self.fullscreenObservers.removeValue(forKey: vmID) {
                     NotificationCenter.default.removeObserver(token)
                 }
-                if let controller = self.fullscreenWindows.removeValue(forKey: vmID),
-                   !controller.closedProgrammatically {
-                    instance.configuration.prefersFullscreen = false
+                if let controller = self.fullscreenWindows.removeValue(forKey: vmID) {
+                    // Always remember which display the VM was on
+                    if let displayID = controller.lastDisplayID {
+                        instance.configuration.lastFullscreenDisplayID = displayID
+                    }
+                    if !controller.closedProgrammatically {
+                        instance.configuration.prefersFullscreen = false
+                        Self.logger.debug("Cleared prefersFullscreen for '\(instance.name)' (user exited fullscreen)")
+                    }
                     self.viewModel.saveConfiguration(for: instance)
                 }
 
@@ -314,7 +320,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         }
         fullscreenObservers[vmID] = token
 
+        // Position on the remembered display so toggleFullScreen picks the correct screen
+        if let screen = targetScreen(for: instance),
+           let window = controller.window {
+            let frame = screen.frame
+            let centeredOrigin = NSPoint(
+                x: frame.midX - window.frame.width / 2,
+                y: frame.midY - window.frame.height / 2
+            )
+            window.setFrameOrigin(centeredOrigin)
+        }
+
         controller.showWindow(nil)
+    }
+
+    /// Returns the best screen for entering fullscreen, using a fallback chain:
+    /// 1. The display the VM was last fullscreen on (persisted in configuration)
+    /// 2. The library window's current display
+    /// 3. The primary display
+    private func targetScreen(for instance: VMInstance) -> NSScreen? {
+        if let savedID = instance.configuration.lastFullscreenDisplayID {
+            if let target = NSScreen.screens.first(where: { $0.displayID == savedID }) {
+                Self.logger.debug("targetScreen for '\(instance.name)': using saved display \(savedID)")
+                return target
+            }
+            Self.logger.debug("targetScreen for '\(instance.name)': saved display \(savedID) not found, falling back")
+        }
+        if let libraryScreen = mainWindowController?.window?.screen {
+            return libraryScreen
+        }
+        return NSScreen.screens.first
     }
 
     // MARK: - Menu Validation

--- a/Kernova/App/FullscreenWindowController.swift
+++ b/Kernova/App/FullscreenWindowController.swift
@@ -13,6 +13,7 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
 
     let vmID: UUID
     private(set) var closedProgrammatically = false
+    private(set) var lastDisplayID: CGDirectDisplayID?
     private let instance: VMInstance
     private var observingStatus = false
 
@@ -56,6 +57,10 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
     // MARK: - NSWindowDelegate
 
     func windowWillClose(_ notification: Notification) {
+        // Capture display ID if not already set by the programmatic-close path
+        if lastDisplayID == nil {
+            lastDisplayID = window?.screen?.displayID
+        }
         observingStatus = false
         instance.isInFullscreen = false
     }
@@ -78,6 +83,7 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
                 guard let self, self.observingStatus else { return }
                 let status = self.instance.status
                 if status == .stopped || status == .error || self.instance.isColdPaused {
+                    self.lastDisplayID = self.window?.screen?.displayID
                     self.closedProgrammatically = true
                     self.window?.close()
                 } else {
@@ -85,6 +91,14 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
                 }
             }
         }
+    }
+}
+
+// MARK: - NSScreen Display ID
+
+extension NSScreen {
+    var displayID: CGDirectDisplayID? {
+        deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
     }
 }
 

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -24,6 +24,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     var displayHeight: Int
     var displayPPI: Int
     var prefersFullscreen: Bool
+    var lastFullscreenDisplayID: UInt32?
 
     // MARK: - Network
 
@@ -81,6 +82,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         displayHeight: Int = 1200,
         displayPPI: Int = 144,
         prefersFullscreen: Bool = false,
+        lastFullscreenDisplayID: UInt32? = nil,
         networkEnabled: Bool = true,
         macAddress: String? = nil,
         hardwareModelData: Data? = nil,
@@ -106,6 +108,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         self.displayHeight = displayHeight
         self.displayPPI = displayPPI
         self.prefersFullscreen = prefersFullscreen
+        self.lastFullscreenDisplayID = lastFullscreenDisplayID
         self.networkEnabled = networkEnabled
         self.macAddress = macAddress
         self.hardwareModelData = hardwareModelData
@@ -126,7 +129,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case id, name, guestOS, bootMode
         case cpuCount, memorySizeInGB, diskSizeInGB
-        case displayWidth, displayHeight, displayPPI, prefersFullscreen
+        case displayWidth, displayHeight, displayPPI, prefersFullscreen, lastFullscreenDisplayID
         case networkEnabled, macAddress
         case hardwareModelData, machineIdentifierData
         case genericMachineIdentifierData
@@ -150,6 +153,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         displayHeight = try container.decode(Int.self, forKey: .displayHeight)
         displayPPI = try container.decode(Int.self, forKey: .displayPPI)
         prefersFullscreen = try container.decodeIfPresent(Bool.self, forKey: .prefersFullscreen) ?? false
+        lastFullscreenDisplayID = try container.decodeIfPresent(UInt32.self, forKey: .lastFullscreenDisplayID)
         networkEnabled = try container.decode(Bool.self, forKey: .networkEnabled)
         macAddress = try container.decodeIfPresent(String.self, forKey: .macAddress)
         hardwareModelData = try container.decodeIfPresent(Data.self, forKey: .hardwareModelData)
@@ -181,6 +185,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         clone.createdAt = Date()
         clone.name = Self.generateCloneName(baseName: name, existingNames: existingNames)
         clone.prefersFullscreen = false
+        clone.lastFullscreenDisplayID = nil
 
         // Regenerate shared directory IDs to avoid VirtioFS collisions
         clone.sharedDirectories = sharedDirectories?.map { dir in

--- a/KernovaTests/VMConfigurationCloneTests.swift
+++ b/KernovaTests/VMConfigurationCloneTests.swift
@@ -167,6 +167,14 @@ struct VMConfigurationCloneTests {
         #expect(clone.prefersFullscreen == false)
     }
 
+    @Test("Clone resets lastFullscreenDisplayID to nil")
+    func cloneResetsLastFullscreenDisplayID() {
+        var config = makeConfig()
+        config.lastFullscreenDisplayID = 4_280_803_137
+        let clone = config.clonedForNewInstance(existingNames: [])
+        #expect(clone.lastFullscreenDisplayID == nil)
+    }
+
     // MARK: - Shared Directories
 
     @Test("Clone regenerates shared directory IDs")

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -439,4 +439,63 @@ struct VMConfigurationTests {
         #expect(config.prefersFullscreen == false)
     }
 
+    // MARK: - lastFullscreenDisplayID Tests
+
+    @Test("Default lastFullscreenDisplayID is nil")
+    func defaultLastFullscreenDisplayID() {
+        let config = VMConfiguration(
+            name: "Test VM",
+            guestOS: .linux,
+            bootMode: .efi
+        )
+        #expect(config.lastFullscreenDisplayID == nil)
+    }
+
+    @Test("Configuration preserves lastFullscreenDisplayID")
+    func lastFullscreenDisplayIDRoundTrip() throws {
+        let config = VMConfiguration(
+            name: "Display VM",
+            guestOS: .linux,
+            bootMode: .efi,
+            lastFullscreenDisplayID: 4_280_803_137
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(config)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: data)
+
+        #expect(decoded.lastFullscreenDisplayID == 4_280_803_137)
+    }
+
+    @Test("Backward compatibility: decoding JSON without lastFullscreenDisplayID defaults to nil")
+    func backwardCompatibilityLastFullscreenDisplayID() throws {
+        let json = """
+        {
+            "id": "12345678-1234-1234-1234-123456789012",
+            "name": "Old VM",
+            "guestOS": "linux",
+            "bootMode": "efi",
+            "cpuCount": 4,
+            "memorySizeInGB": 8,
+            "diskSizeInGB": 64,
+            "displayWidth": 1920,
+            "displayHeight": 1200,
+            "displayPPI": 144,
+            "networkEnabled": true,
+            "createdAt": "2025-01-01T00:00:00Z",
+            "notes": ""
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let config = try decoder.decode(VMConfiguration.self, from: Data(json.utf8))
+
+        #expect(config.lastFullscreenDisplayID == nil)
+    }
+
 }


### PR DESCRIPTION
## Summary
- Persist which display a VM was fullscreen on so it reopens on the same monitor after suspend/resume, stop/start, or error/restart
- Display preference survives app restarts via `config.json` serialization
- Falls back gracefully: saved display → library window's display → primary

## Changes
- Add `lastFullscreenDisplayID: UInt32?` to `VMConfiguration` with backward-compatible decoding and clone reset
- Capture display ID in `FullscreenWindowController` on both programmatic close (VM stopped/saved/error) and user-initiated close (Esc/menu)
- Add `NSScreen.displayID` convenience extension
- Add `targetScreen(for:)` helper in `AppDelegate` with fallback chain
- Position fullscreen window on target screen before `toggleFullScreen`
- Add 4 tests: default nil, round-trip encoding, backward compat, clone reset
- Update ARCHITECTURE.md with new field description and test count

## Test plan
- [ ] Built successfully on macOS 26
- [ ] All existing tests pass
- [ ] VM fullscreen on secondary → save state → resume → reopens on secondary
- [ ] VM fullscreen on secondary → stop → start → reopens on secondary
- [ ] Quit/relaunch → start VM with prefersFullscreen → opens on remembered display
- [ ] Disconnect secondary → start → falls back to library window's display
- [ ] Clone VM with display preference → clone has no display preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)