### PR TITLE
fix: Restore tooltip text on toolbar buttons

### DIFF
--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -29,6 +29,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
     private static let toolbarNewVM = NSToolbarItem.Identifier("newVM")
     private static let toolbarLifecycle = NSToolbarItem.Identifier("lifecycle")
     private static let toolbarSaveState = NSToolbarItem.Identifier("saveState")
+    private static let saveStateToolTip = "Save the virtual machine state to disk"
     private static let toolbarDisplay = NSToolbarItem.Identifier("display")
 
     private enum DisplaySegment: Int {
@@ -315,7 +316,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 label: "Save State",
                 symbol: "square.and.arrow.down",
                 action: #selector(AppDelegate.saveVM(_:)),
-                toolTip: "Save the virtual machine state to disk"
+                toolTip: Self.saveStateToolTip
             )
 
         case Self.toolbarDisplay:

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -17,6 +17,11 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
 
     private enum LifecycleSegment: Int {
         case play = 0, pause = 1, stop = 2
+
+        static let startToolTip = "Start the virtual machine"
+        static let resumeToolTip = "Resume the virtual machine"
+        static let pauseToolTip = "Pause the virtual machine"
+        static let stopToolTip = "Stop the virtual machine"
     }
 
     // MARK: - Toolbar Item Identifiers
@@ -28,6 +33,11 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
 
     private enum DisplaySegment: Int {
         case popOut = 0, fullscreen = 1
+
+        static let popOutToolTip = "Open display in a separate window"
+        static let popInToolTip = "Return display to the main window"
+        static let fullscreenToolTip = "Enter fullscreen display"
+        static let exitFullscreenToolTip = "Exit fullscreen display"
     }
 
     // MARK: - Init
@@ -170,7 +180,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
         if play.label != playLabel {
             play.label = playLabel
             play.image = NSImage(systemSymbolName: "play.fill", accessibilityDescription: playLabel)
-            play.toolTip = canResume ? "Resume the virtual machine" : "Start the virtual machine"
+            play.toolTip = canResume ? LifecycleSegment.resumeToolTip : LifecycleSegment.startToolTip
         }
 
         play.isEnabled = instance.status.canStart || canResume
@@ -219,8 +229,8 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 accessibilityDescription: popLabel
             )
             popOutItem.toolTip = instance.isInSeparateWindow
-                ? "Return display to the main window"
-                : "Open display in a separate window"
+                ? DisplaySegment.popInToolTip
+                : DisplaySegment.popOutToolTip
         }
 
         let fsLabel = instance.isInFullscreen ? "Exit Fullscreen" : "Fullscreen"
@@ -233,8 +243,8 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 accessibilityDescription: fsLabel
             )
             fullscreenItem.toolTip = instance.isInFullscreen
-                ? "Exit fullscreen display"
-                : "Enter fullscreen display"
+                ? DisplaySegment.exitFullscreenToolTip
+                : DisplaySegment.fullscreenToolTip
         }
     }
 
@@ -293,9 +303,9 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 action: #selector(lifecycleAction(_:))
             )
             group.label = "State Controls"
-            group.subitems[LifecycleSegment.play.rawValue].toolTip = "Start the virtual machine"
-            group.subitems[LifecycleSegment.pause.rawValue].toolTip = "Pause the virtual machine"
-            group.subitems[LifecycleSegment.stop.rawValue].toolTip = "Stop the virtual machine"
+            group.subitems[LifecycleSegment.play.rawValue].toolTip = LifecycleSegment.startToolTip
+            group.subitems[LifecycleSegment.pause.rawValue].toolTip = LifecycleSegment.pauseToolTip
+            group.subitems[LifecycleSegment.stop.rawValue].toolTip = LifecycleSegment.stopToolTip
             group.autovalidates = false
             return group
 
@@ -321,8 +331,8 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 action: #selector(displayAction(_:))
             )
             group.label = "Display"
-            group.subitems[DisplaySegment.popOut.rawValue].toolTip = "Open display in a separate window"
-            group.subitems[DisplaySegment.fullscreen.rawValue].toolTip = "Enter fullscreen display"
+            group.subitems[DisplaySegment.popOut.rawValue].toolTip = DisplaySegment.popOutToolTip
+            group.subitems[DisplaySegment.fullscreen.rawValue].toolTip = DisplaySegment.fullscreenToolTip
             group.autovalidates = false
             return group
 

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -170,6 +170,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
         if play.label != playLabel {
             play.label = playLabel
             play.image = NSImage(systemSymbolName: "play.fill", accessibilityDescription: playLabel)
+            play.toolTip = canResume ? "Resume the virtual machine" : "Start the virtual machine"
         }
 
         play.isEnabled = instance.status.canStart || canResume
@@ -217,6 +218,9 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 systemSymbolName: instance.isInSeparateWindow ? "pip.enter" : "pip.exit",
                 accessibilityDescription: popLabel
             )
