### PR TITLE
fix: Show confirmation dialog when stopping a suspended VM

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -202,7 +202,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     @objc func stopVM(_ sender: Any?) {
         guard let instance = activeInstance else { return }
-        viewModel.stop(instance)
+        // Require explicit confirmation before discarding saved state
+        if instance.isColdPaused {
+            viewModel.confirmForceStop(instance)
+        } else {
+            viewModel.stop(instance)
+        }
     }
 
     @objc func forceStopVM(_ sender: Any?) {
@@ -462,7 +467,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         case #selector(resumeVM(_:)):
             return activeInstance?.status.canResume ?? false
         case #selector(stopVM(_:)):
-            return activeInstance?.status.canStop ?? false
+            guard let instance = activeInstance else { return false }
+            return instance.canStop || instance.isColdPaused
         case #selector(forceStopVM(_:)):
             return activeInstance?.status.canForceStop ?? false
         case #selector(saveVM(_:)):

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -186,7 +186,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
 
         play.isEnabled = instance.status.canStart || canResume
         group.subitems[LifecycleSegment.pause.rawValue].isEnabled = instance.status.canPause
-        group.subitems[LifecycleSegment.stop.rawValue].isEnabled = instance.status.canStop
+        group.subitems[LifecycleSegment.stop.rawValue].isEnabled = instance.canStop || instance.isColdPaused
     }
 
     private func updateSaveStateItem(in toolbar: NSToolbar) {

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -168,7 +168,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
 
         play.isEnabled = instance.status.canStart || canResume
         group.subitems[LifecycleSegment.pause.rawValue].isEnabled = instance.status.canPause
-        group.subitems[LifecycleSegment.stop.rawValue].isEnabled = instance.status.canStop
+        group.subitems[LifecycleSegment.stop.rawValue].isEnabled = instance.canStop || instance.isColdPaused
     }
 
     private func updateSaveStateItem(in toolbar: NSToolbar) {

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -153,6 +153,11 @@ final class VMInstance: Identifiable {
         isPreparing || status.isActive || (status == .paused && virtualMachine != nil)
     }
 
+    /// `true` when the VM is eligible for graceful stop (running or live-paused, not cold-paused).
+    var canStop: Bool {
+        status.canStop && !isColdPaused
+    }
+
     /// `true` when the VM is eligible to save state (active + live VM, not cold-paused).
     var canSave: Bool {
         status.canSave && !isColdPaused

--- a/Kernova/Models/VMStatus.swift
+++ b/Kernova/Models/VMStatus.swift
@@ -43,6 +43,8 @@ enum VMStatus: String, Codable, Sendable {
     }
 
     var canStart: Bool { self == .stopped || self == .error }
+    /// Status-level stop eligibility. Does not account for cold-paused state;
+    /// prefer `VMInstance.canStop` for runtime checks.
     var canStop: Bool { self == .running || self == .paused }
     var canPause: Bool { self == .running }
     var canResume: Bool { self == .paused }

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -65,21 +65,27 @@ struct VMDetailView: View {
             Text("The operation will be stopped and any partially copied files will be removed.")
         }
         .alert(
-            "Force Stop Virtual Machine",
+            viewModel.instanceToForceStop?.isColdPaused == true
+                ? "Discard Saved State"
+                : "Force Stop Virtual Machine",
             isPresented: $viewModel.showForceStopConfirmation,
             presenting: viewModel.instanceToForceStop
         ) { vm in
-            Button("Force Stop", role: .destructive) {
+            Button(vm.isColdPaused ? "Discard" : "Force Stop", role: .destructive) {
                 Task { await viewModel.forceStopConfirmed(vm) }
             }
-            if vm.status.canStop {
+            if vm.canStop {
                 Button("Shut Down") {
                     viewModel.stop(vm)
                 }
             }
             Button("Cancel", role: .cancel) {}
         } message: { vm in
-            Text("\"\(vm.name)\" will be immediately terminated. Any unsaved data inside the guest will be lost.")
+            if vm.isColdPaused {
+                Text("\"\(vm.name)\" has its state saved to disk. Discarding will permanently delete the saved state.")
+            } else {
+                Text("\"\(vm.name)\" will be immediately terminated. Any unsaved data inside the guest will be lost.")
+            }
         }
     }
 

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -84,12 +84,16 @@ struct SidebarView: View {
                     Task { await viewModel.resume(instance) }
                 }
             }
-            if instance.status.canStop {
+            if instance.canStop {
                 Button("Stop") {
                     viewModel.stop(instance)
                 }
             }
-            if instance.status.canForceStop && !instance.status.canStop {
+            if instance.isColdPaused {
+                Button("Discard Saved State") {
+                    viewModel.confirmForceStop(instance)
+                }
+            } else if instance.status.canForceStop && !instance.status.canStop {
                 Button("Force Stop") {
                     viewModel.confirmForceStop(instance)
                 }

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -156,6 +156,42 @@ struct VMInstanceTests {
         }
     }
 
+    // MARK: - canStop
+
+    @Test("canStop is true when running (without live VM, tests model logic)")
+    func canStopRunning() {
+        let instance = makeInstance(status: .running)
+        // status.canStop is true and isColdPaused is false
+        #expect(instance.canStop == true)
+    }
+
+    @Test("canStop is false when stopped")
+    func canStopStopped() {
+        let instance = makeInstance(status: .stopped)
+        #expect(instance.canStop == false)
+    }
+
+    @Test("canStop is false for cold-paused VM (paused without live VM)")
+    func canStopColdPaused() {
+        let instance = makeInstance(status: .paused)
+        #expect(instance.isColdPaused == true)
+        #expect(instance.canStop == false)
+    }
+
+    @Test("canStop is false during transitions")
+    func canStopTransitions() {
+        for status in [VMStatus.starting, .saving, .restoring, .installing] {
+            let instance = makeInstance(status: status)
+            #expect(instance.canStop == false)
+        }
+    }
+
+    @Test("canStop is false in error state")
+    func canStopError() {
+        let instance = makeInstance(status: .error)
+        #expect(instance.canStop == false)
+    }
+
     // MARK: - canSave
 
     @Test("canSave is true when running (without live VM, tests model logic)")


### PR DESCRIPTION
## Summary
- A suspended (cold-paused) VM no longer silently discards saved state when Stop is invoked
- All stop entry points now route suspended VMs through a "Discard Saved State" confirmation dialog
- Adds `VMInstance.canStop` computed property mirroring the existing `canSave` pattern

Closes #37

## Changes
- Add `VMInstance.canStop` that excludes cold-paused VMs from graceful stop eligibility
- Route `AppDelegate.stopVM` through `confirmForceStop` when the VM is cold-paused
- Update sidebar context menu to show "Discard Saved State" instead of "Stop" for suspended VMs
- Adapt force-stop dialog title, button label, and message for cold-paused VMs
- Fix menu validation to use `instance.canStop || instance.isColdPaused` (avoids `??` optional chain bug)
- Update toolbar enablement in MainWindowController and VMDisplayWindowController
- Add doc comment to `VMStatus.canStop` clarifying the instance-level property should be preferred
- Add 5 unit tests for `VMInstance.canStop`

## Test plan
- [ ] Built successfully on macOS 26
- [ ] All existing and new tests pass
- [ ] Suspend a VM, verify Stop toolbar button shows "Discard Saved State" confirmation
- [ ] Verify "Discard" button in dialog discards saved state and transitions VM to Stopped
- [ ] Verify "Cancel" in dialog leaves VM in Suspended state
- [ ] Verify context menu shows "Discard Saved State" for suspended VMs
- [ ] Verify Stop menu item is enabled for suspended VMs
- [ ] Verify normal Stop behavior unchanged for running/live-paused VMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)