### PR TITLE
refactor: Remove `notes` field from VMConfiguration

### DIFF
--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -66,7 +66,6 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     // MARK: - Metadata
 
     var createdAt: Date
-    var notes: String
 
     // MARK: - Initializer
 
@@ -94,8 +93,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         initrdPath: String? = nil,
         kernelCommandLine: String? = nil,
         sharedDirectories: [SharedDirectory]? = nil,
-        createdAt: Date = Date(),
-        notes: String = ""
+        createdAt: Date = Date()
     ) {
         self.id = id
         self.name = name
@@ -121,7 +119,6 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         self.kernelCommandLine = kernelCommandLine
         self.sharedDirectories = sharedDirectories
         self.createdAt = createdAt
-        self.notes = notes
     }
 
     // MARK: - Codable
@@ -136,7 +133,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         case isoPath, bootFromDiscImage
         case kernelPath, initrdPath, kernelCommandLine
         case sharedDirectories
-        case createdAt, notes
+        case createdAt
     }
 
     init(from decoder: Decoder) throws {
@@ -166,7 +163,6 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         kernelCommandLine = try container.decodeIfPresent(String.self, forKey: .kernelCommandLine)
         sharedDirectories = try container.decodeIfPresent([SharedDirectory].self, forKey: .sharedDirectories)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
-        notes = try container.decode(String.self, forKey: .notes)
     }
 
     // MARK: - Cloning

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -22,7 +22,6 @@ struct VMSettingsView: View {
                 resourcesSection
                 networkSection
                 sharedDirectoriesSection
-                notesSection
             }
             .formStyle(.grouped)
             .padding()
@@ -246,11 +245,4 @@ struct VMSettingsView: View {
         sharedDirectoriesBinding.wrappedValue = current
     }
 
-    @ViewBuilder
-    private var notesSection: some View {
-        Section("Notes") {
-            TextEditor(text: $instance.configuration.notes)
-                .frame(minHeight: 60)
-        }
-    }
 }

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -244,5 +244,4 @@ struct VMSettingsView: View {
 
         sharedDirectoriesBinding.wrappedValue = current
     }
-
 }

--- a/KernovaTests/VMConfigurationCloneTests.swift
+++ b/KernovaTests/VMConfigurationCloneTests.swift
@@ -10,7 +10,6 @@ struct VMConfigurationCloneTests {
         guestOS: VMGuestOS = .linux,
         bootMode: VMBootMode = .efi,
         prefersFullscreen: Bool = true,
-        notes: String = "Some notes",
         sharedDirectories: [SharedDirectory]? = nil,
         hardwareModelData: Data? = nil
     ) -> VMConfiguration {
@@ -20,8 +19,7 @@ struct VMConfigurationCloneTests {
             bootMode: bootMode,
             prefersFullscreen: prefersFullscreen,
             hardwareModelData: hardwareModelData,
-            sharedDirectories: sharedDirectories,
-            notes: notes
+            sharedDirectories: sharedDirectories
         )
     }
 
@@ -144,12 +142,6 @@ struct VMConfigurationCloneTests {
 
         #expect(clone.guestOS == .linux)
         #expect(clone.bootMode == .linuxKernel)
-    }
-
-    @Test("Clone preserves notes")
-    func clonePreservesNotes() {
-        let clone = makeConfig(notes: "Important notes").clonedForNewInstance(existingNames: [])
-        #expect(clone.notes == "Important notes")
     }
 
     @Test("Clone preserves macOS hardware model data")

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -293,6 +293,34 @@ struct VMConfigurationTests {
         #expect(config.sharedDirectories == nil)
     }
 
