### PR TITLE
fix: Auto-quit app when main window is closed and last VM stops

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -332,17 +332,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                         instance.configuration.lastFullscreenDisplayID = displayID
                     }
 
+                    if !controller.closedProgrammatically {
+                        // User manually closed the display window
+                        instance.configuration.displayPreference = .inline
+                        Self.logger.debug("Cleared displayPreference for '\(instance.name)' (user closed display window)")
+                    }
+
+                    self.viewModel.saveConfiguration(for: instance)
+
                     if controller.closedProgrammatically {
                         // VM stopped/errored/cold-paused — check if app should quit
-                        self.viewModel.saveConfiguration(for: instance)
                         self.terminateIfIdle()
                         return
                     }
-
-                    // User manually closed the display window
-                    instance.configuration.displayPreference = .inline
-                    Self.logger.debug("Cleared displayPreference for '\(instance.name)' (user closed display window)")
-                    self.viewModel.saveConfiguration(for: instance)
                 }
                 self.viewModel.selectedID = vmID
 

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -58,13 +58,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             viewModel.importVM(from: url)
         }
         pendingOpenURLs.removeAll()
+
+        observeForTermination()
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        let hasActiveVMs = viewModel.instances.contains { instance in
-            // Live-paused VMs (not cold-paused to disk) and preparing VMs should also keep the app alive
-            instance.isPreparing || instance.status.isActive || (instance.status == .paused && instance.virtualMachine != nil)
-        }
+        let hasActiveVMs = viewModel.instances.contains(where: \.isKeepingAppAlive)
 
         // Stay alive if VMs are active or display windows still exist
         if hasActiveVMs || !displayWindows.isEmpty {
@@ -257,6 +256,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                     NotificationCenter.default.removeObserver(token)
                 }
                 self?.serialConsoleWindows.removeValue(forKey: vmID)
+                self?.terminateIfIdle()
             }
         }
         serialConsoleObservers[vmID] = token
@@ -331,17 +331,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                     if let displayID = controller.lastDisplayID {
                         instance.configuration.lastFullscreenDisplayID = displayID
                     }
-                    if !controller.closedProgrammatically {
-                        instance.configuration.displayPreference = .inline
-                        Self.logger.debug("Cleared displayPreference for '\(instance.name)' (user closed display window)")
+
+                    if controller.closedProgrammatically {
+                        // VM stopped/errored/cold-paused — check if app should quit
+                        self.viewModel.saveConfiguration(for: instance)
+                        self.terminateIfIdle()
+                        return
                     }
+
+                    // User manually closed the display window
+                    instance.configuration.displayPreference = .inline
+                    Self.logger.debug("Cleared displayPreference for '\(instance.name)' (user closed display window)")
                     self.viewModel.saveConfiguration(for: instance)
                 }
                 self.viewModel.selectedID = vmID
 
-                // Restore library window based on context:
+                // Restore library window for user-initiated close:
                 // - Key + active app: user deliberately closed display → focus library
-                // - App not active: VM stopped while user is elsewhere → show library in background
+                // - App not active: user closed display while elsewhere → show library in background
                 // - Active but not key: user is in another Kernova window → no action needed
                 if wasKeyWindow && appWasActive {
                     self.showLibrary(nil)
@@ -384,6 +391,52 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             return libraryScreen
         }
         return NSScreen.screens.first
