### PR TITLE
fix: Deduplicate repeated error dialogs for corrupted VM bundles

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -47,6 +47,13 @@ final class VMLibraryViewModel {
     /// Current VM ordering used by sortInstances(); synchronized with UserDefaults via persistOrder().
     private var customOrder: [UUID] = []
 
+    /// Bundle names whose load failures have already been reported to the user.
+    /// Prevents repeated error dialogs for persistently corrupted bundles across successive
+    /// `reconcileWithDisk()` calls. Populated by both `loadVMs()` and `reconcileWithDisk()`.
+    /// Reset on full reload (`loadVMs`), when a previously-failed bundle loads successfully,
+    /// or when a bundle is removed from disk.
+    private var reportedFailedBundles: Set<String> = []
+
     /// Called when a VM with a non-inline `displayPreference` is about to start or resume,
     /// allowing the app delegate to pre-create the display window with a spinner.
     @ObservationIgnored var onOpenDisplayWindow: ((VMInstance) -> Void)?
@@ -89,6 +96,7 @@ final class VMLibraryViewModel {
     // MARK: - Load
 
     func loadVMs() {
+        reportedFailedBundles.removeAll()
         do {
             let bundles = try storageService.listVMBundles()
             var failedBundles: [String] = []
@@ -106,6 +114,7 @@ final class VMLibraryViewModel {
                 }
             }
             if !failedBundles.isEmpty {
+                reportedFailedBundles.formUnion(failedBundles)
                 presentError(LoadError.bundleLoadFailed(names: failedBundles))
             }
 
@@ -818,12 +827,14 @@ final class VMLibraryViewModel {
             var diskConfigs: [(VMConfiguration, URL)] = []
             var failedBundles: [String] = []
             for bundleURL in diskBundles {
+                let bundleName = bundleURL.deletingPathExtension().lastPathComponent
                 do {
                     let config = try storageService.loadConfiguration(from: bundleURL)
                     diskConfigs.append((config, bundleURL))
+                    reportedFailedBundles.remove(bundleName)
                 } catch {
                     Self.logger.error("Failed to load config from \(bundleURL.lastPathComponent, privacy: .public) during reconciliation: \(error.localizedDescription, privacy: .public)")
-                    failedBundles.append(bundleURL.deletingPathExtension().lastPathComponent)
+                    failedBundles.append(bundleName)
                 }
             }
             let diskIDs = Set(diskConfigs.map(\.0.id))
@@ -865,9 +876,20 @@ final class VMLibraryViewModel {
                 persistOrder()
             }
 
-            if !failedBundles.isEmpty {
-                presentError(LoadError.bundleLoadFailed(names: failedBundles))
+            let newFailures = failedBundles.filter { !reportedFailedBundles.contains($0) }
+            let suppressedCount = failedBundles.count - newFailures.count
+            if suppressedCount > 0 {
+                Self.logger.debug("reconcileWithDisk: suppressed \(suppressedCount, privacy: .public) already-reported bundle failure(s)")
             }
+            if !newFailures.isEmpty {
+                reportedFailedBundles.formUnion(newFailures)
+                presentError(LoadError.bundleLoadFailed(names: newFailures))
+            }
+
+            // Prune names of bundles no longer on disk so a new bundle with the same name
+            // is not silently suppressed.
+            let currentDiskNames = Set(diskBundles.map { $0.deletingPathExtension().lastPathComponent })
+            reportedFailedBundles.formIntersection(currentDiskNames)
 
             Self.logger.debug("reconcileWithDisk: complete — \(self.instances.count, privacy: .public) VM(s) in library")
         } catch {

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -678,29 +678,33 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.errorMessage == nil)
     }
 
-    @Test("reconcileWithDisk re-presents error after loadVMs resets reported failures")
-    func reconcileReReportsAfterFullReload() {
+    @Test("reconcileWithDisk suppression is maintained after full reload")
+    func reconcileSuppressionMaintainedAfterReload() {
         let storage = MockVMStorageService()
         let badURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("broken-vm.kernova", isDirectory: true)
         storage.bundles[badURL] = VMConfiguration(name: "Bad VM", guestOS: .linux, bootMode: .efi)
         storage.loadConfigurationFailURLs.insert(badURL)
 
+        // loadVMs() in init reports the error and seeds reportedFailedBundles
         let (viewModel, _, _, _) = makeViewModel(storageService: storage)
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage?.contains("broken-vm") == true)
 
-        // First reconciliation reports the error (loadVMs already seeded reportedFailedBundles,
-        // so the first reconcile is actually suppressed — verify that)
+        // First reconcile after init is suppressed
         viewModel.showError = false
         viewModel.errorMessage = nil
         viewModel.reconcileWithDisk()
         #expect(viewModel.showError == false)
 
-        // Full reload resets the tracking, then re-seeds it from its own failures
+        // Full reload resets suppression, then re-seeds from its own failures
         viewModel.loadVMs()
-        viewModel.showError = false
-        viewModel.errorMessage = nil
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage?.contains("broken-vm") == true)
 
         // Reconciliation should still be suppressed since loadVMs re-seeded the set
+        viewModel.showError = false
+        viewModel.errorMessage = nil
         viewModel.reconcileWithDisk()
         #expect(viewModel.showError == false)
     }

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -617,19 +617,22 @@ struct VMLibraryViewModelTests {
             .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
         storage.bundles[goodURL] = config
 
+        // Create viewModel first (no bad bundles yet)
+        let (viewModel, _, _, _) = makeViewModel(storageService: storage)
+
+        // Introduce the bad bundle after init so it's new to reconcileWithDisk
         let badURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("corrupted.kernova", isDirectory: true)
+            .appendingPathComponent("broken-vm.kernova", isDirectory: true)
         storage.bundles[badURL] = VMConfiguration(name: "Bad VM", guestOS: .linux, bootMode: .efi)
         storage.loadConfigurationFailURLs.insert(badURL)
 
-        let (viewModel, _, _, _) = makeViewModel(storageService: storage)
         viewModel.showError = false
         viewModel.errorMessage = nil
 
         viewModel.reconcileWithDisk()
 
         #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage?.contains("corrupted") == true)
+        #expect(viewModel.errorMessage?.contains("broken-vm") == true)
         #expect(viewModel.instances.contains { $0.name == "Good VM" })
     }
 
@@ -647,6 +650,121 @@ struct VMLibraryViewModelTests {
 
         #expect(viewModel.showError == true)
         #expect(viewModel.errorMessage?.contains("VM bundle not found") == true)
+    }
+
+    @Test("reconcileWithDisk does not re-present error for already-reported corrupted bundles")
+    func reconcileDeduplicatesFailedBundleErrors() {
+        let storage = MockVMStorageService()
+        let (viewModel, _, _, _) = makeViewModel(storageService: storage)
+
+        // Introduce the bad bundle after init so it's new to reconcileWithDisk
+        let badURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("broken-vm.kernova", isDirectory: true)
+        storage.bundles[badURL] = VMConfiguration(name: "Bad VM", guestOS: .linux, bootMode: .efi)
+        storage.loadConfigurationFailURLs.insert(badURL)
+
+        // First reconciliation should present the error
+        viewModel.showError = false
+        viewModel.errorMessage = nil
+        viewModel.reconcileWithDisk()
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage?.contains("broken-vm") == true)
+
+        // Second reconciliation should NOT re-present the same error
+        viewModel.showError = false
+        viewModel.errorMessage = nil
+        viewModel.reconcileWithDisk()
+        #expect(viewModel.showError == false)
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    @Test("reconcileWithDisk re-presents error after loadVMs resets reported failures")
+    func reconcileReReportsAfterFullReload() {
+        let storage = MockVMStorageService()
+        let badURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("broken-vm.kernova", isDirectory: true)
+        storage.bundles[badURL] = VMConfiguration(name: "Bad VM", guestOS: .linux, bootMode: .efi)
+        storage.loadConfigurationFailURLs.insert(badURL)
+
+        let (viewModel, _, _, _) = makeViewModel(storageService: storage)
+
+        // First reconciliation reports the error (loadVMs already seeded reportedFailedBundles,
+        // so the first reconcile is actually suppressed — verify that)
+        viewModel.showError = false
+        viewModel.errorMessage = nil
+        viewModel.reconcileWithDisk()
+        #expect(viewModel.showError == false)
+
+        // Full reload resets the tracking, then re-seeds it from its own failures
+        viewModel.loadVMs()
+        viewModel.showError = false
+        viewModel.errorMessage = nil
+
+        // Reconciliation should still be suppressed since loadVMs re-seeded the set
+        viewModel.reconcileWithDisk()
+        #expect(viewModel.showError == false)
+    }
+
+    @Test("reconcileWithDisk does not re-present errors already reported by loadVMs")
+    func reconcileDoesNotDuplicateLoadVMsErrors() {
+        let storage = MockVMStorageService()
+        let badURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("broken-vm.kernova", isDirectory: true)
+        storage.bundles[badURL] = VMConfiguration(name: "Bad VM", guestOS: .linux, bootMode: .efi)
+        storage.loadConfigurationFailURLs.insert(badURL)
+
+        // loadVMs() runs in init and should report the error
+        let (viewModel, _, _, _) = makeViewModel(storageService: storage)
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage?.contains("broken-vm") == true)
+
+        // Clear the alert state (simulating user dismissing the dialog)
+        viewModel.showError = false
+        viewModel.errorMessage = nil
+
+        // First reconcileWithDisk should NOT re-present the same error
+        viewModel.reconcileWithDisk()
+        #expect(viewModel.showError == false)
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    @Test("reconcileWithDisk re-presents error after previously-failed bundle loads successfully")
+    func reconcileReReportsAfterBundleRecovery() {
+        let storage = MockVMStorageService()
+        let (viewModel, _, _, _) = makeViewModel(storageService: storage)
+
+        // Introduce the bad bundle after init so it's new to reconcileWithDisk
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("recoverable.kernova", isDirectory: true)
+        let config = VMConfiguration(name: "Recoverable VM", guestOS: .linux, bootMode: .efi)
+        storage.bundles[bundleURL] = config
+        storage.loadConfigurationFailURLs.insert(bundleURL)
+
+        // First reconciliation reports the error
+        viewModel.showError = false
+        viewModel.errorMessage = nil
+        viewModel.reconcileWithDisk()
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage?.contains("recoverable") == true)
+
+        // "Fix" the bundle by removing it from the fail set
+        storage.loadConfigurationFailURLs.remove(bundleURL)
+
+        // Reconciliation succeeds — no error, and the bundle is cleared from reported set
+        viewModel.showError = false
+        viewModel.errorMessage = nil
+        viewModel.reconcileWithDisk()
+        #expect(viewModel.showError == false)
+
+        // Re-corrupt it
+        storage.loadConfigurationFailURLs.insert(bundleURL)
+        // Remove the instance that was added on successful load so reconciliation tries again
+        viewModel.instances.removeAll { $0.name == "Recoverable VM" }
+
+        // Should report the error again since it was cleared from the reported set
+        viewModel.reconcileWithDisk()
+        #expect(viewModel.showError == true)
+        #expect(viewModel.errorMessage?.contains("recoverable") == true)
     }
 
     // MARK: - Cancel Installation


### PR DESCRIPTION
## Summary
- Prevent repeated identical error dialogs when `reconcileWithDisk` encounters persistently corrupted bundles on successive filesystem watcher events
- Track reported failures across both `loadVMs` and `reconcileWithDisk` so the startup sequence (`init` → `loadVMs` → watcher → `reconcileWithDisk`) does not double-report the same corrupted bundle
- Prune stale entries when bundles are removed from disk so a new bundle with the same name is not silently suppressed

Closes #100

## Test plan
- [x] Built successfully on macOS 26
- [x] All existing tests pass (full suite)
- [x] New tests verify: suppression, `loadVMs`-reconcile interaction, reload reset, and recovery
- [ ] Manual: drop a bundle with corrupted `config.json` into the VMs directory and confirm the error appears once, not on every filesystem event

🤖 Generated with [Claude Code](https://claude.com/claude-code)