+    @Test("Backward compatibility: decoding JSON with removed notes field is silently ignored")
+    func backwardCompatibilityRemovedNotesField() throws {
+        let json = """
+        {
+            "id": "12345678-1234-1234-1234-123456789012",
+            "name": "Old VM With Notes",
+            "guestOS": "linux",
+            "bootMode": "efi",
+            "cpuCount": 4,
+            "memorySizeInGB": 8,
+            "diskSizeInGB": 64,
+            "displayWidth": 1920,
+            "displayHeight": 1200,
+            "displayPPI": 144,
+            "networkEnabled": true,
+            "createdAt": "2025-01-01T00:00:00Z",
+            "notes": "These are old notes that should be ignored"
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let config = try decoder.decode(VMConfiguration.self, from: Data(json.utf8))
+
+        #expect(config.name == "Old VM With Notes")
+        #expect(config.guestOS == .linux)
+    }
+
     @Test("VMConfiguration with nil shared directories omits field from JSON")
     func nilSharedDirectoriesOmittedFromJSON() throws {
         let config = VMConfiguration(

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -48,8 +48,7 @@ struct VMConfigurationTests {
             bootMode: .macOS,
             cpuCount: 8,
             memorySizeInGB: 16,
-            diskSizeInGB: 200,
-            notes: "Test notes"
+            diskSizeInGB: 200
         )
 
         let encoder = JSONEncoder()
@@ -67,7 +66,6 @@ struct VMConfigurationTests {
         #expect(decoded.cpuCount == original.cpuCount)
         #expect(decoded.memorySizeInGB == original.memorySizeInGB)
         #expect(decoded.diskSizeInGB == original.diskSizeInGB)
-        #expect(decoded.notes == original.notes)
         #expect(decoded.networkEnabled == original.networkEnabled)
     }
 
@@ -158,8 +156,7 @@ struct VMConfigurationTests {
             "displayHeight": 1200,
             "displayPPI": 144,
             "networkEnabled": true,
-            "createdAt": "2025-01-01T00:00:00Z",
-            "notes": ""
+            "createdAt": "2025-01-01T00:00:00Z"
         }
         """
 
@@ -258,8 +255,7 @@ struct VMConfigurationTests {
             "displayHeight": 1200,
             "displayPPI": 144,
             "networkEnabled": true,
-            "createdAt": "2025-01-01T00:00:00Z",
-            "notes": ""
+            "createdAt": "2025-01-01T00:00:00Z"
         }
         """
 
@@ -286,8 +282,7 @@ struct VMConfigurationTests {
             "displayHeight": 1200,
             "displayPPI": 144,
             "networkEnabled": true,
-            "createdAt": "2025-01-01T00:00:00Z",
-            "notes": ""
+            "createdAt": "2025-01-01T00:00:00Z"
         }
         """
 
@@ -356,8 +351,7 @@ struct VMConfigurationTests {
             "displayPPI": 144,
             "networkEnabled": true,
             "isoPath": "/path/to/old.iso",
-            "createdAt": "2025-01-01T00:00:00Z",
-            "notes": ""
+            "createdAt": "2025-01-01T00:00:00Z"
         }
         """
 
@@ -427,8 +421,7 @@ struct VMConfigurationTests {
             "displayHeight": 1200,
             "displayPPI": 144,
             "networkEnabled": true,
-            "createdAt": "2025-01-01T00:00:00Z",
-            "notes": ""
+            "createdAt": "2025-01-01T00:00:00Z"
         }
         """
 
@@ -486,8 +479,7 @@ struct VMConfigurationTests {
             "displayHeight": 1200,
             "displayPPI": 144,
             "networkEnabled": true,
-            "createdAt": "2025-01-01T00:00:00Z",
-            "notes": ""
+            "createdAt": "2025-01-01T00:00:00Z"
         }
         """
 

--- a/KernovaTests/VMStorageServiceTests.swift
+++ b/KernovaTests/VMStorageServiceTests.swift
@@ -34,8 +34,7 @@ struct VMStorageServiceTests {
             guestOS: .macOS,
             bootMode: .macOS,
             cpuCount: 6,
-            memorySizeInGB: 12,
-            notes: "Test notes"
+            memorySizeInGB: 12
         )
 
         let bundleURL = try service.createVMBundle(for: config)
@@ -46,7 +45,6 @@ struct VMStorageServiceTests {
         #expect(loaded.name == config.name)
         #expect(loaded.cpuCount == 6)
         #expect(loaded.memorySizeInGB == 12)
-        #expect(loaded.notes == "Test notes")
     }
 
     @Test("Save updated configuration")

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ A macOS GUI application for creating and managing virtual machines using Apple's
 ### Management
 
 - **VM renaming** — Inline rename or via menu
-- **VM notes** — Per-VM notes field for metadata and descriptions
 - **Sleep integration** — Auto-pauses running VMs on system sleep, resumes on wake
 - **Directory watching** — Monitors the VMs directory for external filesystem changes
 - **Config migration** — Automatic schema migration for configuration compatibility


### PR DESCRIPTION
## Summary
- Remove the unused `notes` property from `VMConfiguration` and its corresponding UI in `VMSettingsView`
- Existing VM bundles with `"notes"` in their `config.json` will decode fine — unknown keys are silently skipped

## Test plan
- [x] Built successfully on macOS 26
- [x] All 318 tests pass
- [x] Verified backward compatibility — existing JSON with `"notes"` key decodes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)