### PR TITLE
feat: Move New VM button to sidebar

### DIFF
--- a/Kernova/Views/ContentView.swift
+++ b/Kernova/Views/ContentView.swift
@@ -3,10 +3,11 @@ import SwiftUI
 /// Root view wrapping `NavigationSplitView` with sidebar and detail columns.
 struct ContentView: View {
     @Bindable var viewModel: VMLibraryViewModel
+    @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
 
     var body: some View {
-        NavigationSplitView {
-            SidebarView(viewModel: viewModel)
+        NavigationSplitView(columnVisibility: $columnVisibility) {
+            SidebarView(viewModel: viewModel, isSidebarVisible: columnVisibility != .detailOnly)
                 .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 350)
         } detail: {
             if let selected = viewModel.selectedInstance {
@@ -24,15 +25,6 @@ struct ContentView: View {
             }
         }
         .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    viewModel.showCreationWizard = true
-                } label: {
-                    Label("New VM", systemImage: "plus")
-                }
-                .help("Create a new virtual machine")
-            }
-
             ToolbarItemGroup(placement: .principal) {
                 if let instance = viewModel.selectedInstance, !instance.isPreparing {
                     actionButtons(for: instance)

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -41,7 +41,7 @@ struct SidebarView: View {
         }
         .toolbar {
             if isSidebarVisible {
-                ToolbarItem(placement: .automatic) {
+                ToolbarItem(placement: .primaryAction) {
                     Button {
                         viewModel.showCreationWizard = true
                     } label: {

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 /// Sidebar listing all virtual machines with status indicators.
 struct SidebarView: View {
     @Bindable var viewModel: VMLibraryViewModel
+    var isSidebarVisible: Bool = true
 
     var body: some View {
         List(selection: $viewModel.selectedID) {
@@ -36,6 +37,18 @@ struct SidebarView: View {
                 Task { await viewModel.start(instance) }
             } else if instance.status.canResume {
                 Task { await viewModel.resume(instance) }
+            }
+        }
+        .toolbar {
+            if isSidebarVisible {
+                ToolbarItem(placement: .automatic) {
+                    Button {
+                        viewModel.showCreationWizard = true
+                    } label: {
+                        Label("New VM", systemImage: "plus")
+                    }
+                    .help("Create a new virtual machine")
+                }
             }
         }
         .listStyle(.sidebar)


### PR DESCRIPTION
## Summary
- Move the "New VM" button from the main toolbar into the sidebar toolbar, matching Apple's convention for sidebar-scoped actions (Finder, Mail, Notes)
- Button automatically hides when the sidebar is collapsed via `NavigationSplitViewVisibility` tracking

## Changes
- Add `@State columnVisibility` to `ContentView` and pass derived `isSidebarVisible` Bool to `SidebarView`
- Move "New VM" `ToolbarItem` from `ContentView` to `SidebarView` with `.primaryAction` placement
- Conditionally show the toolbar item based on sidebar visibility

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Button appears in sidebar toolbar area with correct "+" icon
- [ ] Button opens the VM creation wizard
- [ ] Button hides when sidebar is collapsed
- [ ] Button reappears when sidebar is expanded
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)