### PR TITLE
refactor: Align toolbar and context menu with menu bar actions

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -403,9 +403,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             return activeInstance?.canShowSerialConsole ?? false
         case #selector(toggleFullscreenDisplay(_:)):
             guard let instance = activeInstance else { return false }
-            // Only allow fullscreen when the VM has a live VZVirtualMachine
-            let canFullscreen = (instance.status == .running || instance.status == .paused)
-                && instance.virtualMachine != nil
+            let canFullscreen = instance.canFullscreen
             if canFullscreen, fullscreenWindows[instance.instanceID] != nil {
                 menuItem.title = "Exit Fullscreen Display"
             } else {

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -210,7 +210,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
                 // State already saved to disk — no Save State, offer Delete instead
                 return [Self.resumeVMIdentifier, Self.stopVMIdentifier, Self.deleteVMIdentifier]
             }
-            return [Self.resumeVMIdentifier, Self.stopVMIdentifier, Self.saveVMIdentifier]
+            return [Self.resumeVMIdentifier, Self.stopVMIdentifier, Self.saveVMIdentifier, Self.fullscreenVMIdentifier]
         case .error:
             return [Self.startVMIdentifier, Self.deleteVMIdentifier]
         case .starting, .saving, .restoring, .installing:

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -19,13 +19,12 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
     private static let resumeVMIdentifier = NSToolbarItem.Identifier("resumeVM")
     private static let stopVMIdentifier = NSToolbarItem.Identifier("stopVM")
     private static let saveVMIdentifier = NSToolbarItem.Identifier("saveVM")
-    private static let deleteVMIdentifier = NSToolbarItem.Identifier("deleteVM")
     private static let fullscreenVMIdentifier = NSToolbarItem.Identifier("fullscreenVM")
 
     /// All possible action identifiers, used for reference.
     private static let allActionIdentifiers: Set<NSToolbarItem.Identifier> = [
         startVMIdentifier, pauseVMIdentifier, resumeVMIdentifier,
-        stopVMIdentifier, saveVMIdentifier, deleteVMIdentifier,
+        stopVMIdentifier, saveVMIdentifier,
         fullscreenVMIdentifier,
     ]
 
@@ -202,17 +201,16 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
 
         switch instance.status {
         case .stopped:
-            return [Self.startVMIdentifier, Self.deleteVMIdentifier]
+            return [Self.startVMIdentifier]
         case .running:
             return [Self.pauseVMIdentifier, Self.stopVMIdentifier, Self.saveVMIdentifier, Self.fullscreenVMIdentifier]
         case .paused:
             if instance.isColdPaused {
-                // State already saved to disk — no Save State, offer Delete instead
-                return [Self.resumeVMIdentifier, Self.stopVMIdentifier, Self.deleteVMIdentifier]
+                return [Self.resumeVMIdentifier, Self.stopVMIdentifier]
             }
             return [Self.resumeVMIdentifier, Self.stopVMIdentifier, Self.saveVMIdentifier, Self.fullscreenVMIdentifier]
         case .error:
-            return [Self.startVMIdentifier, Self.deleteVMIdentifier]
+            return [Self.startVMIdentifier]
         case .starting, .saving, .restoring, .installing:
             return []
         }
@@ -242,7 +240,6 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
             Self.resumeVMIdentifier,
             Self.stopVMIdentifier,
             Self.saveVMIdentifier,
-            Self.deleteVMIdentifier,
             Self.fullscreenVMIdentifier,
         ]
     }
