### PR TITLE
feat: Add SPICE clipboard sharing between host and guest

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -113,7 +113,7 @@ KernovaTests/
 └── NSImageExtensionsTests.swift        # SF Symbol loading utility tests
 ```
 
-**Total: 52 source files, 24 test files (18 suites + 6 mocks).**
+**Total: 56 source files, 25 test files (19 suites + 6 mocks).**
 
 *Note: `ContentView.swift` was removed when `NavigationSplitView` was replaced by `NSSplitViewController` in `MainWindowController`. Its responsibilities were split between `MainWindowController` (toolbar, split view) and `MainDetailView` (detail switching, sheets, alerts).*
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,6 +14,7 @@ Kernova/
 │   ├── VMDisplayWindowController.swift  # Per-VM display window (pop-out or fullscreen), auto-closes on VM stop
 │   ├── VMToolbarManager.swift          # Shared toolbar logic for lifecycle, save-state, and display groups
 │   ├── SerialConsoleWindowController.swift # Per-VM serial console window, auto-closes on VM stop
+│   ├── ClipboardWindowController.swift   # Per-VM clipboard sharing window, auto-closes on VM stop
 │   └── Info.plist                        # App configuration and metadata
 ├── Models/                             # Data types — all value types or @MainActor-isolated
 │   ├── VMConfiguration.swift           # Codable/Sendable struct persisted as config.json per VM bundle
@@ -32,6 +33,8 @@ Kernova/
 │   ├── MacOSInstallService.swift       # Drives macOS guest install via VZMacOSInstaller (@MainActor)
 │   ├── IPSWService.swift               # Fetches/downloads macOS restore images (Sendable struct)
 │   ├── SystemSleepWatcher.swift        # Observes system sleep/wake, triggers VM pause/resume
+│   ├── SpiceAgentProtocol.swift       # SPICE agent wire format: VDI chunks, message headers, clipboard types
+│   ├── SpiceClipboardService.swift    # Host-side SPICE clipboard: pipe I/O, protocol state machine (@MainActor)
 │   └── Protocols/                      # Service protocol abstractions for DI and testing
 │       ├── VirtualizationProviding.swift
 │       ├── VMStorageProviding.swift
@@ -61,6 +64,8 @@ Kernova/
 │   │   ├── VMTransitionOverlay.swift    # Frosted overlay with spinner for saving/restoring states
 │   │   ├── SerialConsoleContentView.swift # Serial console content wrapper
 │   │   └── SerialTerminalView.swift    # Terminal text view for serial output
+│   ├── Clipboard/
+│   │   └── ClipboardContentView.swift # Per-VM clipboard sharing panel (from-guest / to-guest)
 │   └── Creation/
 │       ├── VMCreationWizardView.swift  # Multi-step wizard container
 │       ├── OSSelectionStep.swift       # Step 1: Choose macOS or Linux
@@ -103,6 +108,7 @@ KernovaTests/
 ├── VMBootModeTests.swift               # Boot mode enum tests
 ├── VMGuestOSTests.swift                # Guest OS enum tests
 ├── MacOSInstallStateTests.swift        # Install state tracking tests
+├── SpiceAgentProtocolTests.swift       # SPICE wire format serialization/deserialization tests
 ├── DataFormattersTests.swift           # Formatting utility tests
 └── NSImageExtensionsTests.swift        # SF Symbol loading utility tests
 ```
@@ -115,7 +121,7 @@ KernovaTests/
 
 ### App Layer
 
-**Files:** `AppDelegate.swift`, `MainWindowController.swift`, `VMDisplayWindowController.swift`, `VMToolbarManager.swift`, `SerialConsoleWindowController.swift`
+**Files:** `AppDelegate.swift`, `MainWindowController.swift`, `VMDisplayWindowController.swift`, `VMToolbarManager.swift`, `SerialConsoleWindowController.swift`, `ClipboardWindowController.swift`
 
 `AppDelegate` is the entry point. It creates the `VMLibraryViewModel` and `VMLifecycleCoordinator`, opens the main window, and manages the lifecycle of all windows. It tracks window controllers in dictionaries keyed by VM UUID, enabling one-to-many relationships (a VM can have a main view, a fullscreen window, and a serial console open simultaneously). `AppDelegate` also handles:
 - The application menu (including VM-specific actions, Force Stop with `canForceStop` validation, and Window > Show Library with Cmd+0)
@@ -142,7 +148,7 @@ The remaining models are enums: `VMStatus` (stopped/starting/running/paused/savi
 
 ### Services
 
-**Files:** `ConfigurationBuilder.swift`, `VirtualizationService.swift`, `VMStorageService.swift`, `DiskImageService.swift`, `MacOSInstallService.swift`, `IPSWService.swift`
+**Files:** `ConfigurationBuilder.swift`, `VirtualizationService.swift`, `VMStorageService.swift`, `DiskImageService.swift`, `MacOSInstallService.swift`, `IPSWService.swift`, `SpiceAgentProtocol.swift`, `SpiceClipboardService.swift`
 
 **Protocols:** `VirtualizationProviding`, `VMStorageProviding`, `DiskImageProviding`, `MacOSInstallProviding`, `IPSWProviding`
 
@@ -159,7 +165,11 @@ Services are split by concurrency requirements:
 
 - **`SystemSleepWatcher`** — `@MainActor` observer class that monitors `NSWorkspace.willSleepNotification` and `NSWorkspace.didWakeNotification`. Follows the same pattern as `VMDirectoryWatcher`: callback-driven, `nonisolated(unsafe)` for observer tokens, `start()`/`deinit` lifecycle. Owned by `VMLibraryViewModel`, which uses it to auto-pause running VMs before sleep and resume them on wake.
 
-- **`ConfigurationBuilder`** — Translates a `VMConfiguration` into a `VZVirtualMachineConfiguration`. Handles three boot paths: `VZMacOSBootLoader` (macOS), `VZEFIBootLoader` (EFI/UEFI), and `VZLinuxBootLoader` (direct kernel boot). Configures CPU, memory, storage, network, display, keyboard, trackpad, and audio devices. Resolves symlinks on user-supplied paths (shared directories, kernel/initrd, ISO images) and validates them before passing to VZ. File paths (kernel, initrd, ISO) are checked for existence and rejected if they point to directories. Shared directory validation checks existence, is-directory, readability, and writability (for read-write shares) against the resolved path.
+- **`ConfigurationBuilder`** — Translates a `VMConfiguration` into a `VZVirtualMachineConfiguration`. Handles three boot paths: `VZMacOSBootLoader` (macOS), `VZEFIBootLoader` (EFI/UEFI), and `VZLinuxBootLoader` (direct kernel boot). Configures CPU, memory, storage, network, display, keyboard, trackpad, and audio devices. When `clipboardSharingEnabled` is set, configures a `VZVirtioConsoleDeviceConfiguration` with a SPICE-named port using raw `VZFileHandleSerialPortAttachment` pipes (not `VZSpiceAgentPortAttachment`). Resolves symlinks on user-supplied paths (shared directories, kernel/initrd, ISO images) and validates them before passing to VZ. File paths (kernel, initrd, ISO) are checked for existence and rejected if they point to directories. Shared directory validation checks existence, is-directory, readability, and writability (for read-write shares) against the resolved path.
+
+- **`SpiceAgentProtocol`** — Pure data types and parsing for the SPICE agent wire format. Defines VDI chunk headers, VDAgent message headers, clipboard message types, and capability bitmasks. Includes `SpiceMessageBuilder` (builds wire-ready messages) and `SpiceAgentParser` (incremental parser handling fragmented data across multiple pipe reads). Fully `Sendable`, no I/O.
+
+- **`SpiceClipboardService`** — `@MainActor` service that manages SPICE clipboard sharing for a single VM. Reads from the guest pipe on a background GCD queue, parses messages via `SpiceAgentParser`, and exposes `guestClipboardText` (observable) and `isConnected` to the UI. Sends clipboard data to the guest via `sendToGuest(_:)`. Uses raw pipes rather than `VZSpiceAgentPortAttachment` so clipboard data flows through the gated UI instead of the host `NSPasteboard`.
 
 All service implementations conform to protocols defined in `Services/Protocols/`. This enables full dependency injection — tests use mock implementations that track call counts and support error injection.
 
@@ -219,7 +229,8 @@ AppDelegate
     │                 └── Detail:  NSHostingController(MainDetailView → VMDetailView)
     │
     ├── manages → VMDisplayWindowController (per VM)
-    └── manages → SerialConsoleWindowController (per VM)
+    ├── manages → SerialConsoleWindowController (per VM)
+    └── manages → ClipboardWindowController (per VM)
 
 SwiftUI views ──observe──→ VMLibraryViewModel ──delegates──→ VMLifecycleCoordinator ──calls──→ Services
                            VMInstance (per VM)
@@ -330,6 +341,7 @@ No external package dependencies. No Swift Package Manager, CocoaPods, or Cartha
 | `VMToolbarManager` | 22 tests | Item creation, state updates, configuration flags, label toggling |
 | `DataFormatters` | Yes | Byte formatting, CPU count formatting |
 | `NSImageExtensions` | Yes | SF Symbol loading with known symbol validation |
+| `SpiceAgentProtocol` | Yes | VDI chunk/message serialization round-trips, parser with multi-message feeds, partial data, unknown types |
 
 ### Mocked but Not Directly Tested
 
@@ -338,6 +350,7 @@ These services interact with system processes, the network, or VZ installer inte
 - `DiskImageService` — decompresses bundled templates (no subprocess; direct testing feasible but requires bundled resources in test target)
 - `IPSWService` — makes network requests to Apple
 - `MacOSInstallService` — requires a real `VZVirtualMachine` and restore image
+- `SpiceClipboardService` — requires active SPICE pipe I/O (protocol parsing tested via `SpiceAgentProtocol` suite)
 
 ### Not Tested
 
@@ -346,7 +359,7 @@ These services interact with system processes, the network, or VZ installer inte
 - `IPSWDownloadViewModel` — wraps async download state
 - `KernovaUTType` — static UTType declaration
 - `FileManagerExtensions` — FileManager convenience methods
-- All window controllers (`MainWindowController`, `VMDisplayWindowController`, `SerialConsoleWindowController`)
+- All window controllers (`MainWindowController`, `VMDisplayWindowController`, `SerialConsoleWindowController`, `ClipboardWindowController`)
 - `AppDelegate` — app lifecycle and window management
 - All SwiftUI views
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -169,7 +169,7 @@ Services are split by concurrency requirements:
 
 - **`SpiceAgentProtocol`** — Pure data types and parsing for the SPICE agent wire format. Defines VDI chunk headers, VDAgent message headers, clipboard message types, and capability bitmasks. Includes `SpiceMessageBuilder` (builds wire-ready messages) and `SpiceAgentParser` (incremental parser handling fragmented data across multiple pipe reads). Fully `Sendable`, no I/O.
 
-- **`SpiceClipboardService`** — `@MainActor` service that manages SPICE clipboard sharing for a single VM. Reads from the guest pipe on a background GCD queue, parses messages via `SpiceAgentParser`, and exposes `guestClipboardText` (observable) and `isConnected` to the UI. Sends clipboard data to the guest via `sendToGuest(_:)`. Uses raw pipes rather than `VZSpiceAgentPortAttachment` so clipboard data flows through the gated UI instead of the host `NSPasteboard`.
+- **`SpiceClipboardService`** — `@MainActor` service that manages SPICE clipboard sharing for a single VM. Reads from the guest pipe on a background GCD queue, parses messages via `SpiceAgentParser`, and exposes `clipboardText` (observable, editable by the UI) and `isConnected`. When the clipboard window loses focus, `grabIfChanged()` sends a `CLIPBOARD_GRAB` if the text was edited. Uses raw pipes rather than `VZSpiceAgentPortAttachment` so clipboard data flows through the gated UI instead of the host `NSPasteboard`.
 
 All service implementations conform to protocols defined in `Services/Protocols/`. This enables full dependency injection — tests use mock implementations that track call counts and support error injection.
 

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -11,9 +11,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private var pendingOpenURLs: [URL] = []
     private var serialConsoleWindows: [UUID: SerialConsoleWindowController] = [:]
     private var serialConsoleObservers: [UUID: Any] = [:]
+    private var clipboardWindows: [UUID: ClipboardWindowController] = [:]
+    private var clipboardObservers: [UUID: Any] = [:]
     private var displayWindows: [UUID: VMDisplayWindowController] = [:]
     private var displayWindowObservers: [UUID: Any] = [:]
     private var serialConsoleMenuItem: NSMenuItem!
+    private var clipboardMenuItem: NSMenuItem!
     /// Set in `applicationWillBecomeActive` and read in `applicationShouldHandleReopen`
     /// to distinguish a dock click that activates the app from one on an already-active app.
     ///
@@ -33,6 +36,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                 return controller.instance
             }
             if let controller = serialConsoleWindows.values.first(where: { $0.window === keyWindow }) {
+                return controller.instance
+            }
+            if let controller = clipboardWindows.values.first(where: { $0.window === keyWindow }) {
                 return controller.instance
             }
         }
@@ -301,6 +307,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         controller.showWindow(nil)
     }
 
+    // MARK: - Clipboard
+
+    @objc func showClipboard(_ sender: Any?) {
+        guard let instance = activeInstance,
+              instance.canShowClipboard else { return }
+
+        if let existing = clipboardWindows[instance.instanceID] {
+            existing.window?.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        let controller = ClipboardWindowController(instance: instance)
+        let vmID = instance.instanceID
+        clipboardWindows[vmID] = controller
+
+        // Clean up when window closes
+        let token = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: controller.window,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                if let token = self?.clipboardObservers.removeValue(forKey: vmID) {
+                    NotificationCenter.default.removeObserver(token)
+                }
+                self?.clipboardWindows.removeValue(forKey: vmID)
+                self?.terminateIfIdle()
+            }
+        }
+        clipboardObservers[vmID] = token
+
+        controller.showWindow(nil)
+    }
+
     // MARK: - Display Window (Pop-Out / Fullscreen)
 
     @objc func togglePopOut(_ sender: Any?) {
@@ -456,6 +496,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         guard isMainWindowDismissed else { return false }
         guard displayWindows.isEmpty else { return false }
         guard serialConsoleWindows.isEmpty else { return false }
+        guard clipboardWindows.isEmpty else { return false }
         return !viewModel.instances.contains(where: \.isKeepingAppAlive)
     }
 
@@ -524,6 +565,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // shortcut validation, which still routes through validateMenuItem(_:).
         case #selector(showSerialConsole(_:)):
             return activeInstance?.canShowSerialConsole ?? false
+        case #selector(showClipboard(_:)):
+            return activeInstance?.canShowClipboard ?? false
         case #selector(togglePopOut(_:)):
             guard let instance = activeInstance else { return false }
             let canUse = instance.canUseExternalDisplay
@@ -543,6 +586,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     func menuNeedsUpdate(_ menu: NSMenu) {
         if menu === NSApp.windowsMenu {
             serialConsoleMenuItem.isEnabled = activeInstance?.canShowSerialConsole ?? false
+            clipboardMenuItem.isEnabled = activeInstance?.canShowClipboard ?? false
         }
     }
 
