### PR TITLE
fix: Surface silently swallowed errors in VMLibraryViewModel

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -831,8 +831,10 @@ final class VMLibraryViewModel {
         var errorDescription: String? {
             switch self {
             case .pauseFailed(let vmNames):
+                assert(!vmNames.isEmpty, "pauseFailed requires at least one VM name")
                 return "Failed to pause the following VMs before sleep: \(vmNames.joined(separator: ", ")). They may experience data corruption."
             case .resumeFailed(let vmNames):
+                assert(!vmNames.isEmpty, "resumeFailed requires at least one VM name")
                 return "Failed to resume the following VMs after wake: \(vmNames.joined(separator: ", ")). You may need to restart them manually."
             }
         }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -91,6 +91,7 @@ final class VMLibraryViewModel {
     func loadVMs() {
         do {
             let bundles = try storageService.listVMBundles()
+            var failedBundles: [String] = []
             instances = bundles.compactMap { bundleURL in
                 do {
                     let migratedURL = try storageService.migrateBundleIfNeeded(at: bundleURL)
@@ -106,8 +107,12 @@ final class VMLibraryViewModel {
                     return instance
                 } catch {
                     Self.logger.error("Failed to load VM from \(bundleURL.lastPathComponent): \(error.localizedDescription)")
+                    failedBundles.append(bundleURL.deletingPathExtension().lastPathComponent)
                     return nil
                 }
+            }
+            if !failedBundles.isEmpty {
+                presentError(LoadError.bundleLoadFailed(names: failedBundles))
             }
 
             // Load persisted order, sort by it, then normalize customOrder to match
@@ -477,6 +482,7 @@ final class VMLibraryViewModel {
             try storageService.saveConfiguration(instance.configuration, to: instance.bundleURL)
         } catch {
             Self.logger.error("Failed to save configuration: \(error.localizedDescription)")
+            presentError(error)
         }
     }
 
@@ -819,6 +825,19 @@ final class VMLibraryViewModel {
             switch self {
             case .operationInProgress:
                 return "Another clone or import operation is already in progress. Please wait for it to finish."
+            }
+        }
+    }
+
+    /// Error type for VM loading failures.
+    private enum LoadError: LocalizedError {
+        case bundleLoadFailed(names: [String])
+
+        var errorDescription: String? {
+            switch self {
+            case .bundleLoadFailed(let names):
+                assert(!names.isEmpty, "bundleLoadFailed requires at least one bundle name")
+                return "Failed to load the following VMs: \(names.joined(separator: ", ")). They may have corrupted configurations."
             }
         }
     }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -219,6 +219,7 @@ final class VMLibraryViewModel {
             try storageService.deleteVMBundle(at: instance.bundleURL)
         } catch {
             Self.logger.error("Failed to trash VM bundle during cancellation: \(error.localizedDescription)")
+            presentError(error)
         }
 
         // 4. Remove from library and update selection
@@ -587,6 +588,7 @@ final class VMLibraryViewModel {
 
         Self.logger.notice("System going to sleep — pausing \(runningInstances.count) running VM(s)")
 
+        var failedNames: [String] = []
         for instance in runningInstances {
             do {
                 try await lifecycle.pause(instance)
@@ -594,7 +596,12 @@ final class VMLibraryViewModel {
                 Self.logger.debug("Paused '\(instance.name)' for sleep (status: \(instance.status.displayName))")
             } catch {
                 Self.logger.error("Failed to pause '\(instance.name)' for sleep: \(error.localizedDescription)")
+                failedNames.append(instance.name)
             }
+        }
+        if !failedNames.isEmpty {
+            let names = failedNames.joined(separator: ", ")
+            presentError(SleepWakeError.pauseFailed(vmNames: names))
         }
     }
 
@@ -612,13 +619,19 @@ final class VMLibraryViewModel {
 
         Self.logger.notice("System woke up — resuming \(instancesToResume.count) sleep-paused VM(s)")
 
+        var failedNames: [String] = []
         for instance in instancesToResume {
             do {
                 try await lifecycle.resume(instance)
                 Self.logger.debug("Resumed '\(instance.name)' after wake (status: \(instance.status.displayName))")
             } catch {
                 Self.logger.error("Failed to resume '\(instance.name)' after wake: \(error.localizedDescription)")
+                failedNames.append(instance.name)
             }
+        }
+        if !failedNames.isEmpty {
+            let names = failedNames.joined(separator: ", ")
+            presentError(SleepWakeError.resumeFailed(vmNames: names))
         }
     }
 
@@ -638,8 +651,11 @@ final class VMLibraryViewModel {
     // MARK: - Directory Watcher
 
     private func startDirectoryWatcher() {
-        guard let vmsDir = try? storageService.vmsDirectory else {
-            Self.logger.warning("Could not resolve VMs directory for file system watcher")
+        let vmsDir: URL
+        do {
+            vmsDir = try storageService.vmsDirectory
+        } catch {
+            Self.logger.warning("Could not resolve VMs directory for file system watcher: \(error.localizedDescription)")
             return
         }
 
@@ -660,9 +676,18 @@ final class VMLibraryViewModel {
             // Build a map of UUID → bundle URL for bundles currently on disk
             var diskConfigs: [(VMConfiguration, URL)] = []
             for bundleURL in diskBundles {
-                let migratedURL = (try? storageService.migrateBundleIfNeeded(at: bundleURL)) ?? bundleURL
-                if let config = try? storageService.loadConfiguration(from: migratedURL) {
+                let migratedURL: URL
+                do {
+                    migratedURL = try storageService.migrateBundleIfNeeded(at: bundleURL)
+                } catch {
+                    Self.logger.warning("Failed to migrate bundle at \(bundleURL.lastPathComponent): \(error.localizedDescription)")
+                    migratedURL = bundleURL
+                }
+                do {
+                    let config = try storageService.loadConfiguration(from: migratedURL)
                     diskConfigs.append((config, migratedURL))
+                } catch {
+                    Self.logger.warning("Failed to load config from \(migratedURL.lastPathComponent) during reconciliation: \(error.localizedDescription)")
                 }
             }
             let diskIDs = Set(diskConfigs.map(\.0.id))
@@ -783,7 +808,7 @@ final class VMLibraryViewModel {
             do {
                 try FileManager.default.trashItem(at: url, resultingItemURL: nil)
             } catch {
-                log.warning("Failed to clean up partial bundle at \(url.lastPathComponent): \(error.localizedDescription)")
+                log.error("Failed to clean up partial bundle at \(url.lastPathComponent): \(error.localizedDescription)")
             }
         }
     }
@@ -796,6 +821,21 @@ final class VMLibraryViewModel {
             switch self {
             case .operationInProgress:
                 return "Another clone or import operation is already in progress. Please wait for it to finish."
+            }
+        }
+    }
+
+    /// Error type for sleep/wake lifecycle failures.
+    private enum SleepWakeError: LocalizedError {
+        case pauseFailed(vmNames: String)
+        case resumeFailed(vmNames: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .pauseFailed(let vmNames):
+                return "Failed to pause the following VMs before sleep: \(vmNames). They may experience data corruption."
+            case .resumeFailed(let vmNames):
+                return "Failed to resume the following VMs after wake: \(vmNames). You may need to restart them manually."
             }
         }
     }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -600,8 +600,7 @@ final class VMLibraryViewModel {
             }
         }
         if !failedNames.isEmpty {
-            let names = failedNames.joined(separator: ", ")
-            presentError(SleepWakeError.pauseFailed(vmNames: names))
+            presentError(SleepWakeError.pauseFailed(vmNames: failedNames))
         }
     }
 
@@ -630,8 +629,7 @@ final class VMLibraryViewModel {
             }
         }
         if !failedNames.isEmpty {
-            let names = failedNames.joined(separator: ", ")
-            presentError(SleepWakeError.resumeFailed(vmNames: names))
+            presentError(SleepWakeError.resumeFailed(vmNames: failedNames))
         }
     }
 
@@ -827,15 +825,15 @@ final class VMLibraryViewModel {
 
     /// Error type for sleep/wake lifecycle failures.
     private enum SleepWakeError: LocalizedError {
-        case pauseFailed(vmNames: String)
-        case resumeFailed(vmNames: String)
+        case pauseFailed(vmNames: [String])
+        case resumeFailed(vmNames: [String])
 
         var errorDescription: String? {
             switch self {
             case .pauseFailed(let vmNames):
-                return "Failed to pause the following VMs before sleep: \(vmNames). They may experience data corruption."
+                return "Failed to pause the following VMs before sleep: \(vmNames.joined(separator: ", ")). They may experience data corruption."
             case .resumeFailed(let vmNames):
-                return "Failed to resume the following VMs after wake: \(vmNames). You may need to restart them manually."
+                return "Failed to resume the following VMs after wake: \(vmNames.joined(separator: ", ")). You may need to restart them manually."
             }
         }
     }

--- a/KernovaTests/Mocks/MockVMStorageService.swift
+++ b/KernovaTests/Mocks/MockVMStorageService.swift
@@ -21,6 +21,10 @@ final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
 
     var createVMBundleError: (any Error)?
     var cloneVMBundleError: (any Error)?
+    var saveConfigurationError: (any Error)?
+    var deleteVMBundleError: (any Error)?
+    /// Set of bundle URLs whose loadConfiguration should throw.
+    var loadConfigurationFailURLs: Set<URL> = []
 
     // MARK: - VMStorageProviding
 
@@ -40,6 +44,9 @@ final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
     }
 
     func loadConfiguration(from bundleURL: URL) throws -> VMConfiguration {
+        if loadConfigurationFailURLs.contains(bundleURL) {
+            throw VMStorageError.bundleNotFound(bundleURL)
+        }
         guard let config = bundles[bundleURL] else {
             throw VMStorageError.bundleNotFound(bundleURL)
         }
@@ -48,6 +55,7 @@ final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
 
     func saveConfiguration(_ configuration: VMConfiguration, to bundleURL: URL) throws {
         saveConfigurationCallCount += 1
+        if let error = saveConfigurationError { throw error }
         bundles[bundleURL] = configuration
     }
 
@@ -69,6 +77,7 @@ final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
 
     func deleteVMBundle(at bundleURL: URL) throws {
         deleteVMBundleCallCount += 1
+        if let error = deleteVMBundleError { throw error }
         bundles.removeValue(forKey: bundleURL)
     }
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -140,6 +140,31 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.selectedID == config2.id)
     }
 
+    @Test("loadVMs surfaces error when individual bundles fail to load")
+    func loadVMsSurfacesErrorForFailedBundles() {
+        let storage = MockVMStorageService()
+        // Add a good bundle and a bad bundle
+        let goodConfig = VMConfiguration(name: "Good VM", guestOS: .linux, bootMode: .efi)
+        let goodURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(goodConfig.id.uuidString).kernova", isDirectory: true)
+        storage.bundles[goodURL] = goodConfig
+
+        let badURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bad-bundle.kernova", isDirectory: true)
+        // Register the URL so listVMBundles returns it, but mark it to fail on load
+        storage.bundles[badURL] = VMConfiguration(name: "Bad VM", guestOS: .linux, bootMode: .efi)
+        storage.loadConfigurationFailURLs = [badURL]
+
+        let (viewModel, _, _, _) = makeViewModel(storageService: storage)
+
+        // Good VM loaded, bad VM skipped
+        #expect(viewModel.instances.count == 1)
+        #expect(viewModel.instances.first?.name == "Good VM")
+        // Error surfaced to user about the failed bundle
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage != nil)
+    }
+
     @Test("loadVMs falls back to first VM when stored ID is invalid")
     func loadVMsFallsBackWhenStoredIDInvalid() {
         let storage = MockVMStorageService()
@@ -383,6 +408,21 @@ struct VMLibraryViewModelTests {
         #expect(storage.saveConfigurationCallCount == 1)
     }
 
+    @Test("saveConfiguration surfaces error to user on failure")
+    func saveConfigurationSurfacesError() {
+        let storage = MockVMStorageService()
+        storage.saveConfigurationError = VMStorageError.bundleNotFound(
+            FileManager.default.temporaryDirectory
+        )
+        let (viewModel, _, _, _) = makeViewModel(storageService: storage)
+        let instance = makeInstance()
+
+        viewModel.saveConfiguration(for: instance)
+
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage != nil)
+    }
+
     // MARK: - trySave / tryForceStop
 
     @Test("trySave throws on failure")
