### PR TITLE
fix: Route menu actions to the active window's VM

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -17,6 +17,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "AppDelegate")
 
+    /// Returns the VM that menu actions should target: the fullscreen VM if its window
+    /// is key, otherwise the sidebar-selected VM.
+    private var activeInstance: VMInstance? {
+        if let keyWindow = NSApp.keyWindow,
+           let controller = fullscreenWindows.values.first(where: { $0.window === keyWindow }) {
+            return controller.instance
+        }
+        return viewModel.selectedInstance
+    }
+
     // MARK: - Entry Point
 
     static func main() {
@@ -173,54 +183,54 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     // MARK: - VM Actions
 
     @objc func startVM(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance else { return }
+        guard let instance = activeInstance else { return }
         Task { await viewModel.start(instance) }
     }
 
     @objc func pauseVM(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance else { return }
+        guard let instance = activeInstance else { return }
         Task { await viewModel.pause(instance) }
     }
 
     @objc func resumeVM(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance else { return }
+        guard let instance = activeInstance else { return }
         Task { await viewModel.resume(instance) }
     }
 
     @objc func stopVM(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance else { return }
+        guard let instance = activeInstance else { return }
         viewModel.stop(instance)
     }
 
     @objc func forceStopVM(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance else { return }
+        guard let instance = activeInstance else { return }
         viewModel.confirmForceStop(instance)
     }
 
     @objc func saveVM(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance else { return }
+        guard let instance = activeInstance else { return }
         Task { await viewModel.save(instance) }
     }
 
     @objc func renameVM(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance else { return }
+        guard let instance = activeInstance else { return }
         viewModel.renameVM(instance)
     }
 
     @objc func cloneVM(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance else { return }
+        guard let instance = activeInstance else { return }
         viewModel.cloneVM(instance)
     }
 
     @objc func deleteVM(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance else { return }
+        guard let instance = activeInstance else { return }
         viewModel.confirmDelete(instance)
     }
 
     // MARK: - Serial Console
 
     @objc func showSerialConsole(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance,
+        guard let instance = activeInstance,
               instance.canShowSerialConsole else { return }
 
         if let existing = serialConsoleWindows[instance.instanceID] {
@@ -253,7 +263,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     // MARK: - Fullscreen Display
 
     @objc func toggleFullscreenDisplay(_ sender: Any?) {
-        guard let instance = viewModel.selectedInstance else { return }
+        guard let instance = activeInstance else { return }
 
         if let existing = fullscreenWindows[instance.instanceID] {
             existing.window?.close()
@@ -356,7 +366,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         // Preparing instances disable all VM menu bar actions (cancel is only available via sidebar context menu)
-        if let instance = viewModel.selectedInstance, instance.isPreparing {
+        if let instance = activeInstance, instance.isPreparing {
             switch menuItem.action {
             case #selector(showLibrary(_:)), #selector(newVM(_:)):
                 return true
@@ -367,31 +377,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
         switch menuItem.action {
         case #selector(startVM(_:)):
-            return viewModel.selectedInstance?.status.canStart ?? false
+            return activeInstance?.status.canStart ?? false
         case #selector(pauseVM(_:)):
-            return viewModel.selectedInstance?.status.canPause ?? false
+            return activeInstance?.status.canPause ?? false
         case #selector(resumeVM(_:)):
-            return viewModel.selectedInstance?.status.canResume ?? false
+            return activeInstance?.status.canResume ?? false
         case #selector(stopVM(_:)):
-            return viewModel.selectedInstance?.status.canStop ?? false
+            return activeInstance?.status.canStop ?? false
         case #selector(forceStopVM(_:)):
-            return viewModel.selectedInstance?.status.canForceStop ?? false
+            return activeInstance?.status.canForceStop ?? false
         case #selector(saveVM(_:)):
-            return viewModel.selectedInstance?.status.canSave ?? false
+            return activeInstance?.status.canSave ?? false
         case #selector(renameVM(_:)):
-            return viewModel.selectedInstance?.status.canEditSettings ?? false
+            return activeInstance?.status.canEditSettings ?? false
         case #selector(cloneVM(_:)):
-            guard let instance = viewModel.selectedInstance else { return false }
+            guard let instance = activeInstance else { return false }
             return instance.status.canEditSettings && !viewModel.hasPreparing
         case #selector(deleteVM(_:)):
-            return viewModel.selectedInstance?.status.canEditSettings ?? false
+            return activeInstance?.status.canEditSettings ?? false
         // AppKit bypasses NSMenuItemValidation for windowsMenu items, so
         // menuNeedsUpdate(_:) handles visual state. This case covers keyboard
         // shortcut validation, which still routes through validateMenuItem(_:).
         case #selector(showSerialConsole(_:)):
-            return viewModel.selectedInstance?.canShowSerialConsole ?? false
+            return activeInstance?.canShowSerialConsole ?? false
         case #selector(toggleFullscreenDisplay(_:)):
-            guard let instance = viewModel.selectedInstance else { return false }
+            guard let instance = activeInstance else { return false }
             // Only allow fullscreen when the VM has a live VZVirtualMachine
             let canFullscreen = (instance.status == .running || instance.status == .paused)
                 && instance.virtualMachine != nil
@@ -408,7 +418,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     func menuNeedsUpdate(_ menu: NSMenu) {
         if menu === NSApp.windowsMenu {
-            serialConsoleMenuItem.isEnabled = viewModel.selectedInstance?.canShowSerialConsole ?? false
+            serialConsoleMenuItem.isEnabled = activeInstance?.canShowSerialConsole ?? false
         }
     }
 

--- a/Kernova/App/FullscreenWindowController.swift
+++ b/Kernova/App/FullscreenWindowController.swift
@@ -14,7 +14,7 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
     let vmID: UUID
     private(set) var closedProgrammatically = false
     private(set) var lastDisplayID: CGDirectDisplayID?
-    private let instance: VMInstance
+    let instance: VMInstance
     private var observingStatus = false
 
     init(instance: VMInstance, onResume: @escaping () -> Void) {


### PR DESCRIPTION
## Summary
- Menu bar actions (Pause, Stop, Save State, etc.) now target the VM whose fullscreen window is key, instead of always targeting the sidebar selection
- Fixes incorrect routing when using the menu bar from a fullscreen VM's Space

## Changes
- Expose `instance` on `FullscreenWindowController` (was `private`)
- Add `activeInstance` computed property on `AppDelegate` that checks `NSApp.keyWindow` against fullscreen windows, falling back to sidebar selection
- Replace all `viewModel.selectedInstance` references in VM action methods, serial console, fullscreen toggle, and menu validation with `activeInstance`
- `MainWindowController` left unchanged (sidebar/toolbar are main-window-specific)

## Test plan
- [ ] Built successfully on macOS 26
- [ ] All 316 existing tests pass
- [ ] Start VM, enter fullscreen, verify menu actions target the fullscreen VM
- [ ] Swipe back to library Space, verify menu actions target sidebar selection
- [ ] Test Pause/Resume/Stop/Save State from fullscreen menu bar
- [ ] Verify Rename/Clone/Delete disabled in fullscreen (VM is running)
- [ ] Test "Exit Fullscreen Display" via menu from fullscreen Space

🤖 Generated with [Claude Code](https://claude.com/claude-code)