### PR TITLE
refactor: Extract shared toolbar coordinator from window controllers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,6 +12,7 @@ Kernova/
 │   ├── AppDelegate.swift               # NSApplicationDelegate — startup, window tracking, menu, save-on-quit
 │   ├── MainWindowController.swift      # NSSplitViewController + NSToolbar with native items
 │   ├── VMDisplayWindowController.swift  # Per-VM display window (pop-out or fullscreen), auto-closes on VM stop
+│   ├── VMToolbarManager.swift          # Shared toolbar logic for lifecycle, save-state, and display groups
 │   └── SerialConsoleWindowController.swift # Per-VM serial console window, auto-closes on VM stop
 ├── Models/                             # Data types — all value types or @MainActor-isolated
 │   ├── VMConfiguration.swift           # Codable/Sendable struct persisted as config.json per VM bundle
@@ -82,6 +83,7 @@ KernovaTests/
 │   ├── MockMacOSInstallService.swift
 │   └── MockIPSWService.swift
 ├── VMConfigurationTests.swift          # 43 tests for VMConfiguration
+├── VMToolbarManagerTests.swift          # Toolbar manager item creation and state update tests
 ├── VMConfigurationCloneTests.swift     # Clone-specific configuration tests
 ├── VMLibraryViewModelTests.swift       # 39 tests for the central view model
 ├── VMCreationViewModelTests.swift      # 44 tests for the creation wizard