@@ -603,6 +643,26 @@ struct VMLibraryViewModelTests {
 
         #expect(viewModel.instances.count == 1)
         #expect(viewModel.selectedID == first.id)
+    }
+
+    @Test("cancelInstallation surfaces error when trash fails")
+    func cancelInstallationSurfacesTrashError() {
+        let storage = MockVMStorageService()
+        storage.deleteVMBundleError = VMStorageError.bundleNotFound(
+            FileManager.default.temporaryDirectory
+        )
+        let (viewModel, _, _, _) = makeViewModel(storageService: storage)
+        let instance = makeInstance(name: "Installing VM")
+        instance.status = .installing
+        viewModel.instances.append(instance)
+
+        viewModel.cancelInstallation(instance)
+
+        // Error surfaced to user
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage != nil)
+        // Instance still removed from library despite trash failure
+        #expect(viewModel.instances.isEmpty)
     }
     #endif
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -752,8 +752,9 @@ struct VMLibraryViewModelTests {
 
         await viewModel.pauseAllForSleep()
 
-        // Error is logged, not presented to user
-        #expect(viewModel.showError == false)
+        // Error is surfaced to the user
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage?.contains("Running") == true)
         // Failed pause should not track the instance
         #expect(viewModel.sleepPausedInstanceIDs.isEmpty)
     }