+            popOutItem.toolTip = instance.isInSeparateWindow
+                ? "Return display to the main window"
+                : "Open display in a separate window"
         }
 
         let fsLabel = instance.isInFullscreen ? "Exit Fullscreen" : "Fullscreen"
@@ -228,6 +232,9 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                     : "arrow.up.left.and.arrow.down.right",
                 accessibilityDescription: fsLabel
             )
+            fullscreenItem.toolTip = instance.isInFullscreen
+                ? "Exit fullscreen display"
+                : "Enter fullscreen display"
         }
     }
 
@@ -286,6 +293,9 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 action: #selector(lifecycleAction(_:))
             )
             group.label = "State Controls"
+            group.subitems[LifecycleSegment.play.rawValue].toolTip = "Start the virtual machine"
+            group.subitems[LifecycleSegment.pause.rawValue].toolTip = "Pause the virtual machine"
+            group.subitems[LifecycleSegment.stop.rawValue].toolTip = "Stop the virtual machine"
             group.autovalidates = false
             return group
 
@@ -294,7 +304,8 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 identifier: itemIdentifier,
                 label: "Save State",
                 symbol: "square.and.arrow.down",
-                action: #selector(AppDelegate.saveVM(_:))
+                action: #selector(AppDelegate.saveVM(_:)),
+                toolTip: "Save the virtual machine state to disk"
             )
 
         case Self.toolbarDisplay:
@@ -310,6 +321,8 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 action: #selector(displayAction(_:))
             )
             group.label = "Display"
+            group.subitems[DisplaySegment.popOut.rawValue].toolTip = "Open display in a separate window"
+            group.subitems[DisplaySegment.fullscreen.rawValue].toolTip = "Enter fullscreen display"
             group.autovalidates = false
             return group
 
@@ -376,7 +389,8 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
         identifier: NSToolbarItem.Identifier,
         label: String,
         symbol: String,
-        action: Selector
+        action: Selector,
+        toolTip: String? = nil
     ) -> NSToolbarItemGroup {
         let group = NSToolbarItemGroup(
             itemIdentifier: identifier,
@@ -387,6 +401,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             action: action
         )
         group.label = label
+        if let toolTip { group.subitems.first?.toolTip = toolTip }
         group.autovalidates = false
         return group
     }

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -26,6 +26,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
 
     private static let toolbarLifecycle = NSToolbarItem.Identifier("displayLifecycle")
     private static let toolbarSaveState = NSToolbarItem.Identifier("displaySaveState")
+    private static let saveStateToolTip = "Save the virtual machine state to disk"
     private static let toolbarDisplay = NSToolbarItem.Identifier("displayDisplay")
 
     private enum LifecycleSegment: Int {
@@ -306,7 +307,7 @@ extension VMDisplayWindowController: NSToolbarDelegate {
                 action: #selector(AppDelegate.saveVM(_:))
             )
             group.label = "Save State"
-            group.subitems.first?.toolTip = "Save the virtual machine state to disk"
+            group.subitems.first?.toolTip = Self.saveStateToolTip
             group.autovalidates = false
             return group
 

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -30,10 +30,20 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
 
     private enum LifecycleSegment: Int {
         case play = 0, pause = 1, stop = 2
+
+        static let startToolTip = "Start the virtual machine"
+        static let resumeToolTip = "Resume the virtual machine"
+        static let pauseToolTip = "Pause the virtual machine"
+        static let stopToolTip = "Stop the virtual machine"
     }
 
     private enum DisplaySegment: Int {
         case popIn = 0, fullscreen = 1
+
+        static let popOutToolTip = "Open display in a separate window"
+        static let popInToolTip = "Return display to the main window"
+        static let fullscreenToolTip = "Enter fullscreen display"
+        static let exitFullscreenToolTip = "Exit fullscreen display"
     }
 
     init(instance: VMInstance, enterFullscreen: Bool, onResume: @escaping () -> Void) {
@@ -152,7 +162,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
         if play.label != playLabel {
             play.label = playLabel
             play.image = NSImage(systemSymbolName: "play.fill", accessibilityDescription: playLabel)
-            play.toolTip = canResume ? "Resume the virtual machine" : "Start the virtual machine"
+            play.toolTip = canResume ? LifecycleSegment.resumeToolTip : LifecycleSegment.startToolTip
         }
 
         play.isEnabled = instance.status.canStart || canResume
@@ -184,8 +194,8 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
                 accessibilityDescription: popLabel
             )
             popInItem.toolTip = instance.isInSeparateWindow
-                ? "Return display to the main window"
-                : "Open display in a separate window"
+                ? DisplaySegment.popInToolTip
+                : DisplaySegment.popOutToolTip
         }
 
         let fsLabel = instance.isInFullscreen ? "Exit Fullscreen" : "Fullscreen"
@@ -198,8 +208,8 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
                 accessibilityDescription: fsLabel
             )
             fullscreenItem.toolTip = instance.isInFullscreen
-                ? "Exit fullscreen display"
-                : "Enter fullscreen display"
+                ? DisplaySegment.exitFullscreenToolTip
+                : DisplaySegment.fullscreenToolTip
         }
     }
 
