### PR TITLE
fix: Replace byte-by-byte IPSW download with URLSessionDownloadTask

### DIFF
--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -25,62 +25,29 @@ struct IPSWService: Sendable {
     ) async throws {
         Self.logger.info("Downloading restore image from \(remoteURL, privacy: .public)")
 
-        // Create the destination file up-front so it's visible in Finder immediately.
-        FileManager.default.createFile(atPath: destinationURL.path(percentEncoded: false), contents: nil)
-
-        var cleanUpPartial = true
-        defer {
-            if cleanUpPartial {
-                Self.logger.info("Removing partial download at \(destinationURL.lastPathComponent, privacy: .public)")
-                try? FileManager.default.removeItem(at: destinationURL)
-            }
-        }
-
-        let (asyncBytes, response) = try await URLSession.shared.bytes(from: remoteURL)
-        let expectedBytes = response.expectedContentLength  // -1 if unknown
-        let expected = expectedBytes > 0 ? expectedBytes : Int64.max
-
-        let fileHandle: FileHandle
+        // RATIONALE: removeItem (not trashItem) is used here because these are incomplete/partial
+        // IPSW files from a prior failed download — not user data worth preserving. Trashing
+        // multi-gigabyte partial files would waste disk space and may fail on volumes without Trash.
         do {
-            fileHandle = try FileHandle(forWritingTo: destinationURL)
-        } catch {
-            throw IPSWError.downloadFailed("Could not open destination file for writing: \(error.localizedDescription)")
-        }
-        defer { try? fileHandle.close() }
-
-        let bufferSize = 512 * 1024  // 512 KB
-        var buffer = Data(capacity: bufferSize)
-        var bytesWritten: Int64 = 0
-
-        for try await byte in asyncBytes {
-            buffer.append(byte)
-            if buffer.count >= bufferSize {
-                try fileHandle.write(contentsOf: buffer)
-                bytesWritten += Int64(buffer.count)
-                buffer.removeAll(keepingCapacity: true)
-
-                if expectedBytes > 0 {
-                    let written = bytesWritten
-                    let fraction = Double(written) / Double(expected)
-                    let handler = progressHandler
-                    Task { @MainActor in handler(fraction, written, expected) }
-                }
-            }
+            try FileManager.default.removeItem(at: destinationURL)
+        } catch CocoaError.fileNoSuchFile {
+            // No existing file to clean up — expected on first download.
         }
 
-        // Flush any remaining bytes
-        if !buffer.isEmpty {
-            try fileHandle.write(contentsOf: buffer)
-            bytesWritten += Int64(buffer.count)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            let delegate = IPSWDownloadDelegate(
+                destinationURL: destinationURL,
+                progressHandler: progressHandler,
+                continuation: continuation
+            )
+            let session = URLSession(
+                configuration: .default,
+                delegate: delegate,
+                delegateQueue: nil
+            )
+            session.downloadTask(with: remoteURL).resume()
         }
 
-        if expectedBytes > 0 {
-            let written = bytesWritten
-            let handler = progressHandler
-            Task { @MainActor in handler(1.0, written, expected) }
-        }
-
-        cleanUpPartial = false
         Self.logger.info("Restore image downloaded to \(destinationURL.lastPathComponent, privacy: .public)")
     }
 
