### PR TITLE
fix: Increase download progress precision to 3 decimal places

### DIFF
--- a/Kernova/Utilities/DataFormatters.swift
+++ b/Kernova/Utilities/DataFormatters.swift
@@ -14,8 +14,8 @@ enum DataFormatters {
         byteFormatter.string(fromByteCount: Int64(bytes))
     }
 
-    /// Formats a byte count with fixed width for stable progress display (e.g., "861.9 MB").
-    /// Uses `%5.1f` padding so the numeric part is always 5 characters wide, preventing
+    /// Formats a byte count with fixed width for stable progress display (e.g., "861.900 MB").
+    /// Uses `%7.3f` padding so the numeric part is always 7 characters wide, preventing
     /// horizontal jitter as values change during downloads.
     static func formatBytesFixedWidth(_ bytes: UInt64) -> String {
         let kb = Double(bytes) / 1_000
@@ -33,7 +33,7 @@ enum DataFormatters {
         } else {
             (value, unit) = (kb, "KB")
         }
-        return String(format: "%5.1f %@", value, unit)
+        return String(format: "%7.3f %@", value, unit)
             .replacingOccurrences(of: " ", with: "\u{2007}")
     }
 

--- a/KernovaTests/DataFormattersTests.swift
+++ b/KernovaTests/DataFormattersTests.swift
@@ -51,16 +51,19 @@ struct DataFormattersTests {
         #expect(result.contains("MB"))
     }
 
-    @Test("formatBytesFixedWidth formats GB values")
+    @Test("formatBytesFixedWidth formats GB values with 3 decimal places")
     func formatBytesFixedWidthGB() {
         let result = DataFormatters.formatBytesFixedWidth(4_200_000_000)
         #expect(result.contains("GB"))
+        // Verify 3 decimal places (e.g., "4.200")
+        #expect(result.contains("4.200"))
     }
 
-    @Test("formatBytesFixedWidth formats TB values")
+    @Test("formatBytesFixedWidth formats TB values with 3 decimal places")
     func formatBytesFixedWidthTB() {
         let result = DataFormatters.formatBytesFixedWidth(2_000_000_000_000)
         #expect(result.contains("TB"))
+        #expect(result.contains("2.000"))
     }
 
     @Test("formatBytesFixedWidth uses figure spaces instead of regular spaces")
@@ -69,6 +72,14 @@ struct DataFormattersTests {
         // Should use figure space U+2007, not regular space U+0020
         #expect(!result.contains(" "))
         #expect(result.contains("\u{2007}"))
+    }
+
+    @Test("formatBytesFixedWidth shows 3 decimal places for sub-unit precision")
+    func formatBytesFixedWidthPrecision() {
+        // 10.642 GB = 10_642_000_000 bytes
+        let result = DataFormatters.formatBytesFixedWidth(10_642_000_000)
+        #expect(result.contains("10.642"))
+        #expect(result.contains("GB"))
     }
 
     // MARK: - formatDiskSize


### PR DESCRIPTION
## Summary
- Increase byte formatting precision from 1 to 3 decimal places (e.g., `10.6 GB` → `10.642 GB`) so users on slow connections see continuous progress instead of values appearing stuck
- Format string updated from `%5.1f` to `%7.3f`, preserving fixed-width alignment with figure spaces to prevent layout jitter
- Added precision-specific test assertions and a new sub-unit precision test case

Closes #95

## Test plan
- [ ] Verified format output: `10.642 GB`, `19.732 GB`, `861.900 MB`
- [ ] Fixed-width alignment confirmed (7-char numeric field)
- [ ] Figure space (U+2007) substitution preserved
- [ ] Existing `DataFormattersTests` updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)