### PR TITLE
feat: Add heartbeat to SPICE clipboard connection status

### DIFF
--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -83,7 +83,6 @@ final class SpiceClipboardService {
         outputPipe.fileHandleForReading.readabilityHandler = nil
         pendingOutboundText = nil
         guestSupportsByDemand = false
-        receivedSinceLastProbe = false
         Self.logger.info("SPICE clipboard service stopped")
     }
 
@@ -333,6 +332,7 @@ final class SpiceClipboardService {
         heartbeatTask?.cancel()
         heartbeatTask = nil
         isConnected = false
+        receivedSinceLastProbe = false
     }
 
     // MARK: - Capability Helpers

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -48,6 +48,17 @@ final class SpiceClipboardService {
     /// instead of waiting for a REQUEST.
     private var guestSupportsByDemand = false
 
+    // MARK: - Heartbeat
+
+    private static let heartbeatInterval: Duration = .seconds(5)
+    private static let heartbeatTimeout: Duration = .seconds(5)
+
+    /// Set to `true` whenever a valid message arrives from the guest; reset by
+    /// the heartbeat loop after each check. Avoids wall-clock comparisons.
+    private var receivedSinceLastProbe = false
+
+    private var heartbeatTask: Task<Void, Never>?
+
     private static let logger = Logger(subsystem: "com.kernova.app", category: "SpiceClipboardService")
 
     // MARK: - Init
@@ -66,12 +77,13 @@ final class SpiceClipboardService {
         Self.logger.info("SPICE clipboard service started")
     }
 
-    /// Stops reading and releases resources.
+    /// Stops reading, cancels the heartbeat, and releases resources.
     func stop() {
+        disconnect()
         outputPipe.fileHandleForReading.readabilityHandler = nil
-        isConnected = false
         pendingOutboundText = nil
         guestSupportsByDemand = false
+        receivedSinceLastProbe = false
         Self.logger.info("SPICE clipboard service stopped")
     }
 
@@ -122,7 +134,7 @@ final class SpiceClipboardService {
                 handle.readabilityHandler = nil
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    self.isConnected = false
+                    self.disconnect()
                     Self.logger.notice("SPICE pipe closed (EOF)")
                 }
                 return
@@ -141,6 +153,10 @@ final class SpiceClipboardService {
 
         if parser.didReset {
             Self.logger.error("SPICE parser buffer reset — stream may be corrupted")
+        }
+
+        if !messages.isEmpty {
+            receivedSinceLastProbe = true
         }
 
         for message in messages {
@@ -185,6 +201,7 @@ final class SpiceClipboardService {
 
         isConnected = true
         guestSupportsByDemand = byDemand
+        startHeartbeat()
 
         // If the guest requested our capabilities, send them back (non-requesting)
         if request {
@@ -265,9 +282,57 @@ final class SpiceClipboardService {
             return true
         } catch {
             Self.logger.error("Failed to write to SPICE pipe: \(error.localizedDescription, privacy: .public)")
-            isConnected = false
+            disconnect()
             return false
         }
+    }
+
+    // MARK: - Heartbeat
+
+    /// Monitors guest agent liveness. Skips probing when the agent was recently
+    /// active; otherwise sends a capabilities request and waits for a reply.
+    /// Marks the connection as dead and stops if no response arrives.
+    private func startHeartbeat() {
+        heartbeatTask?.cancel()
+        Self.logger.debug("Starting heartbeat monitor")
+        heartbeatTask = Task { [weak self] in
+            do {
+                while true {
+                    try await Task.sleep(for: Self.heartbeatInterval)
+                    guard let self, self.isConnected else { return }
+
+                    // Agent was active during the interval — no probe needed
+                    if self.receivedSinceLastProbe {
+                        self.receivedSinceLastProbe = false
+                        continue
+                    }
+
+                    // No recent activity — send a probe and wait for response
+                    self.sendCapabilities()
+
+                    try await Task.sleep(for: Self.heartbeatTimeout)
+                    guard self.isConnected else { return }
+
+                    if self.receivedSinceLastProbe {
+                        self.receivedSinceLastProbe = false
+                        continue
+                    }
+
+                    self.disconnect()
+                    Self.logger.notice("Heartbeat timeout — guest agent not responding")
+                    return
+                }
+            } catch {
+                // CancellationError from stop() — normal teardown
+            }
+        }
+    }
+
+    /// Cancels the heartbeat and marks the connection as inactive.
+    private func disconnect() {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        isConnected = false
     }
 
     // MARK: - Capability Helpers


### PR DESCRIPTION
## Summary
- Adds a heartbeat mechanism to `SpiceClipboardService` that detects when the guest SPICE agent stops responding (e.g., guest user logout) and updates the "Connected" status within ~10 seconds
- Uses `ANNOUNCE_CAPABILITIES(request: true)` as a liveness probe — the standard SPICE handshake message, lightweight and idempotent
- Skips probes when the agent was recently active, so the heartbeat adds zero overhead during active clipboard use

## Changes
- Add heartbeat loop with 5s interval + 5s timeout for ~10s worst-case detection
- Use a boolean flag (`receivedSinceLastProbe`) instead of wall-clock timestamps to avoid NTP/sleep-wake drift
- Extract `disconnect()` helper to centralize `isConnected = false` + heartbeat cancellation across all disconnect paths (EOF, write failure, timeout)
- Use `try`/`catch` for `Task.sleep` so task cancellation exits immediately on `stop()`

## Test plan
- [x] Built successfully on macOS 26
- [x] All 407 existing tests pass
- [ ] Start macOS guest → open clipboard window → verify "Connected"
- [ ] Log out of guest → verify status changes to "Waiting for guest agent" within ~10s
- [ ] Log back in → verify "Connected" returns automatically

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)