### PR TITLE
fix: Add distinct logging for TCC quit event sender resolution failures

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -227,14 +227,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // Extract the sender's PID from the Apple Event and resolve its bundle ID.
         if let senderPIDDescriptor = event.attributeDescriptor(forKeyword: keySenderPIDAttr) {
             let senderPID = senderPIDDescriptor.int32Value
-            if let senderApp = NSRunningApplication(processIdentifier: senderPID),
-               let bundleID = senderApp.bundleIdentifier {
-                Self.logger.debug("Quit Apple Event received from '\(bundleID, privacy: .public)' (PID \(senderPID, privacy: .public))")
-                if Self.tccSenderBundleIDs.contains(bundleID) {
-                    terminationIsTCCRevocation = true
+            if let senderApp = NSRunningApplication(processIdentifier: senderPID) {
+                if let bundleID = senderApp.bundleIdentifier {
+                    Self.logger.debug("Quit Apple Event received from '\(bundleID, privacy: .public)' (PID \(senderPID, privacy: .public))")
+                    if Self.tccSenderBundleIDs.contains(bundleID) {
+                        terminationIsTCCRevocation = true
+                    }
+                } else {
+                    Self.logger.warning("Quit Apple Event: sender PID \(senderPID, privacy: .public) resolved to an application with no bundle identifier — TCC detection may miss this event")
                 }
             } else {
-                Self.logger.warning("Quit Apple Event: could not resolve sender PID \(senderPID, privacy: .public) to a running application — TCC detection may miss this event")
+                Self.logger.warning("Quit Apple Event: sender PID \(senderPID, privacy: .public) could not be resolved to a running application (process may have already exited) — TCC detection may miss this event")
             }
         } else {
             Self.logger.debug("Quit Apple Event received with no sender PID attribute")


### PR DESCRIPTION
## Summary
- Splits the combined optional binding in `handleQuitAppleEvent` into separate checks so each failure branch produces a distinct diagnostic message
- Closes #108 and #109 which were already fixed in commit f360887 but never closed

Closes #107

## Changes
- **AppDelegate.swift**: Split `if let senderApp, let bundleID` into two nested `if let` checks with distinct `.warning` messages:
  - "could not be resolved to a running application (process may have already exited)" — when `NSRunningApplication(processIdentifier:)` returns nil (race condition)
  - "resolved to an application with no bundle identifier" — when the process exists but has no bundle ID

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Verified each branch logs distinctly via Console.app log stream
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)