### PR TITLE
refactor: Resolve all review-debt issues

### DIFF
--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -486,7 +486,12 @@ struct ConfigurationBuilder: Sendable {
                 throw isDirectory
             case .notWritable:
                 logger.error("\(context, privacy: .public) is not writable: '\(path, privacy: .public)'")
-                throw notWritable ?? notFound
+                guard let notWritableError = notWritable else {
+                    logger.fault("resolveFile called with requireWritable but no notWritable error for '\(path, privacy: .public)'")
+                    assertionFailure("'notWritable' error must be provided when 'requireWritable' is true")
+                    throw notFound
+                }
+                throw notWritableError
             case .notReadable:
                 logger.fault("Unexpected .notReadable from resolveFile for '\(path, privacy: .public)'")
                 assertionFailure("resolveFile should never throw .notReadable")
@@ -521,10 +526,20 @@ struct ConfigurationBuilder: Sendable {
                 throw notADirectory
             case .notReadable:
                 logger.error("\(context, privacy: .public) is not readable: '\(path, privacy: .public)'")
-                throw notReadable ?? notFound
+                guard let notReadableError = notReadable else {
+                    logger.fault("resolveDirectory called with requireReadable but no notReadable error for '\(path, privacy: .public)'")
+                    assertionFailure("'notReadable' error must be provided when 'requireReadable' is true")
+                    throw notFound
+                }
+                throw notReadableError
             case .notWritable:
                 logger.error("\(context, privacy: .public) is not writable: '\(path, privacy: .public)'")
-                throw notWritable ?? notFound
+                guard let notWritableError = notWritable else {
+                    logger.fault("resolveDirectory called with requireWritable but no notWritable error for '\(path, privacy: .public)'")
+                    assertionFailure("'notWritable' error must be provided when 'requireWritable' is true")
+                    throw notFound
+                }
+                throw notWritableError
             }
         }
     }

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -488,6 +488,8 @@ struct ConfigurationBuilder: Sendable {
                 logger.error("\(context, privacy: .public) is not writable: '\(path, privacy: .public)'")
                 throw notWritable ?? notFound
             case .notReadable:
+                logger.fault("Unexpected .notReadable from resolveFile for '\(path, privacy: .public)'")
+                assertionFailure("resolveFile should never throw .notReadable")
                 throw notFound
             }
         }

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -193,43 +193,16 @@ struct ConfigurationBuilder: Sendable {
             throw ConfigurationBuilderError.missingKernelPath
         }
 
-        let fileManager = FileManager.default
-        let kernelURL = URL(fileURLWithPath: kernelPath).resolvingSymlinksInPath()
-        let resolvedKernelPath = kernelURL.path(percentEncoded: false)
+        let kernel = try Self.resolveFile(at: kernelPath, context: "Kernel",
+                                          notFound: .kernelNotFound(kernelPath),
+                                          isDirectory: .kernelPathIsDirectory(kernelPath))
 
-        if resolvedKernelPath != kernelPath {
-            Self.logger.info("Kernel path '\(kernelPath, privacy: .public)' resolved to '\(resolvedKernelPath, privacy: .public)'")
-        }
-
-        var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: resolvedKernelPath, isDirectory: &isDirectory) else {
-            Self.logger.error("Kernel image not found at '\(kernelPath, privacy: .public)' (resolved: '\(resolvedKernelPath, privacy: .public)')")
-            throw ConfigurationBuilderError.kernelNotFound(kernelPath)
-        }
-        guard !isDirectory.boolValue else {
-            Self.logger.error("Kernel path is a directory, not a file: '\(kernelPath, privacy: .public)' (resolved: '\(resolvedKernelPath, privacy: .public)')")
-            throw ConfigurationBuilderError.kernelPathIsDirectory(kernelPath)
-        }
-
-        let bootLoader = VZLinuxBootLoader(kernelURL: kernelURL)
+        let bootLoader = VZLinuxBootLoader(kernelURL: kernel.url)
         if let initrdPath = config.initrdPath {
-            let initrdURL = URL(fileURLWithPath: initrdPath).resolvingSymlinksInPath()
-            let resolvedInitrdPath = initrdURL.path(percentEncoded: false)
-
-            if resolvedInitrdPath != initrdPath {
-                Self.logger.info("Initrd path '\(initrdPath, privacy: .public)' resolved to '\(resolvedInitrdPath, privacy: .public)'")
-            }
-
-            var isInitrdDirectory: ObjCBool = false
-            guard fileManager.fileExists(atPath: resolvedInitrdPath, isDirectory: &isInitrdDirectory) else {
-                Self.logger.error("Initial ramdisk not found at '\(initrdPath, privacy: .public)' (resolved: '\(resolvedInitrdPath, privacy: .public)')")
-                throw ConfigurationBuilderError.initrdNotFound(initrdPath)
-            }
-            guard !isInitrdDirectory.boolValue else {
-                Self.logger.error("Initrd path is a directory, not a file: '\(initrdPath, privacy: .public)' (resolved: '\(resolvedInitrdPath, privacy: .public)')")
-                throw ConfigurationBuilderError.initrdPathIsDirectory(initrdPath)
-            }
-            bootLoader.initialRamdiskURL = initrdURL
+            let initrd = try Self.resolveFile(at: initrdPath, context: "Initrd",
+                                              notFound: .initrdNotFound(initrdPath),
+                                              isDirectory: .initrdPathIsDirectory(initrdPath))
+            bootLoader.initialRamdiskURL = initrd.url
         }
         bootLoader.commandLine = config.kernelCommandLine ?? "console=hvc0"
         vzConfig.bootLoader = bootLoader