@@ -94,6 +61,100 @@ struct IPSWService: Sendable {
 // MARK: - IPSWProviding
 
 extension IPSWService: IPSWProviding {}
+
+// MARK: - Download Delegate
+
+#if arch(arm64)
+/// URLSession delegate that handles IPSW download progress reporting and file placement.
+// RATIONALE: @unchecked Sendable is safe because URLSession creates a serial delegate
+// queue when delegateQueue is nil, guaranteeing all callbacks are serialised.
+// No mutable state is accessed outside of delegate callbacks.
+private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+
+    private static let logger = Logger(subsystem: "com.kernova.app", category: "IPSWDownloadDelegate")
+    private static let progressInterval: TimeInterval = 0.1  // 100 ms
+
+    private let destinationURL: URL
+    private let progressHandler: @MainActor @Sendable (Double, Int64, Int64) -> Void
+    // RATIONALE: URLSession guarantees exactly one didCompleteWithError call per task,
+    // so this continuation is always resumed exactly once.
+    private let continuation: CheckedContinuation<Void, any Error>
+    private var moveError: (any Error)?
+    private var lastProgressReport: TimeInterval = 0
+
+    init(
+        destinationURL: URL,
+        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64) -> Void,
+        continuation: CheckedContinuation<Void, any Error>
+    ) {
+        self.destinationURL = destinationURL
+        self.progressHandler = progressHandler
+        self.continuation = continuation
+    }
+
+    // MARK: URLSessionDownloadDelegate
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard totalBytesExpectedToWrite > 0 else { return }
+
+        let now = ProcessInfo.processInfo.systemUptime
+        guard now - lastProgressReport >= Self.progressInterval else { return }
+        lastProgressReport = now
+
+        let fraction = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        let handler = self.progressHandler
+        Task { @MainActor in handler(fraction, totalBytesWritten, totalBytesExpectedToWrite) }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        // URLSession deletes the temporary file after this method returns,
+        // so the move must happen synchronously here.
+        do {
+            try FileManager.default.moveItem(at: location, to: destinationURL)
+        } catch {
+            Self.logger.error("Failed to move IPSW from '\(location.path(percentEncoded: false), privacy: .public)' to '\(self.destinationURL.path(percentEncoded: false), privacy: .public)': \(error.localizedDescription, privacy: .public)")
+            self.moveError = error
+        }
+    }
+
+    // MARK: URLSessionTaskDelegate
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: (any Error)?
+    ) {
+        // Break URLSession's strong reference to the delegate.
+        session.finishTasksAndInvalidate()
+
+        if let error = error ?? moveError {
+            Self.logger.error("Restore image download failed: \(error.localizedDescription, privacy: .public)")
+            do {
+                try FileManager.default.removeItem(at: destinationURL)
+            } catch {
+                Self.logger.warning("Failed to clean up partial download at '\(self.destinationURL.path(percentEncoded: false), privacy: .public)': \(error.localizedDescription, privacy: .public)")
+            }
+            continuation.resume(throwing: IPSWError.downloadFailed(error.localizedDescription))
+        } else {
+            let handler = self.progressHandler
+            let received = task.countOfBytesReceived
+            let expected = task.countOfBytesExpectedToReceive
+            Task { @MainActor in handler(1.0, received, expected) }
+            continuation.resume()
+        }
+    }
+}
+#endif
 
 // MARK: - Errors
 


### PR DESCRIPTION
## Summary
- Fix slow macOS IPSW downloads caused by iterating ~15 billion async suspension points via `URLSession.AsyncBytes` for a ~15 GB file
- Delegate the transfer to the OS networking stack via `URLSessionDownloadTask`, which uses optimised kernel-level I/O
- Throttle progress callbacks to 100ms intervals to avoid flooding the MainActor with ~900K `Task` allocations

## Changes
- Replace `URLSession.shared.bytes(from:)` with a `URLSessionDownloadTask` wrapped in `withCheckedThrowingContinuation`
- Add `IPSWDownloadDelegate` (private, `@unchecked Sendable`) handling progress, file placement, error propagation, and session lifecycle
- Replace TOCTOU `fileExists` + `removeItem` with direct `removeItem` catching `CocoaError.fileNoSuchFile`
- Add error logging at point of failure for `moveItem` and cleanup paths
- Add `RATIONALE:` annotations for `@unchecked Sendable`, continuation resume-once guarantee, and `removeItem` over `trashItem`

## Related issues
- Filed #73 (cancellation support) and #74 (preserve original error type) as review debt

## Test plan
- [x] Built successfully on macOS 26
- [x] All 407 existing tests pass
- [x] Protocol (`IPSWProviding`) and mock (`MockIPSWService`) unchanged — no downstream breakage
- [ ] Manual test: download a macOS IPSW during VM creation and verify speed improvement and progress reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)