### PR TITLE
fix: Remember last-selected VM across launches

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -8,7 +8,7 @@ import os
 final class VMLibraryViewModel {
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VMLibraryViewModel")
-    static let lastSelectedVMIDKey = "lastSelectedVMID"
+    private static let lastSelectedVMIDKey = "lastSelectedVMID"
 
     // MARK: - Services
 

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -8,7 +8,7 @@ import os
 final class VMLibraryViewModel {
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VMLibraryViewModel")
-    private static let lastSelectedVMIDKey = "lastSelectedVMID"
+    static let lastSelectedVMIDKey = "lastSelectedVMID"
 
     // MARK: - Services
 
@@ -21,6 +21,7 @@ final class VMLibraryViewModel {
     var instances: [VMInstance] = []
     var selectedID: UUID? {
         didSet {
+            guard selectedID != oldValue else { return }
             if let selectedID {
                 UserDefaults.standard.set(selectedID.uuidString, forKey: Self.lastSelectedVMIDKey)
             } else {

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -8,6 +8,7 @@ import os
 final class VMLibraryViewModel {
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VMLibraryViewModel")
+    private static let lastSelectedVMIDKey = "lastSelectedVMID"
 
     // MARK: - Services
 
@@ -18,7 +19,15 @@ final class VMLibraryViewModel {
     // MARK: - State
 
     var instances: [VMInstance] = []
-    var selectedID: UUID?
+    var selectedID: UUID? {
+        didSet {
+            if let selectedID {
+                UserDefaults.standard.set(selectedID.uuidString, forKey: Self.lastSelectedVMIDKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Self.lastSelectedVMIDKey)
+            }
+        }
+    }
     var showCreationWizard = false
     var showDeleteConfirmation = false
     var showError = false
@@ -98,7 +107,14 @@ final class VMLibraryViewModel {
             .sorted { $0.configuration.createdAt < $1.configuration.createdAt }
 
             if selectedID == nil || !instances.contains(where: { $0.id == selectedID }) {
-                selectedID = instances.first?.id
+                if let savedString = UserDefaults.standard.string(forKey: Self.lastSelectedVMIDKey),
+                   let savedID = UUID(uuidString: savedString),
+                   instances.contains(where: { $0.id == savedID }) {
+                    selectedID = savedID
+                    Self.logger.debug("Restored last-selected VM from UserDefaults: \(savedID.uuidString)")
+                } else {
+                    selectedID = instances.first?.id
+                }
             }
             Self.logger.notice("Loaded \(self.instances.count) VMs")
         } catch {

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -8,7 +8,7 @@ import os
 final class VMLibraryViewModel {
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VMLibraryViewModel")
-    private static let lastSelectedVMIDKey = "lastSelectedVMID"
+    static let lastSelectedVMIDKey = "lastSelectedVMID"
 
     // MARK: - Services
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2,7 +2,7 @@ import Testing
 import Foundation
 @testable import Kernova
 
-@Suite("VMLibraryViewModel Tests")
+@Suite("VMLibraryViewModel Tests", .serialized)
 @MainActor
 struct VMLibraryViewModelTests {
 
@@ -11,7 +11,7 @@ struct VMLibraryViewModelTests {
         diskImageService: MockDiskImageService = MockDiskImageService(),
         virtualizationService: MockVirtualizationService = MockVirtualizationService()
     ) -> (VMLibraryViewModel, MockVMStorageService, MockDiskImageService, MockVirtualizationService) {
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        UserDefaults.standard.removeObject(forKey: "lastSelectedVMID")
         let vm = VMLibraryViewModel(
             storageService: storageService,
             diskImageService: diskImageService,
@@ -95,7 +95,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.selectedID = instance.id
 
-        let stored = UserDefaults.standard.string(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        let stored = UserDefaults.standard.string(forKey: "lastSelectedVMID")
         #expect(stored == instance.id.uuidString)
     }
 
@@ -108,7 +108,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.selectedID = nil
 
-        let stored = UserDefaults.standard.string(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        let stored = UserDefaults.standard.string(forKey: "lastSelectedVMID")
         #expect(stored == nil)
     }
 
@@ -125,8 +125,8 @@ struct VMLibraryViewModelTests {
         storage.bundles[url2] = config2
 
         // Clear then seed UserDefaults before ViewModel init triggers loadVMs()
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
-        UserDefaults.standard.set(config2.id.uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        UserDefaults.standard.removeObject(forKey: "lastSelectedVMID")
+        UserDefaults.standard.set(config2.id.uuidString, forKey: "lastSelectedVMID")
 
         let viewModel = VMLibraryViewModel(
             storageService: storage,
@@ -148,8 +148,8 @@ struct VMLibraryViewModelTests {
         storage.bundles[url] = config
 
         // Clear then seed UserDefaults with a UUID that doesn't match any VM
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
-        UserDefaults.standard.set(UUID().uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        UserDefaults.standard.removeObject(forKey: "lastSelectedVMID")
+        UserDefaults.standard.set(UUID().uuidString, forKey: "lastSelectedVMID")
 
         let viewModel = VMLibraryViewModel(
             storageService: storage,

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -6,14 +6,12 @@ import Foundation
 @MainActor
 struct VMLibraryViewModelTests {
 
-    private static let lastSelectedVMIDKey = "lastSelectedVMID"
-
     private func makeViewModel(
         storageService: MockVMStorageService = MockVMStorageService(),
         diskImageService: MockDiskImageService = MockDiskImageService(),
         virtualizationService: MockVirtualizationService = MockVirtualizationService()
     ) -> (VMLibraryViewModel, MockVMStorageService, MockDiskImageService, MockVirtualizationService) {
-        UserDefaults.standard.removeObject(forKey: Self.lastSelectedVMIDKey)
+        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
         let vm = VMLibraryViewModel(
             storageService: storageService,
             diskImageService: diskImageService,
@@ -97,7 +95,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.selectedID = instance.id
 
-        let stored = UserDefaults.standard.string(forKey: Self.lastSelectedVMIDKey)
+        let stored = UserDefaults.standard.string(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
         #expect(stored == instance.id.uuidString)
     }
 
@@ -110,7 +108,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.selectedID = nil
 
-        let stored = UserDefaults.standard.string(forKey: Self.lastSelectedVMIDKey)
+        let stored = UserDefaults.standard.string(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
         #expect(stored == nil)
     }
 
@@ -127,8 +125,8 @@ struct VMLibraryViewModelTests {
         storage.bundles[url2] = config2
 
         // Clear then seed UserDefaults before ViewModel init triggers loadVMs()
-        UserDefaults.standard.removeObject(forKey: Self.lastSelectedVMIDKey)
-        UserDefaults.standard.set(config2.id.uuidString, forKey: Self.lastSelectedVMIDKey)
+        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        UserDefaults.standard.set(config2.id.uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
 
         let viewModel = VMLibraryViewModel(
             storageService: storage,
@@ -150,8 +148,8 @@ struct VMLibraryViewModelTests {
         storage.bundles[url] = config
 
         // Clear then seed UserDefaults with a UUID that doesn't match any VM
-        UserDefaults.standard.removeObject(forKey: Self.lastSelectedVMIDKey)
-        UserDefaults.standard.set(UUID().uuidString, forKey: Self.lastSelectedVMIDKey)
+        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        UserDefaults.standard.set(UUID().uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
 
         let viewModel = VMLibraryViewModel(
             storageService: storage,

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -11,7 +11,7 @@ struct VMLibraryViewModelTests {
         diskImageService: MockDiskImageService = MockDiskImageService(),
         virtualizationService: MockVirtualizationService = MockVirtualizationService()
     ) -> (VMLibraryViewModel, MockVMStorageService, MockDiskImageService, MockVirtualizationService) {
-        UserDefaults.standard.removeObject(forKey: "lastSelectedVMID")
+        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
         let vm = VMLibraryViewModel(
             storageService: storageService,
             diskImageService: diskImageService,
@@ -95,7 +95,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.selectedID = instance.id
 
-        let stored = UserDefaults.standard.string(forKey: "lastSelectedVMID")
+        let stored = UserDefaults.standard.string(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
         #expect(stored == instance.id.uuidString)
     }
 
@@ -108,7 +108,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.selectedID = nil
 
-        let stored = UserDefaults.standard.string(forKey: "lastSelectedVMID")
+        let stored = UserDefaults.standard.string(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
         #expect(stored == nil)
     }
 
@@ -125,8 +125,8 @@ struct VMLibraryViewModelTests {
         storage.bundles[url2] = config2
 
         // Clear then seed UserDefaults before ViewModel init triggers loadVMs()
-        UserDefaults.standard.removeObject(forKey: "lastSelectedVMID")
-        UserDefaults.standard.set(config2.id.uuidString, forKey: "lastSelectedVMID")
+        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        UserDefaults.standard.set(config2.id.uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
 
         let viewModel = VMLibraryViewModel(
             storageService: storage,
@@ -148,8 +148,8 @@ struct VMLibraryViewModelTests {
         storage.bundles[url] = config
 
         // Clear then seed UserDefaults with a UUID that doesn't match any VM
-        UserDefaults.standard.removeObject(forKey: "lastSelectedVMID")
-        UserDefaults.standard.set(UUID().uuidString, forKey: "lastSelectedVMID")
+        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        UserDefaults.standard.set(UUID().uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
 
         let viewModel = VMLibraryViewModel(
             storageService: storage,

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -6,11 +6,14 @@ import Foundation
 @MainActor
 struct VMLibraryViewModelTests {
 
+    private static let lastSelectedVMIDKey = "lastSelectedVMID"
+
     private func makeViewModel(
         storageService: MockVMStorageService = MockVMStorageService(),
         diskImageService: MockDiskImageService = MockDiskImageService(),
         virtualizationService: MockVirtualizationService = MockVirtualizationService()
     ) -> (VMLibraryViewModel, MockVMStorageService, MockDiskImageService, MockVirtualizationService) {
+        UserDefaults.standard.removeObject(forKey: Self.lastSelectedVMIDKey)
         let vm = VMLibraryViewModel(
             storageService: storageService,
             diskImageService: diskImageService,
@@ -82,6 +85,83 @@ struct VMLibraryViewModelTests {
         viewModel.loadVMs()
 
         #expect(viewModel.selectedID == secondID)
+    }
+
+    // MARK: - Selection Persistence
+
+    @Test("selectedID persists to UserDefaults on change")
+    func selectedIDPersistsToUserDefaults() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        viewModel.instances.append(instance)
+
+        viewModel.selectedID = instance.id
+
+        let stored = UserDefaults.standard.string(forKey: Self.lastSelectedVMIDKey)
+        #expect(stored == instance.id.uuidString)
+    }
+
+    @Test("selectedID clears UserDefaults when set to nil")
+    func selectedIDClearsUserDefaults() {
+        let (viewModel, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        viewModel.instances.append(instance)
+        viewModel.selectedID = instance.id
+
+        viewModel.selectedID = nil
+
+        let stored = UserDefaults.standard.string(forKey: Self.lastSelectedVMIDKey)
+        #expect(stored == nil)
+    }
+
+    @Test("loadVMs restores selection from UserDefaults when VM still exists")
+    func loadVMsRestoresFromUserDefaults() {
+        let storage = MockVMStorageService()
+        let config1 = VMConfiguration(name: "First VM", guestOS: .linux, bootMode: .efi)
+        let config2 = VMConfiguration(name: "Second VM", guestOS: .linux, bootMode: .efi)
+        let url1 = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config1.id.uuidString).kernova", isDirectory: true)
+        let url2 = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config2.id.uuidString).kernova", isDirectory: true)
+        storage.bundles[url1] = config1
+        storage.bundles[url2] = config2
+
+        // Clear then seed UserDefaults before ViewModel init triggers loadVMs()
+        UserDefaults.standard.removeObject(forKey: Self.lastSelectedVMIDKey)
+        UserDefaults.standard.set(config2.id.uuidString, forKey: Self.lastSelectedVMIDKey)
+
+        let viewModel = VMLibraryViewModel(
+            storageService: storage,
+            diskImageService: MockDiskImageService(),
+            virtualizationService: MockVirtualizationService(),
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService()
+        )
+
+        #expect(viewModel.selectedID == config2.id)
+    }
+
+    @Test("loadVMs falls back to first VM when stored ID is invalid")
+    func loadVMsFallsBackWhenStoredIDInvalid() {
+        let storage = MockVMStorageService()
+        let config = VMConfiguration(name: "Only VM", guestOS: .linux, bootMode: .efi)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+        storage.bundles[url] = config
+
+        // Clear then seed UserDefaults with a UUID that doesn't match any VM
+        UserDefaults.standard.removeObject(forKey: Self.lastSelectedVMIDKey)
+        UserDefaults.standard.set(UUID().uuidString, forKey: Self.lastSelectedVMIDKey)
+
+        let viewModel = VMLibraryViewModel(
+            storageService: storage,
+            diskImageService: MockDiskImageService(),
+            virtualizationService: MockVirtualizationService(),
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService()
+        )
+
+        #expect(viewModel.selectedID == config.id)
     }
 
     // MARK: - Delete


### PR DESCRIPTION
## Summary
- Persist the selected VM's UUID to `UserDefaults` so it is restored on relaunch
- Lightweight UI state — `UserDefaults` is the right fit, not VM configuration data

## Changes
- Add `lastSelectedVMIDKey` constant and `didSet` on `selectedID` to persist/clear the UUID
- Update `loadVMs()` to restore selection from `UserDefaults` before falling back to first VM
- Add debug log when restoring persisted selection
- Add 4 tests for selection persistence (persist, clear, restore, fallback on invalid ID)
- Clean `UserDefaults` in test factory to ensure test isolation

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Launch app → first VM selected (no prior state)
- [ ] Select a different VM, quit, relaunch → that VM is restored
- [ ] Delete the last-selected VM, relaunch → falls back to first VM
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)