@@ -267,35 +240,17 @@ struct ConfigurationBuilder: Sendable {
 
         // Attach disc image as USB mass storage device
         if let discImagePath = config.discImagePath {
-            let discImageURL = URL(fileURLWithPath: discImagePath).resolvingSymlinksInPath()
-            let resolvedDiscImagePath = discImageURL.path(percentEncoded: false)
-
-            if resolvedDiscImagePath != discImagePath {
-                Self.logger.info("Disc image path '\(discImagePath, privacy: .public)' resolved to '\(resolvedDiscImagePath, privacy: .public)'")
-            }
-
-            var isDiscImageDirectory: ObjCBool = false
-            guard FileManager.default.fileExists(atPath: resolvedDiscImagePath, isDirectory: &isDiscImageDirectory) else {
-                Self.logger.error("Disc image not found at '\(discImagePath, privacy: .public)' (resolved: '\(resolvedDiscImagePath, privacy: .public)')")
-                throw ConfigurationBuilderError.discImageNotFound(discImagePath)
-            }
-            guard !isDiscImageDirectory.boolValue else {
-                Self.logger.error("Disc image path is a directory, not a file: '\(discImagePath, privacy: .public)' (resolved: '\(resolvedDiscImagePath, privacy: .public)')")
-                throw ConfigurationBuilderError.discImagePathIsDirectory(discImagePath)
-            }
-
-            if !config.discImageReadOnly {
-                guard FileManager.default.isWritableFile(atPath: resolvedDiscImagePath) else {
-                    Self.logger.error("Disc image is not writable: '\(discImagePath, privacy: .public)' (resolved: '\(resolvedDiscImagePath, privacy: .public)')")
-                    throw ConfigurationBuilderError.discImageNotWritable(discImagePath)
-                }
-            }
+            let discImage = try Self.resolveFile(at: discImagePath, context: "Disc image",
+                                                 requireWritable: !config.discImageReadOnly,
+                                                 notFound: .discImageNotFound(discImagePath),
+                                                 isDirectory: .discImagePathIsDirectory(discImagePath),
+                                                 notWritable: .discImageNotWritable(discImagePath))
 
             let discImageAttachment: VZDiskImageStorageDeviceAttachment
             do {
-                discImageAttachment = try VZDiskImageStorageDeviceAttachment(url: discImageURL, readOnly: config.discImageReadOnly)
+                discImageAttachment = try VZDiskImageStorageDeviceAttachment(url: discImage.url, readOnly: config.discImageReadOnly)
             } catch {
-                Self.logger.error("Failed to attach disc image at '\(discImagePath, privacy: .public)' (resolved: '\(resolvedDiscImagePath, privacy: .public)'): \(error.localizedDescription, privacy: .public)")
+                Self.logger.error("Failed to attach disc image at '\(discImagePath, privacy: .public)': \(error.localizedDescription, privacy: .public)")
                 throw error
             }
             let usbStorage = VZUSBMassStorageDeviceConfiguration(attachment: discImageAttachment)
@@ -311,30 +266,18 @@ struct ConfigurationBuilder: Sendable {
         // Attach additional virtio block devices
         if let additionalDisks = config.additionalDisks {
             for disk in additionalDisks {
-                let diskURL = URL(fileURLWithPath: disk.path).resolvingSymlinksInPath()
-                let resolvedPath = diskURL.path(percentEncoded: false)
-
-                var isDirectory: ObjCBool = false
-                guard FileManager.default.fileExists(atPath: resolvedPath, isDirectory: &isDirectory) else {
-                    Self.logger.error("Additional disk '\(disk.label, privacy: .public)' not found at '\(disk.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
-                    throw ConfigurationBuilderError.additionalDiskNotFound(disk.path, disk.label)
-                }
-                guard !isDirectory.boolValue else {
-                    Self.logger.error("Additional disk '\(disk.label, privacy: .public)' path is a directory: '\(disk.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
-                    throw ConfigurationBuilderError.additionalDiskPathIsDirectory(disk.path, disk.label)
-                }
-                if !disk.readOnly {
-                    guard FileManager.default.isWritableFile(atPath: resolvedPath) else {
-                        Self.logger.error("Additional disk '\(disk.label, privacy: .public)' is not writable: '\(disk.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
-                        throw ConfigurationBuilderError.additionalDiskNotWritable(disk.path, disk.label)
-                    }
-                }
+                let resolved = try Self.resolveFile(
+                    at: disk.path, context: "Additional disk '\(disk.label)'",
+                    requireWritable: !disk.readOnly,
+                    notFound: .additionalDiskNotFound(disk.path, disk.label),
+                    isDirectory: .additionalDiskPathIsDirectory(disk.path, disk.label),
+                    notWritable: .additionalDiskNotWritable(disk.path, disk.label))
 
                 let attachment: VZDiskImageStorageDeviceAttachment
                 do {
-                    attachment = try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: disk.readOnly)
+                    attachment = try VZDiskImageStorageDeviceAttachment(url: resolved.url, readOnly: disk.readOnly)
                 } catch {
-                    Self.logger.error("Failed to attach additional disk '\(disk.label, privacy: .public)' at '\(disk.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)'): \(error.localizedDescription, privacy: .public)")
+                    Self.logger.error("Failed to attach additional disk '\(disk.label, privacy: .public)' at '\(disk.path, privacy: .public)': \(error.localizedDescription, privacy: .public)")
                     throw error
                 }
                 let blockDevice = VZVirtioBlockDeviceConfiguration(attachment: attachment)
@@ -462,36 +405,16 @@ struct ConfigurationBuilder: Sendable {
 
     /// Validates shared directories and returns resolved URLs (symlinks followed).
     private func validateSharedDirectories(_ directories: [SharedDirectory]) throws -> [URL] {
-        let fileManager = FileManager.default
         var resolvedURLs: [URL] = []
         for directory in directories {
-            let resolvedURL = URL(fileURLWithPath: directory.path).resolvingSymlinksInPath()
-            let resolvedPath = resolvedURL.path(percentEncoded: false)
-
-            if resolvedPath != directory.path {
-                Self.logger.info("Shared directory '\(directory.path, privacy: .public)' resolved to '\(resolvedPath, privacy: .public)'")
-            }
-
-            var isDirectory: ObjCBool = false
-            guard fileManager.fileExists(atPath: resolvedPath, isDirectory: &isDirectory) else {
-                Self.logger.error("Shared directory not found at '\(directory.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
-                throw ConfigurationBuilderError.sharedDirectoryNotFound(directory.path)
-            }
-            guard isDirectory.boolValue else {
-                Self.logger.error("Shared path is not a directory: '\(directory.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
-                throw ConfigurationBuilderError.sharedDirectoryNotADirectory(directory.path)
-            }
-            guard fileManager.isReadableFile(atPath: resolvedPath) else {
-                Self.logger.error("Shared directory is not readable: '\(directory.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
-                throw ConfigurationBuilderError.sharedDirectoryNotReadable(directory.path)
-            }
-            if !directory.readOnly {
-                guard fileManager.isWritableFile(atPath: resolvedPath) else {
-                    Self.logger.error("Shared directory is not writable: '\(directory.path, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
-                    throw ConfigurationBuilderError.sharedDirectoryNotWritable(directory.path)
-                }
-            }
-            resolvedURLs.append(resolvedURL)
+            let resolved = try Self.resolveDirectory(
+                at: directory.path, context: "Shared directory",
+                requireReadable: true, requireWritable: !directory.readOnly,
+                notFound: .sharedDirectoryNotFound(directory.path),
+                notADirectory: .sharedDirectoryNotADirectory(directory.path),
+                notReadable: .sharedDirectoryNotReadable(directory.path),
+                notWritable: .sharedDirectoryNotWritable(directory.path))
+            resolvedURLs.append(resolved.url)
         }
         return resolvedURLs
     }
@@ -536,6 +459,72 @@ struct ConfigurationBuilder: Sendable {
             devices.append(device)
         }
         vzConfig.directorySharingDevices = devices
+    }
+
+    // MARK: - Path Validation Helpers
+
+    /// Resolves and validates a file path, mapping `PathValidation.Failure` to `ConfigurationBuilderError`.
+    private static func resolveFile(
+        at path: String,
+        context: String,
+        requireWritable: Bool = false,
+        notFound: ConfigurationBuilderError,
+        isDirectory: ConfigurationBuilderError,
+        notWritable: ConfigurationBuilderError? = nil
+    ) throws -> PathValidation.ResolvedPath {
+        do {
+            let resolved = try PathValidation.resolveFile(at: path, requireWritable: requireWritable)
+            resolved.logResolution(logger: logger, context: context)
+            return resolved
+        } catch let error as PathValidation.Failure {
+            switch error {
+            case .notFound:
+                logger.error("\(context, privacy: .public) not found at '\(path, privacy: .public)'")
+                throw notFound
+            case .unexpectedType:
+                logger.error("\(context, privacy: .public) path is a directory: '\(path, privacy: .public)'")
+                throw isDirectory
+            case .notWritable:
+                logger.error("\(context, privacy: .public) is not writable: '\(path, privacy: .public)'")
+                throw notWritable ?? notFound
+            case .notReadable:
+                throw notFound
+            }
+        }
+    }
+
+    /// Resolves and validates a directory path, mapping `PathValidation.Failure` to `ConfigurationBuilderError`.
+    private static func resolveDirectory(
+        at path: String,
+        context: String,
+        requireReadable: Bool = false,
+        requireWritable: Bool = false,
+        notFound: ConfigurationBuilderError,
+        notADirectory: ConfigurationBuilderError,
+        notReadable: ConfigurationBuilderError? = nil,
+        notWritable: ConfigurationBuilderError? = nil
+    ) throws -> PathValidation.ResolvedPath {
+        do {
+            let resolved = try PathValidation.resolveDirectory(
+                at: path, requireReadable: requireReadable, requireWritable: requireWritable)
+            resolved.logResolution(logger: logger, context: context)
+            return resolved
+        } catch let error as PathValidation.Failure {
+            switch error {
+            case .notFound:
+                logger.error("\(context, privacy: .public) not found at '\(path, privacy: .public)'")
+                throw notFound
+            case .unexpectedType:
+                logger.error("\(context, privacy: .public) path is not a directory: '\(path, privacy: .public)'")
+                throw notADirectory
+            case .notReadable:
+                logger.error("\(context, privacy: .public) is not readable: '\(path, privacy: .public)'")
+                throw notReadable ?? notFound
+            case .notWritable:
+                logger.error("\(context, privacy: .public) is not writable: '\(path, privacy: .public)'")
+                throw notWritable ?? notFound
+            }
+        }
     }
 }
 

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -171,7 +171,7 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
                 continuation.resume(throwing: CancellationError())
             } else {
                 Self.logger.error("Restore image download failed: \(error.localizedDescription, privacy: .public)")
-                continuation.resume(throwing: IPSWError.downloadFailed(error.localizedDescription))
+                continuation.resume(throwing: IPSWError.downloadFailed(error))
             }
         } else {
             let handler = self.progressHandler
@@ -188,14 +188,14 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
 
 enum IPSWError: LocalizedError {
     case noDownloadURL
-    case downloadFailed(String)
+    case downloadFailed(any Error)
 
     var errorDescription: String? {
         switch self {
         case .noDownloadURL:
             "The restore image does not have a download URL."
-        case .downloadFailed(let message):
-            "Failed to download restore image: \(message)"
+        case .downloadFailed(let underlyingError):
+            "Failed to download restore image: \(underlyingError.localizedDescription)"
         }
     }
 }

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -34,18 +34,36 @@ struct IPSWService: Sendable {
             // No existing file to clean up — expected on first download.
         }
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-            let delegate = IPSWDownloadDelegate(
-                destinationURL: destinationURL,
-                progressHandler: progressHandler,
-                continuation: continuation
-            )
-            let session = URLSession(
-                configuration: .default,
-                delegate: delegate,
-                delegateQueue: nil
-            )
-            session.downloadTask(with: remoteURL).resume()
+        // nonisolated(unsafe) is needed because URLSessionDownloadTask is not Sendable,
+        // but URLSessionTask.cancel() is documented as thread-safe. The onCancel closure
+        // runs on an arbitrary thread; this is the only safe operation we perform on it.
+        nonisolated(unsafe) var downloadTask: URLSessionDownloadTask?
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                let delegate = IPSWDownloadDelegate(
+                    destinationURL: destinationURL,
+                    progressHandler: progressHandler,
+                    continuation: continuation
+                )
+                let session = URLSession(
+                    configuration: .default,
+                    delegate: delegate,
+                    delegateQueue: nil
+                )
+                let task = session.downloadTask(with: remoteURL)
+                downloadTask = task
+
+                // Close the race where the Task was cancelled before downloadTask
+                // was assigned — onCancel would have seen nil and done nothing.
+                guard !Task.isCancelled else {
+                    task.cancel()
+                    return
+                }
+                task.resume()
+            }
+        } onCancel: {
+            downloadTask?.cancel()
         }
 
         Self.logger.info("Restore image downloaded to \(destinationURL.lastPathComponent, privacy: .public)")
@@ -138,13 +156,23 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
         session.finishTasksAndInvalidate()
 
         if let error = error ?? moveError {
-            Self.logger.error("Restore image download failed: \(error.localizedDescription, privacy: .public)")
             do {
                 try FileManager.default.removeItem(at: destinationURL)
             } catch {
                 Self.logger.warning("Failed to clean up partial download at '\(self.destinationURL.path(percentEncoded: false), privacy: .public)': \(error.localizedDescription, privacy: .public)")
             }
-            continuation.resume(throwing: IPSWError.downloadFailed(error.localizedDescription))
+
+            // Propagate cancellation as CancellationError so callers can distinguish
+            // user-initiated cancellation from genuine download failures.
+            if let nsError = error as NSError?,
+               nsError.domain == NSURLErrorDomain,
+               nsError.code == NSURLErrorCancelled {
+                Self.logger.info("Restore image download cancelled")
+                continuation.resume(throwing: CancellationError())
+            } else {
+                Self.logger.error("Restore image download failed: \(error.localizedDescription, privacy: .public)")
+                continuation.resume(throwing: IPSWError.downloadFailed(error.localizedDescription))
+            }
         } else {
             let handler = self.progressHandler
             let received = task.countOfBytesReceived

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -56,8 +56,10 @@ struct IPSWService: Sendable {
 
                 // Close the race where the Task was cancelled before downloadTask
                 // was assigned — onCancel would have seen nil and done nothing.
+                // Resume the continuation directly because a never-started task
+                // won't fire didCompleteWithError.
                 guard !Task.isCancelled else {
-                    task.cancel()
+                    continuation.resume(throwing: CancellationError())
                     return
                 }
                 task.resume()

--- a/Kernova/Services/USBDeviceService.swift
+++ b/Kernova/Services/USBDeviceService.swift
@@ -60,7 +60,6 @@ final class USBDeviceService: USBDeviceProviding {
         }
 
         let info = USBDeviceInfo(id: usbConfig.uuid, path: diskImagePath, readOnly: readOnly)
-        instance.attachedUSBDevices.append(info)
 
         Self.logger.notice("Attached USB device '\(resolved.url.lastPathComponent, privacy: .public)' to VM '\(instance.name, privacy: .public)' (readOnly: \(readOnly, privacy: .public))")
         return info
@@ -90,8 +89,6 @@ final class USBDeviceService: USBDeviceProviding {
             Self.logger.error("Failed to detach USB device '\(deviceInfo.displayName, privacy: .public)' from VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             throw error
         }
-
-        instance.attachedUSBDevices.removeAll { $0.id == deviceInfo.id }
 
         Self.logger.notice("Detached USB device '\(deviceInfo.displayName, privacy: .public)' from VM '\(instance.name, privacy: .public)'")
     }

--- a/Kernova/Services/USBDeviceService.swift
+++ b/Kernova/Services/USBDeviceService.swift
@@ -22,30 +22,31 @@ final class USBDeviceService: USBDeviceProviding {
             throw USBDeviceError.noUSBController
         }
 
-        let url = URL(fileURLWithPath: diskImagePath).resolvingSymlinksInPath()
-        let resolvedPath = url.path(percentEncoded: false)
-
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: resolvedPath, isDirectory: &isDirectory) else {
-            Self.logger.error("USB disk image not found at '\(diskImagePath, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
-            throw USBDeviceError.diskImageNotFound(diskImagePath)
-        }
-        guard !isDirectory.boolValue else {
-            Self.logger.error("USB disk image path is a directory: '\(diskImagePath, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
-            throw USBDeviceError.diskImageIsDirectory(diskImagePath)
-        }
-        if !readOnly {
-            guard FileManager.default.isWritableFile(atPath: resolvedPath) else {
-                Self.logger.error("USB disk image is not writable: '\(diskImagePath, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)')")
+        let resolved: PathValidation.ResolvedPath
+        do {
+            resolved = try PathValidation.resolveFile(at: diskImagePath, requireWritable: !readOnly)
+            resolved.logResolution(logger: Self.logger, context: "USB disk image")
+        } catch let error as PathValidation.Failure {
+            switch error {
+            case .notFound:
+                Self.logger.error("USB disk image not found at '\(diskImagePath, privacy: .public)'")
+                throw USBDeviceError.diskImageNotFound(diskImagePath)
+            case .unexpectedType:
+                Self.logger.error("USB disk image path is a directory: '\(diskImagePath, privacy: .public)'")
+                throw USBDeviceError.diskImageIsDirectory(diskImagePath)
+            case .notWritable:
+                Self.logger.error("USB disk image is not writable: '\(diskImagePath, privacy: .public)'")
                 throw USBDeviceError.diskImageNotWritable(diskImagePath)
+            case .notReadable:
+                throw USBDeviceError.diskImageNotFound(diskImagePath)
             }
         }
 
         let attachment: VZDiskImageStorageDeviceAttachment
         do {
-            attachment = try VZDiskImageStorageDeviceAttachment(url: url, readOnly: readOnly)
+            attachment = try VZDiskImageStorageDeviceAttachment(url: resolved.url, readOnly: readOnly)
         } catch {
-            Self.logger.error("Failed to create disk attachment for '\(diskImagePath, privacy: .public)' (resolved: '\(resolvedPath, privacy: .public)'): \(error.localizedDescription, privacy: .public)")
+            Self.logger.error("Failed to create disk attachment for '\(diskImagePath, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             throw error
         }
         let usbConfig = VZUSBMassStorageDeviceConfiguration(attachment: attachment)
@@ -54,14 +55,14 @@ final class USBDeviceService: USBDeviceProviding {
         do {
             try await controller.attach(device: usbDevice)
         } catch {
-            Self.logger.error("Failed to attach USB device '\(url.lastPathComponent, privacy: .public)' to VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
+            Self.logger.error("Failed to attach USB device '\(resolved.url.lastPathComponent, privacy: .public)' to VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             throw error
         }
 
         let info = USBDeviceInfo(id: usbConfig.uuid, path: diskImagePath, readOnly: readOnly)
         instance.attachedUSBDevices.append(info)
 
-        Self.logger.notice("Attached USB device '\(url.lastPathComponent, privacy: .public)' to VM '\(instance.name, privacy: .public)' (readOnly: \(readOnly, privacy: .public))")
+        Self.logger.notice("Attached USB device '\(resolved.url.lastPathComponent, privacy: .public)' to VM '\(instance.name, privacy: .public)' (readOnly: \(readOnly, privacy: .public))")
         return info
     }
 

--- a/Kernova/Services/USBDeviceService.swift
+++ b/Kernova/Services/USBDeviceService.swift
@@ -38,6 +38,8 @@ final class USBDeviceService: USBDeviceProviding {
                 Self.logger.error("USB disk image is not writable: '\(diskImagePath, privacy: .public)'")
                 throw USBDeviceError.diskImageNotWritable(diskImagePath)
             case .notReadable:
+                Self.logger.fault("Unexpected .notReadable from resolveFile for '\(diskImagePath, privacy: .public)'")
+                assertionFailure("resolveFile should never throw .notReadable")
                 throw USBDeviceError.diskImageNotFound(diskImagePath)
             }
         }

--- a/Kernova/Utilities/NSOpenPanelExtensions.swift
+++ b/Kernova/Utilities/NSOpenPanelExtensions.swift
@@ -1,0 +1,25 @@
+import AppKit
+import UniformTypeIdentifiers
+
+extension NSOpenPanel {
+
+    /// Presents a pre-configured disk image browser and returns the selected URLs.
+    ///
+    /// Returns an empty array if the user cancels.
+    @MainActor
+    static func browseDiskImages(
+        message: String,
+        allowsMultipleSelection: Bool = false
+    ) -> [URL] {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = allowsMultipleSelection
+        panel.allowedContentTypes = UTType.diskImageTypes
+        panel.message = message
+        panel.prompt = "Attach"
+
+        guard panel.runModal() == .OK else { return [] }
+        return panel.urls
+    }
+}

--- a/Kernova/Utilities/PathValidation.swift
+++ b/Kernova/Utilities/PathValidation.swift
@@ -32,12 +32,13 @@ enum PathValidation {
 
     /// Resolves symlinks and validates that a regular file exists at the given path.
     ///
-    // RATIONALE: No `requireReadable` parameter for files. `FileManager.isReadableFile`
-    // reflects POSIX permission bits, which are unreliable for regular files on macOS
-    // (sandboxing, SIP, and TCC can independently grant/deny access). The authoritative
-    // readability check happens when Virtualization.framework opens the file. Callers
-    // must still handle `.notReadable` in their switch for exhaustiveness, but this
-    // method never throws it.
+    // RATIONALE: No `requireReadable` parameter for files. A pre-flight readability
+    // check adds little value since the authoritative test occurs when
+    // Virtualization.framework opens the file, and a TOCTOU race could invalidate
+    // any earlier check. The writable check is retained because "not writable" is a
+    // common, actionable user misconfiguration worth surfacing early. Callers must
+    // still handle `.notReadable` in their switch for exhaustiveness, but this method
+    // never throws it.
     static func resolveFile(at path: String, requireWritable: Bool = false) throws(Failure) -> ResolvedPath {
         let resolved = resolve(path)
         let fm = FileManager.default

--- a/Kernova/Utilities/PathValidation.swift
+++ b/Kernova/Utilities/PathValidation.swift
@@ -1,0 +1,97 @@
+import Foundation
+import os
+
+/// Shared path validation for user-supplied file and directory paths.
+///
+/// Consolidates the resolve-symlinks → check-exists → check-type → check-permissions
+/// pattern used by `ConfigurationBuilder` and `USBDeviceService`.
+enum PathValidation {
+
+    /// The result of resolving a path through symlinks.
+    struct ResolvedPath: Sendable {
+        let url: URL
+        let resolvedPath: String
+        let originalPath: String
+
+        var wasSymlink: Bool { resolvedPath != originalPath }
+
+        /// Logs an info message when the path was a symlink, using the given context label.
+        func logResolution(logger: Logger, context: String) {
+            guard wasSymlink else { return }
+            logger.info("\(context, privacy: .public) path '\(originalPath, privacy: .public)' resolved to '\(resolvedPath, privacy: .public)'")
+        }
+    }
+
+    /// Reasons a path validation can fail.
+    enum Failure: Error, Sendable {
+        case notFound
+        case unexpectedType
+        case notReadable
+        case notWritable
+    }
+
+    /// Resolves symlinks and validates that a regular file exists at the given path.
+    ///
+    // RATIONALE: No `requireReadable` parameter for files. `FileManager.isReadableFile`
+    // reflects POSIX permission bits, which are unreliable for regular files on macOS
+    // (sandboxing, SIP, and TCC can independently grant/deny access). The authoritative
+    // readability check happens when Virtualization.framework opens the file. Callers
+    // must still handle `.notReadable` in their switch for exhaustiveness, but this
+    // method never throws it.
+    static func resolveFile(at path: String, requireWritable: Bool = false) throws(Failure) -> ResolvedPath {
+        let resolved = resolve(path)
+        let fm = FileManager.default
+
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: resolved.resolvedPath, isDirectory: &isDirectory) else {
+            throw .notFound
+        }
+        guard !isDirectory.boolValue else {
+            throw .unexpectedType
+        }
+        if requireWritable {
+            guard fm.isWritableFile(atPath: resolved.resolvedPath) else {
+                throw .notWritable
+            }
+        }
+        return resolved
+    }
+
+    /// Resolves symlinks and validates that a directory exists at the given path.
+    static func resolveDirectory(
+        at path: String,
+        requireReadable: Bool = false,
+        requireWritable: Bool = false
+    ) throws(Failure) -> ResolvedPath {
+        let resolved = resolve(path)
+        let fm = FileManager.default
+
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: resolved.resolvedPath, isDirectory: &isDirectory) else {
+            throw .notFound
+        }
+        guard isDirectory.boolValue else {
+            throw .unexpectedType
+        }
+        if requireReadable {
+            guard fm.isReadableFile(atPath: resolved.resolvedPath) else {
+                throw .notReadable
+            }
+        }
+        if requireWritable {
+            guard fm.isWritableFile(atPath: resolved.resolvedPath) else {
+                throw .notWritable
+            }
+        }
+        return resolved
+    }
+
+    private static func resolve(_ path: String) -> ResolvedPath {
+        let url = URL(fileURLWithPath: path).resolvingSymlinksInPath()
+        return ResolvedPath(
+            url: url,
+            resolvedPath: url.path(percentEncoded: false),
+            originalPath: path
+        )
+    }
+}

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -227,11 +227,14 @@ final class VMLifecycleCoordinator {
     /// Does not use the lifecycle operation token — USB operations are short
     /// and independent of start/stop/save lifecycle transitions.
     func attachUSBDevice(diskImagePath: String, readOnly: Bool, to instance: VMInstance) async throws -> USBDeviceInfo {
-        try await usbDeviceService.attach(diskImagePath: diskImagePath, readOnly: readOnly, to: instance)
+        let info = try await usbDeviceService.attach(diskImagePath: diskImagePath, readOnly: readOnly, to: instance)
+        instance.attachedUSBDevices.append(info)
+        return info
     }
 
     /// Detaches a USB mass storage device from a running VM.
     func detachUSBDevice(_ deviceInfo: USBDeviceInfo, from instance: VMInstance) async throws {
         try await usbDeviceService.detach(deviceInfo: deviceInfo, from: instance)
+        instance.attachedUSBDevices.removeAll { $0.id == deviceInfo.id }
     }
 }

--- a/Kernova/Views/Console/RemovableMediaPopoverView.swift
+++ b/Kernova/Views/Console/RemovableMediaPopoverView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UniformTypeIdentifiers
 
 /// Popover content for managing runtime USB mass storage devices on a running VM.
 /// Shown from the "Removable Media" toolbar button.
@@ -59,15 +58,9 @@ struct RemovableMediaPopoverView: View {
     }
 
     private func browseAndAttach() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = false
-        panel.canChooseFiles = true
-        panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = UTType.diskImageTypes
-        panel.message = "Select a disk image to attach as removable media"
-        panel.prompt = "Attach"
-
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard let url = NSOpenPanel.browseDiskImages(
+            message: "Select a disk image to attach as removable media"
+        ).first else { return }
         viewModel.attachUSBDevice(
             diskImagePath: url.path(percentEncoded: false),
             readOnly: true,

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -1,6 +1,5 @@
 import AVFoundation
 import SwiftUI
-import UniformTypeIdentifiers
 
 /// Settings form for editing a stopped VM's configuration.
 struct VMSettingsView: View {
@@ -152,15 +151,9 @@ struct VMSettingsView: View {
     }
 
     private func browseRemovableMedia() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = false
-        panel.canChooseFiles = true
-        panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = UTType.diskImageTypes
-        panel.message = "Select a disk image to attach to the VM"
-        panel.prompt = "Attach"
-
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard let url = NSOpenPanel.browseDiskImages(
+            message: "Select a disk image to attach to the VM"
+        ).first else { return }
         instance.configuration.discImagePath = url.path(percentEncoded: false)
     }
 
@@ -246,20 +239,16 @@ struct VMSettingsView: View {
     }
 
     private func addExternalDisk() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = false
-        panel.canChooseFiles = true
-        panel.allowsMultipleSelection = true
-        panel.allowedContentTypes = UTType.diskImageTypes
-        panel.message = "Select disk images to attach to the VM"
-        panel.prompt = "Attach"
-
-        guard panel.runModal() == .OK else { return }
+        let urls = NSOpenPanel.browseDiskImages(
+            message: "Select disk images to attach to the VM",
+            allowsMultipleSelection: true
+        )
+        guard !urls.isEmpty else { return }
 
         var current = storageDiskBinding.wrappedValue
         let existingPaths = Set(current.map(\.path))
 
-        for url in panel.urls {
+        for url in urls {
             let path = url.path(percentEncoded: false)
             guard !existingPaths.contains(path) else { continue }
             current.append(AdditionalDisk(path: path))

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -743,14 +743,14 @@ struct ConfigurationBuilderTests {
         config.clipboardSharingEnabled = true
 
         let builder = ConfigurationBuilder()
-        // VZ validation may throw in the test runner (no virtualization entitlement).
-        // We're testing that clipboard pipes are populated — the VZ error is expected.
         do {
             let result = try builder.build(from: config, bundleURL: bundleURL)
             #expect(result.clipboardInputPipe != nil)
             #expect(result.clipboardOutputPipe != nil)
         } catch {
-            // VZ framework errors are expected in the test environment
+            withKnownIssue("VZ validation unavailable — assertions skipped") {
+                Issue.record("\(error)")
+            }
         }
     }
 
@@ -768,7 +768,9 @@ struct ConfigurationBuilderTests {
             #expect(result.clipboardInputPipe == nil)
             #expect(result.clipboardOutputPipe == nil)
         } catch {
-            // VZ framework errors are expected in the test environment
+            withKnownIssue("VZ validation unavailable — assertions skipped") {
+                Issue.record("\(error)")
+            }
         }
     }
 
@@ -791,7 +793,9 @@ struct ConfigurationBuilderTests {
             #expect(hasInput)
             #expect(hasOutput)
         } catch {
-            // VZ framework errors are expected in the test environment
+            withKnownIssue("VZ validation unavailable — assertions skipped") {
+                Issue.record("\(error)")
+            }
         }
     }
 
@@ -812,7 +816,9 @@ struct ConfigurationBuilderTests {
             #expect(!hasInput)
             #expect(hasOutput)
         } catch {
-            // VZ framework errors are expected in the test environment
+            withKnownIssue("VZ validation unavailable — assertions skipped") {
+                Issue.record("\(error)")
+            }
         }
     }
 }

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -748,8 +748,13 @@ struct ConfigurationBuilderTests {
             #expect(result.clipboardInputPipe != nil)
             #expect(result.clipboardOutputPipe != nil)
         } catch {
-            withKnownIssue("VZ validation unavailable — assertions skipped") {
-                Issue.record("\(error)")
+            let isVZError = (error as NSError).domain == "VZErrorDomain"
+            if isVZError {
+                withKnownIssue("VZ validation unavailable — assertions skipped") {
+                    Issue.record("\(error)")
+                }
+            } else {
+                Issue.record("Unexpected non-VZ error: \(error)")
             }
         }
     }
@@ -768,8 +773,13 @@ struct ConfigurationBuilderTests {
             #expect(result.clipboardInputPipe == nil)
             #expect(result.clipboardOutputPipe == nil)
         } catch {
-            withKnownIssue("VZ validation unavailable — assertions skipped") {
-                Issue.record("\(error)")
+            let isVZError = (error as NSError).domain == "VZErrorDomain"
+            if isVZError {
+                withKnownIssue("VZ validation unavailable — assertions skipped") {
+                    Issue.record("\(error)")
+                }
+            } else {
+                Issue.record("Unexpected non-VZ error: \(error)")
             }
         }
     }
@@ -793,8 +803,13 @@ struct ConfigurationBuilderTests {
             #expect(hasInput)
             #expect(hasOutput)
         } catch {
-            withKnownIssue("VZ validation unavailable — assertions skipped") {
-                Issue.record("\(error)")
+            let isVZError = (error as NSError).domain == "VZErrorDomain"
+            if isVZError {
+                withKnownIssue("VZ validation unavailable — assertions skipped") {
+                    Issue.record("\(error)")
+                }
+            } else {
+                Issue.record("Unexpected non-VZ error: \(error)")
             }
         }
     }
@@ -816,8 +831,13 @@ struct ConfigurationBuilderTests {
             #expect(!hasInput)
             #expect(hasOutput)
         } catch {
-            withKnownIssue("VZ validation unavailable — assertions skipped") {
-                Issue.record("\(error)")
+            let isVZError = (error as NSError).domain == "VZErrorDomain"
+            if isVZError {
+                withKnownIssue("VZ validation unavailable — assertions skipped") {
+                    Issue.record("\(error)")
+                }
+            } else {
+                Issue.record("Unexpected non-VZ error: \(error)")
             }
         }
     }

--- a/KernovaTests/Mocks/MockUSBDeviceService.swift
+++ b/KernovaTests/Mocks/MockUSBDeviceService.swift
@@ -19,9 +19,7 @@ final class MockUSBDeviceService: USBDeviceProviding {
         lastAttachedPath = diskImagePath
         lastAttachedReadOnly = readOnly
         if let error = attachError { throw error }
-        let info = USBDeviceInfo(path: diskImagePath, readOnly: readOnly)
-        instance.attachedUSBDevices.append(info)
-        return info
+        return USBDeviceInfo(path: diskImagePath, readOnly: readOnly)
     }
 
     func detach(
@@ -30,6 +28,5 @@ final class MockUSBDeviceService: USBDeviceProviding {
     ) async throws {
         detachCallCount += 1
         if let error = detachError { throw error }
-        instance.attachedUSBDevices.removeAll { $0.id == deviceInfo.id }
     }
 }

--- a/KernovaTests/PathValidationTests.swift
+++ b/KernovaTests/PathValidationTests.swift
@@ -1,0 +1,150 @@
+import Testing
+import Foundation
+@testable import Kernova
+
+@Suite("PathValidation Tests")
+struct PathValidationTests {
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: - resolveFile
+
+    @Test("resolveFile succeeds for an existing regular file")
+    func resolveFileSuccess() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let filePath = dir.appendingPathComponent("test.img").path(percentEncoded: false)
+        FileManager.default.createFile(atPath: filePath, contents: Data([0]))
+
+        let resolved = try PathValidation.resolveFile(at: filePath)
+        #expect(resolved.resolvedPath == filePath)
+        #expect(resolved.wasSymlink == false)
+    }
+
+    @Test("resolveFile throws notFound for nonexistent path")
+    func resolveFileNotFound() throws {
+        #expect {
+            try PathValidation.resolveFile(at: "/nonexistent/path/file.img")
+        } throws: { error in
+            guard let failure = error as? PathValidation.Failure,
+                  case .notFound = failure else { return false }
+            return true
+        }
+    }
+
+    @Test("resolveFile throws unexpectedType for a directory")
+    func resolveFileDirectory() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        #expect {
+            try PathValidation.resolveFile(at: dir.path(percentEncoded: false))
+        } throws: { error in
+            guard let failure = error as? PathValidation.Failure,
+                  case .unexpectedType = failure else { return false }
+            return true
+        }
+    }
+
+    @Test("resolveFile follows symlink to real file")
+    func resolveFileFollowsSymlink() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let realPath = dir.appendingPathComponent("real.img").path(percentEncoded: false)
+        FileManager.default.createFile(atPath: realPath, contents: Data([0]))
+
+        let linkPath = dir.appendingPathComponent("link.img").path(percentEncoded: false)
+        try FileManager.default.createSymbolicLink(atPath: linkPath, withDestinationPath: realPath)
+
+        let resolved = try PathValidation.resolveFile(at: linkPath)
+        #expect(resolved.wasSymlink == true)
+        #expect(resolved.originalPath == linkPath)
+        #expect(resolved.url.lastPathComponent == "real.img")
+    }
+
+    @Test("resolveFile throws notFound for dangling symlink")
+    func resolveFileDanglingSymlink() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let linkPath = dir.appendingPathComponent("dangling.img").path(percentEncoded: false)
+        try FileManager.default.createSymbolicLink(atPath: linkPath, withDestinationPath: "/nonexistent/target")
+
+        #expect {
+            try PathValidation.resolveFile(at: linkPath)
+        } throws: { error in
+            guard let failure = error as? PathValidation.Failure,
+                  case .notFound = failure else { return false }
+            return true
+        }
+    }
+
+    // MARK: - resolveDirectory
+
+    @Test("resolveDirectory succeeds for an existing directory")
+    func resolveDirectorySuccess() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let resolved = try PathValidation.resolveDirectory(at: dir.path(percentEncoded: false))
+        #expect(resolved.wasSymlink == false)
+    }
+
+    @Test("resolveDirectory throws unexpectedType for a regular file")
+    func resolveDirectoryFile() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let filePath = dir.appendingPathComponent("file.txt").path(percentEncoded: false)
+        FileManager.default.createFile(atPath: filePath, contents: Data([0]))
+
+        #expect {
+            try PathValidation.resolveDirectory(at: filePath)
+        } throws: { error in
+            guard let failure = error as? PathValidation.Failure,
+                  case .unexpectedType = failure else { return false }
+            return true
+        }
+    }
+
+    @Test("resolveDirectory throws notFound for nonexistent path")
+    func resolveDirectoryNotFound() throws {
+        #expect {
+            try PathValidation.resolveDirectory(at: "/nonexistent/directory")
+        } throws: { error in
+            guard let failure = error as? PathValidation.Failure,
+                  case .notFound = failure else { return false }
+            return true
+        }
+    }
+
+    // MARK: - ResolvedPath
+
+    @Test("ResolvedPath wasSymlink is false when paths match")
+    func resolvedPathNotSymlink() {
+        let path = "/tmp/test"
+        let resolved = PathValidation.ResolvedPath(
+            url: URL(fileURLWithPath: path),
+            resolvedPath: path,
+            originalPath: path
+        )
+        #expect(resolved.wasSymlink == false)
+    }
+
+    @Test("ResolvedPath wasSymlink is true when paths differ")
+    func resolvedPathIsSymlink() {
+        let resolved = PathValidation.ResolvedPath(
+            url: URL(fileURLWithPath: "/real/path"),
+            resolvedPath: "/real/path",
+            originalPath: "/link/path"
+        )
+        #expect(resolved.wasSymlink == true)
+    }
+}

--- a/KernovaTests/SpiceAgentProtocolTests.swift
+++ b/KernovaTests/SpiceAgentProtocolTests.swift
@@ -321,6 +321,95 @@ struct SpiceAgentProtocolTests {
         }
     }
 
+    // MARK: - Buffer Overflow and Corruption Guards
+
+    /// Must match SpiceAgentParser.maxBufferSize / maxChunkDataSize (both 1 MB).
+    private static let parserSizeLimit = 1_048_576
+
+    @Test("Parser resets buffer when it exceeds maxBufferSize")
+    func bufferOverflowTriggersReset() {
+        var parser = SpiceAgentParser()
+        let oversized = Data(repeating: 0xFF, count: Self.parserSizeLimit + 1)
+        let results = parser.feed(oversized)
+
+        #expect(results.isEmpty)
+        #expect(parser.didReset == true)
+    }
+
+    @Test("Parser accepts chunk header with dataSize at exactly maxChunkDataSize")
+    func chunkDataSizeAtExactLimitDoesNotReset() {
+        var parser = SpiceAgentParser()
+
+        let header = VDIChunkHeader(port: SpiceConstants.serverPort, dataSize: UInt32(Self.parserSizeLimit))
+        // Don't supply the full payload — parser will wait for more data, not reset
+        let results = parser.feed(header.serialize())
+
+        #expect(results.isEmpty)
+        #expect(parser.didReset == false)
+    }
+
+    @Test("Parser resets buffer when chunk header claims unreasonable dataSize")
+    func corruptChunkHeaderTriggersReset() {
+        var parser = SpiceAgentParser()
+
+        let corruptHeader = VDIChunkHeader(port: SpiceConstants.serverPort, dataSize: UInt32(Self.parserSizeLimit + 1))
+        var data = corruptHeader.serialize()
+        // Extra bytes so the parser can read the full chunk header
+        data.append(Data(repeating: 0, count: 8))
+
+        let results = parser.feed(data)
+
+        #expect(results.isEmpty)
+        #expect(parser.didReset == true)
+    }
+
+    @Test("Parser recovers and parses correctly after a reset")
+    func parserRecoveryAfterReset() {
+        var parser = SpiceAgentParser()
+
+        // Trigger a reset via buffer overflow
+        _ = parser.feed(Data(repeating: 0xFF, count: Self.parserSizeLimit + 1))
+        #expect(parser.didReset == true)
+
+        // Parser should recover on next valid feed
+        var payload = Data()
+        payload.appendLittleEndian(SpiceClipboardType.utf8Text.rawValue)
+        let validMessage = buildGuestMessage(type: .clipboardGrab, payload: payload)
+        let results = parser.feed(validMessage)
+
+        #expect(parser.didReset == false)
+        #expect(results.count == 1)
+        if case .clipboardGrab(let types) = results[0] {
+            #expect(types == [.utf8Text])
+        } else {
+            Issue.record("Expected clipboardGrab message after recovery")
+        }
+    }
+
+    @Test("Parser returns malformedChunk for invalid payloads",
+          arguments: [
+              Data(repeating: 0, count: 4),  // truncated: needs 20 bytes, only 4
+              Data(),                          // empty payload
+          ])
+    func malformedPayloadReturnsMalformed(payload: Data) {
+        var parser = SpiceAgentParser()
+
+        let chunk = VDIChunkHeader(
+            port: SpiceConstants.serverPort,
+            dataSize: UInt32(payload.count)
+        )
+        let message = chunk.serialize() + payload
+
+        let results = parser.feed(message)
+
+        #expect(results.count == 1)
+        if case .malformedChunk = results[0] {
+            // pass
+        } else {
+            Issue.record("Expected malformedChunk")
+        }
+    }
+
     // MARK: - Data Extension Helpers
 
     @Test("Little-endian UInt32 read/write round-trips")

--- a/KernovaTests/USBDeviceServiceTests.swift
+++ b/KernovaTests/USBDeviceServiceTests.swift
@@ -27,37 +27,33 @@ struct USBDeviceServiceTests {
 
     // MARK: - Mock Service Tests
 
-    @Test("Attach adds device to instance tracking")
-    func attachAddsToTracking() async throws {
+    @Test("Mock service records attach call parameters")
+    func mockServiceRecordsAttach() async throws {
         let service = MockUSBDeviceService()
         let instance = makeInstance()
 
         let info = try await service.attach(diskImagePath: "/tmp/test.dmg", readOnly: false, to: instance)
 
-        #expect(instance.attachedUSBDevices.count == 1)
-        #expect(instance.attachedUSBDevices[0].id == info.id)
-        #expect(instance.attachedUSBDevices[0].path == "/tmp/test.dmg")
-        #expect(instance.attachedUSBDevices[0].readOnly == false)
+        #expect(info.path == "/tmp/test.dmg")
+        #expect(info.readOnly == false)
         #expect(service.attachCallCount == 1)
         #expect(service.lastAttachedPath == "/tmp/test.dmg")
         #expect(service.lastAttachedReadOnly == false)
+        #expect(instance.attachedUSBDevices.isEmpty)
     }
 
-    @Test("Detach removes device from instance tracking")
-    func detachRemovesFromTracking() async throws {
+    @Test("Mock service records detach call")
+    func mockServiceRecordsDetach() async throws {
         let service = MockUSBDeviceService()
         let instance = makeInstance()
 
         let info = try await service.attach(diskImagePath: "/tmp/test.dmg", readOnly: false, to: instance)
-        #expect(instance.attachedUSBDevices.count == 1)
-
         try await service.detach(deviceInfo: info, from: instance)
 
-        #expect(instance.attachedUSBDevices.isEmpty)
         #expect(service.detachCallCount == 1)
     }
 
-    @Test("Attach propagates errors")
+    @Test("Attach propagates errors without modifying tracking")
     func attachPropagatesErrors() async {
         let service = MockUSBDeviceService()
         service.attachError = USBDeviceError.noVirtualMachine
@@ -79,7 +75,7 @@ struct USBDeviceServiceTests {
         let service = MockUSBDeviceService()
         let instance = makeInstance()
 
-        let info = try await service.attach(diskImagePath: "/tmp/test.dmg", readOnly: false, to: instance)
+        let info = USBDeviceInfo(path: "/tmp/test.dmg", readOnly: false)
         service.detachError = USBDeviceError.deviceNotFound
 
         await #expect {
@@ -89,20 +85,16 @@ struct USBDeviceServiceTests {
                   case .deviceNotFound = e else { return false }
             return true
         }
-
-        // Device should still be tracked since detach failed
-        #expect(instance.attachedUSBDevices.count == 1)
     }
 
     // MARK: - VMInstance State Tests
 
     @Test("tearDownSession clears attachedUSBDevices")
-    func tearDownClearsUSBDevices() async throws {
-        let service = MockUSBDeviceService()
+    func tearDownClearsUSBDevices() {
         let instance = makeInstance()
 
-        _ = try await service.attach(diskImagePath: "/tmp/a.dmg", readOnly: false, to: instance)
-        _ = try await service.attach(diskImagePath: "/tmp/b.dmg", readOnly: true, to: instance)
+        instance.attachedUSBDevices.append(USBDeviceInfo(path: "/tmp/a.dmg", readOnly: false))
+        instance.attachedUSBDevices.append(USBDeviceInfo(path: "/tmp/b.dmg", readOnly: true))
         #expect(instance.attachedUSBDevices.count == 2)
 
         instance.tearDownSession()
@@ -115,26 +107,11 @@ struct USBDeviceServiceTests {
         let instance = makeInstance(status: .running)
         // Without a real VZVirtualMachine, this is false
         #expect(instance.canAttachUSBDevices == false)
-
-        // When running + VM present, it would be true, but we can't mock VZVirtualMachine
     }
 
     @Test("canAttachUSBDevices is false when stopped")
     func cannotAttachWhenStopped() {
         let instance = makeInstance(status: .stopped)
         #expect(instance.canAttachUSBDevices == false)
-    }
-
-    @Test("Multiple attach calls accumulate devices")
-    func multipleAttaches() async throws {
-        let service = MockUSBDeviceService()
-        let instance = makeInstance()
-
-        _ = try await service.attach(diskImagePath: "/tmp/a.dmg", readOnly: false, to: instance)
-        _ = try await service.attach(diskImagePath: "/tmp/b.iso", readOnly: true, to: instance)
-        _ = try await service.attach(diskImagePath: "/tmp/c.img", readOnly: false, to: instance)
-
-        #expect(instance.attachedUSBDevices.count == 3)
-        #expect(service.attachCallCount == 3)
     }
 }

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -402,7 +402,7 @@ struct VMLifecycleCoordinatorTests {
     @Test("installMacOS sets status to error on service failure")
     func installMacOSError() async {
         let (coordinator, _, installService, _, _) = makeCoordinator()
-        installService.installError = IPSWError.downloadFailed("test failure")
+        installService.installError = IPSWError.downloadFailed(URLError(.badServerResponse))
         let instance = makeInstance()
         let wizard = VMCreationViewModel()
         wizard.selectedOS = .macOS

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -443,6 +443,8 @@ struct VMLifecycleCoordinatorTests {
         #expect(usbService.lastAttachedReadOnly == true)
         #expect(info.path == "/tmp/test.dmg")
         #expect(info.readOnly == true)
+        #expect(instance.attachedUSBDevices.count == 1)
+        #expect(instance.attachedUSBDevices[0].id == info.id)
     }
 
     @Test("detachUSBDevice forwards to USB device service")


### PR DESCRIPTION
## Summary
- Work through all 9 open `review-debt/*` issues, addressing each with code changes, investigation-only conclusions, or already-resolved determinations
- Fix critical continuation leak and other findings surfaced during PR self-review
- Net result: +594 / -224 lines across 14 files, with 16 new unit tests

## Issues Addressed

| Issue | Label | Outcome |
|-------|-------|---------|
| #62 — Parser buffer overflow/corruption tests | `test-gap` | Added 6 tests for `SpiceAgentParser` safety guards (overflow, corruption, recovery, malformed chunks) |
| #64 — Consolidate path validation logic | `refactor` | Extracted `PathValidation` utility with `resolveFile`/`resolveDirectory`, replacing ~70 lines of duplicated validation across `ConfigurationBuilder` and `USBDeviceService` |
| #65 — Decouple USBDeviceService from VMInstance | `refactor` | Moved `attachedUSBDevices` tracking from service to `VMLifecycleCoordinator`; mock simplified to pure spy |
| #69 — Move USB management to toolbar | `refactor` | Already resolved — USB management was implemented as toolbar item from the start |
| #73 — Add IPSW download cancellation | `refactor` | Added `withTaskCancellationHandler` with `nonisolated(unsafe)` bridge; fixed `NSURLErrorCancelled` being wrapped in `IPSWError.downloadFailed` (was a bug making the coordinator's catch clause dead code) |
| #74 — Preserve original error type in IPSWError | `refactor` | Changed `downloadFailed(String)` to `downloadFailed(any Error)` |
| #76 — Simplify keep-alive logic | `refactor` | Investigation confirmed logic is already minimal — each condition handles a real edge case |
| #78 — ConfigurationBuilder tests silently pass | `test-gap` | Replaced silent catch-all handlers with `withKnownIssue`, narrowed to VZ errors only |
| #81 — Extract NSOpenPanel helper | `refactor` | Extracted `NSOpenPanel.browseDiskImages(message:allowsMultipleSelection:)`, 3 call sites reduced to one-liners |

## PR Self-Review Fixes

A 5-agent parallel review (code, errors, tests, types, comments) surfaced additional findings that were fixed in the final commit:

- **Critical**: Continuation leak when `Task` is cancelled before `downloadTask` is assigned — a never-resumed `URLSessionDownloadTask` won't fire `didCompleteWithError`, hanging the async function forever. Fixed by resuming with `CancellationError()` directly.
- **Important**: `.notReadable` fallback in file resolution lacked logging/`assertionFailure` — added per CLAUDE.md defensive unwrapping guidelines
- **Important**: `withKnownIssue` catch blocks suppressed all errors, not just VZ validation — narrowed to check `VZErrorDomain` first
- **Important**: Missing direct unit tests for `PathValidation` — added 10 tests
- **Important**: RATIONALE comment overstated `isReadableFile` unreliability — rewritten

## Changes

### New Files
- `Kernova/Utilities/PathValidation.swift` — shared resolve-symlinks → validate path utility
- `Kernova/Utilities/NSOpenPanelExtensions.swift` — disk image browsing helper
- `KernovaTests/PathValidationTests.swift` — 10 direct unit tests

### Modified Production Code
- `ConfigurationBuilder.swift` — refactored 6 validation sites to use `PathValidation`
- `IPSWService.swift` — cancellation support, error type preservation, `CancellationError` propagation
- `USBDeviceService.swift` — uses `PathValidation`, no longer mutates `attachedUSBDevices`
- `VMLifecycleCoordinator.swift` — now owns USB device tracking (append/removeAll)
- `RemovableMediaPopoverView.swift` — uses `NSOpenPanel.browseDiskImages`
- `VMSettingsView.swift` — uses `NSOpenPanel.browseDiskImages`

### Modified Test Code
- `SpiceAgentProtocolTests.swift` — 6 new parser safety guard tests
- `ConfigurationBuilderTests.swift` — `withKnownIssue` for VZ-unavailable environments
- `USBDeviceServiceTests.swift` — restructured for service-as-spy pattern
- `MockUSBDeviceService.swift` — simplified to pure spy
- `VMLifecycleCoordinatorTests.swift` — added tracking assertion, updated error construction

## Test plan
- [x] Built successfully on macOS 26
- [x] Full test suite passes (16 new tests across 3 test files)
- [ ] Manual: verify USB attach/detach in running VM
- [ ] Manual: start macOS install, cancel during download — should clean up silently
- [ ] Manual: verify NSOpenPanel disk image browsing in settings and removable media popover


🤖 Generated with [Claude Code](https://claude.com/claude-code)