### PR TITLE
fix: Return stopped status for transient VM start errors

### DIFF
--- a/Kernova/Services/VirtualizationService.swift
+++ b/Kernova/Services/VirtualizationService.swift
@@ -40,7 +40,7 @@ final class VirtualizationService {
         } catch {
             Self.logger.error("Failed to start VM '\(instance.name)': \(error.localizedDescription)")
             instance.tearDownSession()
-            instance.status = .error
+            instance.status = Self.isTransientStartError(error) ? .stopped : .error
             instance.errorMessage = error.localizedDescription
             throw error
         }
@@ -199,6 +199,25 @@ final class VirtualizationService {
             instance.status = .error
             instance.errorMessage = error.localizedDescription
             throw error
+        }
+    }
+
+    // MARK: - Error Classification
+
+    /// Returns `true` when the error is a transient environmental condition (e.g. too many
+    /// concurrent VMs) rather than a problem with the VM itself. Transient errors leave the
+    /// VM in `.stopped` so the indicator stays grey; permanent errors set `.error` (red).
+    static func isTransientStartError(_ error: Error) -> Bool {
+        if error is ConfigurationBuilderError { return false }
+
+        let nsError = error as NSError
+        guard nsError.domain == VZError.errorDomain else { return false }
+
+        switch VZError.Code(rawValue: nsError.code) {
+        case .virtualMachineLimitExceeded, .operationCancelled:
+            return true
+        default:
+            return false
         }
     }
 

--- a/KernovaTests/Mocks/MockVirtualizationService.swift
+++ b/KernovaTests/Mocks/MockVirtualizationService.swift
@@ -15,9 +15,11 @@ final class MockVirtualizationService: VirtualizationProviding {
     var saveCallCount = 0
     var restoreCallCount = 0
 
-    // MARK: - Error Injection
+    // MARK: - Error Injection & Recovery
 
     var startError: (any Error)?
+    /// Status to set on start failure. Defaults to `.error`; set to `.stopped` to simulate transient errors.
+    var startErrorRecoveryStatus: VMStatus = .error
     var stopError: (any Error)?
     var forceStopError: (any Error)?
     var pauseError: (any Error)?
@@ -31,7 +33,7 @@ final class MockVirtualizationService: VirtualizationProviding {
         startCallCount += 1
         if let error = startError {
             instance.tearDownSession()
-            instance.status = .error
+            instance.status = startErrorRecoveryStatus
             instance.errorMessage = error.localizedDescription
             throw error
         }

--- a/KernovaTests/VirtualizationServiceTests.swift
+++ b/KernovaTests/VirtualizationServiceTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Virtualization
 @testable import Kernova
 
 @Suite("VirtualizationService Tests")
@@ -129,5 +130,57 @@ struct VirtualizationServiceTests {
         await #expect(throws: VirtualizationError.self) {
             try await service.forceStop(instance)
         }
+    }
+
+    // MARK: - Transient Start Error Classification
+
+    @Test("VM limit exceeded error is transient")
+    func vmLimitExceededIsTransient() {
+        let error = NSError(domain: VZError.errorDomain, code: VZError.Code.virtualMachineLimitExceeded.rawValue)
+        #expect(VirtualizationService.isTransientStartError(error))
+    }
+
+    @Test("operation cancelled error is transient")
+    func operationCancelledIsTransient() {
+        let error = NSError(domain: VZError.errorDomain, code: VZError.Code.operationCancelled.rawValue)
+        #expect(VirtualizationService.isTransientStartError(error))
+    }
+
+    @Test("invalid VM configuration error is permanent")
+    func invalidConfigurationIsPermanent() {
+        let error = NSError(domain: VZError.errorDomain, code: VZError.Code.invalidVirtualMachineConfiguration.rawValue)
+        #expect(!VirtualizationService.isTransientStartError(error))
+    }
+
+    @Test("internal VZ error is permanent")
+    func internalVZErrorIsPermanent() {
+        let error = NSError(domain: VZError.errorDomain, code: VZError.Code.internalError.rawValue)
+        #expect(!VirtualizationService.isTransientStartError(error))
+    }
+
+    @Test("configuration builder error is permanent")
+    func configBuilderErrorIsPermanent() {
+        let error = ConfigurationBuilderError.missingKernelPath
+        #expect(!VirtualizationService.isTransientStartError(error))
+    }
+
+    @Test("unknown domain error is permanent")
+    func unknownDomainIsPermanent() {
+        let error = NSError(domain: "SomeOtherDomain", code: 42)
+        #expect(!VirtualizationService.isTransientStartError(error))
+    }
+
+    @Test("start sets error status for permanent config error")
+    func startSetsErrorForPermanentConfigError() async throws {
+        let instance = makeInstance(status: .stopped)
+
+        // start() fails at buildConfiguration (no real disk image) with a
+        // ConfigurationBuilderError — a permanent error. The transient path
+        // is covered by the isTransientStartError unit tests above.
+        await #expect(throws: (any Error).self) {
+            try await service.start(instance)
+        }
+        #expect(instance.status == .error)
+        #expect(instance.errorMessage != nil)
     }
 }


### PR DESCRIPTION
## Summary
- Transient errors (e.g. VM count limit exceeded) no longer leave the sidebar status indicator permanently red — the VM returns to stopped (grey) since nothing is wrong with it
- Permanent errors (bad config, missing files, VM crashes) still set the error state (red) as before
- Adds `isTransientStartError` classifier that identifies `VZError.virtualMachineLimitExceeded` and `.operationCancelled` as transient, defaulting all other errors to permanent

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Start a VM when 2 are already running — error alert shown, indicator stays grey
- [ ] Start a VM with missing disk image — error alert shown, indicator turns red
- [ ] Start a VM normally — indicator goes green
- [ ] All existing and new tests pass (7 new tests for error classification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)