### PR TITLE
feat: Add pop-out display mode for VM windows

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -280,7 +280,7 @@ SystemSleepWatcher ──sleep/wake──→ VMLibraryViewModel ──pause/resu
 
 ### 7. Native NSToolbar with observation-driven validation
 
-**What:** The main window uses an `NSToolbar` with `NSToolbarDelegate` creating native `NSToolbarItem`s. Toolbar state (enabled/disabled, Start/Resume label) is driven by `withObservationTracking` on the view model, triggering `validateVisibleItems()` on change. `NSToolbarItemValidation` on `MainWindowController` handles per-item enable/disable logic.
+**What:** The main window uses an `NSToolbar` with `NSToolbarDelegate` creating native `NSToolbarItem`s. Toolbar state (enabled/disabled, Start/Resume label) is driven by `withObservationTracking` on the view model, directly setting `isEnabled` on subitems on change. All toolbar item groups use `autovalidates = false` to prevent AppKit's automatic validation from overriding the observation-driven state.
 
 **Why:** Native `NSToolbarItem`s provide reliable layout, proper `.sidebarTrackingSeparator` support, and standard macOS toolbar appearance. The `withObservationTracking` pattern (already used in `VMDisplayWindowController` and `SerialConsoleWindowController`) re-evaluates on any observed property change and re-registers itself, providing reactive updates without SwiftUI.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@ Kernova/
 ├── App/                                # App lifecycle and window management
 │   ├── AppDelegate.swift               # NSApplicationDelegate — startup, window tracking, menu, save-on-quit
 │   ├── MainWindowController.swift      # NSSplitViewController + NSToolbar with native items
-│   ├── FullscreenWindowController.swift # Per-VM fullscreen window, auto-closes on VM stop
+│   ├── VMDisplayWindowController.swift  # Per-VM display window (pop-out or fullscreen), auto-closes on VM stop
 │   └── SerialConsoleWindowController.swift # Per-VM serial console window, auto-closes on VM stop
 ├── Models/                             # Data types — all value types or @MainActor-isolated
 │   ├── VMConfiguration.swift           # Codable/Sendable struct persisted as config.json per VM bundle
@@ -107,7 +107,7 @@ KernovaTests/
 
 ### App Layer
 
-**Files:** `AppDelegate.swift`, `MainWindowController.swift`, `FullscreenWindowController.swift`, `SerialConsoleWindowController.swift`
+**Files:** `AppDelegate.swift`, `MainWindowController.swift`, `VMDisplayWindowController.swift`, `SerialConsoleWindowController.swift`
 
 `AppDelegate` is the entry point. It creates the `VMLibraryViewModel` and `VMLifecycleCoordinator`, opens the main window, and manages the lifecycle of all windows. It tracks window controllers in dictionaries keyed by VM UUID, enabling one-to-many relationships (a VM can have a main view, a fullscreen window, and a serial console open simultaneously). `AppDelegate` also handles:
 - The application menu (including VM-specific actions, Force Stop with `canForceStop` validation, and Window > Show Library with Cmd+0)
@@ -210,7 +210,7 @@ AppDelegate
     │                 ├── Sidebar: NSHostingController(SidebarView)
     │                 └── Detail:  NSHostingController(MainDetailView → VMDetailView)
     │
-    ├── manages → FullscreenWindowController (per VM)
+    ├── manages → VMDisplayWindowController (per VM)
     └── manages → SerialConsoleWindowController (per VM)
 
 SwiftUI views ──observe──→ VMLibraryViewModel ──delegates──→ VMLifecycleCoordinator ──calls──→ Services
@@ -282,7 +282,7 @@ SystemSleepWatcher ──sleep/wake──→ VMLibraryViewModel ──pause/resu
 
 **What:** The main window uses an `NSToolbar` with `NSToolbarDelegate` creating native `NSToolbarItem`s. Toolbar state (enabled/disabled, Start/Resume label) is driven by `withObservationTracking` on the view model, triggering `validateVisibleItems()` on change. `NSToolbarItemValidation` on `MainWindowController` handles per-item enable/disable logic.
 
-**Why:** Native `NSToolbarItem`s provide reliable layout, proper `.sidebarTrackingSeparator` support, and standard macOS toolbar appearance. The `withObservationTracking` pattern (already used in `FullscreenWindowController` and `SerialConsoleWindowController`) re-evaluates on any observed property change and re-registers itself, providing reactive updates without SwiftUI.
+**Why:** Native `NSToolbarItem`s provide reliable layout, proper `.sidebarTrackingSeparator` support, and standard macOS toolbar appearance. The `withObservationTracking` pattern (already used in `VMDisplayWindowController` and `SerialConsoleWindowController`) re-evaluates on any observed property change and re-registers itself, providing reactive updates without SwiftUI.
 
 **Alternatives:** SwiftUI `.toolbar` modifiers on a hosting controller — simpler declarative API but caused persistent layout issues with grouped items and sidebar tracking.
 
@@ -336,7 +336,7 @@ These services interact with system processes, the network, or VZ installer inte
 - `KernovaUTType` — static UTType declaration
 - `FileManagerExtensions` — FileManager convenience methods
 - `Logger` — thin os.Logger wrapper
-- All window controllers (`MainWindowController`, `FullscreenWindowController`, `SerialConsoleWindowController`)
+- All window controllers (`MainWindowController`, `VMDisplayWindowController`, `SerialConsoleWindowController`)
 - `AppDelegate` — app lifecycle and window management
 - All SwiftUI views
 

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -11,17 +11,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private var pendingOpenURLs: [URL] = []
     private var serialConsoleWindows: [UUID: SerialConsoleWindowController] = [:]
     private var serialConsoleObservers: [UUID: Any] = [:]
-    private var fullscreenWindows: [UUID: FullscreenWindowController] = [:]
-    private var fullscreenObservers: [UUID: Any] = [:]
+    private var displayWindows: [UUID: VMDisplayWindowController] = [:]
+    private var displayWindowObservers: [UUID: Any] = [:]
     private var serialConsoleMenuItem: NSMenuItem!
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "AppDelegate")
 
