### PR TITLE
feat: Add toolbar dividers between button groups

### DIFF
--- a/Kernova/Views/ContentView.swift
+++ b/Kernova/Views/ContentView.swift
@@ -51,22 +51,32 @@ struct ContentView: View {
     private func actionButtons(for instance: VMInstance) -> some View {
         switch instance.status {
         case .stopped, .error:
-            startButton
+            ControlGroup {
+                startButton
+            }
         case .running:
-            pauseButton
-            stopMenu(for: instance)
-            Divider()
-            saveStateButton
-            Divider()
-            fullscreenButton
-        case .paused:
-            resumeButton
-            stopMenu(for: instance)
-            if !instance.isColdPaused {
-                Divider()
+            ControlGroup {
+                pauseButton
+                stopMenu(for: instance)
+            }
+            ControlGroup {
                 saveStateButton
-                Divider()
+            }
+            ControlGroup {
                 fullscreenButton
+            }
+        case .paused:
+            ControlGroup {
+                resumeButton
+                stopMenu(for: instance)
+            }
+            if !instance.isColdPaused {
+                ControlGroup {
+                    saveStateButton
+                }
+                ControlGroup {
+                    fullscreenButton
+                }
             }
         case .starting, .saving, .restoring, .installing:
             EmptyView()
@@ -110,6 +120,7 @@ struct ContentView: View {
         } primaryAction: {
             NSApp.sendAction(#selector(AppDelegate.stopVM(_:)), to: nil, from: nil)
         }
+        .menuIndicator(.hidden)
         .help("Stop the virtual machine. Click and hold for Force Stop.")
     }
 

--- a/Kernova/Views/ContentView.swift
+++ b/Kernova/Views/ContentView.swift
@@ -25,7 +25,7 @@ struct ContentView: View {
             }
         }
         .toolbar {
-            ToolbarItemGroup(placement: .principal) {
+            ToolbarItemGroup(placement: .primaryAction) {
                 if let instance = viewModel.selectedInstance, !instance.isPreparing {
                     actionButtons(for: instance)
                 }
@@ -55,13 +55,17 @@ struct ContentView: View {
         case .running:
             pauseButton
             stopMenu(for: instance)
+            Divider()
             saveStateButton
+            Divider()
             fullscreenButton
         case .paused:
             resumeButton
             stopMenu(for: instance)
             if !instance.isColdPaused {
+                Divider()
                 saveStateButton
+                Divider()
                 fullscreenButton
             }
         case .starting, .saving, .restoring, .installing:


### PR DESCRIPTION
## Summary
- Wrap toolbar action buttons in `ControlGroup` to create visually separated pill-shaped groups
- Move toolbar placement from `.principal` to `.primaryAction` for correct positioning
- Hide the menu indicator on the stop button for a cleaner look

## Changes
- Wrap each logical button group in `ControlGroup` (start; pause+stop; save state; fullscreen)
- Change `ToolbarItemGroup` placement from `.principal` to `.primaryAction`
- Add `.menuIndicator(.hidden)` to the stop menu

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Button groups render as separate pills in the toolbar
- [ ] Stop button click triggers stop, long-press shows Force Stop menu
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)