@@ -645,6 +689,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         serialItem.keyEquivalentModifierMask = [.command, .shift]
         self.serialConsoleMenuItem = serialItem
         windowMenu.addItem(serialItem)
+        let clipboardItem = NSMenuItem(
+            title: "Clipboard",
+            action: #selector(showClipboard(_:)),
+            keyEquivalent: "v"
+        )
+        clipboardItem.keyEquivalentModifierMask = [.command, .shift]
+        self.clipboardMenuItem = clipboardItem
+        windowMenu.addItem(clipboardItem)
         windowMenu.addItem(.separator())
         windowMenu.addItem(withTitle: "Minimize", action: #selector(NSWindow.performMiniaturize(_:)), keyEquivalent: "m")
         windowMenu.addItem(withTitle: "Zoom", action: #selector(NSWindow.performZoom(_:)), keyEquivalent: "")

--- a/Kernova/App/ClipboardWindowController.swift
+++ b/Kernova/App/ClipboardWindowController.swift
@@ -1,0 +1,83 @@
+import Cocoa
+import os
+import SwiftUI
+
+/// Manages a clipboard sharing window for a single VM instance.
+///
+/// Each VM gets its own window controller. The window hosts a `ClipboardContentView`
+/// via `NSHostingController` and persists its frame position per VM ID.
+///
+/// The controller observes the VM's status and automatically closes the window when
+/// the VM stops or enters an error state, mirroring `SerialConsoleWindowController` behavior.
+@MainActor
+final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
+
+    private static let logger = Logger(subsystem: "com.kernova.app", category: "ClipboardWindowController")
+
+    let vmID: UUID
+    let instance: VMInstance
+    private var observingStatus = false
+
+    init(instance: VMInstance) {
+        self.vmID = instance.instanceID
+        self.instance = instance
+
+        let contentView = ClipboardContentView(instance: instance)
+        let hostingController = NSHostingController(rootView: contentView)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 400),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = hostingController
+        window.title = "\(instance.name) — Clipboard"
+        window.minSize = NSSize(width: 320, height: 280)
+
+        super.init(window: window)
+        window.delegate = self
+
+        window.restoreFrame(named: "Clipboard-\(instance.instanceID.uuidString)")
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func showWindow(_ sender: Any?) {
+        super.showWindow(sender)
+        if !observingStatus { observeStatus() }
+        Self.logger.debug("Clipboard window shown for VM '\(self.instance.name, privacy: .public)'")
+    }
+
+    // MARK: - NSWindowDelegate
+
+    func windowWillClose(_ notification: Notification) {
+        observingStatus = false
+        Self.logger.debug("Clipboard window closing for VM '\(self.instance.name, privacy: .public)'")
+    }
+
+    // MARK: - Status Observation
+
+    /// Automatically closes the clipboard window when the VM stops or errors out.
+    private func observeStatus() {
+        observingStatus = true
+        withObservationTracking {
+            _ = self.instance.status
+        } onChange: {
+            Task { @MainActor [weak self] in
+                guard let self, self.observingStatus else { return }
+                let status = self.instance.status
+                if status == .stopped || status == .error {
+                    Self.logger.notice("Auto-closing clipboard window for VM '\(self.instance.name, privacy: .public)' (status: \(status.displayName, privacy: .public))")
+                    self.window?.close()
+                } else {
+                    self.observeStatus()
+                }
+            }
+        }
+    }
+}

--- a/Kernova/App/ClipboardWindowController.swift
+++ b/Kernova/App/ClipboardWindowController.swift
@@ -33,7 +33,7 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
         )
         window.contentViewController = hostingController
         window.title = "\(instance.name) — Clipboard"
-        window.minSize = NSSize(width: 320, height: 200)
+        window.minSize = NSSize(width: 320, height: 250)
 
         super.init(window: window)
         window.delegate = self
@@ -56,6 +56,10 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
     // MARK: - NSWindowDelegate
 
     func windowWillClose(_ notification: Notification) {
+        // Flush any pending edits before the window goes away
+        if instance.status == .running || instance.status == .paused {
+            instance.clipboardService?.grabIfChanged()
+        }
         observingStatus = false
         Self.logger.debug("Clipboard window closing for VM '\(self.instance.name, privacy: .public)'")
     }

--- a/Kernova/App/ClipboardWindowController.swift
+++ b/Kernova/App/ClipboardWindowController.swift
@@ -26,14 +26,14 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
         let hostingController = NSHostingController(rootView: contentView)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 400),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 300),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
         window.contentViewController = hostingController
         window.title = "\(instance.name) — Clipboard"
-        window.minSize = NSSize(width: 320, height: 280)
+        window.minSize = NSSize(width: 320, height: 200)
 
         super.init(window: window)
         window.delegate = self
@@ -58,6 +58,10 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
         observingStatus = false
         Self.logger.debug("Clipboard window closing for VM '\(self.instance.name, privacy: .public)'")