-    /// Returns the VM that menu actions should target: the fullscreen VM if its window
+    /// Returns the VM that menu actions should target: the display-window VM if its window
     /// is key, otherwise the sidebar-selected VM.
     private var activeInstance: VMInstance? {
         if let keyWindow = NSApp.keyWindow,
-           let controller = fullscreenWindows.values.first(where: { $0.window === keyWindow }) {
+           let controller = displayWindows.values.first(where: { $0.window === keyWindow }) {
             return controller.instance
         }
         return viewModel.selectedInstance
@@ -40,8 +40,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         viewModel = VMLibraryViewModel()
-        viewModel.onEnterFullscreen = { [weak self] instance in
-            self?.enterFullscreen(for: instance)
+        viewModel.onOpenDisplayWindow = { [weak self] instance in
+            self?.openDisplayWindow(for: instance)
         }
         setupMainMenu()
 
@@ -62,9 +62,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             instance.isPreparing || instance.status.isActive || (instance.status == .paused && instance.virtualMachine != nil)
         }
 
-        // Stay alive if VMs are active or fullscreen windows still exist
-        if hasActiveVMs || !fullscreenWindows.isEmpty {
-            Self.logger.debug("applicationShouldTerminateAfterLastWindowClosed: false (activeVMs=\(hasActiveVMs), fullscreenWindows=\(self.fullscreenWindows.count))")
+        // Stay alive if VMs are active or display windows still exist
+        if hasActiveVMs || !displayWindows.isEmpty {
+            Self.logger.debug("applicationShouldTerminateAfterLastWindowClosed: false (activeVMs=\(hasActiveVMs), displayWindows=\(self.displayWindows.count))")
             return false
         }
 
@@ -260,32 +260,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         controller.showWindow(nil)
     }
 
-    // MARK: - Fullscreen Display
+    // MARK: - Display Window (Pop-Out / Fullscreen)
 
-    @objc func toggleFullscreenDisplay(_ sender: Any?) {
+    @objc func togglePopOut(_ sender: Any?) {
         guard let instance = activeInstance else { return }
 
-        if let existing = fullscreenWindows[instance.instanceID] {
+        if let existing = displayWindows[instance.instanceID] {
             existing.window?.close()
             return
         }
 
-        instance.configuration.prefersFullscreen = true
+        instance.configuration.displayPreference = .popOut
         viewModel.saveConfiguration(for: instance)
-        enterFullscreen(for: instance)
+        openDisplayWindow(for: instance, enterFullscreen: false)
     }
 
-    private func enterFullscreen(for instance: VMInstance) {
+    @objc func toggleFullscreen(_ sender: Any?) {
+        guard let instance = activeInstance else { return }
+
+        if let existing = displayWindows[instance.instanceID] {
+            existing.window?.toggleFullScreen(nil)
+            return
+        }
+
+        instance.configuration.displayPreference = .fullscreen
+        viewModel.saveConfiguration(for: instance)
+        openDisplayWindow(for: instance, enterFullscreen: true)
+    }
+
+    private func openDisplayWindow(for instance: VMInstance) {
+        openDisplayWindow(for: instance, enterFullscreen: instance.configuration.displayPreference == .fullscreen)
+    }
+
+    private func openDisplayWindow(for instance: VMInstance, enterFullscreen: Bool) {
         let vmID = instance.instanceID
 
-        // Already showing fullscreen for this VM
-        guard fullscreenWindows[vmID] == nil else { return }
+        // Already showing a display window for this VM
+        guard displayWindows[vmID] == nil else { return }
 
-        let controller = FullscreenWindowController(instance: instance) { [weak self] in
+        let controller = VMDisplayWindowController(instance: instance, enterFullscreen: enterFullscreen) { [weak self] in
             guard let self else { return }
             Task { await self.viewModel.resume(instance) }
         }
-        fullscreenWindows[vmID] = controller
+        displayWindows[vmID] = controller
 
         let token = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
@@ -302,24 +319,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             }
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                if let token = self.fullscreenObservers.removeValue(forKey: vmID) {
+                if let token = self.displayWindowObservers.removeValue(forKey: vmID) {
                     NotificationCenter.default.removeObserver(token)
                 }
-                if let controller = self.fullscreenWindows.removeValue(forKey: vmID) {
+                if let controller = self.displayWindows.removeValue(forKey: vmID) {
                     // Always remember which display the VM was on
                     if let displayID = controller.lastDisplayID {
                         instance.configuration.lastFullscreenDisplayID = displayID
                     }
                     if !controller.closedProgrammatically {
-                        instance.configuration.prefersFullscreen = false
-                        Self.logger.debug("Cleared prefersFullscreen for '\(instance.name)' (user exited fullscreen)")
+                        instance.configuration.displayPreference = .inline
+                        Self.logger.debug("Cleared displayPreference for '\(instance.name)' (user closed display window)")
                     }
                     self.viewModel.saveConfiguration(for: instance)
                 }
                 self.viewModel.selectedID = vmID
 
                 // Restore library window based on context:
-                // - Key + active app: user deliberately left fullscreen → focus library
+                // - Key + active app: user deliberately closed display → focus library
                 // - App not active: VM stopped while user is elsewhere → show library in background
                 // - Active but not key: user is in another Kernova window → no action needed
                 if wasKeyWindow && appWasActive {
@@ -329,17 +346,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                 }
             }
         }
-        fullscreenObservers[vmID] = token
+        displayWindowObservers[vmID] = token
 
-        // Position on the remembered display so toggleFullScreen picks the correct screen
-        if let screen = targetScreen(for: instance),
-           let window = controller.window {
-            let frame = screen.frame
-            let centeredOrigin = NSPoint(
-                x: frame.midX - window.frame.width / 2,
-                y: frame.midY - window.frame.height / 2
-            )
-            window.setFrameOrigin(centeredOrigin)
+        // For fullscreen: position on the remembered display so toggleFullScreen picks the correct screen
+        if enterFullscreen {
+            if let screen = targetScreen(for: instance),
+               let window = controller.window {
+                let frame = screen.frame
+                let centeredOrigin = NSPoint(
+                    x: frame.midX - window.frame.width / 2,
+                    y: frame.midY - window.frame.height / 2
+                )
+                window.setFrameOrigin(centeredOrigin)
+            }
         }
 
         controller.showWindow(nil)
@@ -401,15 +420,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // shortcut validation, which still routes through validateMenuItem(_:).
         case #selector(showSerialConsole(_:)):
             return activeInstance?.canShowSerialConsole ?? false
-        case #selector(toggleFullscreenDisplay(_:)):
+        case #selector(togglePopOut(_:)):
             guard let instance = activeInstance else { return false }
-            let canFullscreen = instance.canFullscreen
-            if canFullscreen, fullscreenWindows[instance.instanceID] != nil {
-                menuItem.title = "Exit Fullscreen Display"
-            } else {
-                menuItem.title = "Fullscreen Display"
-            }
-            return canFullscreen
+            let canUse = instance.canUseExternalDisplay
+            menuItem.title = displayWindows[instance.instanceID] != nil ? "Pop In Display" : "Pop Out Display"
+            return canUse
+        case #selector(toggleFullscreen(_:)):
+            guard let instance = activeInstance else { return false }
+            let canUse = instance.canUseExternalDisplay
+            let isFullscreen = displayWindows[instance.instanceID] != nil && instance.isInFullscreen
+            menuItem.title = isFullscreen ? "Exit Fullscreen Display" : "Fullscreen Display"
+            return canUse
         default:
             return true
         }
@@ -482,9 +503,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         let saveItem = vmMenu.addItem(withTitle: "Save State", action: #selector(saveVM(_:)), keyEquivalent: "s")
         saveItem.keyEquivalentModifierMask = [.command, .option]
         vmMenu.addItem(.separator())
+        let popOutItem = vmMenu.addItem(
+            withTitle: "Pop Out Display",
+            action: #selector(togglePopOut(_:)),
+            keyEquivalent: "o"
+        )
+        popOutItem.keyEquivalentModifierMask = [.command, .shift]
         let fullscreenItem = vmMenu.addItem(
             withTitle: "Fullscreen Display",
-            action: #selector(toggleFullscreenDisplay(_:)),
+            action: #selector(toggleFullscreen(_:)),
             keyEquivalent: "f"
         )
         fullscreenItem.keyEquivalentModifierMask = [.command, .shift]

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -17,12 +17,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "AppDelegate")
 
-    /// Returns the VM that menu actions should target: the display-window VM if its window
-    /// is key, otherwise the sidebar-selected VM.
+    /// Returns the VM that menu actions should target: the display or serial console
+    /// window's VM if its window is key, otherwise the sidebar-selected VM.
     private var activeInstance: VMInstance? {
-        if let keyWindow = NSApp.keyWindow,
-           let controller = displayWindows.values.first(where: { $0.window === keyWindow }) {
-            return controller.instance
+        if let keyWindow = NSApp.keyWindow {
+            if let controller = displayWindows.values.first(where: { $0.window === keyWindow }) {
+                return controller.instance
+            }
+            if let controller = serialConsoleWindows.values.first(where: { $0.window === keyWindow }) {
+                return controller.instance
+            }
         }
         return viewModel.selectedInstance
     }

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -72,6 +72,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
 
         window.restoreFrame(named: "KernovaMainWindow")
 
+        updateToolbarItems()
         observeToolbarState()
         observeSidebarCollapse()
         Self.logger.notice("Main window controller initialized")
@@ -124,7 +125,6 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
 
     private func observeToolbarState() {
         observingToolbar = true
-        updateToolbarItems()
         withObservationTracking {
             _ = self.viewModel.selectedID
             _ = self.viewModel.selectedInstance?.status

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -210,7 +210,6 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
         popOutItem.isEnabled = canUse
         fullscreenItem.isEnabled = canUse
 
-        // Pop-out / Pop-in button
         let popLabel = instance.isInSeparateWindow ? "Pop In" : "Pop Out"
         if popOutItem.label != popLabel {
             popOutItem.label = popLabel
@@ -220,7 +219,6 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             )
         }
 
-        // Fullscreen / Exit Fullscreen button
         let fsLabel = instance.isInFullscreen ? "Exit Fullscreen" : "Fullscreen"
         if fullscreenItem.label != fsLabel {
             fullscreenItem.label = fsLabel

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -24,7 +24,11 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
     private static let toolbarNewVM = NSToolbarItem.Identifier("newVM")
     private static let toolbarLifecycle = NSToolbarItem.Identifier("lifecycle")
     private static let toolbarSaveState = NSToolbarItem.Identifier("saveState")
-    private static let toolbarFullscreen = NSToolbarItem.Identifier("fullscreen")
+    private static let toolbarDisplay = NSToolbarItem.Identifier("display")
+
+    private enum DisplaySegment: Int {
+        case popOut = 0, fullscreen = 1
+    }
 
     // MARK: - Init
 
@@ -124,7 +128,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             _ = self.viewModel.selectedID
             _ = self.viewModel.selectedInstance?.status
             _ = self.viewModel.selectedInstance?.isPreparing
-            _ = self.viewModel.selectedInstance?.isInFullscreen
+            _ = self.viewModel.selectedInstance?.displayMode
             _ = self.viewModel.selectedInstance?.virtualMachine
         } onChange: {
             Task { @MainActor [weak self] in
@@ -143,7 +147,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
 
         updateLifecycleGroup(in: toolbar)
         updateSaveStateItem(in: toolbar)
-        updateFullscreenItem(in: toolbar)
+        updateDisplayGroup(in: toolbar)
         toolbar.validateVisibleItems()
     }
 
@@ -186,21 +190,46 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
         subitem.isEnabled = instance.canSave
     }
 
-    private func updateFullscreenItem(in toolbar: NSToolbar) {
-        guard let group = toolbar.items.first(where: { $0.itemIdentifier == Self.toolbarFullscreen }) as? NSToolbarItemGroup,
-              let subitem = group.subitems.first else {
-            Self.logger.warning("updateFullscreenItem: fullscreen group missing or empty")
+    private func updateDisplayGroup(in toolbar: NSToolbar) {
+        guard let group = toolbar.items.first(where: { $0.itemIdentifier == Self.toolbarDisplay }) as? NSToolbarItemGroup,
+              group.subitems.count == 2 else {
+            Self.logger.warning("updateDisplayGroup: display group missing or has unexpected subitem count")
             return
         }
+
+        let popOutItem = group.subitems[DisplaySegment.popOut.rawValue]
+        let fullscreenItem = group.subitems[DisplaySegment.fullscreen.rawValue]
+
         guard let instance = viewModel.selectedInstance, !instance.isPreparing else {
-            subitem.isEnabled = false
+            popOutItem.isEnabled = false
+            fullscreenItem.isEnabled = false
             return
         }
-        subitem.isEnabled = instance.canFullscreen
-        let label = instance.isInFullscreen ? "Exit Fullscreen" : "Fullscreen"
-        if subitem.label != label {
-            subitem.label = label
-            group.label = label
+
+        let canUse = instance.canUseExternalDisplay
+        popOutItem.isEnabled = canUse
+        fullscreenItem.isEnabled = canUse
+
+        // Pop-out / Pop-in button
+        let popLabel = instance.isInSeparateWindow ? "Pop In" : "Pop Out"
+        if popOutItem.label != popLabel {
+            popOutItem.label = popLabel
+            popOutItem.image = NSImage(
+                systemSymbolName: instance.isInSeparateWindow ? "pip.enter" : "pip.exit",
+                accessibilityDescription: popLabel
+            )
+        }
+
+        // Fullscreen / Exit Fullscreen button
+        let fsLabel = instance.isInFullscreen ? "Exit Fullscreen" : "Fullscreen"
+        if fullscreenItem.label != fsLabel {
+            fullscreenItem.label = fsLabel
+            fullscreenItem.image = NSImage(
+                systemSymbolName: instance.isInFullscreen
+                    ? "arrow.down.right.and.arrow.up.left"
+                    : "arrow.up.left.and.arrow.down.right",
+                accessibilityDescription: fsLabel
+            )
         }
     }
 
@@ -214,7 +243,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             .sidebarTrackingSeparator,
             Self.toolbarLifecycle,
             Self.toolbarSaveState,
-            Self.toolbarFullscreen,
+            Self.toolbarDisplay,
         ]
     }
 
@@ -226,7 +255,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             .flexibleSpace,
             Self.toolbarLifecycle,
             Self.toolbarSaveState,
-            Self.toolbarFullscreen,
+            Self.toolbarDisplay,
         ]
     }
 
@@ -269,13 +298,20 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 action: #selector(AppDelegate.saveVM(_:))
             )
 
-        case Self.toolbarFullscreen:
-            return makeSingleItemGroup(
-                identifier: itemIdentifier,
-                label: "Fullscreen",
-                symbol: "arrow.up.left.and.arrow.down.right",
-                action: #selector(AppDelegate.toggleFullscreenDisplay(_:))
+        case Self.toolbarDisplay:
+            let group = NSToolbarItemGroup(
+                itemIdentifier: itemIdentifier,
+                images: [
+                    NSImage(systemSymbolName: "pip.exit", accessibilityDescription: "Pop Out")!,
+                    NSImage(systemSymbolName: "arrow.up.left.and.arrow.down.right", accessibilityDescription: "Fullscreen")!,
+                ],
+                selectionMode: .momentary,
+                labels: ["Pop Out", "Fullscreen"],
+                target: self,
+                action: #selector(displayAction(_:))
             )
+            group.label = "Display"
+            return group
 
         default:
             return nil
@@ -300,6 +336,21 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             NSApp.sendAction(#selector(AppDelegate.pauseVM(_:)), to: nil, from: nil)
         case .stop:
             NSApp.sendAction(#selector(AppDelegate.stopVM(_:)), to: nil, from: nil)
+        }
+    }
+
+    // MARK: - Display Group Action
+
+    @objc private func displayAction(_ group: NSToolbarItemGroup) {
+        guard let segment = DisplaySegment(rawValue: group.selectedIndex) else {
+            Self.logger.warning("displayAction: unexpected selectedIndex \(group.selectedIndex)")
+            return
+        }
+        switch segment {
+        case .popOut:
+            NSApp.sendAction(#selector(AppDelegate.togglePopOut(_:)), to: nil, from: nil)
+        case .fullscreen:
+            NSApp.sendAction(#selector(AppDelegate.toggleFullscreen(_:)), to: nil, from: nil)
         }
     }
 
@@ -349,7 +400,7 @@ extension MainWindowController: NSToolbarItemValidation {
         }
 
         switch item.itemIdentifier {
-        case Self.toolbarNewVM, Self.toolbarLifecycle, Self.toolbarSaveState, Self.toolbarFullscreen:
+        case Self.toolbarNewVM, Self.toolbarLifecycle, Self.toolbarSaveState, Self.toolbarDisplay:
             // Group subitems are enabled/disabled directly in updateToolbarItems()
             return true
         default:

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -124,6 +124,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
 
     private func observeToolbarState() {
         observingToolbar = true
+        updateToolbarItems()
         withObservationTracking {
             _ = self.viewModel.selectedID
             _ = self.viewModel.selectedInstance?.status
@@ -148,7 +149,6 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
         updateLifecycleGroup(in: toolbar)
         updateSaveStateItem(in: toolbar)
         updateDisplayGroup(in: toolbar)
-        toolbar.validateVisibleItems()
     }
 
     private func updateLifecycleGroup(in toolbar: NSToolbar) {
@@ -286,6 +286,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 action: #selector(lifecycleAction(_:))
             )
             group.label = "State Controls"
+            group.autovalidates = false
             return group
 
         case Self.toolbarSaveState:
@@ -309,6 +310,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 action: #selector(displayAction(_:))
             )
             group.label = "Display"
+            group.autovalidates = false
             return group
 
         default:
@@ -385,6 +387,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             action: action
         )
         group.label = label
+        group.autovalidates = false
         return group
     }
 }

--- a/Kernova/App/SerialConsoleWindowController.swift
+++ b/Kernova/App/SerialConsoleWindowController.swift
@@ -15,7 +15,7 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "SerialConsoleWindowController")
 
     let vmID: UUID
-    private let instance: VMInstance
+    let instance: VMInstance
     private var observingStatus = false
 
     init(instance: VMInstance) {

--- a/Kernova/App/SerialConsoleWindowController.swift
+++ b/Kernova/App/SerialConsoleWindowController.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// via `NSHostingController` and persists its frame position per VM ID.
 ///
 /// The controller observes the VM's status and automatically closes the window when
-/// the VM stops or enters an error state, mirroring `FullscreenWindowController` behavior.
+/// the VM stops or enters an error state, mirroring `VMDisplayWindowController` behavior.
 @MainActor
 final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate {
 

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -94,11 +94,13 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
 
     func windowDidEnterFullScreen(_ notification: Notification) {
         instance.displayMode = .fullscreen
+        window?.toolbar?.isVisible = false
     }
 
     func windowDidExitFullScreen(_ notification: Notification) {
         guard instance.displayMode == .fullscreen else { return }
         instance.displayMode = .popOut
+        window?.toolbar?.isVisible = true
     }
 
     // MARK: - Instance Observation

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -78,6 +78,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
         if enterFullscreen {
             window?.toggleFullScreen(nil)
         }
+        updateToolbarItems()
         observeInstance()
     }
 
@@ -110,7 +111,6 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     /// and to keep toolbar items in sync with current status.
     private func observeInstance() {
         observingInstance = true
-        updateToolbarItems()
         withObservationTracking {
             _ = self.instance.status
             _ = self.instance.virtualMachine
@@ -308,15 +308,6 @@ extension VMDisplayWindowController: NSToolbarDelegate {
         default:
             return nil
         }
-    }
-}
-
-// MARK: - NSToolbarItemValidation
-
-extension VMDisplayWindowController: NSToolbarItemValidation {
-    func validateToolbarItem(_ item: NSToolbarItem) -> Bool {
-        // Group subitems are enabled/disabled directly in updateToolbarItems()
-        true
     }
 }
 

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -89,6 +89,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
             lastDisplayID = window?.screen?.displayID
         }
         observingInstance = false
+        window?.toolbar?.isVisible = true
         instance.displayMode = .inline
     }
 

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import os
 import SwiftUI
 import Virtualization
 
@@ -17,7 +18,23 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     private(set) var lastDisplayID: CGDirectDisplayID?
     let instance: VMInstance
     private let enterFullscreen: Bool
-    private var observingStatus = false
+    private var observingInstance = false
+
+    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMDisplayWindowController")
+
+    // MARK: - Toolbar Item Identifiers
+
+    private static let toolbarLifecycle = NSToolbarItem.Identifier("displayLifecycle")
+    private static let toolbarSaveState = NSToolbarItem.Identifier("displaySaveState")
+    private static let toolbarDisplay = NSToolbarItem.Identifier("displayDisplay")
+
+    private enum LifecycleSegment: Int {
+        case play = 0, pause = 1, stop = 2
+    }
+
+    private enum DisplaySegment: Int {
+        case popIn = 0, fullscreen = 1
+    }
 
     init(instance: VMInstance, enterFullscreen: Bool, onResume: @escaping () -> Void) {
         self.vmID = instance.instanceID
@@ -30,19 +47,23 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1280, height: 800),
-            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
         window.contentViewController = hostingController
         window.title = "\(instance.name) — Display"
-        window.titlebarAppearsTransparent = true
-        window.isMovableByWindowBackground = true
         window.collectionBehavior = [.fullScreenPrimary]
-        window.setFrameAutosaveName("VMDisplay-\(instance.instanceID)")
+        window.restoreFrame(named: "VMDisplay-\(instance.instanceID)")
 
         super.init(window: window)
         window.delegate = self
+
+        let toolbar = NSToolbar(identifier: "VMDisplayToolbar-\(instance.instanceID)")
+        toolbar.delegate = self
+        toolbar.displayMode = .iconOnly
+        window.toolbar = toolbar
+        window.toolbarStyle = .unified
     }
 
     required init?(coder: NSCoder) {
@@ -57,7 +78,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
         if enterFullscreen {
             window?.toggleFullScreen(nil)
         }
-        observeStatus()
+        observeInstance()
     }
 
     // MARK: - NSWindowDelegate
@@ -67,7 +88,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
         if lastDisplayID == nil {
             lastDisplayID = window?.screen?.displayID
         }
-        observingStatus = false
+        observingInstance = false
         instance.displayMode = .inline
     }
 
@@ -79,26 +100,220 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
         instance.displayMode = .popOut
     }
 
-    // MARK: - Status Observation
+    // MARK: - Instance Observation
 
-    /// Automatically closes the display window when the VM stops, errors, or is cold-paused (save state).
-    private func observeStatus() {
-        observingStatus = true
+    /// Observes VM state changes to auto-close the window when the VM stops/errors/saves
+    /// and to keep toolbar items in sync with current status.
+    private func observeInstance() {
+        observingInstance = true
         withObservationTracking {
             _ = self.instance.status
             _ = self.instance.virtualMachine
+            _ = self.instance.displayMode
         } onChange: {
             Task { @MainActor [weak self] in
-                guard let self, self.observingStatus else { return }
+                guard let self, self.observingInstance else { return }
                 let status = self.instance.status
                 if status == .stopped || status == .error || self.instance.isColdPaused {
                     self.lastDisplayID = self.window?.screen?.displayID
                     self.closedProgrammatically = true
                     self.window?.close()
                 } else {
-                    self.observeStatus()
+                    self.updateToolbarItems()
+                    self.observeInstance()
                 }
             }
+        }
+    }
+
+    // MARK: - Toolbar State
+
+    private func updateToolbarItems() {
+        guard let toolbar = window?.toolbar else { return }
+
+        updateLifecycleGroup(in: toolbar)
+        updateSaveStateItem(in: toolbar)
+        updateDisplayGroup(in: toolbar)
+        toolbar.validateVisibleItems()
+    }
+
+    private func updateLifecycleGroup(in toolbar: NSToolbar) {
+        guard let group = toolbar.items.first(where: { $0.itemIdentifier == Self.toolbarLifecycle }) as? NSToolbarItemGroup,
+              group.subitems.count == 3 else { return }
+
+        let canResume = instance.status.canResume
+        let playLabel = canResume ? "Resume" : "Start"
+
+        let play = group.subitems[LifecycleSegment.play.rawValue]
+        if play.label != playLabel {
+            play.label = playLabel
+            play.image = NSImage(systemSymbolName: "play.fill", accessibilityDescription: playLabel)
+        }
+
+        play.isEnabled = instance.status.canStart || canResume
+        group.subitems[LifecycleSegment.pause.rawValue].isEnabled = instance.status.canPause
+        group.subitems[LifecycleSegment.stop.rawValue].isEnabled = instance.status.canStop
+    }
+
+    private func updateSaveStateItem(in toolbar: NSToolbar) {
+        guard let group = toolbar.items.first(where: { $0.itemIdentifier == Self.toolbarSaveState }) as? NSToolbarItemGroup,
+              let subitem = group.subitems.first else { return }
+        subitem.isEnabled = instance.canSave
+    }
+
+    private func updateDisplayGroup(in toolbar: NSToolbar) {
+        guard let group = toolbar.items.first(where: { $0.itemIdentifier == Self.toolbarDisplay }) as? NSToolbarItemGroup,
+              group.subitems.count == 2 else { return }
+
+        let popInItem = group.subitems[DisplaySegment.popIn.rawValue]
+        let fullscreenItem = group.subitems[DisplaySegment.fullscreen.rawValue]
+
+        popInItem.isEnabled = true
+        fullscreenItem.isEnabled = true
+
+        let popLabel = instance.isInSeparateWindow ? "Pop In" : "Pop Out"
+        if popInItem.label != popLabel {
+            popInItem.label = popLabel
+            popInItem.image = NSImage(
+                systemSymbolName: instance.isInSeparateWindow ? "pip.enter" : "pip.exit",
+                accessibilityDescription: popLabel
+            )
+        }
+
+        let fsLabel = instance.isInFullscreen ? "Exit Fullscreen" : "Fullscreen"
+        if fullscreenItem.label != fsLabel {
+            fullscreenItem.label = fsLabel
+            fullscreenItem.image = NSImage(
+                systemSymbolName: instance.isInFullscreen
+                    ? "arrow.down.right.and.arrow.up.left"
+                    : "arrow.up.left.and.arrow.down.right",
+                accessibilityDescription: fsLabel
+            )
+        }
+    }
+
+    // MARK: - Toolbar Actions
+
+    @objc private func lifecycleAction(_ group: NSToolbarItemGroup) {
+        guard let segment = LifecycleSegment(rawValue: group.selectedIndex) else {
+            Self.logger.warning("lifecycleAction: unexpected selectedIndex \(group.selectedIndex)")
+            return
+        }
+        switch segment {
+        case .play:
+            if instance.status.canResume {
+                NSApp.sendAction(#selector(AppDelegate.resumeVM(_:)), to: nil, from: nil)
+            } else {
+                NSApp.sendAction(#selector(AppDelegate.startVM(_:)), to: nil, from: nil)
+            }
+        case .pause:
+            NSApp.sendAction(#selector(AppDelegate.pauseVM(_:)), to: nil, from: nil)
+        case .stop:
+            NSApp.sendAction(#selector(AppDelegate.stopVM(_:)), to: nil, from: nil)
+        }
+    }
+
+    @objc private func displayAction(_ group: NSToolbarItemGroup) {
+        guard let segment = DisplaySegment(rawValue: group.selectedIndex) else {
+            Self.logger.warning("displayAction: unexpected selectedIndex \(group.selectedIndex)")
+            return
+        }
+        switch segment {
+        case .popIn:
+            NSApp.sendAction(#selector(AppDelegate.togglePopOut(_:)), to: nil, from: nil)
+        case .fullscreen:
+            NSApp.sendAction(#selector(AppDelegate.toggleFullscreen(_:)), to: nil, from: nil)
+        }
+    }
+}
+
+// MARK: - NSToolbarDelegate
+
+extension VMDisplayWindowController: NSToolbarDelegate {
+
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [
+            Self.toolbarLifecycle,
+            Self.toolbarSaveState,
+            .flexibleSpace,
+            Self.toolbarDisplay,
+        ]
+    }
+
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [
+            Self.toolbarLifecycle,
+            Self.toolbarSaveState,
+            .flexibleSpace,
+            Self.toolbarDisplay,
+        ]
+    }
+
+    func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool
+    ) -> NSToolbarItem? {
+        switch itemIdentifier {
+        case Self.toolbarLifecycle:
+            let group = NSToolbarItemGroup(
+                itemIdentifier: itemIdentifier,
+                images: [
+                    NSImage(systemSymbolName: "play.fill", accessibilityDescription: "Start")!,
+                    NSImage(systemSymbolName: "pause.fill", accessibilityDescription: "Pause")!,
+                    NSImage(systemSymbolName: "stop.fill", accessibilityDescription: "Stop")!,
+                ],
+                selectionMode: .momentary,
+                labels: ["Start", "Pause", "Stop"],
+                target: self,
+                action: #selector(lifecycleAction(_:))
+            )
+            group.label = "State Controls"
+            return group
+
+        case Self.toolbarSaveState:
+            let group = NSToolbarItemGroup(
+                itemIdentifier: itemIdentifier,
+                images: [NSImage(systemSymbolName: "square.and.arrow.down", accessibilityDescription: "Save State")!],
+                selectionMode: .momentary,
+                labels: ["Save State"],
+                target: nil,
+                action: #selector(AppDelegate.saveVM(_:))
+            )
+            group.label = "Save State"
+            return group
+
+        case Self.toolbarDisplay:
+            let group = NSToolbarItemGroup(
+                itemIdentifier: itemIdentifier,
+                images: [
+                    NSImage(systemSymbolName: "pip.enter", accessibilityDescription: "Pop In")!,
+                    NSImage(systemSymbolName: "arrow.up.left.and.arrow.down.right", accessibilityDescription: "Fullscreen")!,
+                ],
+                selectionMode: .momentary,
+                labels: ["Pop In", "Fullscreen"],
+                target: self,
+                action: #selector(displayAction(_:))
+            )
+            group.label = "Display"
+            return group
+
+        default:
+            return nil
+        }
+    }
+}
+
+// MARK: - NSToolbarItemValidation
+
+extension VMDisplayWindowController: NSToolbarItemValidation {
+    func validateToolbarItem(_ item: NSToolbarItem) -> Bool {
+        switch item.itemIdentifier {
+        case Self.toolbarLifecycle, Self.toolbarSaveState, Self.toolbarDisplay:
+            // Group subitems are enabled/disabled directly in updateToolbarItems()
+            return true
+        default:
+            return true
         }
     }
 }

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -311,13 +311,8 @@ extension VMDisplayWindowController: NSToolbarDelegate {
 
 extension VMDisplayWindowController: NSToolbarItemValidation {
     func validateToolbarItem(_ item: NSToolbarItem) -> Bool {
-        switch item.itemIdentifier {
-        case Self.toolbarLifecycle, Self.toolbarSaveState, Self.toolbarDisplay:
-            // Group subitems are enabled/disabled directly in updateToolbarItems()
-            return true
-        default:
-            return true
-        }
+        // Group subitems are enabled/disabled directly in updateToolbarItems()
+        true
     }
 }
 

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -97,6 +97,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     }
 
     func windowDidExitFullScreen(_ notification: Notification) {
+        guard instance.displayMode == .fullscreen else { return }
         instance.displayMode = .popOut
     }
 

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -109,6 +109,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     /// and to keep toolbar items in sync with current status.
     private func observeInstance() {
         observingInstance = true
+        updateToolbarItems()
         withObservationTracking {
             _ = self.instance.status
             _ = self.instance.virtualMachine
@@ -137,7 +138,6 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
         updateLifecycleGroup(in: toolbar)
         updateSaveStateItem(in: toolbar)
         updateDisplayGroup(in: toolbar)
-        toolbar.validateVisibleItems()
     }
 
     private func updateLifecycleGroup(in toolbar: NSToolbar) {
@@ -272,6 +272,7 @@ extension VMDisplayWindowController: NSToolbarDelegate {
                 action: #selector(lifecycleAction(_:))
             )
             group.label = "State Controls"
+            group.autovalidates = false
             return group
 
         case Self.toolbarSaveState:
@@ -284,6 +285,7 @@ extension VMDisplayWindowController: NSToolbarDelegate {
                 action: #selector(AppDelegate.saveVM(_:))
             )
             group.label = "Save State"
+            group.autovalidates = false
             return group
 
         case Self.toolbarDisplay:
@@ -299,6 +301,7 @@ extension VMDisplayWindowController: NSToolbarDelegate {
                 action: #selector(displayAction(_:))
             )
             group.label = "Display"
+            group.autovalidates = false
             return group
 
         default:

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -236,18 +236,18 @@ extension VMDisplayWindowController: NSToolbarDelegate {
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         [
+            .flexibleSpace,
             Self.toolbarLifecycle,
             Self.toolbarSaveState,
-            .flexibleSpace,
             Self.toolbarDisplay,
         ]
     }
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         [
+            .flexibleSpace,
             Self.toolbarLifecycle,
             Self.toolbarSaveState,
-            .flexibleSpace,
             Self.toolbarDisplay,
         ]
     }

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -2,26 +2,29 @@ import Cocoa
 import SwiftUI
 import Virtualization
 
-/// Manages a dedicated fullscreen window displaying a single VM's screen.
+/// Manages a dedicated window displaying a single VM's screen, either as a
+/// resizable pop-out window or in native macOS fullscreen.
 ///
 /// On show the inline `VMDisplayView` in the main window is replaced by a placeholder
-/// (via `VMInstance.isInFullscreen`), and this controller creates its own
+/// (via `VMInstance.displayMode`), and this controller creates its own
 /// `VZVirtualMachineView` bound to the same `VZVirtualMachine`. On close the process
 /// reverses so the inline display re-appears.
 @MainActor
-final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
+final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
 
     let vmID: UUID
     private(set) var closedProgrammatically = false
     private(set) var lastDisplayID: CGDirectDisplayID?
     let instance: VMInstance
+    private let enterFullscreen: Bool
     private var observingStatus = false
 
-    init(instance: VMInstance, onResume: @escaping () -> Void) {
+    init(instance: VMInstance, enterFullscreen: Bool, onResume: @escaping () -> Void) {
         self.vmID = instance.instanceID
         self.instance = instance
+        self.enterFullscreen = enterFullscreen
 
-        let contentView = FullscreenVMView(instance: instance, onResume: onResume)
+        let contentView = DetachedVMView(instance: instance, onResume: onResume)
         let hostingController = NSHostingController(rootView: contentView)
         hostingController.sizingOptions = []
 
@@ -36,6 +39,7 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = true
         window.collectionBehavior = [.fullScreenPrimary]
+        window.setFrameAutosaveName("VMDisplay-\(instance.instanceID)")
 
         super.init(window: window)
         window.delegate = self
@@ -48,9 +52,11 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
     // MARK: - Lifecycle
 
     override func showWindow(_ sender: Any?) {
-        instance.isInFullscreen = true
+        instance.displayMode = enterFullscreen ? .fullscreen : .popOut
         super.showWindow(sender)
-        window?.toggleFullScreen(nil)
+        if enterFullscreen {
+            window?.toggleFullScreen(nil)
+        }
         observeStatus()
     }
 
@@ -62,17 +68,20 @@ final class FullscreenWindowController: NSWindowController, NSWindowDelegate {
             lastDisplayID = window?.screen?.displayID
         }
         observingStatus = false
-        instance.isInFullscreen = false
+        instance.displayMode = .inline
+    }
+
+    func windowDidEnterFullScreen(_ notification: Notification) {
+        instance.displayMode = .fullscreen
     }
 
     func windowDidExitFullScreen(_ notification: Notification) {
-        // User pressed Esc or swiped to exit macOS fullscreen — close the window entirely
-        window?.close()
+        instance.displayMode = .popOut
     }
 
     // MARK: - Status Observation
 
-    /// Automatically closes the fullscreen window when the VM stops, errors, or is cold-paused (save state).
+    /// Automatically closes the display window when the VM stops, errors, or is cold-paused (save state).
     private func observeStatus() {
         observingStatus = true
         withObservationTracking {
@@ -102,11 +111,11 @@ extension NSScreen {
     }
 }
 
-// MARK: - Fullscreen SwiftUI View
+// MARK: - Detached VM SwiftUI View
 
-/// SwiftUI view used inside the fullscreen window. Shows the VM display when a
+/// SwiftUI view used inside the display window. Shows the VM display when a
 /// `VZVirtualMachine` is available (with a pause overlay when live-paused), or a placeholder otherwise.
-private struct FullscreenVMView: View {
+private struct DetachedVMView: View {
     let instance: VMInstance
     var onResume: () -> Void
 

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// The user's preferred display hosting for a VM on start/resume.
+enum VMDisplayPreference: String, Codable, Sendable, Equatable {
+    case inline
+    case popOut
+    case fullscreen
+}
+
 /// Persistent configuration for a virtual machine.
 ///
 /// This type is serialized to `config.json` inside each VM bundle directory.
@@ -23,7 +30,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     var displayWidth: Int
     var displayHeight: Int
     var displayPPI: Int
-    var prefersFullscreen: Bool
+    var displayPreference: VMDisplayPreference
     var lastFullscreenDisplayID: UInt32?
 
     // MARK: - Network
@@ -80,7 +87,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         displayWidth: Int = 1920,
         displayHeight: Int = 1200,
         displayPPI: Int = 144,
-        prefersFullscreen: Bool = false,
+        displayPreference: VMDisplayPreference = .inline,
         lastFullscreenDisplayID: UInt32? = nil,
         networkEnabled: Bool = true,
         macAddress: String? = nil,
@@ -105,7 +112,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         self.displayWidth = displayWidth
         self.displayHeight = displayHeight
         self.displayPPI = displayPPI
-        self.prefersFullscreen = prefersFullscreen
+        self.displayPreference = displayPreference
         self.lastFullscreenDisplayID = lastFullscreenDisplayID
         self.networkEnabled = networkEnabled
         self.macAddress = macAddress
@@ -126,7 +133,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case id, name, guestOS, bootMode
         case cpuCount, memorySizeInGB, diskSizeInGB
-        case displayWidth, displayHeight, displayPPI, prefersFullscreen, lastFullscreenDisplayID
+        case displayWidth, displayHeight, displayPPI, displayPreference, lastFullscreenDisplayID
         case networkEnabled, macAddress
         case hardwareModelData, machineIdentifierData
         case genericMachineIdentifierData
@@ -149,7 +156,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         displayWidth = try container.decode(Int.self, forKey: .displayWidth)
         displayHeight = try container.decode(Int.self, forKey: .displayHeight)
         displayPPI = try container.decode(Int.self, forKey: .displayPPI)
-        prefersFullscreen = try container.decodeIfPresent(Bool.self, forKey: .prefersFullscreen) ?? false
+        displayPreference = try container.decodeIfPresent(VMDisplayPreference.self, forKey: .displayPreference) ?? .inline
         lastFullscreenDisplayID = try container.decodeIfPresent(UInt32.self, forKey: .lastFullscreenDisplayID)
         networkEnabled = try container.decode(Bool.self, forKey: .networkEnabled)
         macAddress = try container.decodeIfPresent(String.self, forKey: .macAddress)
@@ -180,7 +187,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         clone.id = UUID()
         clone.createdAt = Date()
         clone.name = Self.generateCloneName(baseName: name, existingNames: existingNames)
-        clone.prefersFullscreen = false
+        clone.displayPreference = .inline
         clone.lastFullscreenDisplayID = nil
 
         // Regenerate shared directory IDs to avoid VirtioFS collisions

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -2,6 +2,16 @@ import Foundation
 import os
 import Virtualization
 
+/// The VM display's current hosting location.
+enum VMDisplayMode: Sendable {
+    /// Display is embedded in the main window's detail pane.
+    case inline
+    /// Display is in its own resizable window (not fullscreen).
+    case popOut
+    /// Display is in its own window in native macOS fullscreen.
+    case fullscreen
+}
+
 /// Runtime wrapper around a VM configuration, its backing virtual machine, and current status.
 @MainActor
 @Observable
@@ -67,8 +77,8 @@ final class VMInstance: Identifiable {
     /// Error message if the VM entered an error state.
     var errorMessage: String?
 
-    /// `true` when this VM's display is shown in a dedicated fullscreen window.
-    var isInFullscreen: Bool = false
+    /// Where the VM display is currently hosted (inline, pop-out window, or fullscreen).
+    var displayMode: VMDisplayMode = .inline
 
     // MARK: - Serial Console
 
@@ -142,10 +152,16 @@ final class VMInstance: Identifiable {
         status.canSave && !isColdPaused
     }
 
-    /// `true` when the VM is eligible to enter fullscreen display (active status + live VM).
-    var canFullscreen: Bool {
+    /// `true` when the VM is eligible to pop out or enter fullscreen (active status + live VM).
+    var canUseExternalDisplay: Bool {
         (status == .running || status == .paused) && virtualMachine != nil
     }
+
+    /// `true` when this VM's display is shown in a dedicated fullscreen window.
+    var isInFullscreen: Bool { displayMode == .fullscreen }
+
+    /// `true` when the display is in any separate window (pop-out or fullscreen).
+    var isInSeparateWindow: Bool { displayMode != .inline }
 
     /// `true` when the VM is eligible to show a serial console window (active status + live VM).
     var canShowSerialConsole: Bool {

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -47,9 +47,9 @@ final class VMLibraryViewModel {
     /// Current VM ordering used by sortInstances(); synchronized with UserDefaults via persistOrder().
     private var customOrder: [UUID] = []
 
-    /// Called when a VM with `prefersFullscreen` is about to start or resume,
-    /// allowing the app delegate to pre-create the fullscreen window with a spinner.
-    @ObservationIgnored var onEnterFullscreen: ((VMInstance) -> Void)?
+    /// Called when a VM with a non-inline `displayPreference` is about to start or resume,
+    /// allowing the app delegate to pre-create the display window with a spinner.
+    @ObservationIgnored var onOpenDisplayWindow: ((VMInstance) -> Void)?
 
     // MARK: - Directory Watcher
 
@@ -235,8 +235,8 @@ final class VMLibraryViewModel {
     // MARK: - Lifecycle
 
     func start(_ instance: VMInstance) async {
-        if instance.configuration.prefersFullscreen {
-            onEnterFullscreen?(instance)
+        if instance.configuration.displayPreference != .inline {
+            onOpenDisplayWindow?(instance)
         }
         do {
             try await lifecycle.start(instance)
@@ -282,8 +282,8 @@ final class VMLibraryViewModel {
     }
 
     func resume(_ instance: VMInstance) async {
-        if instance.configuration.prefersFullscreen {
-            onEnterFullscreen?(instance)
+        if instance.configuration.displayPreference != .inline {
+            onOpenDisplayWindow?(instance)
         }
         do {
             try await lifecycle.resume(instance)

--- a/Kernova/Views/Console/VMConsoleView.swift
+++ b/Kernova/Views/Console/VMConsoleView.swift
@@ -8,14 +8,24 @@ struct VMConsoleView: View {
     var body: some View {
         VStack(spacing: 0) {
             // VM Display
-            if instance.isInFullscreen {
+            if instance.displayMode == .fullscreen {
                 ContentUnavailableView {
                     Label("Fullscreen", systemImage: "arrow.up.left.and.arrow.down.right")
                 } description: {
                     Text("The virtual machine display is in fullscreen mode.")
                 } actions: {
                     Button("Exit Fullscreen") {
-                        NSApp.sendAction(#selector(AppDelegate.toggleFullscreenDisplay(_:)), to: nil, from: nil)
+                        NSApp.sendAction(#selector(AppDelegate.toggleFullscreen(_:)), to: nil, from: nil)
+                    }
+                }
+            } else if instance.displayMode == .popOut {
+                ContentUnavailableView {
+                    Label("Popped Out", systemImage: "pip.exit")
+                } description: {
+                    Text("The virtual machine display is in a separate window.")
+                } actions: {
+                    Button("Pop In") {
+                        NSApp.sendAction(#selector(AppDelegate.togglePopOut(_:)), to: nil, from: nil)
                     }
                 }
             } else if let vm = instance.virtualMachine {

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -104,10 +104,13 @@ struct SidebarView: View {
             }
 
             // Display
-            if instance.canFullscreen {
+            if instance.canUseExternalDisplay {
                 Divider()
-                Button("Fullscreen Display") {
-                    NSApp.sendAction(#selector(AppDelegate.toggleFullscreenDisplay(_:)), to: nil, from: nil)
+                Button(instance.isInSeparateWindow ? "Pop In Display" : "Pop Out Display") {
+                    NSApp.sendAction(#selector(AppDelegate.togglePopOut(_:)), to: nil, from: nil)
+                }
+                Button(instance.isInFullscreen ? "Exit Fullscreen Display" : "Fullscreen Display") {
+                    NSApp.sendAction(#selector(AppDelegate.toggleFullscreen(_:)), to: nil, from: nil)
                 }
             }
 

--- a/KernovaTests/VMConfigurationCloneTests.swift
+++ b/KernovaTests/VMConfigurationCloneTests.swift
@@ -9,7 +9,7 @@ struct VMConfigurationCloneTests {
         name: String = "My VM",
         guestOS: VMGuestOS = .linux,
         bootMode: VMBootMode = .efi,
-        prefersFullscreen: Bool = true,
+        displayPreference: VMDisplayPreference = .fullscreen,
         sharedDirectories: [SharedDirectory]? = nil,
         hardwareModelData: Data? = nil
     ) -> VMConfiguration {
@@ -17,7 +17,7 @@ struct VMConfigurationCloneTests {
             name: name,
             guestOS: guestOS,
             bootMode: bootMode,
-            prefersFullscreen: prefersFullscreen,
+            displayPreference: displayPreference,
             hardwareModelData: hardwareModelData,
             sharedDirectories: sharedDirectories
         )
@@ -153,10 +153,10 @@ struct VMConfigurationCloneTests {
 
     // MARK: - Reset Fields
 
-    @Test("Clone resets prefersFullscreen to false")
-    func cloneResetsPrefersFullscreen() {
-        let clone = makeConfig(prefersFullscreen: true).clonedForNewInstance(existingNames: [])
-        #expect(clone.prefersFullscreen == false)
+    @Test("Clone resets displayPreference to inline")
+    func cloneResetsDisplayPreference() {
+        let clone = makeConfig(displayPreference: .fullscreen).clonedForNewInstance(existingNames: [])
+        #expect(clone.displayPreference == .inline)
     }
 
     @Test("Clone resets lastFullscreenDisplayID to nil")

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -402,25 +402,25 @@ struct VMConfigurationTests {
         #expect(config.bootFromDiscImage == false)
     }
 
-    // MARK: - prefersFullscreen Tests
+    // MARK: - displayPreference Tests
 
-    @Test("Default prefersFullscreen is false")
-    func defaultPrefersFullscreen() {
+    @Test("Default displayPreference is inline")
+    func defaultDisplayPreference() {
         let config = VMConfiguration(
             name: "Test VM",
             guestOS: .linux,
             bootMode: .efi
         )
-        #expect(config.prefersFullscreen == false)
+        #expect(config.displayPreference == .inline)
     }
 
-    @Test("Configuration preserves prefersFullscreen flag")
-    func prefersFullscreenRoundTrip() throws {
+    @Test("Configuration preserves displayPreference")
+    func displayPreferenceRoundTrip() throws {
         let config = VMConfiguration(
             name: "Fullscreen VM",
             guestOS: .linux,
             bootMode: .efi,
-            prefersFullscreen: true
+            displayPreference: .fullscreen
         )
 
         let encoder = JSONEncoder()
@@ -431,11 +431,31 @@ struct VMConfigurationTests {
         decoder.dateDecodingStrategy = .iso8601
         let decoded = try decoder.decode(VMConfiguration.self, from: data)
 
-        #expect(decoded.prefersFullscreen == true)
+        #expect(decoded.displayPreference == .fullscreen)
     }
 
-    @Test("Backward compatibility: decoding JSON without prefersFullscreen defaults to false")
-    func backwardCompatibilityPrefersFullscreen() throws {
+    @Test("displayPreference round-trips popOut value")
+    func displayPreferencePopOutRoundTrip() throws {
+        let config = VMConfiguration(
+            name: "PopOut VM",
+            guestOS: .linux,
+            bootMode: .efi,
+            displayPreference: .popOut
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(config)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: data)
+
+        #expect(decoded.displayPreference == .popOut)
+    }
+
+    @Test("Decoding JSON without displayPreference defaults to inline")
+    func missingDisplayPreferenceDefaultsToInline() throws {
         let json = """
         {
             "id": "12345678-1234-1234-1234-123456789012",
@@ -457,7 +477,7 @@ struct VMConfigurationTests {
         decoder.dateDecodingStrategy = .iso8601
         let config = try decoder.decode(VMConfiguration.self, from: Data(json.utf8))
 
-        #expect(config.prefersFullscreen == false)
+        #expect(config.displayPreference == .inline)
     }
 
     // MARK: - lastFullscreenDisplayID Tests


### PR DESCRIPTION
## Summary
- Add pop-out display mode allowing VMs to be viewed in separate resizable windows alongside existing fullscreen support
- Replace `FullscreenWindowController` with `VMDisplayWindowController` supporting both pop-out and fullscreen modes
- Add toolbar with lifecycle controls (start/pause/stop), save state, and display mode buttons to the pop-out window
- Introduce `VMDisplayMode` (runtime) and `VMDisplayPreference` (persisted) enums to cleanly separate transient state from user preference

## Changes
- Add `VMDisplayWindowController` with NSToolbar, observation-driven toolbar state, and proper window frame restoration
- Add pop-out/fullscreen toggle buttons to main window toolbar, sidebar context menu, and VM menu bar
- Replace `prefersFullscreen` bool with `VMDisplayPreference` enum (inline/popOut/fullscreen) in `VMConfiguration`
- Replace `isInFullscreen` bool with `VMDisplayMode` enum and derived `isInFullscreen`/`isInSeparateWindow` properties on `VMInstance`
- Add `VMConsoleView` placeholder for popped-out state with "Pop In" button
- Fix toolbar validation: use `autovalidates = false` on all groups with observation-driven `isEnabled` management
- Fix `displayMode` race condition when closing fullscreen windows (guard on current state)
- Update ARCHITECTURE.md to reflect new component and toolbar validation approach

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Pop out a running VM — window appears centered with toolbar
- [ ] Toolbar buttons enable/disable correctly as VM state changes
- [ ] VM guest receives mouse/keyboard input (drag doesn't move window)
- [ ] Pop In button returns display to main window
- [ ] Fullscreen enters/exits correctly via toolbar and menu bar
- [ ] inline → fullscreen → inline → popout preserves toolbar state
- [ ] Closing fullscreen window returns to inline (not stuck on popOut placeholder)
- [ ] VM stop auto-closes the display window
- [ ] Display preference persists across app restarts
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)