### PR TITLE
refactor: Add privacy: .public annotations to os.Logger string interpolations

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -67,7 +67,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
         // Stay alive if VMs are active or display windows still exist
         if hasActiveVMs || !displayWindows.isEmpty {
-            Self.logger.debug("applicationShouldTerminateAfterLastWindowClosed: false (activeVMs=\(hasActiveVMs), displayWindows=\(self.displayWindows.count))")
+            Self.logger.debug("applicationShouldTerminateAfterLastWindowClosed: false (activeVMs=\(hasActiveVMs, privacy: .public), displayWindows=\(self.displayWindows.count, privacy: .public))")
             return false
         }
 
@@ -95,13 +95,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         viewModel.instances.removeAll { instance in
             guard instance.isPreparing else { return false }
 
-            Self.logger.notice("Terminating: cancelling preparing operation for '\(instance.name)'")
+            Self.logger.notice("Terminating: cancelling preparing operation for '\(instance.name, privacy: .public)'")
             instance.preparingState?.task.cancel()
             // Best effort — in-flight copy may still be writing (FileManager.copyItem is not interruptible)
             do {
                 try FileManager.default.trashItem(at: instance.bundleURL, resultingItemURL: nil)
             } catch {
-                Self.logger.warning("Failed to clean up partial bundle for '\(instance.name)' during termination: \(error.localizedDescription)")
+                Self.logger.warning("Failed to clean up partial bundle for '\(instance.name, privacy: .public)' during termination: \(error.localizedDescription, privacy: .public)")
             }
             return true
         }
@@ -121,11 +121,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                     try await viewModel.trySave(instance)
                     viewModel.saveConfiguration(for: instance)
                 } catch {
-                    Self.logger.error("Failed to save '\(instance.name)' during termination: \(error.localizedDescription)")
+                    Self.logger.error("Failed to save '\(instance.name, privacy: .public)' during termination: \(error.localizedDescription, privacy: .public)")
                     do {
                         try await viewModel.tryForceStop(instance)
                     } catch {
-                        Self.logger.error("Failed to force-stop '\(instance.name)' during termination: \(error.localizedDescription)")
+                        Self.logger.error("Failed to force-stop '\(instance.name, privacy: .public)' during termination: \(error.localizedDescription, privacy: .public)")
                     }
                 }
             }
@@ -347,7 +347,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                     if !controller.closedProgrammatically {
                         // User manually closed the display window
                         instance.configuration.displayPreference = .inline
-                        Self.logger.debug("Cleared displayPreference for '\(instance.name)' (user closed display window)")
+                        Self.logger.debug("Cleared displayPreference for '\(instance.name, privacy: .public)' (user closed display window)")
                     }
 
                     self.viewModel.saveConfiguration(for: instance)
@@ -396,10 +396,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private func targetScreen(for instance: VMInstance) -> NSScreen? {
         if let savedID = instance.configuration.lastFullscreenDisplayID {
             if let target = NSScreen.screens.first(where: { $0.displayID == savedID }) {
-                Self.logger.debug("targetScreen for '\(instance.name)': using saved display \(savedID)")
+                Self.logger.debug("targetScreen for '\(instance.name, privacy: .public)': using saved display \(savedID, privacy: .public)")
                 return target
             }
-            Self.logger.debug("targetScreen for '\(instance.name)': saved display \(savedID) not found, falling back")
+            Self.logger.debug("targetScreen for '\(instance.name, privacy: .public)': saved display \(savedID, privacy: .public) not found, falling back")
         }
         if let libraryScreen = mainWindowController?.window?.screen {
             return libraryScreen

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -223,7 +223,7 @@ extension MainWindowController: NSToolbarItemValidation {
             return true
         }
 
-        Self.logger.debug("validateToolbarItem: unrecognized identifier '\(item.itemIdentifier.rawValue)'")
+        Self.logger.debug("validateToolbarItem: unrecognized identifier '\(item.itemIdentifier.rawValue, privacy: .public)'")
         return true
     }
 }
@@ -242,7 +242,7 @@ extension NSWindow {
         }
         let screens = NSScreen.screens
         if !screens.isEmpty, !screens.contains(where: { $0.visibleFrame.intersects(frame) }) {
-            Self.frameLogger.warning("Restored frame for '\(name)' is off-screen, centering window")
+            Self.frameLogger.warning("Restored frame for '\(name, privacy: .public)' is off-screen, centering window")
             center()
         }
         setFrameAutosaveName(name)

--- a/Kernova/App/SerialConsoleWindowController.swift
+++ b/Kernova/App/SerialConsoleWindowController.swift
@@ -51,14 +51,14 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
     override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
         if !observingStatus { observeStatus() }
-        Self.logger.debug("Serial console window shown for VM '\(self.instance.name)'")
+        Self.logger.debug("Serial console window shown for VM '\(self.instance.name, privacy: .public)'")
     }
 
     // MARK: - NSWindowDelegate
 
     func windowWillClose(_ notification: Notification) {
         observingStatus = false
-        Self.logger.debug("Serial console window closing for VM '\(self.instance.name)'")
+        Self.logger.debug("Serial console window closing for VM '\(self.instance.name, privacy: .public)'")
     }
 
     // MARK: - Status Observation