@@ -99,7 +101,7 @@ KernovaTests/
 └── DataFormattersTests.swift           # Formatting utility tests
 ```
 
-**Total: 50 source files, 22 test files (16 suites + 6 mocks).**
+**Total: 51 source files, 23 test files (17 suites + 6 mocks).**
 
 *Note: `ContentView.swift` was removed when `NavigationSplitView` was replaced by `NSSplitViewController` in `MainWindowController`. Its responsibilities were split between `MainWindowController` (toolbar, split view) and `MainDetailView` (detail switching, sheets, alerts).*
 
@@ -107,7 +109,7 @@ KernovaTests/
 
 ### App Layer
 
-**Files:** `AppDelegate.swift`, `MainWindowController.swift`, `VMDisplayWindowController.swift`, `SerialConsoleWindowController.swift`
+**Files:** `AppDelegate.swift`, `MainWindowController.swift`, `VMDisplayWindowController.swift`, `VMToolbarManager.swift`, `SerialConsoleWindowController.swift`
 
 `AppDelegate` is the entry point. It creates the `VMLibraryViewModel` and `VMLifecycleCoordinator`, opens the main window, and manages the lifecycle of all windows. It tracks window controllers in dictionaries keyed by VM UUID, enabling one-to-many relationships (a VM can have a main view, a fullscreen window, and a serial console open simultaneously). `AppDelegate` also handles:
 - The application menu (including VM-specific actions, Force Stop with `canForceStop` validation, and Window > Show Library with Cmd+0)
@@ -116,7 +118,7 @@ KernovaTests/
 - Dock icon reopen: `applicationShouldHandleReopen` restores the main window when clicked with no visible windows
 - Fullscreen exit recovery: closing a fullscreen window automatically re-shows the main library window via `showLibrary(_:)`
 
-`MainWindowController` creates an `NSWindow` with an `NSSplitViewController` as the content view controller. The split view has two panes: a sidebar (`NSSplitViewItem(sidebarWithViewController:)` wrapping `SidebarView`) and a detail pane (wrapping `MainDetailView`). Both panes use `NSHostingController` to embed SwiftUI content. An `NSToolbar` with native `NSToolbarItem`s provides lifecycle controls (Start/Resume, Pause, Stop), Save State, Fullscreen, and New VM buttons. Toolbar state is observed via `withObservationTracking` and items are validated through `NSToolbarItemValidation`. The `.fullSizeContentView` style mask and `.sidebarTrackingSeparator` preserve the full-height sidebar appearance matching Mail/Finder.
+`MainWindowController` creates an `NSWindow` with an `NSSplitViewController` as the content view controller. The split view has two panes: a sidebar (`NSSplitViewItem(sidebarWithViewController:)` wrapping `SidebarView`) and a detail pane (wrapping `MainDetailView`). Both panes use `NSHostingController` to embed SwiftUI content. An `NSToolbar` with native `NSToolbarItem`s provides lifecycle controls (Start/Resume, Pause, Stop), Save State, Fullscreen, and New VM buttons. Shared toolbar groups (lifecycle, save-state, display) are managed by `VMToolbarManager`; the New VM button and sidebar items remain controller-specific. Toolbar state is observed via `withObservationTracking` and items are validated through `NSToolbarItemValidation`. The `.fullSizeContentView` style mask and `.sidebarTrackingSeparator` preserve the full-height sidebar appearance matching Mail/Finder.
 
 ### Models
 
@@ -280,9 +282,9 @@ SystemSleepWatcher ──sleep/wake──→ VMLibraryViewModel ──pause/resu
 
 ### 7. Native NSToolbar with observation-driven validation
 
-**What:** The main window uses an `NSToolbar` with `NSToolbarDelegate` creating native `NSToolbarItem`s. Toolbar state (enabled/disabled, Start/Resume label) is driven by `withObservationTracking` on the view model, directly setting `isEnabled` on subitems on change. All toolbar item groups use `autovalidates = false` to prevent AppKit's automatic validation from overriding the observation-driven state.
+**What:** The main window and display window use `NSToolbar` with `NSToolbarDelegate` creating native `NSToolbarItem`s. Shared toolbar groups (lifecycle, save-state, display) are managed by `VMToolbarManager`, a `@MainActor` `NSObject` subclass that handles item creation, state updates, and action routing for both controllers. Each controller configures it with an `instanceProvider` closure and a `Configuration` struct that captures per-controller differences (identifier strings, `isPreparing` checks, display capability gating). Toolbar state is driven by `withObservationTracking` on the view model, directly setting `isEnabled` on subitems on change. All toolbar item groups use `autovalidates = false` to prevent AppKit's automatic validation from overriding the observation-driven state.
 
-**Why:** Native `NSToolbarItem`s provide reliable layout, proper `.sidebarTrackingSeparator` support, and standard macOS toolbar appearance. The `withObservationTracking` pattern (already used in `VMDisplayWindowController` and `SerialConsoleWindowController`) re-evaluates on any observed property change and re-registers itself, providing reactive updates without SwiftUI.
+**Why:** Native `NSToolbarItem`s provide reliable layout, proper `.sidebarTrackingSeparator` support, and standard macOS toolbar appearance. The `withObservationTracking` pattern (used in all three window controllers) re-evaluates on any observed property change and re-registers itself, providing reactive updates without SwiftUI. The shared `VMToolbarManager` eliminates ~150 lines of duplicated toolbar logic between `MainWindowController` and `VMDisplayWindowController`, ensuring toolbar changes are applied in one place.
 
 **Alternatives:** SwiftUI `.toolbar` modifiers on a hosting controller — simpler declarative API but caused persistent layout issues with grouped items and sidebar tracking.
 
@@ -318,6 +320,7 @@ No external package dependencies. No Swift Package Manager, CocoaPods, or Cartha
 | `VMBootMode` | Yes | Enum cases and properties |
 | `VMGuestOS` | Yes | Enum cases and properties |
 | `MacOSInstallState` | Yes | Phase tracking, progress calculation |
+| `VMToolbarManager` | 22 tests | Item creation, state updates, configuration flags, label toggling |
 | `DataFormatters` | Yes | Byte formatting, CPU count formatting |
 
 ### Mocked but Not Directly Tested

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -8,43 +8,29 @@ import SwiftUI
 final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindowDelegate {
 
     private let viewModel: VMLibraryViewModel
+    private let toolbarManager: VMToolbarManager
     private let splitViewController = NSSplitViewController()
     private let sidebarItem: NSSplitViewItem
     private var observingToolbar = false
     private var sidebarCollapseObservation: NSKeyValueObservation?
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "MainWindowController")
-
-    private enum LifecycleSegment: Int {
-        case play = 0, pause = 1, stop = 2
-
-        static let startToolTip = "Start the virtual machine"
-        static let resumeToolTip = "Resume the virtual machine"
-        static let pauseToolTip = "Pause the virtual machine"
-        static let stopToolTip = "Stop the virtual machine"
-    }
-
-    // MARK: - Toolbar Item Identifiers
-
     private static let toolbarNewVM = NSToolbarItem.Identifier("newVM")
-    private static let toolbarLifecycle = NSToolbarItem.Identifier("lifecycle")
-    private static let toolbarSaveState = NSToolbarItem.Identifier("saveState")
-    private static let saveStateToolTip = "Save the virtual machine state to disk"
-    private static let toolbarDisplay = NSToolbarItem.Identifier("display")
-
-    private enum DisplaySegment: Int {
-        case popOut = 0, fullscreen = 1
-
-        static let popOutToolTip = "Open display in a separate window"
-        static let popInToolTip = "Return display to the main window"
-        static let fullscreenToolTip = "Enter fullscreen display"
-        static let exitFullscreenToolTip = "Exit fullscreen display"
-    }
 
     // MARK: - Init
 
     init(viewModel: VMLibraryViewModel) {
         self.viewModel = viewModel
+        self.toolbarManager = VMToolbarManager(
+            configuration: .init(
+                lifecycleID: NSToolbarItem.Identifier("lifecycle"),
+                saveStateID: NSToolbarItem.Identifier("saveState"),
+                displayID: NSToolbarItem.Identifier("display"),
+                checksPreparing: true,
+                gatesDisplayOnCapability: true
+            ),
+            instanceProvider: { [weak viewModel] in viewModel?.selectedInstance }
+        )
 
         let sidebarHost = NSHostingController(rootView: SidebarView(viewModel: viewModel))
         sidebarHost.sizingOptions = []
@@ -157,96 +143,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             return
         }
 
-        updateLifecycleGroup(in: toolbar)
-        updateSaveStateItem(in: toolbar)
-        updateDisplayGroup(in: toolbar)
-    }
-
-    private func updateLifecycleGroup(in toolbar: NSToolbar) {
-        guard let group = toolbar.items.first(where: { $0.itemIdentifier == Self.toolbarLifecycle }) as? NSToolbarItemGroup,
-              group.subitems.count == 3 else {
-            Self.logger.warning("updateLifecycleGroup: lifecycle group missing or has unexpected subitem count")
-            return
-        }
-
-        guard let instance = viewModel.selectedInstance, !instance.isPreparing else {
-            group.subitems.forEach { $0.isEnabled = false }
-            return
-        }
-
-        let canResume = instance.status.canResume
-        let playLabel = canResume ? "Resume" : "Start"
-
-        let play = group.subitems[LifecycleSegment.play.rawValue]
-        if play.label != playLabel {
-            play.label = playLabel
-            play.image = NSImage(systemSymbolName: "play.fill", accessibilityDescription: playLabel)
-            play.toolTip = canResume ? LifecycleSegment.resumeToolTip : LifecycleSegment.startToolTip
-        }
-
-        play.isEnabled = instance.status.canStart || canResume
-        group.subitems[LifecycleSegment.pause.rawValue].isEnabled = instance.status.canPause
-        group.subitems[LifecycleSegment.stop.rawValue].isEnabled = instance.status.canStop
-    }
-
-    private func updateSaveStateItem(in toolbar: NSToolbar) {
-        guard let group = toolbar.items.first(where: { $0.itemIdentifier == Self.toolbarSaveState }) as? NSToolbarItemGroup,
-              let subitem = group.subitems.first else {
-            Self.logger.warning("updateSaveStateItem: save state group missing or empty")
-            return
-        }
-        guard let instance = viewModel.selectedInstance, !instance.isPreparing else {
-            subitem.isEnabled = false
-            return
-        }
-        subitem.isEnabled = instance.canSave
-    }
-
-    private func updateDisplayGroup(in toolbar: NSToolbar) {
-        guard let group = toolbar.items.first(where: { $0.itemIdentifier == Self.toolbarDisplay }) as? NSToolbarItemGroup,
-              group.subitems.count == 2 else {
-            Self.logger.warning("updateDisplayGroup: display group missing or has unexpected subitem count")
-            return
-        }
-
-        let popOutItem = group.subitems[DisplaySegment.popOut.rawValue]
-        let fullscreenItem = group.subitems[DisplaySegment.fullscreen.rawValue]
-
-        guard let instance = viewModel.selectedInstance, !instance.isPreparing else {
-            popOutItem.isEnabled = false
-            fullscreenItem.isEnabled = false
-            return
-        }
-
-        let canUse = instance.canUseExternalDisplay
-        popOutItem.isEnabled = canUse
-        fullscreenItem.isEnabled = canUse
-
-        let popLabel = instance.isInSeparateWindow ? "Pop In" : "Pop Out"
-        if popOutItem.label != popLabel {
-            popOutItem.label = popLabel
-            popOutItem.image = NSImage(
-                systemSymbolName: instance.isInSeparateWindow ? "pip.enter" : "pip.exit",
-                accessibilityDescription: popLabel
-            )
-            popOutItem.toolTip = instance.isInSeparateWindow
-                ? DisplaySegment.popInToolTip
-                : DisplaySegment.popOutToolTip
-        }
-
-        let fsLabel = instance.isInFullscreen ? "Exit Fullscreen" : "Fullscreen"
-        if fullscreenItem.label != fsLabel {
-            fullscreenItem.label = fsLabel
-            fullscreenItem.image = NSImage(
-                systemSymbolName: instance.isInFullscreen
-                    ? "arrow.down.right.and.arrow.up.left"
-                    : "arrow.up.left.and.arrow.down.right",
-                accessibilityDescription: fsLabel
-            )
-            fullscreenItem.toolTip = instance.isInFullscreen
-                ? DisplaySegment.exitFullscreenToolTip
-                : DisplaySegment.fullscreenToolTip
-        }
+        toolbarManager.updateToolbarItems(in: toolbar)
     }
 
     // MARK: - NSToolbarDelegate
@@ -257,10 +154,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             Self.toolbarNewVM,
             .toggleSidebar,
             .sidebarTrackingSeparator,
-            Self.toolbarLifecycle,
-            Self.toolbarSaveState,
-            Self.toolbarDisplay,
-        ]
+        ] + toolbarManager.sharedItemIdentifiers
     }
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
@@ -269,10 +163,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             .toggleSidebar,
             .sidebarTrackingSeparator,
             .flexibleSpace,
-            Self.toolbarLifecycle,
-            Self.toolbarSaveState,
-            Self.toolbarDisplay,
-        ]
+        ] + toolbarManager.sharedItemIdentifiers
     }
 
     func toolbar(
@@ -280,6 +171,10 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
         itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
         willBeInsertedIntoToolbar flag: Bool
     ) -> NSToolbarItem? {
+        if let sharedItem = toolbarManager.makeToolbarItem(for: itemIdentifier) {
+            return sharedItem
+        }
+
         switch itemIdentifier {
         case Self.toolbarNewVM:
             return makeToolbarItem(
@@ -289,92 +184,8 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
                 action: #selector(AppDelegate.newVM(_:)),
                 toolTip: "Create a new virtual machine"
             )
-
-        case Self.toolbarLifecycle:
-            let group = NSToolbarItemGroup(
-                itemIdentifier: itemIdentifier,
-                images: [
-                    NSImage(systemSymbolName: "play.fill", accessibilityDescription: "Start")!,
-                    NSImage(systemSymbolName: "pause.fill", accessibilityDescription: "Pause")!,
-                    NSImage(systemSymbolName: "stop.fill", accessibilityDescription: "Stop")!,
-                ],
-                selectionMode: .momentary,
-                labels: ["Start", "Pause", "Stop"],
-                target: self,
-                action: #selector(lifecycleAction(_:))
-            )
-            group.label = "State Controls"
-            group.subitems[LifecycleSegment.play.rawValue].toolTip = LifecycleSegment.startToolTip
-            group.subitems[LifecycleSegment.pause.rawValue].toolTip = LifecycleSegment.pauseToolTip
-            group.subitems[LifecycleSegment.stop.rawValue].toolTip = LifecycleSegment.stopToolTip
-            group.autovalidates = false
-            return group
-
-        case Self.toolbarSaveState:
-            return makeSingleItemGroup(
-                identifier: itemIdentifier,
-                label: "Save State",
-                symbol: "square.and.arrow.down",
-                action: #selector(AppDelegate.saveVM(_:)),
-                toolTip: Self.saveStateToolTip
-            )
-
-        case Self.toolbarDisplay:
-            let group = NSToolbarItemGroup(
-                itemIdentifier: itemIdentifier,
-                images: [
-                    NSImage(systemSymbolName: "pip.exit", accessibilityDescription: "Pop Out")!,
-                    NSImage(systemSymbolName: "arrow.up.left.and.arrow.down.right", accessibilityDescription: "Fullscreen")!,
-                ],
-                selectionMode: .momentary,
-                labels: ["Pop Out", "Fullscreen"],
-                target: self,
-                action: #selector(displayAction(_:))
-            )
-            group.label = "Display"
-            group.subitems[DisplaySegment.popOut.rawValue].toolTip = DisplaySegment.popOutToolTip
-            group.subitems[DisplaySegment.fullscreen.rawValue].toolTip = DisplaySegment.fullscreenToolTip
-            group.autovalidates = false
-            return group
-
         default:
             return nil
-        }
-    }
-
-    // MARK: - Lifecycle Group Action
-
-    @objc private func lifecycleAction(_ group: NSToolbarItemGroup) {
-        guard let segment = LifecycleSegment(rawValue: group.selectedIndex) else {
-            Self.logger.warning("lifecycleAction: unexpected selectedIndex \(group.selectedIndex)")
-            return
-        }
-        switch segment {
-        case .play:
-            if viewModel.selectedInstance?.status.canResume ?? false {
-                NSApp.sendAction(#selector(AppDelegate.resumeVM(_:)), to: nil, from: nil)
-            } else {
-                NSApp.sendAction(#selector(AppDelegate.startVM(_:)), to: nil, from: nil)
-            }
-        case .pause:
-            NSApp.sendAction(#selector(AppDelegate.pauseVM(_:)), to: nil, from: nil)
-        case .stop:
-            NSApp.sendAction(#selector(AppDelegate.stopVM(_:)), to: nil, from: nil)
-        }
-    }
-
-    // MARK: - Display Group Action
-
-    @objc private func displayAction(_ group: NSToolbarItemGroup) {
-        guard let segment = DisplaySegment(rawValue: group.selectedIndex) else {
-            Self.logger.warning("displayAction: unexpected selectedIndex \(group.selectedIndex)")
-            return
-        }
-        switch segment {
-        case .popOut:
-            NSApp.sendAction(#selector(AppDelegate.togglePopOut(_:)), to: nil, from: nil)
-        case .fullscreen:
-            NSApp.sendAction(#selector(AppDelegate.toggleFullscreen(_:)), to: nil, from: nil)
         }
     }
 
@@ -396,26 +207,6 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
         return item
     }
 
-    private func makeSingleItemGroup(
-        identifier: NSToolbarItem.Identifier,
-        label: String,
-        symbol: String,
-        action: Selector,
-        toolTip: String? = nil
-    ) -> NSToolbarItemGroup {
-        let group = NSToolbarItemGroup(
-            itemIdentifier: identifier,
-            images: [NSImage(systemSymbolName: symbol, accessibilityDescription: label)!],
-            selectionMode: .momentary,
-            labels: [label],
-            target: nil,
-            action: action
-        )
-        group.label = label
-        if let toolTip { group.subitems.first?.toolTip = toolTip }
-        group.autovalidates = false
-        return group
-    }
 }
 
 // MARK: - NSToolbarItemValidation
@@ -426,14 +217,14 @@ extension MainWindowController: NSToolbarItemValidation {
             return item.itemIdentifier == Self.toolbarNewVM
         }
 
-        switch item.itemIdentifier {
-        case Self.toolbarNewVM, Self.toolbarLifecycle, Self.toolbarSaveState, Self.toolbarDisplay:
+        if item.itemIdentifier == Self.toolbarNewVM
+            || toolbarManager.sharedItemIdentifiers.contains(item.itemIdentifier) {
             // Group subitems are enabled/disabled directly in updateToolbarItems()
             return true
-        default:
-            Self.logger.debug("validateToolbarItem: unrecognized identifier '\(item.itemIdentifier.rawValue)'")
-            return true
         }
+
+        Self.logger.debug("validateToolbarItem: unrecognized identifier '\(item.itemIdentifier.rawValue)'")
+        return true
     }
 }
 

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -17,39 +17,25 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     private(set) var closedProgrammatically = false
     private(set) var lastDisplayID: CGDirectDisplayID?
     let instance: VMInstance
+    private let toolbarManager: VMToolbarManager
     private let enterFullscreen: Bool
     private var observingInstance = false
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VMDisplayWindowController")
 
-    // MARK: - Toolbar Item Identifiers
-
-    private static let toolbarLifecycle = NSToolbarItem.Identifier("displayLifecycle")
-    private static let toolbarSaveState = NSToolbarItem.Identifier("displaySaveState")
-    private static let saveStateToolTip = "Save the virtual machine state to disk"
-    private static let toolbarDisplay = NSToolbarItem.Identifier("displayDisplay")
-
-    private enum LifecycleSegment: Int {
-        case play = 0, pause = 1, stop = 2
-
-        static let startToolTip = "Start the virtual machine"
-        static let resumeToolTip = "Resume the virtual machine"
-        static let pauseToolTip = "Pause the virtual machine"
-        static let stopToolTip = "Stop the virtual machine"
-    }
-
-    private enum DisplaySegment: Int {
-        case popIn = 0, fullscreen = 1
-
-        static let popOutToolTip = "Open display in a separate window"
-        static let popInToolTip = "Return display to the main window"
-        static let fullscreenToolTip = "Enter fullscreen display"
-        static let exitFullscreenToolTip = "Exit fullscreen display"
-    }
-
     init(instance: VMInstance, enterFullscreen: Bool, onResume: @escaping () -> Void) {
         self.vmID = instance.instanceID
         self.instance = instance
+        self.toolbarManager = VMToolbarManager(
+            configuration: .init(
+                lifecycleID: NSToolbarItem.Identifier("displayLifecycle"),
+                saveStateID: NSToolbarItem.Identifier("displaySaveState"),
+                displayID: NSToolbarItem.Identifier("displayDisplay"),
+                checksPreparing: false,
+                gatesDisplayOnCapability: false
+            ),
+            instanceProvider: { [weak instance] in instance }
+        )
         self.enterFullscreen = enterFullscreen
 
         let contentView = DetachedVMView(instance: instance, onResume: onResume)
@@ -145,107 +131,11 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     // MARK: - Toolbar State
 
     private func updateToolbarItems() {
-        guard let toolbar = window?.toolbar else { return }
-
-        updateLifecycleGroup(in: toolbar)
-        updateSaveStateItem(in: toolbar)
-        updateDisplayGroup(in: toolbar)
-    }
-
-    private func updateLifecycleGroup(in toolbar: NSToolbar) {
-        guard let group = toolbar.items.first(where: { $0.itemIdentifier == Self.toolbarLifecycle }) as? NSToolbarItemGroup,
-              group.subitems.count == 3 else { return }
-
-        let canResume = instance.status.canResume
-        let playLabel = canResume ? "Resume" : "Start"
-
-        let play = group.subitems[LifecycleSegment.play.rawValue]
-        if play.label != playLabel {
-            play.label = playLabel
-            play.image = NSImage(systemSymbolName: "play.fill", accessibilityDescription: playLabel)
-            play.toolTip = canResume ? LifecycleSegment.resumeToolTip : LifecycleSegment.startToolTip
-        }
-
-        play.isEnabled = instance.status.canStart || canResume
-        group.subitems[LifecycleSegment.pause.rawValue].isEnabled = instance.status.canPause
-        group.subitems[LifecycleSegment.stop.rawValue].isEnabled = instance.status.canStop
-    }
-
-    private func updateSaveStateItem(in toolbar: NSToolbar) {
-        guard let group = toolbar.items.first(where: { $0.itemIdentifier == Self.toolbarSaveState }) as? NSToolbarItemGroup,
-              let subitem = group.subitems.first else { return }
-        subitem.isEnabled = instance.canSave
-    }
-
-    private func updateDisplayGroup(in toolbar: NSToolbar) {
-        guard let group = toolbar.items.first(where: { $0.itemIdentifier == Self.toolbarDisplay }) as? NSToolbarItemGroup,
-              group.subitems.count == 2 else { return }
-
-        let popInItem = group.subitems[DisplaySegment.popIn.rawValue]
-        let fullscreenItem = group.subitems[DisplaySegment.fullscreen.rawValue]
-
-        popInItem.isEnabled = true
-        fullscreenItem.isEnabled = true
-
-        let popLabel = instance.isInSeparateWindow ? "Pop In" : "Pop Out"
-        if popInItem.label != popLabel {
-            popInItem.label = popLabel
-            popInItem.image = NSImage(
-                systemSymbolName: instance.isInSeparateWindow ? "pip.enter" : "pip.exit",
-                accessibilityDescription: popLabel
-            )
-            popInItem.toolTip = instance.isInSeparateWindow
-                ? DisplaySegment.popInToolTip
-                : DisplaySegment.popOutToolTip
-        }
-
-        let fsLabel = instance.isInFullscreen ? "Exit Fullscreen" : "Fullscreen"
-        if fullscreenItem.label != fsLabel {
-            fullscreenItem.label = fsLabel
-            fullscreenItem.image = NSImage(
-                systemSymbolName: instance.isInFullscreen
-                    ? "arrow.down.right.and.arrow.up.left"
-                    : "arrow.up.left.and.arrow.down.right",
-                accessibilityDescription: fsLabel
-            )
-            fullscreenItem.toolTip = instance.isInFullscreen
-                ? DisplaySegment.exitFullscreenToolTip
-                : DisplaySegment.fullscreenToolTip
-        }
-    }
-
-    // MARK: - Toolbar Actions
-
-    @objc private func lifecycleAction(_ group: NSToolbarItemGroup) {
-        guard let segment = LifecycleSegment(rawValue: group.selectedIndex) else {
-            Self.logger.warning("lifecycleAction: unexpected selectedIndex \(group.selectedIndex)")
+        guard let toolbar = window?.toolbar else {
+            Self.logger.warning("updateToolbarItems: window or toolbar is nil — toolbar state will be stale")
             return
         }
-        switch segment {
-        case .play:
-            if instance.status.canResume {
-                NSApp.sendAction(#selector(AppDelegate.resumeVM(_:)), to: nil, from: nil)
-            } else {
-                NSApp.sendAction(#selector(AppDelegate.startVM(_:)), to: nil, from: nil)
-            }
-        case .pause:
-            NSApp.sendAction(#selector(AppDelegate.pauseVM(_:)), to: nil, from: nil)
-        case .stop:
-            NSApp.sendAction(#selector(AppDelegate.stopVM(_:)), to: nil, from: nil)
-        }
-    }
-
-    @objc private func displayAction(_ group: NSToolbarItemGroup) {
-        guard let segment = DisplaySegment(rawValue: group.selectedIndex) else {
-            Self.logger.warning("displayAction: unexpected selectedIndex \(group.selectedIndex)")
-            return
-        }
-        switch segment {
-        case .popIn:
-            NSApp.sendAction(#selector(AppDelegate.togglePopOut(_:)), to: nil, from: nil)
-        case .fullscreen:
-            NSApp.sendAction(#selector(AppDelegate.toggleFullscreen(_:)), to: nil, from: nil)
-        }
+        toolbarManager.updateToolbarItems(in: toolbar)
     }
 }
 
@@ -254,21 +144,11 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
 extension VMDisplayWindowController: NSToolbarDelegate {
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [
-            .flexibleSpace,
-            Self.toolbarLifecycle,
-            Self.toolbarSaveState,
-            Self.toolbarDisplay,
-        ]
+        [.flexibleSpace] + toolbarManager.sharedItemIdentifiers
     }
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [
-            .flexibleSpace,
-            Self.toolbarLifecycle,
-            Self.toolbarSaveState,
-            Self.toolbarDisplay,
-        ]
+        [.flexibleSpace] + toolbarManager.sharedItemIdentifiers
     }
 
     func toolbar(
@@ -276,62 +156,7 @@ extension VMDisplayWindowController: NSToolbarDelegate {
         itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
         willBeInsertedIntoToolbar flag: Bool
     ) -> NSToolbarItem? {
-        switch itemIdentifier {
-        case Self.toolbarLifecycle:
-            let group = NSToolbarItemGroup(
-                itemIdentifier: itemIdentifier,
-                images: [
-                    NSImage(systemSymbolName: "play.fill", accessibilityDescription: "Start")!,
-                    NSImage(systemSymbolName: "pause.fill", accessibilityDescription: "Pause")!,
-                    NSImage(systemSymbolName: "stop.fill", accessibilityDescription: "Stop")!,
-                ],
-                selectionMode: .momentary,
-                labels: ["Start", "Pause", "Stop"],
-                target: self,
-                action: #selector(lifecycleAction(_:))
-            )
-            group.label = "State Controls"
-            group.subitems[LifecycleSegment.play.rawValue].toolTip = LifecycleSegment.startToolTip
-            group.subitems[LifecycleSegment.pause.rawValue].toolTip = LifecycleSegment.pauseToolTip
-            group.subitems[LifecycleSegment.stop.rawValue].toolTip = LifecycleSegment.stopToolTip
-            group.autovalidates = false
-            return group
-
-        case Self.toolbarSaveState:
-            let group = NSToolbarItemGroup(
-                itemIdentifier: itemIdentifier,
-                images: [NSImage(systemSymbolName: "square.and.arrow.down", accessibilityDescription: "Save State")!],
-                selectionMode: .momentary,
-                labels: ["Save State"],
-                target: nil,
-                action: #selector(AppDelegate.saveVM(_:))
-            )
-            group.label = "Save State"
-            group.subitems.first?.toolTip = Self.saveStateToolTip
-            group.autovalidates = false
-            return group
-
-        case Self.toolbarDisplay:
-            let group = NSToolbarItemGroup(
-                itemIdentifier: itemIdentifier,
-                images: [
-                    NSImage(systemSymbolName: "pip.enter", accessibilityDescription: "Pop In")!,
-                    NSImage(systemSymbolName: "arrow.up.left.and.arrow.down.right", accessibilityDescription: "Fullscreen")!,
-                ],
-                selectionMode: .momentary,
-                labels: ["Pop In", "Fullscreen"],
-                target: self,
-                action: #selector(displayAction(_:))
-            )
-            group.label = "Display"
-            group.subitems[DisplaySegment.popIn.rawValue].toolTip = DisplaySegment.popInToolTip
-            group.subitems[DisplaySegment.fullscreen.rawValue].toolTip = DisplaySegment.fullscreenToolTip
-            group.autovalidates = false
-            return group
-
-        default:
-            return nil
-        }
+        toolbarManager.makeToolbarItem(for: itemIdentifier)
     }
 }
 

--- a/Kernova/App/VMToolbarManager.swift
+++ b/Kernova/App/VMToolbarManager.swift
@@ -1,0 +1,300 @@
+import Cocoa
+import os
+
+/// Shared toolbar logic for VM window controllers. Creates and manages the lifecycle,
+/// save-state, and display toolbar item groups that appear in both the main window
+/// and per-VM display windows.
+///
+/// Each window controller creates its own `VMToolbarManager` with a ``Configuration``
+/// that captures per-controller differences (toolbar item identifiers, preparing checks,
+/// display capability gating) and an `instanceProvider` closure that resolves the
+/// current `VMInstance`.
+@MainActor
+final class VMToolbarManager: NSObject {
+
+    struct Configuration {
+        /// Toolbar item identifiers (different strings per controller to avoid AppKit conflicts).
+        let lifecycleID: NSToolbarItem.Identifier
+        let saveStateID: NSToolbarItem.Identifier
+        let displayID: NSToolbarItem.Identifier
+
+        /// When `true`, checks `instance.isPreparing` and disables all items while preparing.
+        /// `MainWindowController` sets this to `true`; `VMDisplayWindowController` sets it to `false`.
+        let checksPreparing: Bool
+
+        /// When `true`, gates display button enablement on `instance.canUseExternalDisplay`.
+        /// `MainWindowController` sets this to `true`; `VMDisplayWindowController` sets it to `false`
+        /// (display buttons are always enabled in the pop-out window).
+        let gatesDisplayOnCapability: Bool
+    }
+
+    /// All shared toolbar item identifiers, for use in `NSToolbarDelegate` methods.
+    var sharedItemIdentifiers: [NSToolbarItem.Identifier] {
+        [configuration.lifecycleID, configuration.saveStateID, configuration.displayID]
+    }
+
+    private let configuration: Configuration
+    private let instanceProvider: () -> VMInstance?
+
+    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMToolbarManager")
+
+    // MARK: - Tooltip Constants
+
+    private static let startToolTip = "Start the virtual machine"
+    private static let resumeToolTip = "Resume the virtual machine"
+    private static let pauseToolTip = "Pause the virtual machine"
+    private static let stopToolTip = "Stop the virtual machine"
+    private static let saveStateToolTip = "Save the virtual machine state to disk"
+    private static let popOutToolTip = "Open display in a separate window"
+    private static let popInToolTip = "Return display to the main window"
+    private static let fullscreenToolTip = "Enter fullscreen display"
+    private static let exitFullscreenToolTip = "Exit fullscreen display"
+
+    private enum LifecycleSegment: Int {
+        case play = 0, pause = 1, stop = 2
+    }
+
+    private enum DisplaySegment: Int {
+        case popOutOrIn = 0, fullscreen = 1
+    }
+
+    // MARK: - Init
+
+    init(configuration: Configuration, instanceProvider: @escaping () -> VMInstance?) {
+        assert(
+            Set([configuration.lifecycleID, configuration.saveStateID, configuration.displayID]).count == 3,
+            "VMToolbarManager.Configuration identifiers must be distinct"
+        )
+        self.configuration = configuration
+        self.instanceProvider = instanceProvider
+        super.init()
+    }
+
+    // MARK: - Item Factory
+
+    /// Creates the `NSToolbarItem` for the given identifier, or returns `nil` if it is not
+    /// a shared item managed by this manager. Called from the controller's
+    /// `toolbar(_:itemForItemIdentifier:willBeInsertedIntoToolbar:)`.
+    func makeToolbarItem(for identifier: NSToolbarItem.Identifier) -> NSToolbarItem? {
+        switch identifier {
+        case configuration.lifecycleID:
+            let group = NSToolbarItemGroup(
+                itemIdentifier: identifier,
+                images: [
+                    NSImage(systemSymbolName: "play.fill", accessibilityDescription: "Start")!,
+                    NSImage(systemSymbolName: "pause.fill", accessibilityDescription: "Pause")!,
+                    NSImage(systemSymbolName: "stop.fill", accessibilityDescription: "Stop")!,
+                ],
+                selectionMode: .momentary,
+                labels: ["Start", "Pause", "Stop"],
+                target: self,
+                action: #selector(lifecycleAction(_:))
+            )
+            group.label = "State Controls"
+            group.subitems[LifecycleSegment.play.rawValue].toolTip = Self.startToolTip
+            group.subitems[LifecycleSegment.pause.rawValue].toolTip = Self.pauseToolTip
+            group.subitems[LifecycleSegment.stop.rawValue].toolTip = Self.stopToolTip
+            group.autovalidates = false
+            return group
+
+        case configuration.saveStateID:
+            return makeSingleItemGroup(
+                identifier: identifier,
+                label: "Save State",
+                symbol: "square.and.arrow.down",
+                action: #selector(AppDelegate.saveVM(_:)),
+                toolTip: Self.saveStateToolTip
+            )
+
+        case configuration.displayID:
+            let group = NSToolbarItemGroup(
+                itemIdentifier: identifier,
+                images: [
+                    NSImage(systemSymbolName: "pip.exit", accessibilityDescription: "Pop Out")!,
+                    NSImage(systemSymbolName: "arrow.up.left.and.arrow.down.right", accessibilityDescription: "Fullscreen")!,
+                ],
+                selectionMode: .momentary,
+                labels: ["Pop Out", "Fullscreen"],
+                target: self,
+                action: #selector(displayAction(_:))
+            )
+            group.label = "Display"
+            group.subitems[DisplaySegment.popOutOrIn.rawValue].toolTip = Self.popOutToolTip
+            group.subitems[DisplaySegment.fullscreen.rawValue].toolTip = Self.fullscreenToolTip
+            group.autovalidates = false
+            return group
+
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Toolbar State Updates
+
+    /// Updates all shared toolbar items in the given toolbar to reflect current VM state.
+    func updateToolbarItems(in toolbar: NSToolbar) {
+        let instance = resolveActiveInstance()
+        updateLifecycleGroup(in: toolbar, instance: instance)
+        updateSaveStateItem(in: toolbar, instance: instance)
+        updateDisplayGroup(in: toolbar, instance: instance)
+    }
+
+    private func updateLifecycleGroup(in toolbar: NSToolbar, instance: VMInstance?) {
+        guard let group = toolbar.items.first(where: { $0.itemIdentifier == configuration.lifecycleID }) as? NSToolbarItemGroup,
+              group.subitems.count == 3 else {
+            Self.logger.warning("updateLifecycleGroup: lifecycle group missing or has unexpected subitem count")
+            return
+        }
+
+        guard let instance else {
+            group.subitems.forEach { $0.isEnabled = false }
+            return
+        }
+
+        let canResume = instance.status.canResume
+        let playLabel = canResume ? "Resume" : "Start"
+
+        let play = group.subitems[LifecycleSegment.play.rawValue]
+        if play.label != playLabel {
+            play.label = playLabel
+            play.image = NSImage(systemSymbolName: "play.fill", accessibilityDescription: playLabel)
+            play.toolTip = canResume ? Self.resumeToolTip : Self.startToolTip
+        }
+
+        play.isEnabled = instance.status.canStart || canResume
+        group.subitems[LifecycleSegment.pause.rawValue].isEnabled = instance.status.canPause
+        group.subitems[LifecycleSegment.stop.rawValue].isEnabled = instance.status.canStop
+    }
+
+    private func updateSaveStateItem(in toolbar: NSToolbar, instance: VMInstance?) {
+        guard let group = toolbar.items.first(where: { $0.itemIdentifier == configuration.saveStateID }) as? NSToolbarItemGroup,
+              let subitem = group.subitems.first else {
+            Self.logger.warning("updateSaveStateItem: save state group missing or empty")
+            return
+        }
+
+        guard let instance else {
+            subitem.isEnabled = false
+            return
+        }
+
+        subitem.isEnabled = instance.canSave
+    }
+
+    private func updateDisplayGroup(in toolbar: NSToolbar, instance: VMInstance?) {
+        guard let group = toolbar.items.first(where: { $0.itemIdentifier == configuration.displayID }) as? NSToolbarItemGroup,
+              group.subitems.count == 2 else {
+            Self.logger.warning("updateDisplayGroup: display group missing or has unexpected subitem count")
+            return
+        }
+
+        let popItem = group.subitems[DisplaySegment.popOutOrIn.rawValue]
+        let fullscreenItem = group.subitems[DisplaySegment.fullscreen.rawValue]
+
+        guard let instance else {
+            popItem.isEnabled = false
+            fullscreenItem.isEnabled = false
+            return
+        }
+
+        if configuration.gatesDisplayOnCapability {
+            let canUse = instance.canUseExternalDisplay
+            popItem.isEnabled = canUse
+            fullscreenItem.isEnabled = canUse
+        } else {
+            popItem.isEnabled = true
+            fullscreenItem.isEnabled = true
+        }
+
+        let popLabel = instance.isInSeparateWindow ? "Pop In" : "Pop Out"
+        if popItem.label != popLabel {
+            popItem.label = popLabel
+            popItem.image = NSImage(
+                systemSymbolName: instance.isInSeparateWindow ? "pip.enter" : "pip.exit",
+                accessibilityDescription: popLabel
+            )
+            popItem.toolTip = instance.isInSeparateWindow ? Self.popInToolTip : Self.popOutToolTip
+        }
+
+        let fsLabel = instance.isInFullscreen ? "Exit Fullscreen" : "Fullscreen"
+        if fullscreenItem.label != fsLabel {
+            fullscreenItem.label = fsLabel
+            fullscreenItem.image = NSImage(
+                systemSymbolName: instance.isInFullscreen
+                    ? "arrow.down.right.and.arrow.up.left"
+                    : "arrow.up.left.and.arrow.down.right",
+                accessibilityDescription: fsLabel
+            )
+            fullscreenItem.toolTip = instance.isInFullscreen
+                ? Self.exitFullscreenToolTip : Self.fullscreenToolTip
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func lifecycleAction(_ group: NSToolbarItemGroup) {
+        guard let segment = LifecycleSegment(rawValue: group.selectedIndex) else {
+            Self.logger.warning("lifecycleAction: unexpected selectedIndex \(group.selectedIndex)")
+            return
+        }
+        switch segment {
+        case .play:
+            if instanceProvider()?.status.canResume ?? false {
+                NSApp.sendAction(#selector(AppDelegate.resumeVM(_:)), to: nil, from: nil)
+            } else {
+                NSApp.sendAction(#selector(AppDelegate.startVM(_:)), to: nil, from: nil)
+            }
+        case .pause:
+            NSApp.sendAction(#selector(AppDelegate.pauseVM(_:)), to: nil, from: nil)
+        case .stop:
+            NSApp.sendAction(#selector(AppDelegate.stopVM(_:)), to: nil, from: nil)
+        }
+    }
+
+    @objc private func displayAction(_ group: NSToolbarItemGroup) {
+        guard let segment = DisplaySegment(rawValue: group.selectedIndex) else {
+            Self.logger.warning("displayAction: unexpected selectedIndex \(group.selectedIndex)")
+            return
+        }
+        switch segment {
+        case .popOutOrIn:
+            NSApp.sendAction(#selector(AppDelegate.togglePopOut(_:)), to: nil, from: nil)
+        case .fullscreen:
+            NSApp.sendAction(#selector(AppDelegate.toggleFullscreen(_:)), to: nil, from: nil)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Resolves the current VM instance, returning `nil` if no instance is available
+    /// or (when configured) the instance is preparing.
+    private func resolveActiveInstance() -> VMInstance? {
+        guard let instance = instanceProvider() else {
+            Self.logger.debug("resolveActiveInstance: no instance available")
+            return nil
+        }
+        if configuration.checksPreparing && instance.isPreparing { return nil }
+        return instance
+    }
+
+    private func makeSingleItemGroup(
+        identifier: NSToolbarItem.Identifier,
+        label: String,
+        symbol: String,
+        action: Selector,
+        toolTip: String? = nil
+    ) -> NSToolbarItemGroup {
+        let group = NSToolbarItemGroup(
+            itemIdentifier: identifier,
+            images: [NSImage(systemSymbolName: symbol, accessibilityDescription: label)!],
+            selectionMode: .momentary,
+            labels: [label],
+            target: nil,
+            action: action
+        )
+        group.label = label
+        if let toolTip { group.subitems.first?.toolTip = toolTip }
+        group.autovalidates = false
+        return group
+    }
+}

--- a/KernovaTests/VMToolbarManagerTests.swift
+++ b/KernovaTests/VMToolbarManagerTests.swift
@@ -1,0 +1,375 @@
+import Testing
+import Cocoa
+@testable import Kernova
+
+@Suite("VMToolbarManager Tests")
+@MainActor
+struct VMToolbarManagerTests {
+
+    // MARK: - Factories
+
+    private func makeInstance(status: VMStatus = .stopped) -> VMInstance {
+        let config = VMConfiguration(
+            name: "Test VM",
+            guestOS: .linux,
+            bootMode: .efi
+        )
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(config.id.uuidString, isDirectory: true)
+        return VMInstance(configuration: config, bundleURL: bundleURL, status: status)
+    }
+
+    private func makeManager(
+        instance: VMInstance? = nil,
+        checksPreparing: Bool = true,
+        gatesDisplayOnCapability: Bool = true
+    ) -> VMToolbarManager {
+        VMToolbarManager(
+            configuration: .init(
+                lifecycleID: NSToolbarItem.Identifier("testLifecycle"),
+                saveStateID: NSToolbarItem.Identifier("testSaveState"),
+                displayID: NSToolbarItem.Identifier("testDisplay"),
+                checksPreparing: checksPreparing,
+                gatesDisplayOnCapability: gatesDisplayOnCapability
+            ),
+            instanceProvider: { instance }
+        )
+    }
+
+    /// Creates an NSToolbar attached to a window so `toolbar.items` is populated via delegate callbacks.
+    private func makeToolbar(manager: VMToolbarManager) -> (NSToolbar, NSWindow, ToolbarTestDelegate) {
+        let delegate = ToolbarTestDelegate(manager: manager)
+        let toolbar = NSToolbar(identifier: "test-\(UUID().uuidString)")
+        toolbar.delegate = delegate
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.toolbar = toolbar
+        return (toolbar, window, delegate)
+    }
+
+    // MARK: - Item Creation
+
+    @Test("makeToolbarItem returns lifecycle group with 3 subitems")
+    func lifecycleGroupStructure() {
+        let manager = makeManager()
+        let item = manager.makeToolbarItem(for: NSToolbarItem.Identifier("testLifecycle"))
+        let group = item as? NSToolbarItemGroup
+        #expect(group != nil)
+        #expect(group?.subitems.count == 3)
+        #expect(group?.label == "State Controls")
+    }
+
+    @Test("makeToolbarItem returns save state group with 1 subitem")
+    func saveStateGroupStructure() {
+        let manager = makeManager()
+        let item = manager.makeToolbarItem(for: NSToolbarItem.Identifier("testSaveState"))
+        let group = item as? NSToolbarItemGroup
+        #expect(group != nil)
+        #expect(group?.subitems.count == 1)
+        #expect(group?.label == "Save State")
+    }
+
+    @Test("makeToolbarItem returns display group with 2 subitems")
+    func displayGroupStructure() {
+        let manager = makeManager()
+        let item = manager.makeToolbarItem(for: NSToolbarItem.Identifier("testDisplay"))
+        let group = item as? NSToolbarItemGroup
+        #expect(group != nil)
+        #expect(group?.subitems.count == 2)
+        #expect(group?.label == "Display")
+    }
+
+    @Test("makeToolbarItem returns nil for unknown identifier")
+    func unknownIdentifierReturnsNil() {
+        let manager = makeManager()
+        let item = manager.makeToolbarItem(for: NSToolbarItem.Identifier("unknown"))
+        #expect(item == nil)
+    }
+
+    @Test("sharedItemIdentifiers contains all three identifiers")
+    func sharedIdentifiers() {
+        let manager = makeManager()
+        #expect(manager.sharedItemIdentifiers.count == 3)
+        #expect(manager.sharedItemIdentifiers.contains(NSToolbarItem.Identifier("testLifecycle")))
+        #expect(manager.sharedItemIdentifiers.contains(NSToolbarItem.Identifier("testSaveState")))
+        #expect(manager.sharedItemIdentifiers.contains(NSToolbarItem.Identifier("testDisplay")))
+    }
+
+    // MARK: - Nil Instance
+
+    @Test("All items disabled when instance is nil")
+    func nilInstanceDisablesAll() {
+        let manager = makeManager(instance: nil)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let lifecycle = toolbar.items.first { $0.itemIdentifier.rawValue == "testLifecycle" } as? NSToolbarItemGroup
+        let saveState = toolbar.items.first { $0.itemIdentifier.rawValue == "testSaveState" } as? NSToolbarItemGroup
+        let display = toolbar.items.first { $0.itemIdentifier.rawValue == "testDisplay" } as? NSToolbarItemGroup
+
+        #expect(lifecycle?.subitems.allSatisfy { !$0.isEnabled } == true)
+        #expect(saveState?.subitems.first?.isEnabled == false)
+        #expect(display?.subitems.allSatisfy { !$0.isEnabled } == true)
+    }
+
+    // MARK: - Preparing State
+
+    @Test("checksPreparing=true disables all when isPreparing")
+    func checksPreparingDisablesAll() {
+        let instance = makeInstance(status: .running)
+        instance.preparingState = VMInstance.PreparingState(
+            operation: .cloning,
+            task: Task {}
+        )
+        let manager = makeManager(instance: instance, checksPreparing: true)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let lifecycle = toolbar.items.first { $0.itemIdentifier.rawValue == "testLifecycle" } as? NSToolbarItemGroup
+        #expect(lifecycle?.subitems.allSatisfy { !$0.isEnabled } == true)
+    }
+
+    @Test("checksPreparing=false ignores isPreparing")
+    func skipPreparingCheck() {
+        let instance = makeInstance(status: .running)
+        instance.preparingState = VMInstance.PreparingState(
+            operation: .cloning,
+            task: Task {}
+        )
+        let manager = makeManager(instance: instance, checksPreparing: false)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        // With checksPreparing=false and status=running, pause should be enabled
+        let lifecycle = toolbar.items.first { $0.itemIdentifier.rawValue == "testLifecycle" } as? NSToolbarItemGroup
+        let pauseItem = lifecycle?.subitems[1]
+        #expect(pauseItem?.isEnabled == true)
+    }
+
+    // MARK: - Lifecycle Labels
+
+    @Test("Play button shows 'Start' when status is stopped")
+    func playLabelStartWhenStopped() {
+        let instance = makeInstance(status: .stopped)
+        let manager = makeManager(instance: instance)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let lifecycle = toolbar.items.first { $0.itemIdentifier.rawValue == "testLifecycle" } as? NSToolbarItemGroup
+        let playItem = lifecycle?.subitems[0]
+        #expect(playItem?.label == "Start")
+    }
+
+    @Test("Play button shows 'Resume' when status is paused")
+    func playLabelResumeWhenPaused() {
+        let instance = makeInstance(status: .paused)
+        let manager = makeManager(instance: instance)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let lifecycle = toolbar.items.first { $0.itemIdentifier.rawValue == "testLifecycle" } as? NSToolbarItemGroup
+        let playItem = lifecycle?.subitems[0]
+        #expect(playItem?.label == "Resume")
+    }
+
+    // MARK: - Lifecycle Enable States
+
+    @Test("Play enabled when canStart (stopped)")
+    func playEnabledWhenStopped() {
+        let instance = makeInstance(status: .stopped)
+        let manager = makeManager(instance: instance)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let lifecycle = toolbar.items.first { $0.itemIdentifier.rawValue == "testLifecycle" } as? NSToolbarItemGroup
+        #expect(lifecycle?.subitems[0].isEnabled == true)  // play
+        #expect(lifecycle?.subitems[1].isEnabled == false) // pause
+        #expect(lifecycle?.subitems[2].isEnabled == false) // stop
+    }
+
+    @Test("Pause and stop enabled when running")
+    func pauseStopEnabledWhenRunning() {
+        let instance = makeInstance(status: .running)
+        let manager = makeManager(instance: instance)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let lifecycle = toolbar.items.first { $0.itemIdentifier.rawValue == "testLifecycle" } as? NSToolbarItemGroup
+        #expect(lifecycle?.subitems[0].isEnabled == false) // play (can't start when running)
+        #expect(lifecycle?.subitems[1].isEnabled == true)  // pause
+        #expect(lifecycle?.subitems[2].isEnabled == true)  // stop
+    }
+
+    @Test("Play (resume) and stop enabled when paused")
+    func resumeStopEnabledWhenPaused() {
+        let instance = makeInstance(status: .paused)
+        let manager = makeManager(instance: instance)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let lifecycle = toolbar.items.first { $0.itemIdentifier.rawValue == "testLifecycle" } as? NSToolbarItemGroup
+        #expect(lifecycle?.subitems[0].isEnabled == true)  // resume
+        #expect(lifecycle?.subitems[1].isEnabled == false) // pause (already paused)
+        #expect(lifecycle?.subitems[2].isEnabled == true)  // stop
+    }
+
+    @Test("All lifecycle items disabled during transitioning states")
+    func lifecycleDisabledDuringTransition() {
+        let instance = makeInstance(status: .starting)
+        let manager = makeManager(instance: instance)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let lifecycle = toolbar.items.first { $0.itemIdentifier.rawValue == "testLifecycle" } as? NSToolbarItemGroup
+        #expect(lifecycle?.subitems.allSatisfy { !$0.isEnabled } == true)
+    }
+
+    // MARK: - Save State
+
+    @Test("Save state enabled when canSave (running)")
+    func saveEnabledWhenRunning() {
+        let instance = makeInstance(status: .running)
+        let manager = makeManager(instance: instance)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let saveState = toolbar.items.first { $0.itemIdentifier.rawValue == "testSaveState" } as? NSToolbarItemGroup
+        #expect(saveState?.subitems.first?.isEnabled == true)
+    }
+
+    @Test("Save state disabled when stopped")
+    func saveDisabledWhenStopped() {
+        let instance = makeInstance(status: .stopped)
+        let manager = makeManager(instance: instance)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let saveState = toolbar.items.first { $0.itemIdentifier.rawValue == "testSaveState" } as? NSToolbarItemGroup
+        #expect(saveState?.subitems.first?.isEnabled == false)
+    }
+
+    // MARK: - Display Group Gating
+
+    @Test("Display items disabled when gatesDisplayOnCapability=true and canUseExternalDisplay is false")
+    func displayGatedAndDisabled() {
+        let instance = makeInstance(status: .stopped) // canUseExternalDisplay = false
+        let manager = makeManager(instance: instance, gatesDisplayOnCapability: true)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let display = toolbar.items.first { $0.itemIdentifier.rawValue == "testDisplay" } as? NSToolbarItemGroup
+        #expect(display?.subitems[0].isEnabled == false)
+        #expect(display?.subitems[1].isEnabled == false)
+    }
+
+    @Test("Display items enabled when gatesDisplayOnCapability=false regardless of status")
+    func displayNotGatedAlwaysEnabled() {
+        let instance = makeInstance(status: .stopped)
+        let manager = makeManager(instance: instance, gatesDisplayOnCapability: false)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let display = toolbar.items.first { $0.itemIdentifier.rawValue == "testDisplay" } as? NSToolbarItemGroup
+        #expect(display?.subitems[0].isEnabled == true)
+        #expect(display?.subitems[1].isEnabled == true)
+    }
+
+    // MARK: - Display Labels
+
+    @Test("Pop Out label when displayMode is inline")
+    func popOutLabelWhenInline() {
+        let instance = makeInstance(status: .stopped)
+        instance.displayMode = .inline
+        let manager = makeManager(instance: instance, gatesDisplayOnCapability: false)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let display = toolbar.items.first { $0.itemIdentifier.rawValue == "testDisplay" } as? NSToolbarItemGroup
+        #expect(display?.subitems[0].label == "Pop Out")
+    }
+
+    @Test("Pop In label when displayMode is popOut")
+    func popInLabelWhenPopOut() {
+        let instance = makeInstance(status: .stopped)
+        instance.displayMode = .popOut
+        let manager = makeManager(instance: instance, gatesDisplayOnCapability: false)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let display = toolbar.items.first { $0.itemIdentifier.rawValue == "testDisplay" } as? NSToolbarItemGroup
+        #expect(display?.subitems[0].label == "Pop In")
+    }
+
+    @Test("Fullscreen label when not in fullscreen")
+    func fullscreenLabelDefault() {
+        let instance = makeInstance(status: .stopped)
+        instance.displayMode = .inline
+        let manager = makeManager(instance: instance, gatesDisplayOnCapability: false)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let display = toolbar.items.first { $0.itemIdentifier.rawValue == "testDisplay" } as? NSToolbarItemGroup
+        #expect(display?.subitems[1].label == "Fullscreen")
+    }
+
+    @Test("Exit Fullscreen label when in fullscreen")
+    func exitFullscreenLabel() {
+        let instance = makeInstance(status: .stopped)
+        instance.displayMode = .fullscreen
+        let manager = makeManager(instance: instance, gatesDisplayOnCapability: false)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let display = toolbar.items.first { $0.itemIdentifier.rawValue == "testDisplay" } as? NSToolbarItemGroup
+        #expect(display?.subitems[1].label == "Exit Fullscreen")
+    }
+}
+
+// MARK: - Test Helper
+
+/// Minimal NSToolbarDelegate that delegates item creation to VMToolbarManager.
+@MainActor
+private final class ToolbarTestDelegate: NSObject, NSToolbarDelegate {
+    let manager: VMToolbarManager
+
+    init(manager: VMToolbarManager) {
+        self.manager = manager
+    }
+
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        manager.sharedItemIdentifiers
+    }
+
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        manager.sharedItemIdentifiers
+    }
+
+    func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool
+    ) -> NSToolbarItem? {
+        manager.makeToolbarItem(for: itemIdentifier)
+    }
+}


### PR DESCRIPTION
## Summary
- Extract duplicated toolbar logic from `MainWindowController` and `VMDisplayWindowController` into a shared `VMToolbarManager` class
- Eliminates ~330 lines of duplicated code for toolbar item creation, state updates, and action routing
- Each toolbar change (new buttons, icon updates, tooltip changes) now only needs to be made in one place

## Changes
- Add `VMToolbarManager` — `@MainActor` `NSObject` subclass with `Configuration` struct that captures per-controller differences (identifier strings, `isPreparing` checks, display capability gating) and an `instanceProvider` closure for resolving the current `VMInstance`
- Refactor `MainWindowController` to delegate shared toolbar items to `VMToolbarManager` (434 → 252 lines). New VM button and sidebar logic remain controller-specific
- Refactor `VMDisplayWindowController` to delegate all toolbar items to `VMToolbarManager` (355 → 201 lines). Observation and auto-close logic remain controller-specific
- Add 22 tests covering item creation, nil instance, preparing state, lifecycle enable states, save state, display gating, and label toggling
- Update ARCHITECTURE.md with new file in directory structure, component map, design decisions, and test coverage

## Test plan
- [x] Built successfully on macOS 26
- [x] All 22 new VMToolbarManager tests pass
- [x] Full test suite passes with zero failures
- [x] Toolbar behavior unchanged: Start/Resume/Pause/Stop enable states, Save State, Pop Out/In, Fullscreen labels and icons all update correctly in both main and display windows

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)