### PR TITLE
docs: Strengthen review debt filing requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ EOF
 | `review-debt/test-gap` | Missing or insufficient tests for critical code |
 
 **Guidelines:**
+- **File issues immediately** — do not list qualifying findings as "skipped" and wait for the user to ask. If a finding meets the severity criteria above, create the issue as part of the review flow before summarizing results.
 - Always check for existing issues before creating duplicates
 - Reference the source PR or file context in the issue body
 - Keep issue titles actionable and specific (e.g., "Add error handling for disk-full scenario in BundleManager" not "Improve error handling")


### PR DESCRIPTION
## Summary
- Add explicit guideline that qualifying review findings must be filed as GitHub issues immediately, not listed as "skipped" and deferred to user prompting

## Changes
- Add bolded first bullet to Review Debt Tracking guidelines in CLAUDE.md: "File issues immediately — do not list qualifying findings as 'skipped' and wait for the user to ask"

## Test plan
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)