+    }
+
+    // MARK: - Idle Termination
+
+    /// Whether the main library window has been dismissed (closed by the user).
+    /// Distinguishes closed from hidden (Cmd+H) and minimized (Cmd+M) via runtime inspection.
+    /// Returns `false` if the window controller or its window is nil (no window to inspect).
+    private var isMainWindowDismissed: Bool {
+        guard let window = mainWindowController?.window else { return false }
+        if NSApp.isHidden || window.isMiniaturized { return false }
+        return !window.isVisible
+    }
+
+    /// Whether the app has no reason to stay alive: main window dismissed,
+    /// no auxiliary windows remain, and no VMs are active.
+    private var isIdle: Bool {
+        guard isMainWindowDismissed else { return false }
+        guard displayWindows.isEmpty else { return false }
+        guard serialConsoleWindows.isEmpty else { return false }
+        return !viewModel.instances.contains(where: \.isKeepingAppAlive)
+    }
+
+    /// Terminates the app if `isIdle` is true.
+    private func terminateIfIdle() {
+        guard isIdle else { return }
+        Self.logger.notice("No visible windows and no active VMs — requesting termination")
+        NSApp.terminate(nil)
+    }
+
+    /// Registers a one-shot observation on the instances list and each instance's
+    /// `isKeepingAppAlive` state. Re-subscribes after each change for continuous observation.
+    private func observeForTermination() {
+        withObservationTracking {
+            for instance in viewModel.instances {
+                _ = instance.isKeepingAppAlive
+            }
+        } onChange: {
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    Self.logger.warning("observeForTermination: observation chain ended (self deallocated)")
+                    return
+                }
+                self.terminateIfIdle()
+                self.observeForTermination()
+            }
+        }
     }
 
     // MARK: - Menu Validation

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -147,6 +147,12 @@ final class VMInstance: Identifiable {
         status == .paused && virtualMachine == nil
     }
 
+    /// `true` when this VM should keep the app alive: preparing, in an active lifecycle
+    /// state, or live-paused in memory (as opposed to cold-paused to disk).
+    var isKeepingAppAlive: Bool {
+        isPreparing || status.isActive || (status == .paused && virtualMachine != nil)
+    }
+
     /// `true` when the VM is eligible to save state (active + live VM, not cold-paused).
     var canSave: Bool {
         status.canSave && !isColdPaused

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -122,6 +122,40 @@ struct VMInstanceTests {
         #expect(instance.isColdPaused == false)
     }
 
+    // MARK: - isKeepingAppAlive
+
+    @Test("isKeepingAppAlive is true when preparing")
+    func isKeepingAppAlivePreparing() {
+        let instance = makeInstance(status: .stopped)
+        let task = Task {}
+        defer { task.cancel() }
+        instance.preparingState = VMInstance.PreparingState(operation: .cloning, task: task)
+        #expect(instance.isKeepingAppAlive == true)
+    }
+
+    @Test("isKeepingAppAlive is true for active statuses")
+    func isKeepingAppAliveActive() {
+        for status in [VMStatus.running, .starting, .saving, .restoring, .installing] {
+            let instance = makeInstance(status: status)
+            #expect(instance.isKeepingAppAlive == true)
+        }
+    }
+
+    @Test("isKeepingAppAlive is false when cold-paused")
+    func isKeepingAppAliveColdPaused() {
+        let instance = makeInstance(status: .paused)
+        #expect(instance.virtualMachine == nil)
+        #expect(instance.isKeepingAppAlive == false)
+    }
+
+    @Test("isKeepingAppAlive is false when stopped or error")
+    func isKeepingAppAliveStoppedOrError() {
+        for status in [VMStatus.stopped, .error] {
+            let instance = makeInstance(status: status)
+            #expect(instance.isKeepingAppAlive == false)
+        }
+    }
+
     // MARK: - canSave
 
     @Test("canSave is true when running (without live VM, tests model logic)")


### PR DESCRIPTION
## Summary
- When the user closes the main library window while VMs are running, the app stays in the dock. Previously it would linger indefinitely after all VMs stopped — now it detects the idle state and terminates automatically.
- Uses runtime window inspection (no stored flags) to distinguish closed from hidden/minimized, and `withObservationTracking` to detect VM state changes.
- Extracts the duplicated "active VM" predicate into `VMInstance.isKeepingAppAlive` for consistency.

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Start a VM, close main window, shut down guest OS → app quits
- [ ] Pop out display, close main window, stop VM → display closes, app quits
- [ ] Two VMs running, close main window, stop one → app stays; stop second → app quits
- [ ] Close main window, click dock icon → library reappears; close again, stop VM → app quits
- [ ] Hide app (Cmd+H) with VM running, stop VM → app does NOT quit
- [ ] Minimize main window with VM running, stop VM → app does NOT quit
- [ ] Close main window with no VMs → app quits immediately (existing behavior)
- [ ] All existing tests pass, new `isKeepingAppAlive` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)