### PR TITLE
fix: Persist fullscreen display preference on native macOS transitions

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -307,10 +307,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // Already showing a display window for this VM
         guard displayWindows[vmID] == nil else { return }
 
-        let controller = VMDisplayWindowController(instance: instance, enterFullscreen: enterFullscreen) { [weak self] in
-            guard let self else { return }
-            Task { await self.viewModel.resume(instance) }
-        }
+        let controller = VMDisplayWindowController(
+            instance: instance,
+            enterFullscreen: enterFullscreen,
+            onResume: { [weak self] in
+                guard let self else { return }
+                Task { await self.viewModel.resume(instance) }
+            },
+            onSaveConfiguration: { [weak self] in
+                self?.viewModel.saveConfiguration(for: instance)
+            }
+        )
         displayWindows[vmID] = controller
 
         let token = NotificationCenter.default.addObserver(

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -19,11 +19,12 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     let instance: VMInstance
     private let toolbarManager: VMToolbarManager
     private let enterFullscreen: Bool
+    private let onSaveConfiguration: () -> Void
     private var observingInstance = false
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VMDisplayWindowController")
 
-    init(instance: VMInstance, enterFullscreen: Bool, onResume: @escaping () -> Void) {
+    init(instance: VMInstance, enterFullscreen: Bool, onResume: @escaping () -> Void, onSaveConfiguration: @escaping () -> Void) {
         self.vmID = instance.instanceID
         self.instance = instance
         self.toolbarManager = VMToolbarManager(
@@ -37,6 +38,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
             instanceProvider: { [weak instance] in instance }
         )
         self.enterFullscreen = enterFullscreen
+        self.onSaveConfiguration = onSaveConfiguration
 
         let contentView = DetachedVMView(instance: instance, onResume: onResume)
         let hostingController = NSHostingController(rootView: contentView)
@@ -94,12 +96,24 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     func windowDidEnterFullScreen(_ notification: Notification) {
         instance.displayMode = .fullscreen
         window?.toolbar?.isVisible = false
+        if instance.configuration.displayPreference != .fullscreen {
+            instance.configuration.displayPreference = .fullscreen
+            onSaveConfiguration()
+        }
     }
 
     func windowDidExitFullScreen(_ notification: Notification) {
         guard instance.displayMode == .fullscreen else { return }
         instance.displayMode = .popOut
         window?.toolbar?.isVisible = true
+        // Only update the persisted preference for user-initiated exits.
+        // During programmatic close (VM stopped/errored/cold-paused), the
+        // preference should remain .fullscreen so it restores correctly
+        // when the display window is next opened.
+        if !closedProgrammatically && instance.configuration.displayPreference != .popOut {
+            instance.configuration.displayPreference = .popOut
+            onSaveConfiguration()
+        }
     }
 
     // MARK: - Instance Observation


### PR DESCRIPTION
## Summary
- Native macOS fullscreen transitions (green button, title bar double-click) now persist `displayPreference`, so shutting down a fullscreen VM restores fullscreen on relaunch instead of opening as a pop-out window
- Added `onSaveConfiguration` callback to `VMDisplayWindowController` so fullscreen enter/exit delegate callbacks can persist preference changes immediately
- `closedProgrammatically` guard in `windowDidExitFullScreen` preserves `.fullscreen` preference when the VM stops/errors/cold-pauses, ensuring correct restoration on next open

## Test plan
- [ ] Open pop-out window, enter fullscreen via green button, shut down guest → relaunch VM should restore fullscreen
- [ ] Enter fullscreen via Cmd+Shift+F, shut down guest → relaunch restores fullscreen
- [ ] Exit fullscreen via green button → preference updates to pop-out
- [ ] Save state while fullscreen → resume restores fullscreen
- [ ] All existing tests pass

## Notes
- Filed #44 as a follow-up for `saveConfiguration(for:)` silently swallowing errors (pre-existing issue across all callers, not introduced here)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)