+    }
+
+    func windowDidResignKey(_ notification: Notification) {
+        instance.clipboardService?.grabIfChanged()
     }
 
     // MARK: - Status Observation

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -25,6 +25,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             configuration: .init(
                 lifecycleID: NSToolbarItem.Identifier("lifecycle"),
                 saveStateID: NSToolbarItem.Identifier("saveState"),
+                clipboardID: NSToolbarItem.Identifier("clipboard"),
                 displayID: NSToolbarItem.Identifier("display"),
                 checksPreparing: true,
                 gatesDisplayOnCapability: true
@@ -128,6 +129,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             _ = self.viewModel.selectedInstance?.isPreparing
             _ = self.viewModel.selectedInstance?.displayMode
             _ = self.viewModel.selectedInstance?.virtualMachine
+            _ = self.viewModel.selectedInstance?.configuration.clipboardSharingEnabled
         } onChange: {
             Task { @MainActor [weak self] in
                 guard let self, self.observingToolbar else { return }

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -31,6 +31,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
             configuration: .init(
                 lifecycleID: NSToolbarItem.Identifier("displayLifecycle"),
                 saveStateID: NSToolbarItem.Identifier("displaySaveState"),
+                clipboardID: nil,
                 displayID: NSToolbarItem.Identifier("displayDisplay"),
                 checksPreparing: false,
                 gatesDisplayOnCapability: false

--- a/Kernova/App/VMToolbarManager.swift
+++ b/Kernova/App/VMToolbarManager.swift
@@ -16,6 +16,7 @@ final class VMToolbarManager: NSObject {
         /// Toolbar item identifiers (different strings per controller to avoid AppKit conflicts).
         let lifecycleID: NSToolbarItem.Identifier
         let saveStateID: NSToolbarItem.Identifier
+        let clipboardID: NSToolbarItem.Identifier?
         let displayID: NSToolbarItem.Identifier
 
         /// When `true`, checks `instance.isPreparing` and disables all items while preparing.
@@ -30,7 +31,12 @@ final class VMToolbarManager: NSObject {
 
     /// All shared toolbar item identifiers, for use in `NSToolbarDelegate` methods.
     var sharedItemIdentifiers: [NSToolbarItem.Identifier] {
-        [configuration.lifecycleID, configuration.saveStateID, configuration.displayID]
+        var ids = [configuration.lifecycleID, configuration.saveStateID]
+        if let clipboardID = configuration.clipboardID {
+            ids.append(clipboardID)
+        }
+        ids.append(configuration.displayID)
+        return ids
     }
 
     private let configuration: Configuration
@@ -61,10 +67,10 @@ final class VMToolbarManager: NSObject {
     // MARK: - Init
 
     init(configuration: Configuration, instanceProvider: @escaping () -> VMInstance?) {
-        assert(
-            Set([configuration.lifecycleID, configuration.saveStateID, configuration.displayID]).count == 3,
-            "VMToolbarManager.Configuration identifiers must be distinct"
-        )
+        var ids: Set = [configuration.lifecycleID, configuration.saveStateID, configuration.displayID]
+        if let clipboardID = configuration.clipboardID { ids.insert(clipboardID) }
+        assert(ids.count == (configuration.clipboardID != nil ? 4 : 3),
+               "VMToolbarManager.Configuration identifiers must be distinct")
         self.configuration = configuration
         self.instanceProvider = instanceProvider
         super.init()
@@ -106,6 +112,15 @@ final class VMToolbarManager: NSObject {
                 toolTip: Self.saveStateToolTip
             )
 
+        case configuration.clipboardID:
+            return makeSingleItemGroup(
+                identifier: identifier,
+                label: "Clipboard",
+                symbol: "doc.on.clipboard",
+                action: #selector(AppDelegate.showClipboard(_:)),
+                toolTip: "Open the clipboard sharing window"
+            )
+
         case configuration.displayID:
             let group = NSToolbarItemGroup(
                 itemIdentifier: identifier,
@@ -136,6 +151,7 @@ final class VMToolbarManager: NSObject {
         let instance = resolveActiveInstance()
         updateLifecycleGroup(in: toolbar, instance: instance)
         updateSaveStateItem(in: toolbar, instance: instance)
+        updateClipboardItem(in: toolbar, instance: instance)
         updateDisplayGroup(in: toolbar, instance: instance)
     }
 
@@ -180,6 +196,19 @@ final class VMToolbarManager: NSObject {
         }
 
         subitem.isEnabled = instance.canSave
+    }
+
+    private func updateClipboardItem(in toolbar: NSToolbar, instance: VMInstance?) {
+        guard let clipboardID = configuration.clipboardID,
+              let group = toolbar.items.first(where: { $0.itemIdentifier == clipboardID }) as? NSToolbarItemGroup,
+              let subitem = group.subitems.first else { return }
+
+        guard let instance else {
+            subitem.isEnabled = false
+            return
+        }
+
+        subitem.isEnabled = instance.canShowClipboard
     }
 
     private func updateDisplayGroup(in toolbar: NSToolbar, instance: VMInstance?) {

--- a/Kernova/App/VMToolbarManager.swift
+++ b/Kernova/App/VMToolbarManager.swift
@@ -67,9 +67,9 @@ final class VMToolbarManager: NSObject {
     // MARK: - Init
 
     init(configuration: Configuration, instanceProvider: @escaping () -> VMInstance?) {
-        var ids: Set = [configuration.lifecycleID, configuration.saveStateID, configuration.displayID]
-        if let clipboardID = configuration.clipboardID { ids.insert(clipboardID) }
-        assert(ids.count == (configuration.clipboardID != nil ? 4 : 3),
+        var allIDs = [configuration.lifecycleID, configuration.saveStateID, configuration.displayID]
+        if let clipboardID = configuration.clipboardID { allIDs.append(clipboardID) }
+        assert(Set(allIDs).count == allIDs.count,
                "VMToolbarManager.Configuration identifiers must be distinct")
         self.configuration = configuration
         self.instanceProvider = instanceProvider

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -38,6 +38,12 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     var networkEnabled: Bool
     var macAddress: String?
 
+    // MARK: - Clipboard Sharing
+
+    /// When `true`, a SPICE agent console port is configured to enable clipboard
+    /// exchange between host and guest via the clipboard panel window.
+    var clipboardSharingEnabled: Bool
+
     // MARK: - macOS-specific
 
     /// Serialized `VZMacHardwareModel.dataRepresentation`.
@@ -91,6 +97,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         lastFullscreenDisplayID: UInt32? = nil,
         networkEnabled: Bool = true,
         macAddress: String? = nil,
+        clipboardSharingEnabled: Bool = false,
         hardwareModelData: Data? = nil,
         machineIdentifierData: Data? = nil,
         genericMachineIdentifierData: Data? = nil,
@@ -116,6 +123,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         self.lastFullscreenDisplayID = lastFullscreenDisplayID
         self.networkEnabled = networkEnabled
         self.macAddress = macAddress
+        self.clipboardSharingEnabled = clipboardSharingEnabled
         self.hardwareModelData = hardwareModelData
         self.machineIdentifierData = machineIdentifierData
         self.genericMachineIdentifierData = genericMachineIdentifierData
@@ -135,6 +143,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         case cpuCount, memorySizeInGB, diskSizeInGB
         case displayWidth, displayHeight, displayPPI, displayPreference, lastFullscreenDisplayID
         case networkEnabled, macAddress
+        case clipboardSharingEnabled
         case hardwareModelData, machineIdentifierData
         case genericMachineIdentifierData
         case isoPath, bootFromDiscImage
@@ -160,6 +169,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         lastFullscreenDisplayID = try container.decodeIfPresent(UInt32.self, forKey: .lastFullscreenDisplayID)
         networkEnabled = try container.decode(Bool.self, forKey: .networkEnabled)
         macAddress = try container.decodeIfPresent(String.self, forKey: .macAddress)
+        clipboardSharingEnabled = try container.decodeIfPresent(Bool.self, forKey: .clipboardSharingEnabled) ?? false
         hardwareModelData = try container.decodeIfPresent(Data.self, forKey: .hardwareModelData)
         machineIdentifierData = try container.decodeIfPresent(Data.self, forKey: .machineIdentifierData)
         genericMachineIdentifierData = try container.decodeIfPresent(Data.self, forKey: .genericMachineIdentifierData)

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -80,6 +80,15 @@ final class VMInstance: Identifiable {
     /// Where the VM display is currently hosted (inline, pop-out window, or fullscreen).
     var displayMode: VMDisplayMode = .inline
 
+    // MARK: - Clipboard Sharing
+
+    /// Bidirectional pipes for the SPICE clipboard console port.
+    var clipboardInputPipe: Pipe?
+    var clipboardOutputPipe: Pipe?
+
+    /// The SPICE clipboard service managing protocol I/O for this VM.
+    var clipboardService: SpiceClipboardService?
+
     // MARK: - Serial Console
 
     /// Observable text buffer driven by serial port output. Capped at 1 MB in memory;
@@ -179,6 +188,11 @@ final class VMInstance: Identifiable {
         (status == .running || status == .paused) && virtualMachine != nil
     }
 
+    /// `true` when the VM has clipboard sharing enabled and is eligible to show the clipboard window.
+    var canShowClipboard: Bool {
+        configuration.clipboardSharingEnabled && (status == .running || status == .paused) && virtualMachine != nil
+    }
+
     // MARK: - Delegate Setup
 
     func setupDelegate() {
@@ -194,6 +208,7 @@ final class VMInstance: Identifiable {
     /// clears the `VZVirtualMachine` reference. Does **not** change `status` —
     /// callers set the appropriate status after calling this.
     func tearDownSession() {
+        stopClipboardService()
         stopSerialReading()
         serialInputPipe = nil
         serialOutputPipe = nil
@@ -310,6 +325,27 @@ final class VMInstance: Identifiable {
             Self.logger.warning("Failed to close serial log file for VM '\(self.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
         }
         serialLogFileHandle = nil
+    }
+
+    // MARK: - Clipboard Service Lifecycle
+
+    /// Creates and starts the SPICE clipboard service using the clipboard pipes.
+    func startClipboardService() {
+        guard let inputPipe = clipboardInputPipe,
+              let outputPipe = clipboardOutputPipe else { return }
+
+        let service = SpiceClipboardService(inputPipe: inputPipe, outputPipe: outputPipe)
+        service.start()
+        clipboardService = service
+        Self.logger.info("Clipboard service started for '\(self.name, privacy: .public)'")
+    }
+
+    /// Stops and releases the clipboard service and pipes.
+    func stopClipboardService() {
+        clipboardService?.stop()
+        clipboardService = nil
+        clipboardInputPipe = nil
+        clipboardOutputPipe = nil
     }
 }
 

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -331,8 +331,13 @@ final class VMInstance: Identifiable {
 
     /// Creates and starts the SPICE clipboard service using the clipboard pipes.
     func startClipboardService() {
+        guard configuration.clipboardSharingEnabled else { return }
+
         guard let inputPipe = clipboardInputPipe,
-              let outputPipe = clipboardOutputPipe else { return }
+              let outputPipe = clipboardOutputPipe else {
+            Self.logger.error("Clipboard sharing enabled but pipes not configured for '\(self.name, privacy: .public)'")
+            return
+        }
 
         let service = SpiceClipboardService(inputPipe: inputPipe, outputPipe: outputPipe)
         service.start()
@@ -340,10 +345,14 @@ final class VMInstance: Identifiable {
         Self.logger.info("Clipboard service started for '\(self.name, privacy: .public)'")
     }
 
-    /// Stops and releases the clipboard service and pipes.
+    /// Stops and releases the clipboard service and closes pipe file handles.
     func stopClipboardService() {
         clipboardService?.stop()
         clipboardService = nil
+        try? clipboardInputPipe?.fileHandleForReading.close()
+        try? clipboardInputPipe?.fileHandleForWriting.close()
+        try? clipboardOutputPipe?.fileHandleForReading.close()
+        try? clipboardOutputPipe?.fileHandleForWriting.close()
         clipboardInputPipe = nil
         clipboardOutputPipe = nil
     }

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -13,11 +13,14 @@ import os
 /// - **Linux Kernel**: `VZGenericPlatformConfiguration` + `VZLinuxBootLoader`
 struct ConfigurationBuilder: Sendable {
 
-    /// Contains the built VZ configuration along with bidirectional serial port pipes.
+    /// Contains the built VZ configuration along with bidirectional serial port pipes
+    /// and optional SPICE clipboard pipes.
     struct BuildResult: @unchecked Sendable {
         let configuration: VZVirtualMachineConfiguration
         let serialInputPipe: Pipe
         let serialOutputPipe: Pipe
+        let clipboardInputPipe: Pipe?
+        let clipboardOutputPipe: Pipe?
     }
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "ConfigurationBuilder")
@@ -58,11 +61,20 @@ struct ConfigurationBuilder: Sendable {
         // Serial port
         let (inputPipe, outputPipe) = configureSerialPort(vzConfig)
 
+        // Clipboard sharing (SPICE agent console port)
+        let clipboardPipes = configureClipboardSharing(vzConfig, config: config)
+
         // Validate
         try vzConfig.validate()
 
         Self.logger.info("Built VZ configuration for '\(config.name, privacy: .public)' (\(config.bootMode.displayName, privacy: .public))")
-        return BuildResult(configuration: vzConfig, serialInputPipe: inputPipe, serialOutputPipe: outputPipe)
+        return BuildResult(
+            configuration: vzConfig,
+            serialInputPipe: inputPipe,
+            serialOutputPipe: outputPipe,
+            clipboardInputPipe: clipboardPipes?.input,
+            clipboardOutputPipe: clipboardPipes?.output
+        )
     }
 
     // MARK: - macOS Boot
@@ -335,6 +347,43 @@ struct ConfigurationBuilder: Sendable {
         )
         vzConfig.serialPorts = [serialPort]
 
+        return (inputPipe, outputPipe)
+    }
+
+    // MARK: - Clipboard Sharing
+
+    /// Configures a SPICE agent console port for clipboard sharing using raw pipe I/O.
+    ///
+    /// Instead of using `VZSpiceAgentPortAttachment` (which automatically syncs with
+    /// the host `NSPasteboard`), we attach `VZFileHandleSerialPortAttachment` to the
+    /// SPICE-named port. This lets `SpiceClipboardService` speak the SPICE protocol
+    /// directly and present clipboard data in a gated UI rather than hijacking the
+    /// host clipboard.
+    ///
+    /// Returns the (input, output) pipes, or `nil` when clipboard sharing is disabled.
+    private func configureClipboardSharing(
+        _ vzConfig: VZVirtualMachineConfiguration,
+        config: VMConfiguration
+    ) -> (input: Pipe, output: Pipe)? {
+        guard config.clipboardSharingEnabled else { return nil }
+
+        let inputPipe = Pipe()   // host writes → guest reads
+        let outputPipe = Pipe()  // guest writes → host reads
+
+        let consoleDevice = VZVirtioConsoleDeviceConfiguration()
+
+        let spicePort = VZVirtioConsolePortConfiguration()
+        spicePort.name = VZSpiceAgentPortAttachment.spiceAgentPortName
+        spicePort.attachment = VZFileHandleSerialPortAttachment(
+            fileHandleForReading: inputPipe.fileHandleForReading,
+            fileHandleForWriting: outputPipe.fileHandleForWriting
+        )
+        spicePort.isConsole = false
+        consoleDevice.ports[0] = spicePort
+
+        vzConfig.consoleDevices = [consoleDevice]
+
+        Self.logger.info("Configured SPICE clipboard console port for '\(config.name, privacy: .public)'")
         return (inputPipe, outputPipe)
     }
 

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -381,7 +381,7 @@ struct ConfigurationBuilder: Sendable {
         spicePort.isConsole = false
         consoleDevice.ports[0] = spicePort
 
-        vzConfig.consoleDevices = [consoleDevice]
+        vzConfig.consoleDevices.append(consoleDevice)
 
         Self.logger.info("Configured SPICE clipboard console port for '\(config.name, privacy: .public)'")
         return (inputPipe, outputPipe)

--- a/Kernova/Services/MacOSInstallService.swift
+++ b/Kernova/Services/MacOSInstallService.swift
@@ -70,8 +70,11 @@ final class MacOSInstallService {
 
         instance.serialInputPipe = result.serialInputPipe
         instance.serialOutputPipe = result.serialOutputPipe
+        instance.clipboardInputPipe = result.clipboardInputPipe
+        instance.clipboardOutputPipe = result.clipboardOutputPipe
         let vm = instance.attachVirtualMachine(from: result.configuration)
         instance.startSerialReading()
+        instance.startClipboardService()
 
         // 5. Check for cancellation before starting the installer
         try Task.checkCancellation()

--- a/Kernova/Services/SpiceAgentProtocol.swift
+++ b/Kernova/Services/SpiceAgentProtocol.swift
@@ -9,14 +9,9 @@ enum SpiceConstants {
     /// Protocol version stamped in every `VDAgentMessage`.
     static let agentProtocol: UInt32 = 1
 
-    /// Port used for client → agent messages.
-    static let clientPort: UInt32 = 1
-
-    /// Port used for agent → client messages.
+    /// Destination port for host → guest messages (`VDP_SERVER_PORT`).
+    /// The guest agent reads from this port.
     static let serverPort: UInt32 = 2
-
-    /// Maximum data size per chunk recommended by the protocol.
-    static let maxDataSize: Int = 2048
 }
 
 // MARK: - VDI Chunk Header
@@ -136,7 +131,7 @@ enum SpiceAgentCapability: Int, Sendable {
 /// Builds complete wire-ready messages (VDI chunk header + VDAgent message header + data).
 ///
 /// All messages are sent from the host (client) to the guest (agent), so the chunk
-/// port is always `VDP_CLIENT_PORT`.
+/// port is always `VDP_SERVER_PORT` (the destination port the guest agent reads from).
 enum SpiceMessageBuilder {
 
     /// Builds an `ANNOUNCE_CAPABILITIES` message advertising clipboard support.
@@ -220,12 +215,15 @@ enum SpiceAgentParsedMessage: Sendable {
     case clipboardData(type: SpiceClipboardType, data: Data)
     case clipboardRelease
     case other(type: SpiceAgentMessageType)
+    /// Inner header could not be parsed (unknown type, truncated payload, etc.).
+    case malformedChunk
 }
 
 /// Incremental parser for the SPICE agent protocol stream.
 ///
-/// Handles message fragmentation: a single VDAgent message may span multiple
-/// VDI chunks, and a single read from the pipe may contain partial data.
+/// Handles byte-stream fragmentation: a single pipe read may deliver partial
+/// VDI chunks, and multiple complete chunks may arrive in a single read.
+/// Each VDI chunk is expected to contain a complete VDAgent message.
 struct SpiceAgentParser: Sendable {
 
     private var buffer = Data()
@@ -263,7 +261,8 @@ struct SpiceAgentParser: Sendable {
     }
 
     /// Attempts to parse one complete message from the buffer.
-    /// Consumes the bytes on success, leaves the buffer unchanged on failure.
+    /// Consumes the bytes on success, leaves the buffer unchanged when incomplete,
+    /// or resets it entirely when corruption is detected.
     private mutating func tryParseNext() -> SpiceAgentParsedMessage? {
         // Need at least a VDI chunk header
         guard buffer.count >= VDIChunkHeader.size else { return nil }
@@ -289,7 +288,7 @@ struct SpiceAgentParser: Sendable {
         // but continue parsing — don't halt the loop.
         guard chunkPayload.count >= VDAgentMessageHeader.size,
               let msgHeader = VDAgentMessageHeader.deserialize(from: chunkPayload) else {
-            return .other(type: .mouseState)  // Sentinel to keep the while-loop going
+            return .malformedChunk
         }
 
         let msgData = chunkPayload.count > VDAgentMessageHeader.size

--- a/Kernova/Services/SpiceAgentProtocol.swift
+++ b/Kernova/Services/SpiceAgentProtocol.swift
@@ -1,0 +1,365 @@
+import Foundation
+
+// MARK: - Wire Format Constants
+
+/// SPICE agent protocol constants from spice-protocol/spice/vd_agent.h.
+///
+/// All multi-byte integers on the wire are **little-endian**.
+enum SpiceConstants {
+    /// Protocol version stamped in every `VDAgentMessage`.
+    static let agentProtocol: UInt32 = 1
+
+    /// Port used for client → agent messages.
+    static let clientPort: UInt32 = 1
+
+    /// Port used for agent → client messages.
+    static let serverPort: UInt32 = 2
+
+    /// Maximum data size per chunk recommended by the protocol.
+    static let maxDataSize: Int = 2048
+}
+
+// MARK: - VDI Chunk Header
+
+/// The outer framing layer for all SPICE agent communication.
+///
+/// Every read/write on the virtio serial port is wrapped in this 8-byte header:
+/// ```
+/// ┌──────────┬──────────┬────────────────────┐
+/// │ port (4) │ size (4) │ payload (variable)  │
+/// └──────────┴──────────┴────────────────────┘
+/// ```
+struct VDIChunkHeader: Sendable {
+    static let size = 8
+
+    let port: UInt32
+    let dataSize: UInt32
+
+    func serialize() -> Data {
+        var data = Data(capacity: Self.size)
+        data.appendLittleEndian(port)
+        data.appendLittleEndian(dataSize)
+        return data
+    }
+
+    static func deserialize(from data: Data) -> VDIChunkHeader? {
+        guard data.count >= size else { return nil }
+        let port = data.readLittleEndianUInt32(at: 0)
+        let dataSize = data.readLittleEndianUInt32(at: 4)
+        return VDIChunkHeader(port: port, dataSize: dataSize)
+    }
+}
+
+// MARK: - VDAgent Message Header
+
+/// The inner message header inside a VDI chunk payload.
+///
+/// ```
+/// ┌──────────────┬────────────┬────────────────┬────────────┬────────────────────┐
+/// │ protocol (4) │ type (4)   │ opaque (8)     │ size (4)   │ data (variable)    │
+/// └──────────────┴────────────┴────────────────┴────────────┴────────────────────┘
+/// ```
+struct VDAgentMessageHeader: Sendable {
+    static let size = 20
+
+    let type: SpiceAgentMessageType
+    let opaque: UInt64
+    let dataSize: UInt32
+
+    func serialize() -> Data {
+        var data = Data(capacity: Self.size)
+        data.appendLittleEndian(SpiceConstants.agentProtocol)
+        data.appendLittleEndian(type.rawValue)
+        data.appendLittleEndian(opaque)
+        data.appendLittleEndian(dataSize)
+        return data
+    }
+
+    static func deserialize(from data: Data) -> VDAgentMessageHeader? {
+        guard data.count >= size else { return nil }
+        // Skip protocol field (4 bytes) — we don't validate it
+        let typeRaw = data.readLittleEndianUInt32(at: 4)
+        let opaque = data.readLittleEndianUInt64(at: 8)
+        let dataSize = data.readLittleEndianUInt32(at: 16)
+        guard let type = SpiceAgentMessageType(rawValue: typeRaw) else { return nil }
+        return VDAgentMessageHeader(type: type, opaque: opaque, dataSize: dataSize)
+    }
+}
+
+// MARK: - Message Types
+
+/// SPICE agent message types (from `VD_AGENT_*` enum).
+enum SpiceAgentMessageType: UInt32, Sendable {
+    case mouseState             = 1
+    case monitorsConfig         = 2
+    case reply                  = 3
+    case clipboard              = 4
+    case displayConfig          = 5
+    case announceCapabilities   = 6
+    case clipboardGrab          = 7
+    case clipboardRequest       = 8
+    case clipboardRelease       = 9
+}
+
+// MARK: - Clipboard Types
+
+/// Data format identifiers for clipboard content.
+enum SpiceClipboardType: UInt32, Sendable {
+    case none     = 0
+    case utf8Text = 1
+    case png      = 2
+    case bmp      = 3
+    case tiff     = 4
+    case jpg      = 5
+}
+
+// MARK: - Capability Bits
+
+/// Capability bit positions for `VD_AGENT_CAP_*`.
+enum SpiceAgentCapability: Int, Sendable {
+    case mouseState                 = 0
+    case monitorsConfig             = 1
+    case reply                      = 2
+    case clipboard                  = 3
+    case displayConfig              = 4
+    case clipboardByDemand          = 5
+    case clipboardSelection         = 6
+    case sparseMonitorsConfig       = 7
+    case guestLineendLF             = 8
+    case guestLineendCRLF           = 9
+    case maxClipboard               = 10
+    case clipboardNoReleaseOnRegrab = 16
+    case clipboardGrabSerial        = 17
+}
+
+// MARK: - Message Builders
+
+/// Builds complete wire-ready messages (VDI chunk header + VDAgent message header + data).
+///
+/// All messages are sent from the host (client) to the guest (agent), so the chunk
+/// port is always `VDP_CLIENT_PORT`.
+enum SpiceMessageBuilder {
+
+    /// Builds an `ANNOUNCE_CAPABILITIES` message advertising clipboard support.
+    static func buildAnnounceCapabilities(request: Bool) -> Data {
+        // Capabilities payload: request (uint32) + caps array (1 × uint32)
+        var caps: UInt32 = 0
+        setCapability(&caps, .clipboard)
+        setCapability(&caps, .clipboardByDemand)
+
+        var payload = Data(capacity: 8)
+        payload.appendLittleEndian(request ? UInt32(1) : UInt32(0))
+        payload.appendLittleEndian(caps)
+
+        return wrapMessage(type: .announceCapabilities, payload: payload)
+    }
+
+    /// Builds a `CLIPBOARD_GRAB` message announcing available clipboard types.
+    ///
+    /// Without `VD_AGENT_CAP_CLIPBOARD_SELECTION`, the grab payload is simply
+    /// an array of `uint32_t` type values.
+    static func buildClipboardGrab(types: [SpiceClipboardType]) -> Data {
+        var payload = Data(capacity: types.count * 4)
+        for type in types {
+            payload.appendLittleEndian(type.rawValue)
+        }
+        return wrapMessage(type: .clipboardGrab, payload: payload)
+    }
+
+    /// Builds a `CLIPBOARD_REQUEST` message asking the peer for clipboard data.
+    static func buildClipboardRequest(type: SpiceClipboardType) -> Data {
+        var payload = Data(capacity: 4)
+        payload.appendLittleEndian(type.rawValue)
+        return wrapMessage(type: .clipboardRequest, payload: payload)
+    }
+
+    /// Builds a `CLIPBOARD` message delivering clipboard data to the peer.
+    static func buildClipboardData(type: SpiceClipboardType, data clipboardData: Data) -> Data {
+        var payload = Data(capacity: 4 + clipboardData.count)
+        payload.appendLittleEndian(type.rawValue)
+        payload.append(clipboardData)
+        return wrapMessage(type: .clipboard, payload: payload)
+    }
+
+    /// Builds a `CLIPBOARD_RELEASE` message.
+    static func buildClipboardRelease() -> Data {
+        wrapMessage(type: .clipboardRelease, payload: Data())
+    }
+
+    // MARK: - Private
+
+    private static func wrapMessage(type: SpiceAgentMessageType, payload: Data) -> Data {
+        let header = VDAgentMessageHeader(
+            type: type,
+            opaque: 0,
+            dataSize: UInt32(payload.count)
+        )
+
+        let chunkPayload = header.serialize() + payload
+        // Use serverPort (2): the port field indicates the destination, and
+        // the guest agent reads from VDP_SERVER_PORT.
+        let chunk = VDIChunkHeader(
+            port: SpiceConstants.serverPort,
+            dataSize: UInt32(chunkPayload.count)
+        )
+
+        return chunk.serialize() + chunkPayload
+    }
+
+    private static func setCapability(_ caps: inout UInt32, _ cap: SpiceAgentCapability) {
+        caps |= 1 << UInt32(cap.rawValue)
+    }
+}
+
+// MARK: - Message Parser
+
+/// Parsed representation of an inbound SPICE agent message.
+enum SpiceAgentParsedMessage: Sendable {
+    case announceCapabilities(request: Bool, caps: [UInt32])
+    case clipboardGrab(types: [SpiceClipboardType])
+    case clipboardRequest(type: SpiceClipboardType)
+    case clipboardData(type: SpiceClipboardType, data: Data)
+    case clipboardRelease
+    case other(type: SpiceAgentMessageType)
+}
+
+/// Incremental parser for the SPICE agent protocol stream.
+///
+/// Handles message fragmentation: a single VDAgent message may span multiple
+/// VDI chunks, and a single read from the pipe may contain partial data.
+struct SpiceAgentParser: Sendable {
+
+    private var buffer = Data()
+
+    /// Feed raw bytes from the pipe into the parser.
+    /// Returns zero or more fully parsed messages.
+    mutating func feed(_ data: Data) -> [SpiceAgentParsedMessage] {
+        buffer.append(data)
+        var messages: [SpiceAgentParsedMessage] = []
+
+        while let message = tryParseNext() {
+            messages.append(message)
+        }
+
+        return messages
+    }
+
+    /// Attempts to parse one complete message from the buffer.
+    /// Consumes the bytes on success, leaves the buffer unchanged on failure.
+    private mutating func tryParseNext() -> SpiceAgentParsedMessage? {
+        // Need at least a VDI chunk header
+        guard buffer.count >= VDIChunkHeader.size else { return nil }
+
+        guard let chunkHeader = VDIChunkHeader.deserialize(from: buffer) else { return nil }
+
+        let totalChunkSize = VDIChunkHeader.size + Int(chunkHeader.dataSize)
+        guard buffer.count >= totalChunkSize else { return nil }
+
+        let chunkPayload = buffer.subdata(in: VDIChunkHeader.size..<totalChunkSize)
+        buffer = buffer.subdata(in: totalChunkSize..<buffer.count)
+
+        // Parse the agent message header from the chunk payload
+        guard chunkPayload.count >= VDAgentMessageHeader.size else { return nil }
+        guard let msgHeader = VDAgentMessageHeader.deserialize(from: chunkPayload) else { return nil }
+
+        let msgData = chunkPayload.count > VDAgentMessageHeader.size
+            ? chunkPayload.subdata(in: VDAgentMessageHeader.size..<chunkPayload.count)
+            : Data()
+
+        return parseMessageBody(type: msgHeader.type, data: msgData)
+    }
+
+    private func parseMessageBody(
+        type: SpiceAgentMessageType,
+        data: Data
+    ) -> SpiceAgentParsedMessage {
+        switch type {
+        case .announceCapabilities:
+            return parseAnnounceCapabilities(data)
+        case .clipboardGrab:
+            return parseClipboardGrab(data)
+        case .clipboardRequest:
+            return parseClipboardRequest(data)
+        case .clipboard:
+            return parseClipboardData(data)
+        case .clipboardRelease:
+            return .clipboardRelease
+        default:
+            return .other(type: type)
+        }
+    }
+
+    private func parseAnnounceCapabilities(_ data: Data) -> SpiceAgentParsedMessage {
+        guard data.count >= 4 else { return .announceCapabilities(request: false, caps: []) }
+        let request = data.readLittleEndianUInt32(at: 0)
+        var caps: [UInt32] = []
+        var offset = 4
+        while offset + 4 <= data.count {
+            caps.append(data.readLittleEndianUInt32(at: offset))
+            offset += 4
+        }
+        return .announceCapabilities(request: request != 0, caps: caps)
+    }
+
+    private func parseClipboardGrab(_ data: Data) -> SpiceAgentParsedMessage {
+        var types: [SpiceClipboardType] = []
+        var offset = 0
+        while offset + 4 <= data.count {
+            let raw = data.readLittleEndianUInt32(at: offset)
+            if let type = SpiceClipboardType(rawValue: raw) {
+                types.append(type)
+            }
+            offset += 4
+        }
+        return .clipboardGrab(types: types)
+    }
+
+    private func parseClipboardRequest(_ data: Data) -> SpiceAgentParsedMessage {
+        guard data.count >= 4 else { return .clipboardRequest(type: .none) }
+        let raw = data.readLittleEndianUInt32(at: 0)
+        let type = SpiceClipboardType(rawValue: raw) ?? .none
+        return .clipboardRequest(type: type)
+    }
+
+    private func parseClipboardData(_ data: Data) -> SpiceAgentParsedMessage {
+        guard data.count >= 4 else { return .clipboardData(type: .none, data: Data()) }
+        let raw = data.readLittleEndianUInt32(at: 0)
+        let type = SpiceClipboardType(rawValue: raw) ?? .none
+        let clipData = data.count > 4 ? data.subdata(in: 4..<data.count) : Data()
+        return .clipboardData(type: type, data: clipData)
+    }
+}
+
+// MARK: - Data Helpers
+
+extension Data {
+    mutating func appendLittleEndian(_ value: UInt32) {
+        var le = value.littleEndian
+        Swift.withUnsafeBytes(of: &le) { append(contentsOf: $0) }
+    }
+
+    mutating func appendLittleEndian(_ value: UInt64) {
+        var le = value.littleEndian
+        Swift.withUnsafeBytes(of: &le) { append(contentsOf: $0) }
+    }
+
+    func readLittleEndianUInt32(at offset: Int) -> UInt32 {
+        precondition(offset + 4 <= count)
+        return subdata(in: offset..<offset + 4).withUnsafeBytes {
+            $0.loadUnaligned(as: UInt32.self).littleEndian
+        }
+    }
+
+    func readLittleEndianUInt64(at offset: Int) -> UInt64 {
+        precondition(offset + 8 <= count)
+        return subdata(in: offset..<offset + 8).withUnsafeBytes {
+            $0.loadUnaligned(as: UInt64.self).littleEndian
+        }
+    }
+
+    /// First 64 bytes as hex string for diagnostic logging.
+    var hexDump: String {
+        prefix(64).map { String(format: "%02x", $0) }.joined(separator: " ")
+            + (count > 64 ? "..." : "")
+    }
+}

--- a/Kernova/Services/SpiceAgentProtocol.swift
+++ b/Kernova/Services/SpiceAgentProtocol.swift
@@ -43,9 +43,9 @@ struct VDIChunkHeader: Sendable {
     }
 
     static func deserialize(from data: Data) -> VDIChunkHeader? {
-        guard data.count >= size else { return nil }
-        let port = data.readLittleEndianUInt32(at: 0)
-        let dataSize = data.readLittleEndianUInt32(at: 4)
+        guard data.count >= size,
+              let port = data.readLittleEndianUInt32(at: 0),
+              let dataSize = data.readLittleEndianUInt32(at: 4) else { return nil }
         return VDIChunkHeader(port: port, dataSize: dataSize)
     }
 }
@@ -76,12 +76,11 @@ struct VDAgentMessageHeader: Sendable {
     }
 
     static func deserialize(from data: Data) -> VDAgentMessageHeader? {
-        guard data.count >= size else { return nil }
-        // Skip protocol field (4 bytes) — we don't validate it
-        let typeRaw = data.readLittleEndianUInt32(at: 4)
-        let opaque = data.readLittleEndianUInt64(at: 8)
-        let dataSize = data.readLittleEndianUInt32(at: 16)
-        guard let type = SpiceAgentMessageType(rawValue: typeRaw) else { return nil }
+        guard data.count >= size,
+              let typeRaw = data.readLittleEndianUInt32(at: 4),
+              let opaque = data.readLittleEndianUInt64(at: 8),
+              let dataSize = data.readLittleEndianUInt32(at: 16),
+              let type = SpiceAgentMessageType(rawValue: typeRaw) else { return nil }
         return VDAgentMessageHeader(type: type, opaque: opaque, dataSize: dataSize)
     }
 }
@@ -231,10 +230,29 @@ struct SpiceAgentParser: Sendable {
 
     private var buffer = Data()
 
+    /// Maximum buffer size before the parser resets (guards against malformed streams).
+    private static let maxBufferSize = 1_048_576  // 1 MB
+
+    /// Maximum chunk data size we'll accept (rejects corrupt headers claiming huge sizes).
+    private static let maxChunkDataSize: UInt32 = 1_048_576  // 1 MB
+
+    /// `true` when the buffer was reset due to overflow or corruption.
+    /// Checked by `SpiceClipboardService` to log at the appropriate level.
+    private(set) var didReset = false
+
     /// Feed raw bytes from the pipe into the parser.
     /// Returns zero or more fully parsed messages.
     mutating func feed(_ data: Data) -> [SpiceAgentParsedMessage] {
         buffer.append(data)
+        didReset = false
+
+        // Guard against unbounded growth from malformed streams
+        if buffer.count > Self.maxBufferSize {
+            buffer.removeAll()
+            didReset = true
+            return []
+        }
+
         var messages: [SpiceAgentParsedMessage] = []
 
         while let message = tryParseNext() {
@@ -252,15 +270,27 @@ struct SpiceAgentParser: Sendable {
 
         guard let chunkHeader = VDIChunkHeader.deserialize(from: buffer) else { return nil }
 
+        // Reject corrupt chunk headers claiming unreasonable sizes
+        guard chunkHeader.dataSize <= Self.maxChunkDataSize else {
+            buffer.removeAll()
+            didReset = true
+            return nil
+        }
+
         let totalChunkSize = VDIChunkHeader.size + Int(chunkHeader.dataSize)
         guard buffer.count >= totalChunkSize else { return nil }
 
+        // Consume the chunk from the buffer (trim in-place to avoid full copy)
         let chunkPayload = buffer.subdata(in: VDIChunkHeader.size..<totalChunkSize)
-        buffer = buffer.subdata(in: totalChunkSize..<buffer.count)
+        buffer.removeSubrange(0..<totalChunkSize)
 
-        // Parse the agent message header from the chunk payload
-        guard chunkPayload.count >= VDAgentMessageHeader.size else { return nil }
-        guard let msgHeader = VDAgentMessageHeader.deserialize(from: chunkPayload) else { return nil }
+        // Parse the agent message header from the chunk payload.
+        // If the inner header is malformed or has an unknown type, skip the chunk
+        // but continue parsing — don't halt the loop.
+        guard chunkPayload.count >= VDAgentMessageHeader.size,
+              let msgHeader = VDAgentMessageHeader.deserialize(from: chunkPayload) else {
+            return .other(type: .mouseState)  // Sentinel to keep the while-loop going
+        }
 
         let msgData = chunkPayload.count > VDAgentMessageHeader.size
             ? chunkPayload.subdata(in: VDAgentMessageHeader.size..<chunkPayload.count)
@@ -290,12 +320,13 @@ struct SpiceAgentParser: Sendable {
     }
 
     private func parseAnnounceCapabilities(_ data: Data) -> SpiceAgentParsedMessage {
-        guard data.count >= 4 else { return .announceCapabilities(request: false, caps: []) }
-        let request = data.readLittleEndianUInt32(at: 0)
+        guard let request = data.readLittleEndianUInt32(at: 0) else {
+            return .announceCapabilities(request: false, caps: [])
+        }
         var caps: [UInt32] = []
         var offset = 4
-        while offset + 4 <= data.count {
-            caps.append(data.readLittleEndianUInt32(at: offset))
+        while let value = data.readLittleEndianUInt32(at: offset) {
+            caps.append(value)
             offset += 4
         }
         return .announceCapabilities(request: request != 0, caps: caps)
@@ -304,8 +335,7 @@ struct SpiceAgentParser: Sendable {
     private func parseClipboardGrab(_ data: Data) -> SpiceAgentParsedMessage {
         var types: [SpiceClipboardType] = []
         var offset = 0
-        while offset + 4 <= data.count {
-            let raw = data.readLittleEndianUInt32(at: offset)
+        while let raw = data.readLittleEndianUInt32(at: offset) {
             if let type = SpiceClipboardType(rawValue: raw) {
                 types.append(type)
             }
@@ -315,15 +345,17 @@ struct SpiceAgentParser: Sendable {
     }
 
     private func parseClipboardRequest(_ data: Data) -> SpiceAgentParsedMessage {
-        guard data.count >= 4 else { return .clipboardRequest(type: .none) }
-        let raw = data.readLittleEndianUInt32(at: 0)
+        guard let raw = data.readLittleEndianUInt32(at: 0) else {
+            return .clipboardRequest(type: .none)
+        }
         let type = SpiceClipboardType(rawValue: raw) ?? .none
         return .clipboardRequest(type: type)
     }
 
     private func parseClipboardData(_ data: Data) -> SpiceAgentParsedMessage {
-        guard data.count >= 4 else { return .clipboardData(type: .none, data: Data()) }
-        let raw = data.readLittleEndianUInt32(at: 0)
+        guard let raw = data.readLittleEndianUInt32(at: 0) else {
+            return .clipboardData(type: .none, data: Data())
+        }
         let type = SpiceClipboardType(rawValue: raw) ?? .none
         let clipData = data.count > 4 ? data.subdata(in: 4..<data.count) : Data()
         return .clipboardData(type: type, data: clipData)
@@ -343,23 +375,17 @@ extension Data {
         Swift.withUnsafeBytes(of: &le) { append(contentsOf: $0) }
     }
 
-    func readLittleEndianUInt32(at offset: Int) -> UInt32 {
-        precondition(offset + 4 <= count)
+    func readLittleEndianUInt32(at offset: Int) -> UInt32? {
+        guard offset + 4 <= count else { return nil }
         return subdata(in: offset..<offset + 4).withUnsafeBytes {
             $0.loadUnaligned(as: UInt32.self).littleEndian
         }
     }
 
-    func readLittleEndianUInt64(at offset: Int) -> UInt64 {
-        precondition(offset + 8 <= count)
+    func readLittleEndianUInt64(at offset: Int) -> UInt64? {
+        guard offset + 8 <= count else { return nil }
         return subdata(in: offset..<offset + 8).withUnsafeBytes {
             $0.loadUnaligned(as: UInt64.self).littleEndian
         }
-    }
-
-    /// First 64 bytes as hex string for diagnostic logging.
-    var hexDump: String {
-        prefix(64).map { String(format: "%02x", $0) }.joined(separator: " ")
-            + (count > 64 ? "..." : "")
     }
 }

--- a/Kernova/Services/SpiceAgentProtocol.swift
+++ b/Kernova/Services/SpiceAgentProtocol.swift
@@ -376,15 +376,15 @@ extension Data {
 
     func readLittleEndianUInt32(at offset: Int) -> UInt32? {
         guard offset + 4 <= count else { return nil }
-        return subdata(in: offset..<offset + 4).withUnsafeBytes {
-            $0.loadUnaligned(as: UInt32.self).littleEndian
+        return withUnsafeBytes {
+            $0.loadUnaligned(fromByteOffset: offset, as: UInt32.self).littleEndian
         }
     }
 
     func readLittleEndianUInt64(at offset: Int) -> UInt64? {
         guard offset + 8 <= count else { return nil }
-        return subdata(in: offset..<offset + 8).withUnsafeBytes {
-            $0.loadUnaligned(as: UInt64.self).littleEndian
+        return withUnsafeBytes {
+            $0.loadUnaligned(fromByteOffset: offset, as: UInt64.self).littleEndian
         }
     }
 }

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -1,0 +1,240 @@
+import Foundation
+import os
+
+/// Manages SPICE clipboard sharing between the host and a single guest VM.
+///
+/// Instead of using Apple's `VZSpiceAgentPortAttachment` (which automatically syncs
+/// with the host `NSPasteboard`), this service speaks the SPICE agent protocol directly
+/// over raw pipe I/O. Clipboard data is surfaced in an observable property for the UI
+/// rather than written to the system clipboard.
+///
+/// The service acts as the SPICE **client** (host side). The guest runs a standard
+/// SPICE agent (`spice-vdagent` on Linux, or a macOS equivalent).
+///
+/// ## Lifecycle
+/// - Created by `VMInstance.startClipboardService()` after VM start
+/// - Destroyed by `VMInstance.stopClipboardService()` on teardown
+@MainActor
+@Observable
+final class SpiceClipboardService {
+
+    // MARK: - Observable State
+
+    /// The latest text received from the guest clipboard. Updated on the main actor.
+    var guestClipboardText: String = ""
+
+    /// `true` once the guest agent has completed the capabilities handshake.
+    var isConnected: Bool = false
+
+    // MARK: - Private
+
+    private let inputPipe: Pipe    // host writes → guest reads
+    private let outputPipe: Pipe   // guest writes → host reads
+    private var parser = SpiceAgentParser()
+
+    /// Pending clipboard request: when we send a GRAB, the guest replies with a REQUEST,
+    /// and we respond with the DATA. This holds the text until the request arrives.
+    private var pendingOutboundText: String?
+
+    /// Whether the guest has advertised `VD_AGENT_CAP_CLIPBOARD_BY_DEMAND`.
+    private var guestSupportsClipboardByDemand = false
+
+    private static let logger = Logger(subsystem: "com.kernova.app", category: "SpiceClipboardService")
+
+    // MARK: - Init
+
+    init(inputPipe: Pipe, outputPipe: Pipe) {
+        self.inputPipe = inputPipe
+        self.outputPipe = outputPipe
+    }
+
+    // MARK: - Lifecycle
+
+    /// Begins reading from the guest pipe and sends the initial capabilities handshake.
+    func start() {
+        startReading()
+        sendCapabilities()
+        Self.logger.info("SPICE clipboard service started")
+    }
+
+    /// Stops reading and releases resources.
+    func stop() {
+        outputPipe.fileHandleForReading.readabilityHandler = nil
+        Self.logger.info("SPICE clipboard service stopped")
+    }
+
+    // MARK: - Public API
+
+    /// Sends text to the guest clipboard.
+    ///
+    /// Sends a `CLIPBOARD_GRAB` to announce ownership, then waits for the guest
+    /// agent to send a `CLIPBOARD_REQUEST` before delivering the data. The text
+    /// is stored in `pendingOutboundText` and kept across multiple requests so
+    /// the agent can retry if needed.
+    ///
+    /// Sending data eagerly (before the REQUEST) does not work — the guest agent's
+    /// state machine rejects unsolicited CLIPBOARD data and retries via REQUEST.
+    func sendToGuest(_ text: String) {
+        guard isConnected else {
+            Self.logger.warning("Cannot send clipboard: guest agent not connected")
+            return
+        }
+
+        guard let textData = text.data(using: .utf8), !textData.isEmpty else {
+            Self.logger.debug("sendToGuest: empty or non-encodable text, skipping")
+            return
+        }
+
+        Self.logger.notice("sendToGuest: sending clipboard grab (\(textData.count, privacy: .public) bytes pending)")
+
+        // Store for the guest's CLIPBOARD_REQUEST response
+        pendingOutboundText = text
+
+        // Announce we have clipboard data — the guest will request it when ready
+        let grabMessage = SpiceMessageBuilder.buildClipboardGrab(types: [.utf8Text])
+        writeToGuest(grabMessage)
+    }
+
+    // MARK: - Reading
+
+    /// Hooks the readability handler on the output pipe to receive guest messages.
+    private func startReading() {
+        // Capture for the closure (runs on a background GCD queue)
+        let logger = Self.logger
+
+        outputPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+
+            logger.debug("Received \(data.count, privacy: .public) bytes from guest SPICE agent")
+
+            Task { @MainActor [weak self] in
+                self?.handleIncomingData(data)
+            }
+        }
+    }
+
+    /// Parses incoming data and dispatches messages.
+    private func handleIncomingData(_ data: Data) {
+        let messages = parser.feed(data)
+
+        for message in messages {
+            switch message {
+            case .announceCapabilities(let request, let caps):
+                handleCapabilities(request: request, caps: caps)
+
+            case .clipboardGrab(let types):
+                handleClipboardGrab(types: types)
+
+            case .clipboardRequest(let type):
+                handleClipboardRequest(type: type)
+
+            case .clipboardData(let type, let data):
+                handleClipboardData(type: type, data: data)
+
+            case .clipboardRelease:
+                Self.logger.debug("Guest released clipboard")
+
+            case .other(let type):
+                Self.logger.debug("Ignoring unhandled SPICE message type: \(type.rawValue, privacy: .public)")
+            }
+        }
+    }
+
+    // MARK: - Message Handlers
+
+    private func handleCapabilities(request: Bool, caps: [UInt32]) {
+        isConnected = true
+
+        // Check if guest supports clipboard-by-demand
+        guestSupportsClipboardByDemand = hasCapability(
+            caps, .clipboardByDemand
+        )
+
+        Self.logger.notice(
+            "Guest agent connected (caps: \(caps.map { String($0, radix: 16) }, privacy: .public), byDemand: \(self.guestSupportsClipboardByDemand, privacy: .public))"
+        )
+
+        // If the guest requested our capabilities, send them back (non-requesting)
+        if request {
+            let reply = SpiceMessageBuilder.buildAnnounceCapabilities(request: false)
+            writeToGuest(reply)
+        }
+    }
+
+    /// Guest announced it has new clipboard data — request it.
+    private func handleClipboardGrab(types: [SpiceClipboardType]) {
+        Self.logger.debug("Guest clipboard grab: types=\(types.map(\.rawValue), privacy: .public)")
+
+        // We only handle UTF-8 text for now
+        guard types.contains(.utf8Text) else {
+            Self.logger.debug("Guest clipboard has no UTF-8 text type, ignoring")
+            return
+        }
+
+        let request = SpiceMessageBuilder.buildClipboardRequest(type: .utf8Text)
+        writeToGuest(request)
+    }
+
+    /// Guest is requesting clipboard data from us (response to our GRAB).
+    private func handleClipboardRequest(type: SpiceClipboardType) {
+        Self.logger.debug("Guest requested clipboard data (type: \(type.rawValue, privacy: .public))")
+
+        guard type == .utf8Text else {
+            Self.logger.debug("Guest requested non-text type, ignoring")
+            return
+        }
+
+        guard let text = pendingOutboundText,
+              let textData = text.data(using: .utf8) else {
+            Self.logger.debug("No pending outbound text for clipboard request")
+            return
+        }
+
+        // Keep pendingOutboundText intact — the guest agent may retry the request
+        let dataMessage = SpiceMessageBuilder.buildClipboardData(type: .utf8Text, data: textData)
+        writeToGuest(dataMessage)
+        Self.logger.debug("Sent clipboard data to guest (\(textData.count, privacy: .public) bytes)")
+    }
+
+    /// Guest delivered clipboard data — update our observable state.
+    private func handleClipboardData(type: SpiceClipboardType, data: Data) {
+        guard type == .utf8Text else {
+            Self.logger.debug("Received non-text clipboard data (type: \(type.rawValue, privacy: .public)), ignoring")
+            return
+        }
+
+        guard let text = String(data: data, encoding: .utf8) else {
+            Self.logger.warning("Failed to decode guest clipboard data as UTF-8 (\(data.count, privacy: .public) bytes)")
+            return
+        }
+
+        guestClipboardText = text
+        Self.logger.debug("Received guest clipboard text (\(text.count, privacy: .public) characters)")
+    }
+
+    // MARK: - Writing
+
+    private func writeToGuest(_ data: Data) {
+        do {
+            try inputPipe.fileHandleForWriting.write(contentsOf: data)
+        } catch {
+            Self.logger.error("Failed to write to SPICE pipe: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Capability Helpers
+
+    private func sendCapabilities() {
+        let message = SpiceMessageBuilder.buildAnnounceCapabilities(request: true)
+        writeToGuest(message)
+        Self.logger.debug("Sent ANNOUNCE_CAPABILITIES (requesting guest reply)")
+    }
+
+    private func hasCapability(_ caps: [UInt32], _ cap: SpiceAgentCapability) -> Bool {
+        let wordIndex = cap.rawValue / 32
+        let bitIndex = cap.rawValue % 32
+        guard wordIndex < caps.count else { return false }
+        return (caps[wordIndex] & (1 << UInt32(bitIndex))) != 0
+    }
+}

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -42,9 +42,6 @@ final class SpiceClipboardService {
     /// Tracks the last text we sent via GRAB to avoid redundant grabs.
     private var lastGrabbedText: String?
 
-    /// Whether the guest has advertised `VD_AGENT_CAP_CLIPBOARD_BY_DEMAND`.
-    private var guestSupportsClipboardByDemand = false
-
     private static let logger = Logger(subsystem: "com.kernova.app", category: "SpiceClipboardService")
 
     // MARK: - Init
@@ -82,11 +79,13 @@ final class SpiceClipboardService {
         guard !clipboardText.isEmpty else { return }
         guard clipboardText != lastGrabbedText else { return }
 
+        let grabMessage = SpiceMessageBuilder.buildClipboardGrab(types: [.utf8Text])
+        guard writeToGuest(grabMessage) else { return }
+
+        // Only update state after successful write — otherwise a failed grab
+        // would permanently prevent retries (clipboardText == lastGrabbedText).
         lastGrabbedText = clipboardText
         pendingOutboundText = clipboardText
-
-        let grabMessage = SpiceMessageBuilder.buildClipboardGrab(types: [.utf8Text])
-        writeToGuest(grabMessage)
         Self.logger.notice("Sent clipboard grab (\(self.clipboardText.utf8.count, privacy: .public) bytes pending)")
     }
 
@@ -99,7 +98,16 @@ final class SpiceClipboardService {
 
         outputPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
-            guard !data.isEmpty else { return }
+            guard !data.isEmpty else {
+                // EOF — pipe closed. Nil-out immediately to prevent GCD spin loop.
+                handle.readabilityHandler = nil
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.isConnected = false
+                    Self.logger.notice("SPICE pipe closed (EOF)")
+                }
+                return
+            }
 
             logger.debug("Received \(data.count, privacy: .public) bytes from guest SPICE agent")
 
@@ -109,9 +117,12 @@ final class SpiceClipboardService {
         }
     }
 
-    /// Parses incoming data and dispatches messages.
     private func handleIncomingData(_ data: Data) {
         let messages = parser.feed(data)
+
+        if parser.didReset {
+            Self.logger.error("SPICE parser buffer reset — stream may be corrupted")
+        }
 
         for message in messages {
             switch message {
@@ -141,13 +152,9 @@ final class SpiceClipboardService {
     private func handleCapabilities(request: Bool, caps: [UInt32]) {
         isConnected = true
 
-        // Check if guest supports clipboard-by-demand
-        guestSupportsClipboardByDemand = hasCapability(
-            caps, .clipboardByDemand
-        )
-
+        let byDemand = hasCapability(caps, .clipboardByDemand)
         Self.logger.notice(
-            "Guest agent connected (caps: \(caps.map { String($0, radix: 16) }, privacy: .public), byDemand: \(self.guestSupportsClipboardByDemand, privacy: .public))"
+            "Guest agent connected (caps: \(caps.map { String($0, radix: 16) }, privacy: .public), byDemand: \(byDemand, privacy: .public))"
         )
 
         // If the guest requested our capabilities, send them back (non-requesting)
@@ -211,11 +218,15 @@ final class SpiceClipboardService {
 
     // MARK: - Writing
 
-    private func writeToGuest(_ data: Data) {
+    @discardableResult
+    private func writeToGuest(_ data: Data) -> Bool {
         do {
             try inputPipe.fileHandleForWriting.write(contentsOf: data)
+            return true
         } catch {
             Self.logger.error("Failed to write to SPICE pipe: \(error.localizedDescription, privacy: .public)")
+            isConnected = false
+            return false
         }
     }
 

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -24,11 +24,12 @@ final class SpiceClipboardService {
     ///
     /// - Set by the guest agent when the guest copies text (via `handleClipboardData`)
     /// - Editable by the user in the clipboard window's `TextEditor`
-    /// - Sent to the guest (via `CLIPBOARD_GRAB`) when the clipboard window loses focus
+    /// - Announced to the guest (via `CLIPBOARD_GRAB`) when the clipboard window loses
+    ///   focus; the guest then requests the actual data via `CLIPBOARD_REQUEST`
     var clipboardText: String = ""
 
     /// `true` once the guest agent has completed the capabilities handshake.
-    var isConnected: Bool = false
+    private(set) var isConnected: Bool = false
 
     // MARK: - Private
 
@@ -63,6 +64,8 @@ final class SpiceClipboardService {
     /// Stops reading and releases resources.
     func stop() {
         outputPipe.fileHandleForReading.readabilityHandler = nil
+        isConnected = false
+        pendingOutboundText = nil
         Self.logger.info("SPICE clipboard service stopped")
     }
 
@@ -143,6 +146,9 @@ final class SpiceClipboardService {
 
             case .other(let type):
                 Self.logger.debug("Ignoring unhandled SPICE message type: \(type.rawValue, privacy: .public)")
+
+            case .malformedChunk:
+                Self.logger.warning("Skipping malformed SPICE chunk")
             }
         }
     }
@@ -150,12 +156,19 @@ final class SpiceClipboardService {
     // MARK: - Message Handlers
 
     private func handleCapabilities(request: Bool, caps: [UInt32]) {
-        isConnected = true
-
+        let hasClipboard = hasCapability(caps, .clipboard)
         let byDemand = hasCapability(caps, .clipboardByDemand)
+
         Self.logger.notice(
-            "Guest agent connected (caps: \(caps.map { String($0, radix: 16) }, privacy: .public), byDemand: \(byDemand, privacy: .public))"
+            "Guest agent capabilities (caps: \(caps.map { String($0, radix: 16) }, privacy: .public), clipboard: \(hasClipboard, privacy: .public), byDemand: \(byDemand, privacy: .public))"
         )
+
+        guard hasClipboard else {
+            Self.logger.warning("Guest agent does not support clipboard — clipboard sharing will not function")
+            return
+        }
+
+        isConnected = true
 
         // If the guest requested our capabilities, send them back (non-requesting)
         if request {

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -43,6 +43,11 @@ final class SpiceClipboardService {
     /// Tracks the last text we sent via GRAB to avoid redundant grabs.
     private var lastGrabbedText: String?
 
+    /// Whether the guest advertised `VD_AGENT_CAP_CLIPBOARD_BY_DEMAND`.
+    /// When `false` (legacy mode), we send clipboard data immediately after GRAB
+    /// instead of waiting for a REQUEST.
+    private var guestSupportsByDemand = false
+
     private static let logger = Logger(subsystem: "com.kernova.app", category: "SpiceClipboardService")
 
     // MARK: - Init
@@ -66,6 +71,7 @@ final class SpiceClipboardService {
         outputPipe.fileHandleForReading.readabilityHandler = nil
         isConnected = false
         pendingOutboundText = nil
+        guestSupportsByDemand = false
         Self.logger.info("SPICE clipboard service stopped")
     }
 
@@ -75,8 +81,9 @@ final class SpiceClipboardService {
     /// since the last grab (or since the guest last sent us data).
     ///
     /// Called by `ClipboardWindowController` when the clipboard window loses focus.
-    /// The actual data delivery is by-demand: the guest sends a `CLIPBOARD_REQUEST`
-    /// when something pastes, and we respond with `clipboardText` at that point.
+    /// - **By-demand guests** (modern): the guest sends a `CLIPBOARD_REQUEST` when
+    ///   something pastes, and we respond with `clipboardText` at that point.
+    /// - **Legacy guests**: we send `CLIPBOARD` data immediately after the GRAB.
     func grabIfChanged() {
         guard isConnected else { return }
         guard !clipboardText.isEmpty else { return }
@@ -89,7 +96,16 @@ final class SpiceClipboardService {
         // would permanently prevent retries (clipboardText == lastGrabbedText).
         lastGrabbedText = clipboardText
         pendingOutboundText = clipboardText
-        Self.logger.notice("Sent clipboard grab (\(self.clipboardText.utf8.count, privacy: .public) bytes pending)")
+
+        if !guestSupportsByDemand {
+            // Legacy mode: guest won't send REQUEST, deliver data immediately
+            if let textData = clipboardText.data(using: .utf8) {
+                let dataMessage = SpiceMessageBuilder.buildClipboardData(type: .utf8Text, data: textData)
+                writeToGuest(dataMessage)
+            }
+        }
+
+        Self.logger.notice("Sent clipboard grab (\(self.clipboardText.utf8.count, privacy: .public) bytes pending, byDemand: \(self.guestSupportsByDemand, privacy: .public))")
     }
 
     // MARK: - Reading
@@ -155,20 +171,23 @@ final class SpiceClipboardService {
 
     // MARK: - Message Handlers
 
+    // RATIONALE: Modern agents (spice-vdagent, UTM) only set VD_AGENT_CAP_CLIPBOARD_BY_DEMAND
+    // (bit 5) — the legacy VD_AGENT_CAP_CLIPBOARD (bit 3) is the old "always-sync" mode that
+    // no current agent advertises. We accept either bit as proof of clipboard support.
     private func handleCapabilities(request: Bool, caps: [UInt32]) {
         let hasClipboard = hasCapability(caps, .clipboard)
         let byDemand = hasCapability(caps, .clipboardByDemand)
 
-        Self.logger.notice(
-            "Guest agent capabilities (caps: \(caps.map { String($0, radix: 16) }, privacy: .public), clipboard: \(hasClipboard, privacy: .public), byDemand: \(byDemand, privacy: .public))"
-        )
-
-        guard hasClipboard else {
-            Self.logger.warning("Guest agent does not support clipboard — clipboard sharing will not function")
+        guard hasClipboard || byDemand else {
+            Self.logger.warning("Guest agent does not support clipboard (caps: \(caps.map { String($0, radix: 16) }, privacy: .public))")
             return
         }
 
         isConnected = true
+        guestSupportsByDemand = byDemand
+        Self.logger.notice(
+            "Guest agent connected (caps: \(caps.map { String($0, radix: 16) }, privacy: .public), byDemand: \(byDemand, privacy: .public))"
+        )
 
         // If the guest requested our capabilities, send them back (non-requesting)
         if request {

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -20,8 +20,12 @@ final class SpiceClipboardService {
 
     // MARK: - Observable State
 
-    /// The latest text received from the guest clipboard. Updated on the main actor.
-    var guestClipboardText: String = ""
+    /// Unified clipboard text buffer shared between guest and host.
+    ///
+    /// - Set by the guest agent when the guest copies text (via `handleClipboardData`)
+    /// - Editable by the user in the clipboard window's `TextEditor`
+    /// - Sent to the guest (via `CLIPBOARD_GRAB`) when the clipboard window loses focus
+    var clipboardText: String = ""
 
     /// `true` once the guest agent has completed the capabilities handshake.
     var isConnected: Bool = false
@@ -32,9 +36,11 @@ final class SpiceClipboardService {
     private let outputPipe: Pipe   // guest writes → host reads
     private var parser = SpiceAgentParser()
 
-    /// Pending clipboard request: when we send a GRAB, the guest replies with a REQUEST,
-    /// and we respond with the DATA. This holds the text until the request arrives.
+    /// Holds the text for the guest's `CLIPBOARD_REQUEST` response.
     private var pendingOutboundText: String?
+
+    /// Tracks the last text we sent via GRAB to avoid redundant grabs.
+    private var lastGrabbedText: String?
 
     /// Whether the guest has advertised `VD_AGENT_CAP_CLIPBOARD_BY_DEMAND`.
     private var guestSupportsClipboardByDemand = false
@@ -65,34 +71,23 @@ final class SpiceClipboardService {
 
     // MARK: - Public API
 
-    /// Sends text to the guest clipboard.
+    /// Sends a `CLIPBOARD_GRAB` to the guest if `clipboardText` has been edited
+    /// since the last grab (or since the guest last sent us data).
     ///
-    /// Sends a `CLIPBOARD_GRAB` to announce ownership, then waits for the guest
-    /// agent to send a `CLIPBOARD_REQUEST` before delivering the data. The text
-    /// is stored in `pendingOutboundText` and kept across multiple requests so
-    /// the agent can retry if needed.
-    ///
-    /// Sending data eagerly (before the REQUEST) does not work — the guest agent's
-    /// state machine rejects unsolicited CLIPBOARD data and retries via REQUEST.
-    func sendToGuest(_ text: String) {
-        guard isConnected else {
-            Self.logger.warning("Cannot send clipboard: guest agent not connected")
-            return
-        }
+    /// Called by `ClipboardWindowController` when the clipboard window loses focus.
+    /// The actual data delivery is by-demand: the guest sends a `CLIPBOARD_REQUEST`
+    /// when something pastes, and we respond with `clipboardText` at that point.
+    func grabIfChanged() {
+        guard isConnected else { return }
+        guard !clipboardText.isEmpty else { return }
+        guard clipboardText != lastGrabbedText else { return }
 
-        guard let textData = text.data(using: .utf8), !textData.isEmpty else {
-            Self.logger.debug("sendToGuest: empty or non-encodable text, skipping")
-            return
-        }
+        lastGrabbedText = clipboardText
+        pendingOutboundText = clipboardText
 
-        Self.logger.notice("sendToGuest: sending clipboard grab (\(textData.count, privacy: .public) bytes pending)")
-
-        // Store for the guest's CLIPBOARD_REQUEST response
-        pendingOutboundText = text
-
-        // Announce we have clipboard data — the guest will request it when ready
         let grabMessage = SpiceMessageBuilder.buildClipboardGrab(types: [.utf8Text])
         writeToGuest(grabMessage)
+        Self.logger.notice("Sent clipboard grab (\(self.clipboardText.utf8.count, privacy: .public) bytes pending)")
     }
 
     // MARK: - Reading
@@ -209,7 +204,8 @@ final class SpiceClipboardService {
             return
         }
 
-        guestClipboardText = text
+        clipboardText = text
+        lastGrabbedText = nil  // New text is from the guest, not us
         Self.logger.debug("Received guest clipboard text (\(text.count, privacy: .public) characters)")
     }
 

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -98,10 +98,10 @@ final class SpiceClipboardService {
         pendingOutboundText = clipboardText
 
         if !guestSupportsByDemand {
-            // Legacy mode: guest won't send REQUEST, deliver data immediately
-            if let textData = clipboardText.data(using: .utf8) {
-                let dataMessage = SpiceMessageBuilder.buildClipboardData(type: .utf8Text, data: textData)
-                writeToGuest(dataMessage)
+            // Legacy mode: guest won't send REQUEST, deliver data immediately.
+            // Reset lastGrabbedText on failure so the next call retries.
+            if !sendClipboardText(clipboardText) {
+                lastGrabbedText = nil
             }
         }
 
@@ -185,15 +185,16 @@ final class SpiceClipboardService {
 
         isConnected = true
         guestSupportsByDemand = byDemand
-        Self.logger.notice(
-            "Guest agent connected (caps: \(caps.map { String($0, radix: 16) }, privacy: .public), byDemand: \(byDemand, privacy: .public))"
-        )
 
         // If the guest requested our capabilities, send them back (non-requesting)
         if request {
             let reply = SpiceMessageBuilder.buildAnnounceCapabilities(request: false)
-            writeToGuest(reply)
+            guard writeToGuest(reply) else { return }
         }
+
+        Self.logger.notice(
+            "Guest agent connected (caps: \(caps.map { String($0, radix: 16) }, privacy: .public), byDemand: \(byDemand, privacy: .public))"
+        )
     }
 
     /// Guest announced it has new clipboard data — request it.
@@ -207,7 +208,7 @@ final class SpiceClipboardService {
         }
 
         let request = SpiceMessageBuilder.buildClipboardRequest(type: .utf8Text)
-        writeToGuest(request)
+        guard writeToGuest(request) else { return }
     }
 
     /// Guest is requesting clipboard data from us (response to our GRAB).
@@ -219,16 +220,13 @@ final class SpiceClipboardService {
             return
         }
 
-        guard let text = pendingOutboundText,
-              let textData = text.data(using: .utf8) else {
+        guard let text = pendingOutboundText else {
             Self.logger.debug("No pending outbound text for clipboard request")
             return
         }
 
         // Keep pendingOutboundText intact — the guest agent may retry the request
-        let dataMessage = SpiceMessageBuilder.buildClipboardData(type: .utf8Text, data: textData)
-        writeToGuest(dataMessage)
-        Self.logger.debug("Sent clipboard data to guest (\(textData.count, privacy: .public) bytes)")
+        sendClipboardText(text)
     }
 
     /// Guest delivered clipboard data — update our observable state.
@@ -250,7 +248,17 @@ final class SpiceClipboardService {
 
     // MARK: - Writing
 
+    /// Encodes text as UTF-8 and sends a `CLIPBOARD` data message to the guest.
     @discardableResult
+    private func sendClipboardText(_ text: String) -> Bool {
+        guard let textData = text.data(using: .utf8) else {
+            Self.logger.warning("Failed to encode clipboard text as UTF-8 (\(text.count, privacy: .public) characters)")
+            return false
+        }
+        let dataMessage = SpiceMessageBuilder.buildClipboardData(type: .utf8Text, data: textData)
+        return writeToGuest(dataMessage)
+    }
+
     private func writeToGuest(_ data: Data) -> Bool {
         do {
             try inputPipe.fileHandleForWriting.write(contentsOf: data)

--- a/Kernova/Services/VirtualizationService.swift
+++ b/Kernova/Services/VirtualizationService.swift
@@ -30,8 +30,11 @@ final class VirtualizationService {
                 let result = try await buildConfiguration(for: instance)
                 instance.serialInputPipe = result.serialInputPipe
                 instance.serialOutputPipe = result.serialOutputPipe
+                instance.clipboardInputPipe = result.clipboardInputPipe
+                instance.clipboardOutputPipe = result.clipboardOutputPipe
                 let vm = instance.attachVirtualMachine(from: result.configuration)
                 instance.startSerialReading()
+                instance.startClipboardService()
                 try await vm.start()
             }
 
@@ -240,8 +243,11 @@ final class VirtualizationService {
 
         instance.serialInputPipe = result.serialInputPipe
         instance.serialOutputPipe = result.serialOutputPipe
+        instance.clipboardInputPipe = result.clipboardInputPipe
+        instance.clipboardOutputPipe = result.clipboardOutputPipe
         let vm = instance.attachVirtualMachine(from: result.configuration)
         instance.startSerialReading()
+        instance.startClipboardService()
 
         Self.logger.debug("restoreOrColdBoot: attempting restore from save file")
         do {

--- a/Kernova/Views/Clipboard/ClipboardContentView.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import AppKit
+
+/// SwiftUI content view for the per-VM clipboard sharing window.
+///
+/// Presents two panels:
+/// - **From Guest**: read-only display of the latest text the guest copied to its clipboard
+/// - **To Guest**: editable text field where the user can type or paste text to send to the guest
+///
+/// Clipboard data flows through `SpiceClipboardService` rather than the host `NSPasteboard`,
+/// giving the user explicit control over what enters and leaves each VM.
+struct ClipboardContentView: View {
+
+    let instance: VMInstance
+
+    @State private var textToSend: String = ""
+
+    private var service: SpiceClipboardService? {
+        instance.clipboardService
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            fromGuestSection
+            Divider()
+            toGuestSection
+            Divider()
+            statusBar
+        }
+        .frame(minWidth: 320, idealWidth: 480, minHeight: 280, idealHeight: 400)
+    }
+
+    // MARK: - From Guest
+
+    @ViewBuilder
+    private var fromGuestSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Label("From Guest", systemImage: "arrow.down.doc")
+                    .font(.headline)
+                Spacer()
+                Button("Copy to Host Clipboard") {
+                    copyToHostClipboard()
+                }
+                .disabled(service?.guestClipboardText.isEmpty ?? true)
+            }
+
+            ScrollView {
+                Text(service?.guestClipboardText ?? "")
+                    .font(.system(.body, design: .monospaced))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+            .frame(maxHeight: .infinity)
+            .background(.background.secondary)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+        .padding()
+    }
+
+    // MARK: - To Guest
+
+    @ViewBuilder
+    private var toGuestSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Label("To Guest", systemImage: "arrow.up.doc")
+                    .font(.headline)
+                Spacer()
+                Button("Send to Guest") {
+                    sendToGuest()
+                }
+                .disabled(textToSend.isEmpty || !(service?.isConnected ?? false))
+            }
+
+            TextEditor(text: $textToSend)
+                .font(.system(.body, design: .monospaced))
+                .frame(maxHeight: .infinity)
+                .scrollContentBackground(.hidden)
+                .background(.background.secondary)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+        .padding()
+    }
+
+    // MARK: - Status Bar
+
+    @ViewBuilder
+    private var statusBar: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(service?.isConnected ?? false ? .green : .secondary)
+                .frame(width: 8, height: 8)
+
+            Text(service?.isConnected ?? false ? "Connected" : "Waiting for guest agent")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 6)
+    }
+
+    // MARK: - Actions
+
+    private func copyToHostClipboard() {
+        guard let text = service?.guestClipboardText, !text.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    private func sendToGuest() {
+        guard !textToSend.isEmpty else { return }
+        service?.sendToGuest(textToSend)
+        textToSend = ""
+    }
+}

--- a/Kernova/Views/Clipboard/ClipboardContentView.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentView.swift
@@ -32,19 +32,21 @@ struct ClipboardContentView: View {
             statusBar
         }
         .background(.background.secondary)
-        .frame(minWidth: 320, idealWidth: 480, minHeight: 200, idealHeight: 300)
+        .frame(minWidth: 320, idealWidth: 480, minHeight: 250, idealHeight: 300)
     }
 
     // MARK: - Status Bar
 
     @ViewBuilder
     private var statusBar: some View {
+        let isConnected = service?.isConnected ?? false
+
         HStack(spacing: 6) {
             Circle()
-                .fill(service?.isConnected ?? false ? .green : .secondary)
+                .fill(isConnected ? .green : .secondary)
                 .frame(width: 8, height: 8)
 
-            Text(service?.isConnected ?? false ? "Connected" : "Waiting for guest agent")
+            Text(isConnected ? "Connected" : "Waiting for guest agent")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 

--- a/Kernova/Views/Clipboard/ClipboardContentView.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentView.swift
@@ -1,86 +1,38 @@
 import SwiftUI
-import AppKit
 
 /// SwiftUI content view for the per-VM clipboard sharing window.
 ///
-/// Presents two panels:
-/// - **From Guest**: read-only display of the latest text the guest copied to its clipboard
-/// - **To Guest**: editable text field where the user can type or paste text to send to the guest
-///
-/// Clipboard data flows through `SpiceClipboardService` rather than the host `NSPasteboard`,
-/// giving the user explicit control over what enters and leaves each VM.
+/// A single editable text area serves as a unified clipboard buffer:
+/// - When the guest copies text, it appears here automatically
+/// - The user can edit or paste new text freely
+/// - When the window loses focus, any changes are announced to the guest via
+///   `CLIPBOARD_GRAB` — the guest requests the data on its next paste
 struct ClipboardContentView: View {
 
     let instance: VMInstance
-
-    @State private var textToSend: String = ""
 
     private var service: SpiceClipboardService? {
         instance.clipboardService
     }
 
+    private var clipboardTextBinding: Binding<String> {
+        Binding(
+            get: { service?.clipboardText ?? "" },
+            set: { service?.clipboardText = $0 }
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            fromGuestSection
-            Divider()
-            toGuestSection
+            TextEditor(text: clipboardTextBinding)
+                .font(.system(.body, design: .monospaced))
+                .scrollContentBackground(.hidden)
+                .padding(8)
             Divider()
             statusBar
         }
-        .frame(minWidth: 320, idealWidth: 480, minHeight: 280, idealHeight: 400)
-    }
-
-    // MARK: - From Guest
-
-    @ViewBuilder
-    private var fromGuestSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Label("From Guest", systemImage: "arrow.down.doc")
-                    .font(.headline)
-                Spacer()
-                Button("Copy to Host Clipboard") {
-                    copyToHostClipboard()
-                }
-                .disabled(service?.guestClipboardText.isEmpty ?? true)
-            }
-
-            ScrollView {
-                Text(service?.guestClipboardText ?? "")
-                    .font(.system(.body, design: .monospaced))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .textSelection(.enabled)
-            }
-            .frame(maxHeight: .infinity)
-            .background(.background.secondary)
-            .clipShape(RoundedRectangle(cornerRadius: 4))
-        }
-        .padding()
-    }
-
-    // MARK: - To Guest
-
-    @ViewBuilder
-    private var toGuestSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Label("To Guest", systemImage: "arrow.up.doc")
-                    .font(.headline)
-                Spacer()
-                Button("Send to Guest") {
-                    sendToGuest()
-                }
-                .disabled(textToSend.isEmpty || !(service?.isConnected ?? false))
-            }
-
-            TextEditor(text: $textToSend)
-                .font(.system(.body, design: .monospaced))
-                .frame(maxHeight: .infinity)
-                .scrollContentBackground(.hidden)
-                .background(.background.secondary)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-        }
-        .padding()
+        .background(.background.secondary)
+        .frame(minWidth: 320, idealWidth: 480, minHeight: 200, idealHeight: 300)
     }
 
     // MARK: - Status Bar
@@ -100,19 +52,6 @@ struct ClipboardContentView: View {
         }
         .padding(.horizontal)
         .padding(.vertical, 6)
-    }
-
-    // MARK: - Actions
-
-    private func copyToHostClipboard() {
-        guard let text = service?.guestClipboardText, !text.isEmpty else { return }
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
-    }
-
-    private func sendToGuest() {
-        guard !textToSend.isEmpty else { return }
-        service?.sendToGuest(textToSend)
-        textToSend = ""
+        .background(.background)
     }
 }

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -29,6 +29,7 @@ struct VMSettingsView: View {
                 discImageSection
                 resourcesSection
                 networkSection
+                clipboardSection
                 sharedDirectoriesSection
             }
             .formStyle(.grouped)
@@ -191,6 +192,16 @@ struct VMSettingsView: View {
             if let mac = instance.configuration.macAddress {
                 LabeledContent("MAC Address", value: mac)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var clipboardSection: some View {
+        Section("Clipboard") {
+            Toggle("Clipboard Sharing", isOn: $instance.configuration.clipboardSharingEnabled)
+            Text("Enables a SPICE clipboard channel for exchanging text between host and guest. The guest must have a SPICE agent installed (e.g. spice-vdagent on Linux).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -595,4 +595,44 @@ struct ConfigurationBuilderTests {
             // VZ framework or other errors are expected
         }
     }
+
+    // MARK: - Clipboard Sharing
+
+    @Test("BuildResult includes clipboard pipes when clipboard sharing is enabled")
+    func clipboardPipesWhenEnabled() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        var config = makeLinuxConfig()
+        config.clipboardSharingEnabled = true
+
+        let builder = ConfigurationBuilder()
+        // VZ validation may throw in the test runner (no virtualization entitlement).
+        // We're testing that clipboard pipes are populated — the VZ error is expected.
+        do {
+            let result = try builder.build(from: config, bundleURL: bundleURL)
+            #expect(result.clipboardInputPipe != nil)
+            #expect(result.clipboardOutputPipe != nil)
+        } catch {
+            // VZ framework errors are expected in the test environment
+        }
+    }
+
+    @Test("BuildResult has nil clipboard pipes when clipboard sharing is disabled")
+    func clipboardPipesWhenDisabled() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        var config = makeLinuxConfig()
+        config.clipboardSharingEnabled = false
+
+        let builder = ConfigurationBuilder()
+        do {
+            let result = try builder.build(from: config, bundleURL: bundleURL)
+            #expect(result.clipboardInputPipe == nil)
+            #expect(result.clipboardOutputPipe == nil)
+        } catch {
+            // VZ framework errors are expected in the test environment
+        }
+    }
 }

--- a/KernovaTests/SpiceAgentProtocolTests.swift
+++ b/KernovaTests/SpiceAgentProtocolTests.swift
@@ -1,0 +1,356 @@
+import Testing
+import Foundation
+@testable import Kernova
+
+@Suite("SpiceAgentProtocol Tests")
+struct SpiceAgentProtocolTests {
+
+    // MARK: - VDI Chunk Header
+
+    @Test("VDI chunk header serializes and deserializes correctly")
+    func chunkHeaderRoundTrip() {
+        let header = VDIChunkHeader(port: 1, dataSize: 42)
+        let data = header.serialize()
+
+        #expect(data.count == VDIChunkHeader.size)
+
+        let decoded = VDIChunkHeader.deserialize(from: data)
+        #expect(decoded != nil)
+        #expect(decoded?.port == 1)
+        #expect(decoded?.dataSize == 42)
+    }
+
+    @Test("VDI chunk header uses little-endian byte order")
+    func chunkHeaderLittleEndian() {
+        let header = VDIChunkHeader(port: 0x0100, dataSize: 0x0200)
+        let data = header.serialize()
+
+        // Little-endian: LSB first
+        #expect(data[0] == 0x00)
+        #expect(data[1] == 0x01)
+        #expect(data[4] == 0x00)
+        #expect(data[5] == 0x02)
+    }
+
+    @Test("VDI chunk header deserialization fails with insufficient data")
+    func chunkHeaderTooShort() {
+        let data = Data([0x01, 0x00, 0x00])
+        #expect(VDIChunkHeader.deserialize(from: data) == nil)
+    }
+
+    // MARK: - VDAgent Message Header
+
+    @Test("VDAgent message header serializes and deserializes correctly")
+    func messageHeaderRoundTrip() {
+        let header = VDAgentMessageHeader(
+            type: .announceCapabilities,
+            opaque: 0,
+            dataSize: 8
+        )
+        let data = header.serialize()
+
+        #expect(data.count == VDAgentMessageHeader.size)
+
+        let decoded = VDAgentMessageHeader.deserialize(from: data)
+        #expect(decoded != nil)
+        #expect(decoded?.type == .announceCapabilities)
+        #expect(decoded?.opaque == 0)
+        #expect(decoded?.dataSize == 8)
+    }
+
+    @Test("VDAgent message header includes protocol version 1")
+    func messageHeaderProtocolVersion() {
+        let header = VDAgentMessageHeader(
+            type: .clipboard,
+            opaque: 0,
+            dataSize: 0
+        )
+        let data = header.serialize()
+
+        // First 4 bytes should be protocol = 1 (little-endian)
+        let protocol_ = data.readLittleEndianUInt32(at: 0)
+        #expect(protocol_ == 1)
+    }
+
+    @Test("VDAgent message header deserialization fails for unknown type")
+    func messageHeaderUnknownType() {
+        var data = Data(repeating: 0, count: VDAgentMessageHeader.size)
+        // Set type field (offset 4) to an unknown value
+        var unknownType: UInt32 = 99
+        Swift.withUnsafeBytes(of: &unknownType) { ptr in
+            data.replaceSubrange(4..<8, with: ptr)
+        }
+        #expect(VDAgentMessageHeader.deserialize(from: data) == nil)
+    }
+
+    // MARK: - Message Builder
+
+    @Test("Capabilities message has correct structure")
+    func buildCapabilitiesMessage() {
+        let message = SpiceMessageBuilder.buildAnnounceCapabilities(request: true)
+
+        // Total: VDI header (8) + VDAgent header (20) + request (4) + caps (4) = 36
+        #expect(message.count == 36)
+
+        // Check chunk port = VDP_SERVER_PORT (2) — destination is the guest agent
+        let port = message.readLittleEndianUInt32(at: 0)
+        #expect(port == SpiceConstants.serverPort)
+
+        // Check message type = announceCapabilities (6)
+        let msgType = message.readLittleEndianUInt32(at: VDIChunkHeader.size + 4)
+        #expect(msgType == SpiceAgentMessageType.announceCapabilities.rawValue)
+
+        // Check request field = 1
+        let request = message.readLittleEndianUInt32(at: VDIChunkHeader.size + VDAgentMessageHeader.size)
+        #expect(request == 1)
+
+        // Check capabilities include clipboard and clipboardByDemand bits
+        let caps = message.readLittleEndianUInt32(at: VDIChunkHeader.size + VDAgentMessageHeader.size + 4)
+        let clipboardBit: UInt32 = 1 << UInt32(SpiceAgentCapability.clipboard.rawValue)
+        let byDemandBit: UInt32 = 1 << UInt32(SpiceAgentCapability.clipboardByDemand.rawValue)
+        #expect(caps & clipboardBit != 0)
+        #expect(caps & byDemandBit != 0)
+    }
+
+    @Test("Non-requesting capabilities message has request = 0")
+    func buildCapabilitiesNoRequest() {
+        let message = SpiceMessageBuilder.buildAnnounceCapabilities(request: false)
+        let request = message.readLittleEndianUInt32(at: VDIChunkHeader.size + VDAgentMessageHeader.size)
+        #expect(request == 0)
+    }
+
+    @Test("Clipboard grab message lists types correctly")
+    func buildClipboardGrab() {
+        let message = SpiceMessageBuilder.buildClipboardGrab(types: [.utf8Text, .png])
+
+        // Payload: 2 × uint32 = 8 bytes
+        let msgType = message.readLittleEndianUInt32(at: VDIChunkHeader.size + 4)
+        #expect(msgType == SpiceAgentMessageType.clipboardGrab.rawValue)
+
+        let type1 = message.readLittleEndianUInt32(at: VDIChunkHeader.size + VDAgentMessageHeader.size)
+        let type2 = message.readLittleEndianUInt32(at: VDIChunkHeader.size + VDAgentMessageHeader.size + 4)
+        #expect(type1 == SpiceClipboardType.utf8Text.rawValue)
+        #expect(type2 == SpiceClipboardType.png.rawValue)
+    }
+
+    @Test("Clipboard request message has correct type field")
+    func buildClipboardRequest() {
+        let message = SpiceMessageBuilder.buildClipboardRequest(type: .utf8Text)
+
+        let msgType = message.readLittleEndianUInt32(at: VDIChunkHeader.size + 4)
+        #expect(msgType == SpiceAgentMessageType.clipboardRequest.rawValue)
+
+        let clipType = message.readLittleEndianUInt32(at: VDIChunkHeader.size + VDAgentMessageHeader.size)
+        #expect(clipType == SpiceClipboardType.utf8Text.rawValue)
+    }
+
+    @Test("Clipboard data message includes type and payload")
+    func buildClipboardData() {
+        let text = "Hello, guest!"
+        let textData = text.data(using: .utf8)!
+        let message = SpiceMessageBuilder.buildClipboardData(type: .utf8Text, data: textData)
+
+        let msgType = message.readLittleEndianUInt32(at: VDIChunkHeader.size + 4)
+        #expect(msgType == SpiceAgentMessageType.clipboard.rawValue)
+
+        let clipType = message.readLittleEndianUInt32(at: VDIChunkHeader.size + VDAgentMessageHeader.size)
+        #expect(clipType == SpiceClipboardType.utf8Text.rawValue)
+
+        let payloadStart = VDIChunkHeader.size + VDAgentMessageHeader.size + 4
+        let payload = message.subdata(in: payloadStart..<message.count)
+        #expect(String(data: payload, encoding: .utf8) == text)
+    }
+
+    @Test("Clipboard release message has empty payload")
+    func buildClipboardRelease() {
+        let message = SpiceMessageBuilder.buildClipboardRelease()
+
+        let dataSize = message.readLittleEndianUInt32(at: VDIChunkHeader.size + 16)
+        #expect(dataSize == 0)
+    }
+
+    // MARK: - Parser
+
+    @Test("Parser handles announce capabilities from guest")
+    func parseAnnounceCapabilities() {
+        // Build a guest→host capabilities message (port = serverPort)
+        var caps: UInt32 = 0
+        caps |= 1 << UInt32(SpiceAgentCapability.clipboard.rawValue)
+        caps |= 1 << UInt32(SpiceAgentCapability.clipboardByDemand.rawValue)
+
+        let message = buildGuestMessage(type: .announceCapabilities, payload: {
+            var data = Data()
+            data.appendLittleEndian(UInt32(1)) // request = true
+            data.appendLittleEndian(caps)
+            return data
+        }())
+
+        var parser = SpiceAgentParser()
+        let results = parser.feed(message)
+
+        #expect(results.count == 1)
+        if case .announceCapabilities(let request, let parsedCaps) = results[0] {
+            #expect(request == true)
+            #expect(parsedCaps.count == 1)
+            #expect(parsedCaps[0] & (1 << UInt32(SpiceAgentCapability.clipboard.rawValue)) != 0)
+        } else {
+            Issue.record("Expected announceCapabilities message")
+        }
+    }
+
+    @Test("Parser handles clipboard grab from guest")
+    func parseClipboardGrab() {
+        var payload = Data()
+        payload.appendLittleEndian(SpiceClipboardType.utf8Text.rawValue)
+
+        let message = buildGuestMessage(type: .clipboardGrab, payload: payload)
+
+        var parser = SpiceAgentParser()
+        let results = parser.feed(message)
+
+        #expect(results.count == 1)
+        if case .clipboardGrab(let types) = results[0] {
+            #expect(types == [.utf8Text])
+        } else {
+            Issue.record("Expected clipboardGrab message")
+        }
+    }
+
+    @Test("Parser handles clipboard data from guest")
+    func parseClipboardData() {
+        let text = "Guest clipboard content"
+        let textData = text.data(using: .utf8)!
+
+        var payload = Data()
+        payload.appendLittleEndian(SpiceClipboardType.utf8Text.rawValue)
+        payload.append(textData)
+
+        let message = buildGuestMessage(type: .clipboard, payload: payload)
+
+        var parser = SpiceAgentParser()
+        let results = parser.feed(message)
+
+        #expect(results.count == 1)
+        if case .clipboardData(let type, let data) = results[0] {
+            #expect(type == .utf8Text)
+            #expect(String(data: data, encoding: .utf8) == text)
+        } else {
+            Issue.record("Expected clipboardData message")
+        }
+    }
+
+    @Test("Parser handles clipboard request from guest")
+    func parseClipboardRequest() {
+        var payload = Data()
+        payload.appendLittleEndian(SpiceClipboardType.utf8Text.rawValue)
+
+        let message = buildGuestMessage(type: .clipboardRequest, payload: payload)
+
+        var parser = SpiceAgentParser()
+        let results = parser.feed(message)
+
+        #expect(results.count == 1)
+        if case .clipboardRequest(let type) = results[0] {
+            #expect(type == .utf8Text)
+        } else {
+            Issue.record("Expected clipboardRequest message")
+        }
+    }
+
+    @Test("Parser handles clipboard release from guest")
+    func parseClipboardRelease() {
+        let message = buildGuestMessage(type: .clipboardRelease, payload: Data())
+
+        var parser = SpiceAgentParser()
+        let results = parser.feed(message)
+
+        #expect(results.count == 1)
+        if case .clipboardRelease = results[0] {
+            // pass
+        } else {
+            Issue.record("Expected clipboardRelease message")
+        }
+    }
+
+    @Test("Parser handles multiple messages in a single feed")
+    func parseMultipleMessages() {
+        var payload1 = Data()
+        payload1.appendLittleEndian(SpiceClipboardType.utf8Text.rawValue)
+
+        var payload2 = Data()
+        payload2.appendLittleEndian(SpiceClipboardType.utf8Text.rawValue)
+        payload2.append("test".data(using: .utf8)!)
+
+        let msg1 = buildGuestMessage(type: .clipboardGrab, payload: payload1)
+        let msg2 = buildGuestMessage(type: .clipboard, payload: payload2)
+
+        var parser = SpiceAgentParser()
+        let results = parser.feed(msg1 + msg2)
+
+        #expect(results.count == 2)
+    }
+
+    @Test("Parser handles partial data across multiple feeds")
+    func parsePartialData() {
+        var payload = Data()
+        payload.appendLittleEndian(SpiceClipboardType.utf8Text.rawValue)
+        let message = buildGuestMessage(type: .clipboardGrab, payload: payload)
+
+        let splitPoint = message.count / 2
+
+        var parser = SpiceAgentParser()
+        let results1 = parser.feed(message.subdata(in: 0..<splitPoint))
+        #expect(results1.isEmpty)
+
+        let results2 = parser.feed(message.subdata(in: splitPoint..<message.count))
+        #expect(results2.count == 1)
+    }
+
+    @Test("Parser ignores unknown message types gracefully")
+    func parseUnknownMessageType() {
+        let message = buildGuestMessage(type: .mouseState, payload: Data(repeating: 0, count: 16))
+
+        var parser = SpiceAgentParser()
+        let results = parser.feed(message)
+
+        #expect(results.count == 1)
+        if case .other(let type) = results[0] {
+            #expect(type == .mouseState)
+        } else {
+            Issue.record("Expected other message type")
+        }
+    }
+
+    // MARK: - Data Extension Helpers
+
+    @Test("Little-endian UInt32 read/write round-trips")
+    func uint32RoundTrip() {
+        var data = Data()
+        data.appendLittleEndian(UInt32(0xDEADBEEF))
+        #expect(data.readLittleEndianUInt32(at: 0) == 0xDEADBEEF)
+    }
+
+    @Test("Little-endian UInt64 read/write round-trips")
+    func uint64RoundTrip() {
+        var data = Data()
+        data.appendLittleEndian(UInt64(0x0102030405060708))
+        #expect(data.readLittleEndianUInt64(at: 0) == 0x0102030405060708)
+    }
+
+    // MARK: - Test Helpers
+
+    /// Builds a fake guest→host message with the given type and payload.
+    private func buildGuestMessage(type: SpiceAgentMessageType, payload: Data) -> Data {
+        let header = VDAgentMessageHeader(
+            type: type,
+            opaque: 0,
+            dataSize: UInt32(payload.count)
+        )
+        let msgData = header.serialize() + payload
+        let chunk = VDIChunkHeader(
+            port: SpiceConstants.serverPort,
+            dataSize: UInt32(msgData.count)
+        )
+        return chunk.serialize() + msgData
+    }
+}

--- a/KernovaTests/SpiceAgentProtocolTests.swift
+++ b/KernovaTests/SpiceAgentProtocolTests.swift
@@ -86,7 +86,7 @@ struct SpiceAgentProtocolTests {
     // MARK: - Message Builder
 
     @Test("Capabilities message has correct structure")
-    func buildCapabilitiesMessage() {
+    func buildCapabilitiesMessage() throws {
         let message = SpiceMessageBuilder.buildAnnounceCapabilities(request: true)
 
         // Total: VDI header (8) + VDAgent header (20) + request (4) + caps (4) = 36
@@ -105,7 +105,7 @@ struct SpiceAgentProtocolTests {
         #expect(request == 1)
 
         // Check capabilities include clipboard and clipboardByDemand bits
-        let caps = message.readLittleEndianUInt32(at: VDIChunkHeader.size + VDAgentMessageHeader.size + 4)
+        let caps = try #require(message.readLittleEndianUInt32(at: VDIChunkHeader.size + VDAgentMessageHeader.size + 4))
         let clipboardBit: UInt32 = 1 << UInt32(SpiceAgentCapability.clipboard.rawValue)
         let byDemandBit: UInt32 = 1 << UInt32(SpiceAgentCapability.clipboardByDemand.rawValue)
         #expect(caps & clipboardBit != 0)

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -538,4 +538,62 @@ struct VMConfigurationTests {
         #expect(config.lastFullscreenDisplayID == nil)
     }
 
+    // MARK: - clipboardSharingEnabled Tests
+
+    @Test("Default clipboardSharingEnabled is false")
+    func defaultClipboardSharingEnabled() {
+        let config = VMConfiguration(
+            name: "Test VM",
+            guestOS: .linux,
+            bootMode: .efi
+        )
+        #expect(config.clipboardSharingEnabled == false)
+    }
+
+    @Test("Configuration preserves clipboardSharingEnabled flag")
+    func clipboardSharingEnabledRoundTrip() throws {
+        let config = VMConfiguration(
+            name: "Clipboard VM",
+            guestOS: .linux,
+            bootMode: .efi,
+            clipboardSharingEnabled: true
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(config)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: data)
+
+        #expect(decoded.clipboardSharingEnabled == true)
+    }
+
+    @Test("Backward compatibility: decoding JSON without clipboardSharingEnabled defaults to false")
+    func backwardCompatibilityClipboardSharingEnabled() throws {
+        let json = """
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "name": "Old VM",
+            "guestOS": "linux",
+            "bootMode": "efi",
+            "cpuCount": 4,
+            "memorySizeInGB": 4,
+            "diskSizeInGB": 64,
+            "displayWidth": 1920,
+            "displayHeight": 1200,
+            "displayPPI": 144,
+            "networkEnabled": true,
+            "createdAt": "2025-01-01T00:00:00Z"
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let config = try decoder.decode(VMConfiguration.self, from: Data(json.utf8))
+
+        #expect(config.clipboardSharingEnabled == false)
+    }
+
 }

--- a/KernovaTests/VMToolbarManagerTests.swift
+++ b/KernovaTests/VMToolbarManagerTests.swift
@@ -28,6 +28,7 @@ struct VMToolbarManagerTests {
             configuration: .init(
                 lifecycleID: NSToolbarItem.Identifier("testLifecycle"),
                 saveStateID: NSToolbarItem.Identifier("testSaveState"),
+                clipboardID: NSToolbarItem.Identifier("testClipboard"),
                 displayID: NSToolbarItem.Identifier("testDisplay"),
                 checksPreparing: checksPreparing,
                 gatesDisplayOnCapability: gatesDisplayOnCapability
@@ -90,12 +91,13 @@ struct VMToolbarManagerTests {
         #expect(item == nil)
     }
 
-    @Test("sharedItemIdentifiers contains all three identifiers")
+    @Test("sharedItemIdentifiers contains all four identifiers")
     func sharedIdentifiers() {
         let manager = makeManager()
-        #expect(manager.sharedItemIdentifiers.count == 3)
+        #expect(manager.sharedItemIdentifiers.count == 4)
         #expect(manager.sharedItemIdentifiers.contains(NSToolbarItem.Identifier("testLifecycle")))
         #expect(manager.sharedItemIdentifiers.contains(NSToolbarItem.Identifier("testSaveState")))
+        #expect(manager.sharedItemIdentifiers.contains(NSToolbarItem.Identifier("testClipboard")))
         #expect(manager.sharedItemIdentifiers.contains(NSToolbarItem.Identifier("testDisplay")))
     }
 


### PR DESCRIPTION
## Summary
- Add a gated clipboard panel that exchanges text between host and guest VMs via the SPICE agent protocol, without touching the host system clipboard
- Single unified textbox per VM: guest copies populate it, user edits are announced to the guest on window focus loss, data delivered on-demand at paste time
- Works with any standard SPICE guest agent (`spice-vdagent` on Linux, UTM/Tart agents on macOS guests)

## Changes
- Add `clipboardSharingEnabled` to `VMConfiguration` with backward-compatible decoding
- Configure `VZVirtioConsoleDeviceConfiguration` with SPICE-named port using raw `VZFileHandleSerialPortAttachment` pipes (not `VZSpiceAgentPortAttachment`) in `ConfigurationBuilder`
- Implement `SpiceAgentProtocol`: VDI chunk framing, VDAgent message headers, clipboard message types, incremental parser with 1 MB buffer cap and corruption detection
- Implement `SpiceClipboardService`: `@MainActor` service with pipe I/O, SPICE protocol state machine, by-demand clipboard exchange (GRAB → REQUEST → DATA), EOF spin-loop prevention, write-failure recovery
- Add `ClipboardContentView` (single TextEditor + connection status) and `ClipboardWindowController` (auto-GRAB on focus loss, auto-close on VM stop)
- Add clipboard window management, menu item (Cmd+Shift+V), and toolbar button to AppDelegate/VMToolbarManager
- Add Clipboard section with toggle in VMSettingsView
- Wire clipboard pipes and service lifecycle into VMInstance, VirtualizationService, and MacOSInstallService
- Update ARCHITECTURE.md with all new components

## Test plan
- [x] Built successfully on macOS 26
- [x] All 407 tests pass (17 new SpiceAgentProtocol tests, 3 VMConfiguration tests, 2 ConfigurationBuilder tests, VMToolbarManager tests updated)
- [x] Tested bidirectional clipboard with Linux guest (spice-vdagent)
- [x] Backward compatibility: older config.json loads with clipboard disabled
- [ ] Test with macOS guest using UTM or Tart guest agent

## Review debt
- #59 — Extract shared per-VM window management pattern from AppDelegate
- #61 — Add unit tests for SpiceClipboardService
- #62 — Add tests for parser buffer overflow and corruption reset guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)