### PR TITLE
fix: Surface error to user when saveConfiguration fails

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -475,7 +475,8 @@ final class VMLibraryViewModel {
         do {
             try storageService.saveConfiguration(instance.configuration, to: instance.bundleURL)
         } catch {
-            Self.logger.error("Failed to save configuration: \(error.localizedDescription)")
+            Self.logger.error("Failed to save configuration for '\(instance.name)': \(error.localizedDescription)")
+            presentError(error)
         }
     }
 

--- a/KernovaTests/Mocks/MockVMStorageService.swift
+++ b/KernovaTests/Mocks/MockVMStorageService.swift
@@ -19,6 +19,7 @@ final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
 
     // MARK: - Error Injection
 
+    var saveConfigurationError: (any Error)?
     var createVMBundleError: (any Error)?
     var cloneVMBundleError: (any Error)?
 
@@ -48,6 +49,7 @@ final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
 
     func saveConfiguration(_ configuration: VMConfiguration, to bundleURL: URL) throws {
         saveConfigurationCallCount += 1
+        if let error = saveConfigurationError { throw error }
         bundles[bundleURL] = configuration
     }
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -383,6 +383,18 @@ struct VMLibraryViewModelTests {
         #expect(storage.saveConfigurationCallCount == 1)
     }
 
+    @Test("saveConfiguration presents error on failure")
+    func saveConfigurationPresentsError() {
+        let (viewModel, storage, _, _) = makeViewModel()
+        let instance = makeInstance()
+        storage.saveConfigurationError = NSError(domain: "test", code: 1)
+
+        viewModel.saveConfiguration(for: instance)
+
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage != nil)
+    }
+
     // MARK: - trySave / tryForceStop
 
     @Test("trySave throws on failure")


### PR DESCRIPTION
## Summary
- `saveConfiguration(for:)` was the only failable method in `VMLibraryViewModel` that silently swallowed errors — logging but never calling `presentError()`
- If a JSON encode or file write failed (disk full, permissions revoked, bundle deleted), the in-memory state diverged from disk with no user feedback
- Add `presentError(error)` to the catch block, matching every other failable operation in the class

Closes #44

## Changes
- Add `presentError(error)` to the `saveConfiguration(for:)` catch block
- Include VM name in the log message for easier debugging
- Add `saveConfigurationError` error injection to `MockVMStorageService`
- Add `saveConfigurationPresentsError` test verifying the error is surfaced

## Test plan
- [x] Built successfully on macOS 26
- [x] All existing tests pass
- [x] New `saveConfigurationPresentsError` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)