@@ -771,7 +772,9 @@ struct VMLibraryViewModelTests {
         await viewModel.resumeAllAfterWake()
 
         #expect(viewModel.sleepPausedInstanceIDs.isEmpty)
-        #expect(viewModel.showError == false)
+        // Error is surfaced to the user
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage?.contains("Sleep Paused") == true)
     }
 
     @Test("pauseAllForSleep is no-op when no running VMs")


### PR DESCRIPTION
## Summary
- Fix seven silent-failure patterns in VMLibraryViewModel where errors were logged but never surfaced to the user, or swallowed entirely with `try?`
- Closes #47, closes #48, closes #49, closes #50, closes #51
- Additionally fixes two related patterns discovered during PR review: `saveConfiguration` and `loadVMs` inner loop

## Changes
- **#47** `cancelInstallation`: add `presentError()` so the user knows about leftover files when trashing fails
- **#48** `pauseAllForSleep` / `resumeAllAfterWake`: collect failed VM names and present a consolidated error after each loop, with a new `SleepWakeError` enum for descriptive messages
- **#49** `reconcileWithDisk`: replace `try?` with `do-catch` blocks that log at `.warning`, matching the existing pattern in `loadVMs()`
- **#50** `startDirectoryWatcher`: replace `try?` with `do-catch` to include the actual error reason in the log
- **#51** `trashPartialBundle`: change log level from `.warning` to `.error` per project logging guidelines
- **Review-discovered** `saveConfiguration`: add `presentError()` so the user knows their settings change was not persisted
- **Review-discovered** `loadVMs` inner loop: collect failed bundle names and present a consolidated `LoadError` after loading
- Add `LoadError` and `SleepWakeError` enums with debug assertions for empty-array invariants
- Add error injection to `MockVMStorageService` (`saveConfigurationError`, `deleteVMBundleError`, `loadConfigurationFailURLs`)
- Add/update tests for all error-surfacing changes

## Test plan
- [x] Built successfully on macOS 26
- [x] All existing tests pass (including updated sleep/wake error tests)
- [x] New tests: `saveConfigurationSurfacesError`, `loadVMsSurfacesErrorForFailedBundles`, `cancelInstallationSurfacesTrashError`
- [ ] Verify cancelInstallation shows error alert when trash fails
- [ ] Verify sleep/wake errors surface consolidated alert with VM names
- [ ] Verify loadVMs shows alert when individual bundles fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)