@@ -280,9 +290,9 @@ extension VMDisplayWindowController: NSToolbarDelegate {
                 action: #selector(lifecycleAction(_:))
             )
             group.label = "State Controls"
-            group.subitems[LifecycleSegment.play.rawValue].toolTip = "Start the virtual machine"
-            group.subitems[LifecycleSegment.pause.rawValue].toolTip = "Pause the virtual machine"
-            group.subitems[LifecycleSegment.stop.rawValue].toolTip = "Stop the virtual machine"
+            group.subitems[LifecycleSegment.play.rawValue].toolTip = LifecycleSegment.startToolTip
+            group.subitems[LifecycleSegment.pause.rawValue].toolTip = LifecycleSegment.pauseToolTip
+            group.subitems[LifecycleSegment.stop.rawValue].toolTip = LifecycleSegment.stopToolTip
             group.autovalidates = false
             return group
 
@@ -313,8 +323,8 @@ extension VMDisplayWindowController: NSToolbarDelegate {
                 action: #selector(displayAction(_:))
             )
             group.label = "Display"
-            group.subitems[DisplaySegment.popIn.rawValue].toolTip = "Return display to the main window"
-            group.subitems[DisplaySegment.fullscreen.rawValue].toolTip = "Enter fullscreen display"
+            group.subitems[DisplaySegment.popIn.rawValue].toolTip = DisplaySegment.popInToolTip
+            group.subitems[DisplaySegment.fullscreen.rawValue].toolTip = DisplaySegment.fullscreenToolTip
             group.autovalidates = false
             return group
 

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -152,6 +152,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
         if play.label != playLabel {
             play.label = playLabel
             play.image = NSImage(systemSymbolName: "play.fill", accessibilityDescription: playLabel)
+            play.toolTip = canResume ? "Resume the virtual machine" : "Start the virtual machine"
         }
 
         play.isEnabled = instance.status.canStart || canResume
@@ -182,6 +183,9 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
                 systemSymbolName: instance.isInSeparateWindow ? "pip.enter" : "pip.exit",
                 accessibilityDescription: popLabel
             )
+            popInItem.toolTip = instance.isInSeparateWindow
+                ? "Return display to the main window"
+                : "Open display in a separate window"
         }
 
         let fsLabel = instance.isInFullscreen ? "Exit Fullscreen" : "Fullscreen"
@@ -193,6 +197,9 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
                     : "arrow.up.left.and.arrow.down.right",
                 accessibilityDescription: fsLabel
             )
+            fullscreenItem.toolTip = instance.isInFullscreen
+                ? "Exit fullscreen display"
+                : "Enter fullscreen display"
         }
     }
 
@@ -273,6 +280,9 @@ extension VMDisplayWindowController: NSToolbarDelegate {
                 action: #selector(lifecycleAction(_:))
             )
             group.label = "State Controls"
+            group.subitems[LifecycleSegment.play.rawValue].toolTip = "Start the virtual machine"
+            group.subitems[LifecycleSegment.pause.rawValue].toolTip = "Pause the virtual machine"
+            group.subitems[LifecycleSegment.stop.rawValue].toolTip = "Stop the virtual machine"
             group.autovalidates = false
             return group
 
@@ -286,6 +296,7 @@ extension VMDisplayWindowController: NSToolbarDelegate {
                 action: #selector(AppDelegate.saveVM(_:))
             )
             group.label = "Save State"
+            group.subitems.first?.toolTip = "Save the virtual machine state to disk"
             group.autovalidates = false
             return group
 
@@ -302,6 +313,8 @@ extension VMDisplayWindowController: NSToolbarDelegate {
                 action: #selector(displayAction(_:))
             )
             group.label = "Display"
+            group.subitems[DisplaySegment.popIn.rawValue].toolTip = "Return display to the main window"
+            group.subitems[DisplaySegment.fullscreen.rawValue].toolTip = "Enter fullscreen display"
             group.autovalidates = false
             return group
 

--- a/Kernova/Views/Console/VMPauseOverlay.swift
+++ b/Kernova/Views/Console/VMPauseOverlay.swift
@@ -16,6 +16,7 @@ struct VMPauseOverlay: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Resume")
+            .help("Resume the virtual machine")
 
             Text("Paused")
                 .font(.title2)


### PR DESCRIPTION
## Summary
- Restore hover tooltips on all toolbar buttons lost during the SwiftUI-to-AppKit toolbar migration
- Tooltips update dynamically when button meaning changes (Start/Resume, Pop Out/Pop In, Fullscreen/Exit Fullscreen)
- Extract tooltip strings into segment enum constants to prevent drift between creation and update sites

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Hover over each toolbar button in the main window — verify tooltip appears
- [ ] Start a VM, verify Start tooltip changes to Resume
- [ ] Pop out display, verify tooltip updates in both windows
- [ ] Hover over pause overlay resume button — verify tooltip appears
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)