@@ -305,10 +302,6 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
             return ActionButtonSpec(
                 symbolName: "square.and.arrow.down", toolTip: "Save the virtual machine state to disk",
                 accessibilityLabel: "Save State", action: #selector(AppDelegate.saveVM(_:)))
-        case Self.deleteVMIdentifier:
-            return ActionButtonSpec(
-                symbolName: "trash", toolTip: "Move this virtual machine to the Trash",
-                accessibilityLabel: "Move to Trash", action: #selector(AppDelegate.deleteVM(_:)))
         case Self.fullscreenVMIdentifier:
             return ActionButtonSpec(
                 symbolName: "arrow.up.left.and.arrow.down.right", toolTip: "Enter fullscreen display",

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -203,12 +203,20 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSGestu
         case .stopped:
             return [Self.startVMIdentifier]
         case .running:
-            return [Self.pauseVMIdentifier, Self.stopVMIdentifier, Self.saveVMIdentifier, Self.fullscreenVMIdentifier]
+            return [Self.pauseVMIdentifier, Self.stopVMIdentifier,
+                    .space,
+                    Self.saveVMIdentifier,
+                    .space,
+                    Self.fullscreenVMIdentifier]
         case .paused:
             if instance.isColdPaused {
                 return [Self.resumeVMIdentifier, Self.stopVMIdentifier]
             }
-            return [Self.resumeVMIdentifier, Self.stopVMIdentifier, Self.saveVMIdentifier, Self.fullscreenVMIdentifier]
+            return [Self.resumeVMIdentifier, Self.stopVMIdentifier,
+                    .space,
+                    Self.saveVMIdentifier,
+                    .space,
+                    Self.fullscreenVMIdentifier]
         case .error:
             return [Self.startVMIdentifier]
         case .starting, .saving, .restoring, .installing:

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -125,6 +125,11 @@ final class VMInstance: Identifiable {
         status == .paused && virtualMachine == nil
     }
 
+    /// `true` when the VM is eligible to enter fullscreen display (active status + live VM).
+    var canFullscreen: Bool {
+        (status == .running || status == .paused) && virtualMachine != nil
+    }
+
     /// `true` when the VM is eligible to show a serial console window (active status + live VM).
     var canShowSerialConsole: Bool {
         (status == .running || status == .paused) && virtualMachine != nil

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -88,7 +88,7 @@ struct SidebarView: View {
             }
 
             // Display
-            if (instance.status == .running || instance.status == .paused) && instance.virtualMachine != nil {
+            if instance.status.canStop && instance.virtualMachine != nil {
                 Divider()
                 Button("Fullscreen Display") {
                     NSApp.sendAction(#selector(AppDelegate.toggleFullscreenDisplay(_:)), to: nil, from: nil)

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -88,7 +88,7 @@ struct SidebarView: View {
             }
 
             // Display
-            if instance.status.canStop && instance.virtualMachine != nil {
+            if instance.canFullscreen {
                 Divider()
                 Button("Fullscreen Display") {
                     NSApp.sendAction(#selector(AppDelegate.toggleFullscreenDisplay(_:)), to: nil, from: nil)

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -52,6 +52,7 @@ struct SidebarView: View {
                 NSWorkspace.shared.activateFileViewerSelecting([instance.bundleURL])
             }
         } else {
+            // Lifecycle
             if instance.status.canStart {
                 Button("Start") {
                     Task { await viewModel.start(instance) }
@@ -72,9 +73,31 @@ struct SidebarView: View {
                     viewModel.stop(instance)
                 }
             }
+            if instance.status.canForceStop && !instance.status.canStop {
+                Button("Force Stop") {
+                    viewModel.confirmForceStop(instance)
+                }
+            }
+
+            // State
+            if instance.status.canSave && !instance.isColdPaused {
+                Divider()
+                Button("Save State") {
+                    Task { await viewModel.save(instance) }
+                }
+            }
+
+            // Display
+            if (instance.status == .running || instance.status == .paused) && instance.virtualMachine != nil {
+                Divider()
+                Button("Fullscreen Display") {
+                    NSApp.sendAction(#selector(AppDelegate.toggleFullscreenDisplay(_:)), to: nil, from: nil)
+                }
+            }
 
             Divider()
 
+            // Management
             Button("Rename") {
                 viewModel.renameVM(instance)
             }
@@ -89,10 +112,13 @@ struct SidebarView: View {
                 NSWorkspace.shared.activateFileViewerSelecting([instance.bundleURL])
             }
 
+            Divider()
+
+            // Destructive
             Button("Move to Trash", role: .destructive) {
                 viewModel.confirmDelete(instance)
             }
-            .disabled(instance.status != .stopped)
+            .disabled(!instance.status.canEditSettings)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove the trash/delete button from the toolbar — destructive actions belong in the context menu, not the toolbar
- Align the sidebar context menu with the menu bar's action set: add Force Stop, Save State, and Fullscreen Display items with proper divider grouping
- Add space separators between logical toolbar button groups (lifecycle / state / display) to visually match the menu bar's divider structure

## Changes
- Remove `deleteVMIdentifier` and its toolbar button spec from `MainWindowController`
- Add `.space` separators in `desiredActionIdentifiers` between lifecycle, state, and display groups for running and live-paused states
- Expand `SidebarView` context menu with Force Stop, Save State, Fullscreen Display, and proper section dividers
- Update Move to Trash availability to use `canEditSettings` instead of checking for `.stopped` only

## Test plan
- [ ] Built successfully on macOS 26
- [ ] All existing tests pass
- [ ] Running VM toolbar: Pause + Stop | space | Save State | space | Fullscreen
- [ ] Live-paused VM toolbar: Resume + Stop | space | Save State | space | Fullscreen
- [ ] Cold-paused VM toolbar: Resume + Stop (no extra spacing)
- [ ] Stopped/Error VM toolbar: Start (no trash button)
- [ ] Context menu shows all actions with proper divider grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)