### PR TITLE
feat: Add transition overlay for suspending/restoring VMs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,6 +56,7 @@ Kernova/
 │   │   ├── VMConsoleView.swift         # VM display container
 │   │   ├── VMDisplayView.swift         # NSViewRepresentable wrapping VZVirtualMachineView
 │   │   ├── VMPauseOverlay.swift         # Frosted overlay with play button for live-paused VMs
+│   │   ├── VMTransitionOverlay.swift    # Frosted overlay with spinner for saving/restoring states
 │   │   ├── SerialConsoleContentView.swift # Serial console content wrapper
 │   │   └── SerialTerminalView.swift    # Terminal text view for serial output
 │   └── Creation/
@@ -96,7 +97,7 @@ KernovaTests/
 └── DataFormattersTests.swift           # Formatting utility tests
 ```
 
-**Total: 49 source files, 20 test files (15 suites + 5 mocks).**
+**Total: 50 source files, 20 test files (15 suites + 5 mocks).**
 
 ## Component Map
 
@@ -168,7 +169,7 @@ All service implementations conform to protocols defined in `Services/Protocols/
 
 ### Views
 
-**Files:** 17 SwiftUI views across 4 subdirectories + root
+**Files:** 18 SwiftUI views across 4 subdirectories + root
 
 Views observe `VMLibraryViewModel` and individual `VMInstance`s via the Observation framework. The view hierarchy:
 
@@ -176,7 +177,7 @@ Views observe `VMLibraryViewModel` and individual `VMInstance`s via the Observat
 ContentView
 ├── SidebarView → VMRowView (per VM)
 └── VMDetailView
-    ├── VMConsoleView → VMDisplayView (NSViewRepresentable for VZVirtualMachineView) + VMPauseOverlay
+    ├── VMConsoleView → VMDisplayView (NSViewRepresentable for VZVirtualMachineView) + VMPauseOverlay + VMTransitionOverlay
     ├── VMSettingsView
     └── MacOSInstallProgressView
 VMCreationWizardView (modal)

--- a/Kernova/App/FullscreenWindowController.swift
+++ b/Kernova/App/FullscreenWindowController.swift
@@ -115,6 +115,7 @@ private struct FullscreenVMView: View {
             VMDisplayView(virtualMachine: vm)
                 .ignoresSafeArea()
                 .vmPauseOverlay(isPaused: instance.status == .paused, onResume: onResume)
+                .vmTransitionOverlay(status: instance.status)
         } else if instance.status.isTransitioning || instance.isColdPaused {
             VStack(spacing: 12) {
                 ProgressView()

--- a/Kernova/Views/Console/VMConsoleView.swift
+++ b/Kernova/Views/Console/VMConsoleView.swift
@@ -22,6 +22,7 @@ struct VMConsoleView: View {
                 VMDisplayView(virtualMachine: vm)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .vmPauseOverlay(isPaused: instance.status == .paused, onResume: onResume)
+                    .vmTransitionOverlay(status: instance.status)
             } else if instance.isColdPaused {
                 ContentUnavailableView(
                     "Suspended",

--- a/Kernova/Views/Console/VMTransitionOverlay.swift
+++ b/Kernova/Views/Console/VMTransitionOverlay.swift
@@ -9,7 +9,6 @@ struct VMTransitionOverlay: View {
         VStack(spacing: 12) {
             ProgressView()
                 .controlSize(.large)
-                .accessibilityLabel(label)
 
             Text(label)
                 .font(.title2)

--- a/Kernova/Views/Console/VMTransitionOverlay.swift
+++ b/Kernova/Views/Console/VMTransitionOverlay.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Translucent overlay shown during VM state transitions (suspending/restoring).
+/// Displays a spinner and status label over the frozen or incoming display.
+struct VMTransitionOverlay: View {
+    var label: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+                .controlSize(.large)
+                .accessibilityLabel(label)
+
+            Text(label)
+                .font(.title2)
+                .fontWeight(.medium)
+                .foregroundStyle(.white)
+                .shadow(radius: 4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.ultraThinMaterial)
+    }
+}
+
+extension View {
+    /// Adds a transition overlay with animated opacity when the VM is saving or restoring.
+    func vmTransitionOverlay(status: VMStatus) -> some View {
+        let label: String? = switch status {
+        case .saving: "Suspending…"
+        case .restoring: "Restoring…"
+        default: nil
+        }
+        return overlay {
+            if let label {
+                VMTransitionOverlay(label: label)
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: status)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds visual feedback during VM suspend and restore operations with a translucent overlay (spinner + status label) over the VM display
- Follows the same pattern as the existing `VMPauseOverlay` but shows "Suspending…" or "Restoring…" instead of the play button
- Applied in both the main console view and fullscreen window

## Changes
- Add `VMTransitionOverlay` view with `ProgressView` spinner and contextual label
- Add `.vmTransitionOverlay(status:)` view modifier mapping `.saving` → "Suspending…" and `.restoring` → "Restoring…"
- Apply modifier in `VMConsoleView` and `FullscreenVMView` after the pause overlay
- Update ARCHITECTURE.md directory listing, component tree, and file counts

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Suspend a VM while in fullscreen → see "Suspending…" overlay with spinner
- [ ] Resume a cold-paused VM while in fullscreen → see "Restoring…" overlay with spinner
- [ ] Pause a VM in fullscreen → still see existing pause overlay with play button
- [ ] After save completes, fullscreen window auto-closes (existing behavior preserved)
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)