@@ -73,7 +73,7 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
                 guard let self, self.observingStatus else { return }
                 let status = self.instance.status
                 if status == .stopped || status == .error {
-                    Self.logger.notice("Auto-closing serial console for VM '\(self.instance.name)' (status: \(status.displayName))")
+                    Self.logger.notice("Auto-closing serial console for VM '\(self.instance.name, privacy: .public)' (status: \(status.displayName, privacy: .public))")
                     self.window?.close()
                 } else {
                     self.observeStatus()

--- a/Kernova/App/VMToolbarManager.swift
+++ b/Kernova/App/VMToolbarManager.swift
@@ -235,7 +235,7 @@ final class VMToolbarManager: NSObject {
 
     @objc private func lifecycleAction(_ group: NSToolbarItemGroup) {
         guard let segment = LifecycleSegment(rawValue: group.selectedIndex) else {
-            Self.logger.warning("lifecycleAction: unexpected selectedIndex \(group.selectedIndex)")
+            Self.logger.warning("lifecycleAction: unexpected selectedIndex \(group.selectedIndex, privacy: .public)")
             return
         }
         switch segment {
@@ -254,7 +254,7 @@ final class VMToolbarManager: NSObject {
 
     @objc private func displayAction(_ group: NSToolbarItemGroup) {
         guard let segment = DisplaySegment(rawValue: group.selectedIndex) else {
-            Self.logger.warning("displayAction: unexpected selectedIndex \(group.selectedIndex)")
+            Self.logger.warning("displayAction: unexpected selectedIndex \(group.selectedIndex, privacy: .public)")
             return
         }
         switch segment {

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -118,7 +118,7 @@ final class VMInstance: Identifiable {
         let layout = bundleLayout
         let usage = await Task.detached { layout.diskUsageBytes }.value
         cachedDiskUsageBytes = usage
-        Self.logger.debug("Refreshed disk usage for '\(self.name)': \(usage.map { "\($0) bytes" } ?? "nil")")
+        Self.logger.debug("Refreshed disk usage for '\(self.name, privacy: .public)': \(usage.map { "\($0) bytes" } ?? "nil", privacy: .public)")
     }
 
     // MARK: - Initializer
@@ -224,7 +224,7 @@ final class VMInstance: Identifiable {
             && error.code == NSFileNoSuchFileError {
             // File already absent — expected in some flows
         } catch {
-            Self.logger.warning("Failed to remove save file for '\(self.name)': \(error.localizedDescription)")
+            Self.logger.warning("Failed to remove save file for '\(self.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -246,11 +246,11 @@ final class VMInstance: Identifiable {
         do {
             let handle = try FileHandle(forWritingTo: logURL)
             do { _ = try handle.seekToEnd() } catch {
-                Self.logger.warning("Could not seek to end of serial log: \(error.localizedDescription)")
+                Self.logger.warning("Could not seek to end of serial log: \(error.localizedDescription, privacy: .public)")
             }
             serialLogFileHandle = handle
         } catch {
-            Self.logger.warning("Could not open serial log for writing: \(error.localizedDescription)")
+            Self.logger.warning("Could not open serial log for writing: \(error.localizedDescription, privacy: .public)")
         }
 
         // Capture for the readability handler closure (runs on a background GCD queue)
@@ -265,7 +265,7 @@ final class VMInstance: Identifiable {
             do {
                 try logFileHandle?.write(contentsOf: data)
             } catch {
-                logger.error("Failed to write to serial log: \(error.localizedDescription)")
+                logger.error("Failed to write to serial log: \(error.localizedDescription, privacy: .public)")
             }
 
             // Update UI buffer on the main actor
@@ -287,7 +287,7 @@ final class VMInstance: Identifiable {
             }
         }
 
-        Self.logger.info("Serial reading started for '\(self.name)'")
+        Self.logger.info("Serial reading started for '\(self.name, privacy: .public)'")
     }
 
     /// Sends a string to the guest via the serial input pipe.
@@ -297,7 +297,7 @@ final class VMInstance: Identifiable {
         do {
             try inputPipe.fileHandleForWriting.write(contentsOf: data)
         } catch {
-            Self.logger.error("Failed to send serial input to VM '\(self.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to send serial input to VM '\(self.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -307,7 +307,7 @@ final class VMInstance: Identifiable {
         do {
             try serialLogFileHandle?.close()
         } catch {
-            Self.logger.warning("Failed to close serial log file for VM '\(self.name)': \(error.localizedDescription)")
+            Self.logger.warning("Failed to close serial log file for VM '\(self.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
         }
         serialLogFileHandle = nil
     }
@@ -333,7 +333,7 @@ private final class VMDelegateAdapter: NSObject, VZVirtualMachineDelegate {
                 return
             }
             instance.resetToStopped()
-            Self.logger.notice("Guest stopped for VM '\(instance.name)'")
+            Self.logger.notice("Guest stopped for VM '\(instance.name, privacy: .public)'")
         }
     }
 
@@ -346,7 +346,7 @@ private final class VMDelegateAdapter: NSObject, VZVirtualMachineDelegate {
             instance.tearDownSession()
             instance.status = .error
             instance.errorMessage = error.localizedDescription
-            Self.logger.error("VM '\(instance.name)' stopped with error: \(error.localizedDescription)")
+            Self.logger.error("VM '\(instance.name, privacy: .public)' stopped with error: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -26,7 +26,7 @@ struct ConfigurationBuilder: Sendable {
     func build(from config: VMConfiguration, bundleURL: URL) throws -> BuildResult {
         let vzConfig = VZVirtualMachineConfiguration()
 
-        Self.logger.debug("Building config: cpuCount=\(config.cpuCount), memoryMB=\(config.memorySizeInBytes / (1024 * 1024)), bootMode=\(config.bootMode.displayName)")
+        Self.logger.debug("Building config: cpuCount=\(config.cpuCount, privacy: .public), memoryMB=\(config.memorySizeInBytes / (1024 * 1024), privacy: .public), bootMode=\(config.bootMode.displayName, privacy: .public)")
 
         // Resources
         vzConfig.cpuCount = config.cpuCount
@@ -61,7 +61,7 @@ struct ConfigurationBuilder: Sendable {
         // Validate
         try vzConfig.validate()
 
-        Self.logger.info("Built VZ configuration for '\(config.name)' (\(config.bootMode.displayName))")
+        Self.logger.info("Built VZ configuration for '\(config.name, privacy: .public)' (\(config.bootMode.displayName, privacy: .public))")
         return BuildResult(configuration: vzConfig, serialInputPipe: inputPipe, serialOutputPipe: outputPipe)
     }
 
@@ -176,7 +176,7 @@ struct ConfigurationBuilder: Sendable {
         vzConfig.platform = platform
 
         guard let kernelPath = config.kernelPath else {
-            Self.logger.error("Kernel path is required but not set for VM '\(config.name)'")
+            Self.logger.error("Kernel path is required but not set for VM '\(config.name, privacy: .public)'")
             throw ConfigurationBuilderError.missingKernelPath
         }
 
@@ -185,16 +185,16 @@ struct ConfigurationBuilder: Sendable {
         let resolvedKernelPath = kernelURL.path(percentEncoded: false)
 
         if resolvedKernelPath != kernelPath {
-            Self.logger.info("Kernel path '\(kernelPath)' resolved to '\(resolvedKernelPath)'")
+            Self.logger.info("Kernel path '\(kernelPath, privacy: .public)' resolved to '\(resolvedKernelPath, privacy: .public)'")
         }
 
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(atPath: resolvedKernelPath, isDirectory: &isDirectory) else {
-            Self.logger.error("Kernel image not found at '\(kernelPath)' (resolved: '\(resolvedKernelPath)')")
+            Self.logger.error("Kernel image not found at '\(kernelPath, privacy: .public)' (resolved: '\(resolvedKernelPath, privacy: .public)')")
             throw ConfigurationBuilderError.kernelNotFound(kernelPath)
         }
         guard !isDirectory.boolValue else {
-            Self.logger.error("Kernel path is a directory, not a file: '\(kernelPath)' (resolved: '\(resolvedKernelPath)')")
+            Self.logger.error("Kernel path is a directory, not a file: '\(kernelPath, privacy: .public)' (resolved: '\(resolvedKernelPath, privacy: .public)')")
             throw ConfigurationBuilderError.kernelPathIsDirectory(kernelPath)
         }
 
@@ -204,16 +204,16 @@ struct ConfigurationBuilder: Sendable {
             let resolvedInitrdPath = initrdURL.path(percentEncoded: false)
 
             if resolvedInitrdPath != initrdPath {
-                Self.logger.info("Initrd path '\(initrdPath)' resolved to '\(resolvedInitrdPath)'")
+                Self.logger.info("Initrd path '\(initrdPath, privacy: .public)' resolved to '\(resolvedInitrdPath, privacy: .public)'")
             }
 
             var isInitrdDirectory: ObjCBool = false
             guard fileManager.fileExists(atPath: resolvedInitrdPath, isDirectory: &isInitrdDirectory) else {
-                Self.logger.error("Initial ramdisk not found at '\(initrdPath)' (resolved: '\(resolvedInitrdPath)')")
+                Self.logger.error("Initial ramdisk not found at '\(initrdPath, privacy: .public)' (resolved: '\(resolvedInitrdPath, privacy: .public)')")
                 throw ConfigurationBuilderError.initrdNotFound(initrdPath)
             }
             guard !isInitrdDirectory.boolValue else {
-                Self.logger.error("Initrd path is a directory, not a file: '\(initrdPath)' (resolved: '\(resolvedInitrdPath)')")
+                Self.logger.error("Initrd path is a directory, not a file: '\(initrdPath, privacy: .public)' (resolved: '\(resolvedInitrdPath, privacy: .public)')")
                 throw ConfigurationBuilderError.initrdPathIsDirectory(initrdPath)
             }
             bootLoader.initialRamdiskURL = initrdURL
@@ -244,7 +244,7 @@ struct ConfigurationBuilder: Sendable {
     ) throws {
         let layout = VMBundleLayout(bundleURL: bundleURL)
         guard FileManager.default.fileExists(atPath: layout.diskImageURL.path(percentEncoded: false)) else {
-            Self.logger.error("Disk image not found at '\(layout.diskImageURL.path(percentEncoded: false))'")
+            Self.logger.error("Disk image not found at '\(layout.diskImageURL.path(percentEncoded: false), privacy: .public)'")
             throw ConfigurationBuilderError.diskImageNotFound(layout.diskImageURL)
         }
 
@@ -258,16 +258,16 @@ struct ConfigurationBuilder: Sendable {
             let resolvedISOPath = isoURL.path(percentEncoded: false)
 
             if resolvedISOPath != isoPath {
-                Self.logger.info("ISO path '\(isoPath)' resolved to '\(resolvedISOPath)'")
+                Self.logger.info("ISO path '\(isoPath, privacy: .public)' resolved to '\(resolvedISOPath, privacy: .public)'")
             }
 
             var isISODirectory: ObjCBool = false
             guard FileManager.default.fileExists(atPath: resolvedISOPath, isDirectory: &isISODirectory) else {
-                Self.logger.error("ISO image not found at '\(isoPath)' (resolved: '\(resolvedISOPath)')")
+                Self.logger.error("ISO image not found at '\(isoPath, privacy: .public)' (resolved: '\(resolvedISOPath, privacy: .public)')")
                 throw ConfigurationBuilderError.isoImageNotFound(isoPath)
             }
             guard !isISODirectory.boolValue else {
-                Self.logger.error("ISO path is a directory, not a file: '\(isoPath)' (resolved: '\(resolvedISOPath)')")
+                Self.logger.error("ISO path is a directory, not a file: '\(isoPath, privacy: .public)' (resolved: '\(resolvedISOPath, privacy: .public)')")
                 throw ConfigurationBuilderError.isoImagePathIsDirectory(isoPath)
             }
 
@@ -275,7 +275,7 @@ struct ConfigurationBuilder: Sendable {
             do {
                 isoAttachment = try VZDiskImageStorageDeviceAttachment(url: isoURL, readOnly: true)
             } catch {
-                Self.logger.error("Failed to attach ISO at '\(isoPath)' (resolved: '\(resolvedISOPath)'): \(error.localizedDescription)")
+                Self.logger.error("Failed to attach ISO at '\(isoPath, privacy: .public)' (resolved: '\(resolvedISOPath, privacy: .public)'): \(error.localizedDescription, privacy: .public)")
                 throw error
             }
             let usbStorage = VZUSBMassStorageDeviceConfiguration(attachment: isoAttachment)
@@ -362,25 +362,25 @@ struct ConfigurationBuilder: Sendable {
             let resolvedPath = resolvedURL.path(percentEncoded: false)
 
             if resolvedPath != directory.path {
-                Self.logger.info("Shared directory '\(directory.path)' resolved to '\(resolvedPath)'")
+                Self.logger.info("Shared directory '\(directory.path, privacy: .public)' resolved to '\(resolvedPath, privacy: .public)'")
             }
 
             var isDirectory: ObjCBool = false
             guard fileManager.fileExists(atPath: resolvedPath, isDirectory: &isDirectory) else {
-                Self.logger.error("Shared directory not found at '\(directory.path)' (resolved: '\(resolvedPath)')")
+                Self.logger.error("Shared directory not found at '\(directory.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
                 throw ConfigurationBuilderError.sharedDirectoryNotFound(directory.path)
             }
             guard isDirectory.boolValue else {
-                Self.logger.error("Shared path is not a directory: '\(directory.path)' (resolved: '\(resolvedPath)')")
+                Self.logger.error("Shared path is not a directory: '\(directory.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
                 throw ConfigurationBuilderError.sharedDirectoryNotADirectory(directory.path)
             }
             guard fileManager.isReadableFile(atPath: resolvedPath) else {
-                Self.logger.error("Shared directory is not readable: '\(directory.path)' (resolved: '\(resolvedPath)')")
+                Self.logger.error("Shared directory is not readable: '\(directory.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
                 throw ConfigurationBuilderError.sharedDirectoryNotReadable(directory.path)
             }
             if !directory.readOnly {
                 guard fileManager.isWritableFile(atPath: resolvedPath) else {
-                    Self.logger.error("Shared directory is not writable: '\(directory.path)' (resolved: '\(resolvedPath)')")
+                    Self.logger.error("Shared directory is not writable: '\(directory.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
                     throw ConfigurationBuilderError.sharedDirectoryNotWritable(directory.path)
                 }
             }

--- a/Kernova/Services/DiskImageService.swift
+++ b/Kernova/Services/DiskImageService.swift
@@ -22,7 +22,7 @@ struct DiskImageService: Sendable {
     ///   - sizeInGB: The virtual capacity of the disk image in gigabytes. Must match
     ///     one of the sizes in ``VMGuestOS/allDiskSizes``.
     func createDiskImage(at url: URL, sizeInGB: Int) async throws {
-        Self.logger.info("Creating ASIF disk image: \(sizeInGB) GB at \(url.lastPathComponent)")
+        Self.logger.info("Creating ASIF disk image: \(sizeInGB, privacy: .public) GB at \(url.lastPathComponent, privacy: .public)")
 
         guard let templateURL = Bundle.main.url(
             forResource: "BlankDisk-\(sizeInGB)GB.asif",
@@ -39,7 +39,7 @@ struct DiskImageService: Sendable {
             try decompressed.write(to: destination)
         }.value
 
-        Self.logger.notice("Successfully created ASIF disk image at \(url.lastPathComponent)")
+        Self.logger.notice("Successfully created ASIF disk image at \(url.lastPathComponent, privacy: .public)")
     }
 
     /// Returns the physical (actual) size of a disk image on disk.

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -23,7 +23,7 @@ struct IPSWService: Sendable {
         to destinationURL: URL,
         progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64) -> Void
     ) async throws {
-        Self.logger.info("Downloading restore image from \(remoteURL)")
+        Self.logger.info("Downloading restore image from \(remoteURL, privacy: .public)")
 
         // Create the destination file up-front so it's visible in Finder immediately.
         FileManager.default.createFile(atPath: destinationURL.path(percentEncoded: false), contents: nil)
@@ -31,7 +31,7 @@ struct IPSWService: Sendable {
         var cleanUpPartial = true
         defer {
             if cleanUpPartial {
-                Self.logger.info("Removing partial download at \(destinationURL.lastPathComponent)")
+                Self.logger.info("Removing partial download at \(destinationURL.lastPathComponent, privacy: .public)")
                 try? FileManager.default.removeItem(at: destinationURL)
             }
         }
@@ -81,7 +81,7 @@ struct IPSWService: Sendable {
         }
 
         cleanUpPartial = false
-        Self.logger.info("Restore image downloaded to \(destinationURL.lastPathComponent)")
+        Self.logger.info("Restore image downloaded to \(destinationURL.lastPathComponent, privacy: .public)")
     }
 
     /// Loads a restore image from a local IPSW file.

--- a/Kernova/Services/MacOSInstallService.swift
+++ b/Kernova/Services/MacOSInstallService.swift
@@ -34,7 +34,7 @@ final class MacOSInstallService {
     ) async throws {
         instance.status = .installing
 
-        Self.logger.info("Starting macOS installation for '\(instance.name)'")
+        Self.logger.info("Starting macOS installation for '\(instance.name, privacy: .public)'")
 
         // 1. Load restore image
         let restoreImage = try await loadRestoreImage(from: restoreImageURL)
@@ -105,7 +105,7 @@ final class MacOSInstallService {
         instance.resetToStopped()
         instance.installState?.currentPhase = .installing(progress: 1.0)
 
-        Self.logger.info("macOS installation completed for '\(instance.name)'")
+        Self.logger.info("macOS installation completed for '\(instance.name, privacy: .public)'")
     }
 
     // MARK: - Platform Setup
@@ -129,7 +129,7 @@ final class MacOSInstallService {
             options: []
         )
 
-        Self.logger.info("Created platform files for '\(instance.name)'")
+        Self.logger.info("Created platform files for '\(instance.name, privacy: .public)'")
     }
 
     // MARK: - Helpers

--- a/Kernova/Services/VMStorageService.swift
+++ b/Kernova/Services/VMStorageService.swift
@@ -77,7 +77,7 @@ struct VMStorageService: Sendable {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(configuration)
         try data.write(to: configURL, options: .atomic)
-        Self.logger.info("Saved configuration for VM '\(configuration.name)' to \(bundleURL.lastPathComponent)")
+        Self.logger.info("Saved configuration for VM '\(configuration.name, privacy: .public)' to \(bundleURL.lastPathComponent, privacy: .public)")
     }
 
     /// Creates a new VM bundle directory and saves the initial configuration.
@@ -91,7 +91,7 @@ struct VMStorageService: Sendable {
         try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
         try saveConfiguration(configuration, to: bundle)
 
-        Self.logger.notice("Created VM bundle for '\(configuration.name)' at \(bundle.lastPathComponent)")
+        Self.logger.notice("Created VM bundle for '\(configuration.name, privacy: .public)' at \(bundle.lastPathComponent, privacy: .public)")
         return bundle
     }
 
@@ -116,7 +116,7 @@ struct VMStorageService: Sendable {
 
         try saveConfiguration(newConfiguration, to: destinationBundle)
 
-        Self.logger.notice("Cloned VM bundle from '\(sourceBundleURL.lastPathComponent)' to '\(destinationBundle.lastPathComponent)'")
+        Self.logger.notice("Cloned VM bundle from '\(sourceBundleURL.lastPathComponent, privacy: .public)' to '\(destinationBundle.lastPathComponent, privacy: .public)'")
         return destinationBundle
     }
 
@@ -126,7 +126,7 @@ struct VMStorageService: Sendable {
             throw VMStorageError.bundleNotFound(bundleURL)
         }
         try FileManager.default.trashItem(at: bundleURL, resultingItemURL: nil)
-        Self.logger.notice("Moved VM bundle to Trash: \(bundleURL.lastPathComponent)")
+        Self.logger.notice("Moved VM bundle to Trash: \(bundleURL.lastPathComponent, privacy: .public)")
     }
 
     /// Migrates a legacy bare-UUID bundle directory to the `.kernova` package format.
@@ -155,7 +155,7 @@ struct VMStorageService: Sendable {
 
         if legacyExists {
             try fm.moveItem(at: bundleURL, to: migratedURL)
-            Self.logger.notice("Migrated VM bundle: \(bundleURL.lastPathComponent) → \(migratedURL.lastPathComponent)")
+            Self.logger.notice("Migrated VM bundle: \(bundleURL.lastPathComponent, privacy: .public) → \(migratedURL.lastPathComponent, privacy: .public)")
         }
 
         return migratedURL

--- a/Kernova/Services/VirtualizationService.swift
+++ b/Kernova/Services/VirtualizationService.swift
@@ -16,7 +16,7 @@ final class VirtualizationService {
 
     /// Starts a virtual machine, optionally restoring from a saved state.
     func start(_ instance: VMInstance) async throws {
-        Self.logger.debug("start: status=\(instance.status.displayName), hasSaveFile=\(instance.hasSaveFile)")
+        Self.logger.debug("start: status=\(instance.status.displayName, privacy: .public), hasSaveFile=\(instance.hasSaveFile, privacy: .public)")
         guard instance.status.canStart else {
             throw VirtualizationError.invalidStateTransition(from: instance.status, action: "start")
         }
@@ -36,9 +36,9 @@ final class VirtualizationService {
             }
 
             instance.status = .running
-            Self.logger.notice("Started VM '\(instance.name)'")
+            Self.logger.notice("Started VM '\(instance.name, privacy: .public)'")
         } catch {
-            Self.logger.error("Failed to start VM '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to start VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             instance.tearDownSession()
             instance.status = Self.isTransientStartError(error) ? .stopped : .error
             instance.errorMessage = error.localizedDescription
@@ -50,12 +50,12 @@ final class VirtualizationService {
 
     /// Requests a graceful ACPI shutdown of the virtual machine.
     func stop(_ instance: VMInstance) throws {
-        Self.logger.debug("stop: status=\(instance.status.displayName), isColdPaused=\(instance.isColdPaused)")
+        Self.logger.debug("stop: status=\(instance.status.displayName, privacy: .public), isColdPaused=\(instance.isColdPaused, privacy: .public)")
         // Cold-paused: no live VM, just discard the save file
         if instance.isColdPaused {
             instance.removeSaveFile()
             instance.status = .stopped
-            Self.logger.notice("Discarded saved state for VM '\(instance.name)'")
+            Self.logger.notice("Discarded saved state for VM '\(instance.name, privacy: .public)'")
             return
         }
 
@@ -64,17 +64,17 @@ final class VirtualizationService {
         }
 
         try vm.requestStop()
-        Self.logger.notice("Requested stop for VM '\(instance.name)'")
+        Self.logger.notice("Requested stop for VM '\(instance.name, privacy: .public)'")
     }
 
     /// Immediately terminates the virtual machine.
     func forceStop(_ instance: VMInstance) async throws {
-        Self.logger.debug("forceStop: status=\(instance.status.displayName), isColdPaused=\(instance.isColdPaused)")
+        Self.logger.debug("forceStop: status=\(instance.status.displayName, privacy: .public), isColdPaused=\(instance.isColdPaused, privacy: .public)")
         // Cold-paused: no live VM, just discard the save file
         if instance.isColdPaused {
             instance.removeSaveFile()
             instance.status = .stopped
-            Self.logger.notice("Discarded saved state for VM '\(instance.name)'")
+            Self.logger.notice("Discarded saved state for VM '\(instance.name, privacy: .public)'")
             return
         }
 
@@ -84,14 +84,14 @@ final class VirtualizationService {
 
         try await vm.stop()
         instance.resetToStopped()
-        Self.logger.notice("Force-stopped VM '\(instance.name)'")
+        Self.logger.notice("Force-stopped VM '\(instance.name, privacy: .public)'")
     }
 
     // MARK: - Pause / Resume
 
     /// Pauses the virtual machine.
     func pause(_ instance: VMInstance) async throws {
-        Self.logger.debug("pause: status=\(instance.status.displayName)")
+        Self.logger.debug("pause: status=\(instance.status.displayName, privacy: .public)")
         guard instance.status.canPause, let vm = instance.virtualMachine else {
             throw VirtualizationError.invalidStateTransition(from: instance.status, action: "pause")
         }
@@ -99,9 +99,9 @@ final class VirtualizationService {
         do {
             try await vm.pause()
             instance.status = .paused
-            Self.logger.notice("Paused VM '\(instance.name)'")
+            Self.logger.notice("Paused VM '\(instance.name, privacy: .public)'")
         } catch {
-            Self.logger.error("Failed to pause VM '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to pause VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             instance.status = .error
             instance.errorMessage = error.localizedDescription
             throw error
@@ -114,7 +114,7 @@ final class VirtualizationService {
     /// - **Hot resume**: VM is in memory — calls `vm.resume()` directly.
     /// - **Cold resume**: VM state is on disk only — rebuilds the VM and restores from save file.
     func resume(_ instance: VMInstance) async throws {
-        Self.logger.debug("resume: status=\(instance.status.displayName), hasVM=\(instance.virtualMachine != nil), hasSaveFile=\(instance.hasSaveFile)")
+        Self.logger.debug("resume: status=\(instance.status.displayName, privacy: .public), hasVM=\(instance.virtualMachine != nil, privacy: .public), hasSaveFile=\(instance.hasSaveFile, privacy: .public)")
         guard instance.status.canResume else {
             throw VirtualizationError.invalidStateTransition(from: instance.status, action: "resume")
         }
@@ -133,9 +133,9 @@ final class VirtualizationService {
                 throw VirtualizationError.noSaveFile
             }
 
-            Self.logger.notice("Resumed VM '\(instance.name)'")
+            Self.logger.notice("Resumed VM '\(instance.name, privacy: .public)'")
         } catch {
-            Self.logger.error("Failed to resume VM '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to resume VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             instance.tearDownSession()
             instance.status = .error
             instance.errorMessage = error.localizedDescription
@@ -147,7 +147,7 @@ final class VirtualizationService {
 
     /// Saves the current VM state to disk (pause + snapshot).
     func save(_ instance: VMInstance) async throws {
-        Self.logger.debug("save: status=\(instance.status.displayName)")
+        Self.logger.debug("save: status=\(instance.status.displayName, privacy: .public)")
         guard instance.status.canSave, let vm = instance.virtualMachine else {
             throw VirtualizationError.invalidStateTransition(from: instance.status, action: "save")
         }
@@ -163,9 +163,9 @@ final class VirtualizationService {
             try await saveMachineState(vm, to: instance.saveFileURL)
             instance.tearDownSession()
             instance.status = .paused
-            Self.logger.notice("Saved state for VM '\(instance.name)'")
+            Self.logger.notice("Saved state for VM '\(instance.name, privacy: .public)'")
         } catch {
-            Self.logger.error("Failed to save VM '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to save VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             instance.tearDownSession()
             instance.status = .error
             instance.errorMessage = error.localizedDescription
@@ -192,9 +192,9 @@ final class VirtualizationService {
 
             // Remove save file after successful restore
             instance.removeSaveFile()
-            Self.logger.notice("Restored state for VM '\(instance.name)'")
+            Self.logger.notice("Restored state for VM '\(instance.name, privacy: .public)'")
         } catch {
-            Self.logger.error("Failed to restore VM '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to restore VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             instance.tearDownSession()
             instance.status = .error
             instance.errorMessage = error.localizedDescription
@@ -251,7 +251,7 @@ final class VirtualizationService {
             instance.removeSaveFile()
         } catch {
             Self.logger.warning(
-                "Restore failed for VM '\(instance.name)', falling back to cold boot: \(error.localizedDescription)"
+                "Restore failed for VM '\(instance.name, privacy: .public)', falling back to cold boot: \(error.localizedDescription, privacy: .public)"
             )
             instance.removeSaveFile()
 

--- a/Kernova/ViewModels/IPSWDownloadViewModel.swift
+++ b/Kernova/ViewModels/IPSWDownloadViewModel.swift
@@ -50,6 +50,6 @@ final class IPSWDownloadViewModel {
     func failDownload(with error: Error) {
         isDownloading = false
         errorMessage = error.localizedDescription
-        Self.logger.error("IPSW download failed: \(error.localizedDescription)")
+        Self.logger.error("IPSW download failed: \(error.localizedDescription, privacy: .public)")
     }
 }

--- a/Kernova/ViewModels/VMDirectoryWatcher.swift
+++ b/Kernova/ViewModels/VMDirectoryWatcher.swift
@@ -27,7 +27,7 @@ final class VMDirectoryWatcher {
     func start(directory: URL) {
         let fd = open(directory.path(percentEncoded: false), O_EVTONLY)
         guard fd >= 0 else {
-            Self.logger.warning("Could not open VMs directory for monitoring: \(directory.path(percentEncoded: false))")
+            Self.logger.warning("Could not open VMs directory for monitoring: \(directory.path(percentEncoded: false), privacy: .public)")
             return
         }
 
@@ -48,7 +48,7 @@ final class VMDirectoryWatcher {
         source.resume()
         directorySource = source
 
-        Self.logger.info("Started directory watcher on \(directory.path(percentEncoded: false))")
+        Self.logger.info("Started directory watcher on \(directory.path(percentEncoded: false), privacy: .public)")
     }
 
     /// Debounces rapid FS events into a single reconciliation pass after 0.5 seconds of quiet.

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -102,11 +102,11 @@ final class VMLibraryViewModel {
                     let instance = VMInstance(configuration: config, bundleURL: migratedURL, status: initialStatus)
                     if needsMigration {
                         try storageService.saveConfiguration(config, to: migratedURL)
-                        Self.logger.info("Migrated VM '\(config.name)': persisted stable identifiers")
+                        Self.logger.info("Migrated VM '\(config.name, privacy: .public)': persisted stable identifiers")
                     }
                     return instance
                 } catch {
-                    Self.logger.error("Failed to load VM from \(bundleURL.lastPathComponent): \(error.localizedDescription)")
+                    Self.logger.error("Failed to load VM from \(bundleURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
                     failedBundles.append(bundleURL.deletingPathExtension().lastPathComponent)
                     return nil
                 }
@@ -119,7 +119,7 @@ final class VMLibraryViewModel {
             // the actual instance list (prunes stale UUIDs, incorporates new VMs).
             if let savedStrings = UserDefaults.standard.stringArray(forKey: Self.vmOrderKey) {
                 customOrder = savedStrings.compactMap { UUID(uuidString: $0) }
-                Self.logger.debug("Loaded custom VM order: \(self.customOrder.count) UUID(s)")
+                Self.logger.debug("Loaded custom VM order: \(self.customOrder.count, privacy: .public) UUID(s)")
             } else {
                 Self.logger.debug("No custom VM order found — using default createdAt sort")
             }
@@ -136,9 +136,9 @@ final class VMLibraryViewModel {
                     selectedID = instances.first?.id
                 }
             }
-            Self.logger.notice("Loaded \(self.instances.count) VMs")
+            Self.logger.notice("Loaded \(self.instances.count, privacy: .public) VMs")
         } catch {
-            Self.logger.error("Failed to load VM library: \(error.localizedDescription)")
+            Self.logger.error("Failed to load VM library: \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
     }
@@ -194,7 +194,7 @@ final class VMLibraryViewModel {
                         )
                     } catch {
                         if !Task.isCancelled {
-                            Self.logger.error("Failed to install macOS on '\(instance.name)': \(error.localizedDescription)")
+                            Self.logger.error("Failed to install macOS on '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
                             presentError(error)
                         }
                     }
@@ -202,9 +202,9 @@ final class VMLibraryViewModel {
             }
             #endif
 
-            Self.logger.notice("Created VM '\(config.name)'")
+            Self.logger.notice("Created VM '\(config.name, privacy: .public)'")
         } catch {
-            Self.logger.error("Failed to create VM: \(error.localizedDescription)")
+            Self.logger.error("Failed to create VM: \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
     }
@@ -214,7 +214,7 @@ final class VMLibraryViewModel {
     #if arch(arm64)
     /// Cancels an in-progress macOS installation, cleans up the VM bundle, and removes it from the library.
     func cancelInstallation(_ instance: VMInstance) {
-        Self.logger.info("Cancelling installation for '\(instance.name)'")
+        Self.logger.info("Cancelling installation for '\(instance.name, privacy: .public)'")
 
         // 1. Cancel the in-flight task (triggers cooperative cancellation in download/install)
         instance.installTask?.cancel()
@@ -228,7 +228,7 @@ final class VMLibraryViewModel {
         do {
             try storageService.deleteVMBundle(at: instance.bundleURL)
         } catch {
-            Self.logger.error("Failed to trash VM bundle during cancellation: \(error.localizedDescription)")
+            Self.logger.error("Failed to trash VM bundle during cancellation: \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
 
@@ -239,7 +239,7 @@ final class VMLibraryViewModel {
             selectedID = instances.first?.id
         }
 
-        Self.logger.notice("Installation cancelled and VM '\(instance.name)' moved to Trash")
+        Self.logger.notice("Installation cancelled and VM '\(instance.name, privacy: .public)' moved to Trash")
     }
     #endif
 
@@ -252,7 +252,7 @@ final class VMLibraryViewModel {
         do {
             try await lifecycle.start(instance)
         } catch {
-            Self.logger.error("Failed to start '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to start '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
     }
@@ -261,7 +261,7 @@ final class VMLibraryViewModel {
         do {
             try lifecycle.stop(instance)
         } catch {
-            Self.logger.error("Failed to stop '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to stop '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
     }
@@ -269,9 +269,9 @@ final class VMLibraryViewModel {
     func forceStop(_ instance: VMInstance) async {
         do {
             try await lifecycle.forceStop(instance)
-            Self.logger.notice("Force-stopped VM '\(instance.name)'")
+            Self.logger.notice("Force-stopped VM '\(instance.name, privacy: .public)'")
         } catch {
-            Self.logger.error("Failed to force-stop '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to force-stop '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
     }
@@ -291,7 +291,7 @@ final class VMLibraryViewModel {
         do {
             try await lifecycle.pause(instance)
         } catch {
-            Self.logger.error("Failed to pause '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to pause '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
     }
@@ -303,7 +303,7 @@ final class VMLibraryViewModel {
         do {
             try await lifecycle.resume(instance)
         } catch {
-            Self.logger.error("Failed to resume '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to resume '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
     }
@@ -312,7 +312,7 @@ final class VMLibraryViewModel {
         do {
             try await lifecycle.save(instance)
         } catch {
-            Self.logger.error("Failed to save '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to save '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
     }
@@ -345,9 +345,9 @@ final class VMLibraryViewModel {
             if selectedID == instance.id {
                 selectedID = instances.first?.id
             }
-            Self.logger.notice("Moved VM '\(instance.name)' to Trash")
+            Self.logger.notice("Moved VM '\(instance.name, privacy: .public)' to Trash")
         } catch {
-            Self.logger.error("Failed to delete VM '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to delete VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
         instanceToDelete = nil
@@ -379,7 +379,7 @@ final class VMLibraryViewModel {
 
             if let existing = instances.first(where: { $0.id == config.id }) {
                 selectedID = existing.id
-                Self.logger.info("VM '\(config.name)' already in library — selected existing instance")
+                Self.logger.info("VM '\(config.name, privacy: .public)' already in library — selected existing instance")
                 return
             }
 
@@ -428,28 +428,28 @@ final class VMLibraryViewModel {
                     // the phantom row's UI should always reflect completion.
                     phantom.preparingState = nil
                     guard self != nil else {
-                        Self.logger.warning("Import completed but view model was deallocated — VM '\(config.name)' exists on disk but was not added to library")
+                        Self.logger.warning("Import completed but view model was deallocated — VM '\(config.name, privacy: .public)' exists on disk but was not added to library")
                         return
                     }
-                    Self.logger.notice("Imported VM '\(config.name)' from \(sourceURL.lastPathComponent)")
+                    Self.logger.notice("Imported VM '\(config.name, privacy: .public)' from \(sourceURL.lastPathComponent, privacy: .public)")
                 } catch {
                     guard let self else {
                         // Clear preparing state and trash partial bundle even without the view model.
                         phantom.preparingState = nil
                         Self.trashPartialBundle(at: phantom.bundleURL)
-                        Self.logger.error("Import failed and view model was deallocated — trashed partial bundle '\(config.name)': \(error.localizedDescription)")
+                        Self.logger.error("Import failed and view model was deallocated — trashed partial bundle '\(config.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
                         return
                     }
                     self.cleanupPhantomInstance(phantom)
                     if !Task.isCancelled {
-                        Self.logger.error("Failed to import VM '\(config.name)': \(error.localizedDescription)")
+                        Self.logger.error("Failed to import VM '\(config.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
                         self.presentError(error)
                     }
                 }
             }
             phantom.preparingState = VMInstance.PreparingState(operation: .importing, task: task)
         } catch {
-            Self.logger.error("Failed to import VM from \(sourceURL.lastPathComponent): \(error.localizedDescription)")
+            Self.logger.error("Failed to import VM from \(sourceURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
     }
@@ -496,7 +496,7 @@ final class VMLibraryViewModel {
         do {
             try storageService.saveConfiguration(instance.configuration, to: instance.bundleURL)
         } catch {
-            Self.logger.error("Failed to save configuration for '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to save configuration for '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
     }
@@ -505,7 +505,7 @@ final class VMLibraryViewModel {
 
     func cloneVM(_ instance: VMInstance) {
         guard instance.status.canEditSettings else {
-            Self.logger.debug("Clone skipped for '\(instance.name)': status '\(instance.status.displayName)' does not allow editing")
+            Self.logger.debug("Clone skipped for '\(instance.name, privacy: .public)': status '\(instance.status.displayName, privacy: .public)' does not allow editing")
             return
         }
         guard !hasPreparing else {
@@ -546,7 +546,7 @@ final class VMLibraryViewModel {
         do {
             bundleURL = try storageService.bundleURL(for: clonedConfig)
         } catch {
-            Self.logger.error("Failed to derive bundle URL for clone of '\(instance.name)': \(error.localizedDescription)")
+            Self.logger.error("Failed to derive bundle URL for clone of '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             presentError(error)
             return
         }
@@ -580,21 +580,21 @@ final class VMLibraryViewModel {
                 // the phantom row's UI should always reflect completion.
                 phantom.preparingState = nil
                 guard self != nil else {
-                    Self.logger.warning("Clone completed but view model was deallocated — VM '\(config.name)' exists on disk but was not added to library")
+                    Self.logger.warning("Clone completed but view model was deallocated — VM '\(config.name, privacy: .public)' exists on disk but was not added to library")
                     return
                 }
-                Self.logger.notice("Cloned VM '\(instance.name)' as '\(config.name)'")
+                Self.logger.notice("Cloned VM '\(instance.name, privacy: .public)' as '\(config.name, privacy: .public)'")
             } catch {
                 guard let self else {
                     // Clear preparing state and trash partial bundle even without the view model.
                     phantom.preparingState = nil
                     Self.trashPartialBundle(at: phantom.bundleURL)
-                    Self.logger.error("Clone failed and view model was deallocated — trashed partial bundle '\(config.name)': \(error.localizedDescription)")
+                    Self.logger.error("Clone failed and view model was deallocated — trashed partial bundle '\(config.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
                     return
                 }
                 self.cleanupPhantomInstance(phantom)
                 if !Task.isCancelled {
-                    Self.logger.error("Failed to clone VM '\(config.name)': \(error.localizedDescription)")
+                    Self.logger.error("Failed to clone VM '\(config.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
                     self.presentError(error)
                 }
             }
@@ -613,16 +613,16 @@ final class VMLibraryViewModel {
             return
         }
 
-        Self.logger.notice("System going to sleep — pausing \(runningInstances.count) running VM(s)")
+        Self.logger.notice("System going to sleep — pausing \(runningInstances.count, privacy: .public) running VM(s)")
 
         var failedNames: [String] = []
         for instance in runningInstances {
             do {
                 try await lifecycle.pause(instance)
                 sleepPausedInstanceIDs.insert(instance.id)
-                Self.logger.debug("Paused '\(instance.name)' for sleep (status: \(instance.status.displayName))")
+                Self.logger.debug("Paused '\(instance.name, privacy: .public)' for sleep (status: \(instance.status.displayName, privacy: .public))")
             } catch {
-                Self.logger.error("Failed to pause '\(instance.name)' for sleep: \(error.localizedDescription)")
+                Self.logger.error("Failed to pause '\(instance.name, privacy: .public)' for sleep: \(error.localizedDescription, privacy: .public)")
                 failedNames.append(instance.name)
             }
         }
@@ -643,15 +643,15 @@ final class VMLibraryViewModel {
         let instancesToResume = instances.filter { idsToResume.contains($0.id) && $0.status == .paused }
         guard !instancesToResume.isEmpty else { return }
 
-        Self.logger.notice("System woke up — resuming \(instancesToResume.count) sleep-paused VM(s)")
+        Self.logger.notice("System woke up — resuming \(instancesToResume.count, privacy: .public) sleep-paused VM(s)")
 
         var failedNames: [String] = []
         for instance in instancesToResume {
             do {
                 try await lifecycle.resume(instance)
-                Self.logger.debug("Resumed '\(instance.name)' after wake (status: \(instance.status.displayName))")
+                Self.logger.debug("Resumed '\(instance.name, privacy: .public)' after wake (status: \(instance.status.displayName, privacy: .public))")
             } catch {
-                Self.logger.error("Failed to resume '\(instance.name)' after wake: \(error.localizedDescription)")
+                Self.logger.error("Failed to resume '\(instance.name, privacy: .public)' after wake: \(error.localizedDescription, privacy: .public)")
                 failedNames.append(instance.name)
             }
         }
@@ -680,7 +680,7 @@ final class VMLibraryViewModel {
         do {
             vmsDir = try storageService.vmsDirectory
         } catch {
-            Self.logger.warning("Could not resolve VMs directory for file system watcher: \(error.localizedDescription)")
+            Self.logger.warning("Could not resolve VMs directory for file system watcher: \(error.localizedDescription, privacy: .public)")
             return
         }
 
@@ -708,14 +708,14 @@ final class VMLibraryViewModel {
                 do {
                     migratedURL = try storageService.migrateBundleIfNeeded(at: bundleURL)
                 } catch {
-                    Self.logger.warning("Failed to migrate bundle at \(bundleURL.lastPathComponent): \(error.localizedDescription)")
+                    Self.logger.warning("Failed to migrate bundle at \(bundleURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
                     migratedURL = bundleURL
                 }
                 do {
                     let config = try storageService.loadConfiguration(from: migratedURL)
                     diskConfigs.append((config, migratedURL))
                 } catch {
-                    Self.logger.warning("Failed to load config from \(migratedURL.lastPathComponent) during reconciliation: \(error.localizedDescription)")
+                    Self.logger.warning("Failed to load config from \(migratedURL.lastPathComponent, privacy: .public) during reconciliation: \(error.localizedDescription, privacy: .public)")
                 }
             }
             let diskIDs = Set(diskConfigs.map(\.0.id))
@@ -734,7 +734,7 @@ final class VMLibraryViewModel {
                     status: initialStatus
                 )
                 instances.append(instance)
-                Self.logger.info("Discovered VM '\(config.name)' on disk — added to library")
+                Self.logger.info("Discovered VM '\(config.name, privacy: .public)' on disk — added to library")
                 didChange = true
             }
 
@@ -750,7 +750,7 @@ final class VMLibraryViewModel {
                 if selectedID == instance.id {
                     selectedID = instances.first?.id
                 }
-                Self.logger.info("VM '\(instance.name)' no longer on disk — removed from library")
+                Self.logger.info("VM '\(instance.name, privacy: .public)' no longer on disk — removed from library")
                 didChange = true
             }
 
@@ -759,9 +759,9 @@ final class VMLibraryViewModel {
                 persistOrder()
             }
 
-            Self.logger.debug("reconcileWithDisk: complete — \(self.instances.count) VM(s) in library")
+            Self.logger.debug("reconcileWithDisk: complete — \(self.instances.count, privacy: .public) VM(s) in library")
         } catch {
-            Self.logger.error("Directory reconciliation failed: \(error.localizedDescription)")
+            Self.logger.error("Directory reconciliation failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -781,7 +781,7 @@ final class VMLibraryViewModel {
         preparingInstanceToCancel = nil
         showCancelPreparingConfirmation = false
 
-        Self.logger.notice("Cancelled \(operationLabel) for '\(instance.name)'")
+        Self.logger.notice("Cancelled \(operationLabel, privacy: .public) for '\(instance.name, privacy: .public)'")
     }
 
     /// Removes a phantom instance from the library, clears its preparing state, and trashes its partial bundle.
@@ -836,7 +836,7 @@ final class VMLibraryViewModel {
             do {
                 try FileManager.default.trashItem(at: url, resultingItemURL: nil)
             } catch {
-                log.error("Failed to clean up partial bundle at \(url.lastPathComponent): \(error.localizedDescription)")
+                log.error("Failed to clean up partial bundle at \(url.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -77,7 +77,7 @@ final class VMLifecycleCoordinator {
         body: () async throws -> T
     ) async throws -> T {
         guard activeOperations[instance.id] == nil else {
-            Self.logger.warning("Rejected \(action) for '\(instance.name)': operation already in progress")
+            Self.logger.warning("Rejected \(action, privacy: .public) for '\(instance.name, privacy: .public)': operation already in progress")
             throw LifecycleError.operationInProgress(vmName: instance.name)
         }
 
@@ -89,7 +89,7 @@ final class VMLifecycleCoordinator {
             }
         }
 
-        Self.logger.debug("Acquired operation lock for '\(instance.name)' (action: \(action))")
+        Self.logger.debug("Acquired operation lock for '\(instance.name, privacy: .public)' (action: \(action, privacy: .public))")
         return try await body()
     }
 
@@ -146,7 +146,7 @@ final class VMLifecycleCoordinator {
         storageService: any VMStorageProviding
     ) async throws {
         try await serialized(instance, action: "installMacOS") {
-            Self.logger.debug("installMacOS: entering for '\(instance.name)', source=\(String(describing: wizard.ipswSource))")
+            Self.logger.debug("installMacOS: entering for '\(instance.name, privacy: .public)', source=\(String(describing: wizard.ipswSource), privacy: .public)")
             do {
                 let ipswURL: URL
 
@@ -204,9 +204,9 @@ final class VMLifecycleCoordinator {
                     instance.installState?.currentPhase = .installing(progress: progress)
                 }
             } catch is CancellationError {
-                Self.logger.info("macOS installation cancelled for '\(instance.name)'")
+                Self.logger.info("macOS installation cancelled for '\(instance.name, privacy: .public)'")
             } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
-                Self.logger.info("IPSW download cancelled for '\(instance.name)'")
+                Self.logger.info("IPSW download cancelled for '\(instance.name, privacy: .public)'")
             } catch {
                 instance.status = .error
                 instance.errorMessage = error.localizedDescription


### PR DESCRIPTION
## Summary
- Add `privacy: .public` to all dynamic string interpolations in `os.Logger` calls so persisted logs (`.error`, `.warning`, `.notice`) are readable in release builds
- Covers ~134 interpolations across 15 files: VM names, error descriptions, file paths, status enums, numeric values, boolean flags, toolbar identifiers, and network URLs
- One intentional exception: `savedID.uuidString` left unannotated (UUIDs kept redacted by design)

Closes #56

## Test plan
- [x] Built successfully on macOS 26
- [x] All existing tests pass
- [x] Verified via grep that only the intentional UUID exception remains unannotated
- [x] Code review, silent-failure-hunter, and /simplify all pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)