### PR TITLE
feat: Show download speed and ETA during VM installation

### DIFF
--- a/Kernova/Models/MacOSInstallState.swift
+++ b/Kernova/Models/MacOSInstallState.swift
@@ -1,8 +1,16 @@
 import Foundation
 
+/// Snapshot of download progress reported by the IPSW download delegate.
+struct DownloadProgress: Sendable {
+    let fraction: Double
+    let bytesWritten: Int64
+    let totalBytes: Int64
+    let bytesPerSecond: Double
+}
+
 /// Represents the current phase of a macOS installation.
 enum MacOSInstallPhase: Sendable {
-    case downloading(progress: Double, bytesWritten: Int64, totalBytes: Int64, bytesPerSecond: Double)
+    case downloading(DownloadProgress)
     case installing(progress: Double)
 }
 

--- a/Kernova/Models/MacOSInstallState.swift
+++ b/Kernova/Models/MacOSInstallState.swift
@@ -2,10 +2,17 @@ import Foundation
 
 /// Snapshot of download progress reported by the IPSW download delegate.
 struct DownloadProgress: Sendable {
-    let fraction: Double
     let bytesWritten: Int64
     let totalBytes: Int64
+    /// EWMA-smoothed download speed; zero before the first progress report.
     let bytesPerSecond: Double
+
+    /// Fraction complete, derived from `bytesWritten / totalBytes`.
+    var fraction: Double {
+        totalBytes > 0 ? Double(bytesWritten) / Double(totalBytes) : 0
+    }
+
+    static let zero = DownloadProgress(bytesWritten: 0, totalBytes: 0, bytesPerSecond: 0)
 }
 
 /// Represents the current phase of a macOS installation.

--- a/Kernova/Models/MacOSInstallState.swift
+++ b/Kernova/Models/MacOSInstallState.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents the current phase of a macOS installation.
 enum MacOSInstallPhase: Sendable {
-    case downloading(progress: Double, bytesWritten: Int64, totalBytes: Int64)
+    case downloading(progress: Double, bytesWritten: Int64, totalBytes: Int64, bytesPerSecond: Double)
     case installing(progress: Double)
 }
 

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -21,7 +21,7 @@ struct IPSWService: Sendable {
     func downloadRestoreImage(
         from remoteURL: URL,
         to destinationURL: URL,
-        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64, Double) -> Void
+        progressHandler: @MainActor @Sendable @escaping (DownloadProgress) -> Void
     ) async throws {
         Self.logger.info("Downloading restore image from \(remoteURL, privacy: .public)")
 
@@ -95,21 +95,20 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
     private static let progressInterval: TimeInterval = 0.1  // 100 ms
 
     private let destinationURL: URL
-    private let progressHandler: @MainActor @Sendable (Double, Int64, Int64, Double) -> Void
+    private let progressHandler: @MainActor @Sendable (DownloadProgress) -> Void
     // RATIONALE: URLSession guarantees exactly one didCompleteWithError call per task,
     // so this continuation is always resumed exactly once.
     private let continuation: CheckedContinuation<Void, any Error>
     private var moveError: (any Error)?
     private var lastProgressReport: TimeInterval = 0
     private var previousBytesWritten: Int64 = 0
-    private var previousTimestamp: TimeInterval = 0
     private var smoothedBytesPerSecond: Double = 0
     /// EWMA smoothing factor — lower values produce smoother output.
     private static let smoothingAlpha: Double = 0.2
 
     init(
         destinationURL: URL,
-        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64, Double) -> Void,
+        progressHandler: @MainActor @Sendable @escaping (DownloadProgress) -> Void,
         continuation: CheckedContinuation<Void, any Error>
     ) {
         self.destinationURL = destinationURL
@@ -131,7 +130,6 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
         let now = ProcessInfo.processInfo.systemUptime
         guard now - lastProgressReport >= Self.progressInterval else { return }
 
-        // Calculate instantaneous speed and apply EWMA smoothing
         let elapsed = now - lastProgressReport
         if elapsed > 0, lastProgressReport > 0 {
             let deltaBytes = Double(totalBytesWritten - previousBytesWritten)
@@ -146,10 +144,14 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
         previousBytesWritten = totalBytesWritten
         lastProgressReport = now
 
-        let fraction = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
-        let speed = smoothedBytesPerSecond
+        let progress = DownloadProgress(
+            fraction: Double(totalBytesWritten) / Double(totalBytesExpectedToWrite),
+            bytesWritten: totalBytesWritten,
+            totalBytes: totalBytesExpectedToWrite,
+            bytesPerSecond: smoothedBytesPerSecond
+        )
         let handler = self.progressHandler
-        Task { @MainActor in handler(fraction, totalBytesWritten, totalBytesExpectedToWrite, speed) }
+        Task { @MainActor in handler(progress) }
     }
 
     func urlSession(
@@ -197,9 +199,13 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
             }
         } else {
             let handler = self.progressHandler
-            let received = task.countOfBytesReceived
-            let expected = task.countOfBytesExpectedToReceive
-            Task { @MainActor in handler(1.0, received, expected, 0) }
+            let progress = DownloadProgress(
+                fraction: 1.0,
+                bytesWritten: task.countOfBytesReceived,
+                totalBytes: task.countOfBytesExpectedToReceive,
+                bytesPerSecond: 0
+            )
+            Task { @MainActor in handler(progress) }
             continuation.resume()
         }
     }

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -133,6 +133,12 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
         let elapsed = now - lastProgressReport
         if elapsed > 0, lastProgressReport > 0 {
             let deltaBytes = Double(totalBytesWritten - previousBytesWritten)
+            guard deltaBytes >= 0 else {
+                Self.logger.warning("Negative byte delta detected (\(totalBytesWritten) < \(self.previousBytesWritten)) — skipping speed sample")
+                previousBytesWritten = totalBytesWritten
+                lastProgressReport = now
+                return
+            }
             let instantSpeed = deltaBytes / elapsed
             if smoothedBytesPerSecond == 0 {
                 smoothedBytesPerSecond = instantSpeed
@@ -145,7 +151,6 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
         lastProgressReport = now
 
         let progress = DownloadProgress(
-            fraction: Double(totalBytesWritten) / Double(totalBytesExpectedToWrite),
             bytesWritten: totalBytesWritten,
             totalBytes: totalBytesExpectedToWrite,
             bytesPerSecond: smoothedBytesPerSecond
@@ -200,9 +205,8 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
         } else {
             let handler = self.progressHandler
             let progress = DownloadProgress(
-                fraction: 1.0,
-                bytesWritten: task.countOfBytesReceived,
-                totalBytes: task.countOfBytesExpectedToReceive,
+                bytesWritten: max(0, task.countOfBytesReceived),
+                totalBytes: max(0, task.countOfBytesExpectedToReceive),
                 bytesPerSecond: 0
             )
             Task { @MainActor in handler(progress) }

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -21,7 +21,7 @@ struct IPSWService: Sendable {
     func downloadRestoreImage(
         from remoteURL: URL,
         to destinationURL: URL,
-        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64) -> Void
+        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64, Double) -> Void
     ) async throws {
         Self.logger.info("Downloading restore image from \(remoteURL, privacy: .public)")
 
@@ -95,16 +95,21 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
     private static let progressInterval: TimeInterval = 0.1  // 100 ms
 
     private let destinationURL: URL
-    private let progressHandler: @MainActor @Sendable (Double, Int64, Int64) -> Void
+    private let progressHandler: @MainActor @Sendable (Double, Int64, Int64, Double) -> Void
     // RATIONALE: URLSession guarantees exactly one didCompleteWithError call per task,
     // so this continuation is always resumed exactly once.
     private let continuation: CheckedContinuation<Void, any Error>
     private var moveError: (any Error)?
     private var lastProgressReport: TimeInterval = 0
+    private var previousBytesWritten: Int64 = 0
+    private var previousTimestamp: TimeInterval = 0
+    private var smoothedBytesPerSecond: Double = 0
+    /// EWMA smoothing factor — lower values produce smoother output.
+    private static let smoothingAlpha: Double = 0.2
 
     init(
         destinationURL: URL,
-        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64) -> Void,
+        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64, Double) -> Void,
         continuation: CheckedContinuation<Void, any Error>
     ) {
         self.destinationURL = destinationURL
@@ -125,11 +130,26 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
 
         let now = ProcessInfo.processInfo.systemUptime
         guard now - lastProgressReport >= Self.progressInterval else { return }
+
+        // Calculate instantaneous speed and apply EWMA smoothing
+        let elapsed = now - lastProgressReport
+        if elapsed > 0, lastProgressReport > 0 {
+            let deltaBytes = Double(totalBytesWritten - previousBytesWritten)
+            let instantSpeed = deltaBytes / elapsed
+            if smoothedBytesPerSecond == 0 {
+                smoothedBytesPerSecond = instantSpeed
+            } else {
+                smoothedBytesPerSecond = Self.smoothingAlpha * instantSpeed
+                    + (1 - Self.smoothingAlpha) * smoothedBytesPerSecond
+            }
+        }
+        previousBytesWritten = totalBytesWritten
         lastProgressReport = now
 
         let fraction = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        let speed = smoothedBytesPerSecond
         let handler = self.progressHandler
-        Task { @MainActor in handler(fraction, totalBytesWritten, totalBytesExpectedToWrite) }
+        Task { @MainActor in handler(fraction, totalBytesWritten, totalBytesExpectedToWrite, speed) }
     }
 
     func urlSession(
@@ -179,7 +199,7 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
             let handler = self.progressHandler
             let received = task.countOfBytesReceived
             let expected = task.countOfBytesExpectedToReceive
-            Task { @MainActor in handler(1.0, received, expected) }
+            Task { @MainActor in handler(1.0, received, expected, 0) }
             continuation.resume()
         }
     }

--- a/Kernova/Services/Protocols/IPSWProviding.swift
+++ b/Kernova/Services/Protocols/IPSWProviding.swift
@@ -7,7 +7,7 @@ protocol IPSWProviding: Sendable {
     func downloadRestoreImage(
         from remoteURL: URL,
         to destinationURL: URL,
-        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64, Double) -> Void
+        progressHandler: @MainActor @Sendable @escaping (DownloadProgress) -> Void
     ) async throws
     #endif
 }

--- a/Kernova/Services/Protocols/IPSWProviding.swift
+++ b/Kernova/Services/Protocols/IPSWProviding.swift
@@ -7,7 +7,7 @@ protocol IPSWProviding: Sendable {
     func downloadRestoreImage(
         from remoteURL: URL,
         to destinationURL: URL,
-        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64) -> Void
+        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64, Double) -> Void
     ) async throws
     #endif
 }

--- a/Kernova/Utilities/DataFormatters.swift
+++ b/Kernova/Utilities/DataFormatters.swift
@@ -87,11 +87,15 @@ enum DataFormatters {
         count == 1 ? "1 core" : "\(count) cores"
     }
 
-    /// Formats a duration in seconds into a human-readable string.
-    static func formatDuration(_ seconds: TimeInterval) -> String {
+    private nonisolated(unsafe) static let durationFormatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.unitsStyle = .abbreviated
-        return formatter.string(from: seconds) ?? "\(Int(seconds))s"
+        return formatter
+    }()
+
+    /// Formats a duration in seconds into a human-readable string.
+    static func formatDuration(_ seconds: TimeInterval) -> String {
+        durationFormatter.string(from: seconds) ?? "\(Int(seconds))s"
     }
 }

--- a/Kernova/Utilities/DataFormatters.swift
+++ b/Kernova/Utilities/DataFormatters.swift
@@ -57,7 +57,7 @@ enum DataFormatters {
     }
 
     /// Formats an ETA from remaining bytes and current speed into a human-readable string.
-    /// Returns `nil` if speed is zero or negligible.
+    /// Returns `nil` if speed is negligible, the estimate exceeds 100 hours, or the result is non-finite.
     static func formatETA(remainingBytes: Int64, bytesPerSecond: Double) -> String? {
         guard bytesPerSecond > 1_000 else { return nil }
         let seconds = Double(remainingBytes) / bytesPerSecond
@@ -87,6 +87,8 @@ enum DataFormatters {
         count == 1 ? "1 core" : "\(count) cores"
     }
 
+    // RATIONALE: nonisolated(unsafe) is safe because all callers of DataFormatters
+    // are @MainActor-isolated (SwiftUI view bodies). Matches the existing byteFormatter pattern.
     private nonisolated(unsafe) static let durationFormatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]

--- a/Kernova/Utilities/DataFormatters.swift
+++ b/Kernova/Utilities/DataFormatters.swift
@@ -37,6 +37,34 @@ enum DataFormatters {
             .replacingOccurrences(of: " ", with: "\u{2007}")
     }
 
+    /// Formats a download speed in bytes/second into a human-readable string (e.g., "42.5 MB/s").
+    /// Uses fixed-width formatting to prevent horizontal jitter during rapid updates.
+    static func formatSpeed(_ bytesPerSecond: Double) -> String {
+        let kb = bytesPerSecond / 1_000
+        let mb = kb / 1_000
+        let gb = mb / 1_000
+
+        let (value, unit): (Double, String)
+        if gb >= 1 {
+            (value, unit) = (gb, "GB/s")
+        } else if mb >= 1 {
+            (value, unit) = (mb, "MB/s")
+        } else {
+            (value, unit) = (kb, "KB/s")
+        }
+        return String(format: "%5.1f %@", value, unit)
+            .replacingOccurrences(of: " ", with: "\u{2007}")
+    }
+
+    /// Formats an ETA from remaining bytes and current speed into a human-readable string.
+    /// Returns `nil` if speed is zero or negligible.
+    static func formatETA(remainingBytes: Int64, bytesPerSecond: Double) -> String? {
+        guard bytesPerSecond > 1_000 else { return nil }
+        let seconds = Double(remainingBytes) / bytesPerSecond
+        guard seconds.isFinite, seconds > 0, seconds < 360_000 else { return nil }
+        return formatDuration(seconds)
+    }
+
     /// Formats a disk size in GB for display, using TB for sizes >= 1000 GB.
     ///
     /// The numeric part is right-justified to 3 characters using figure spaces

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -163,7 +163,7 @@ final class VMLifecycleCoordinator {
                     // Set up two-step install state before changing status
                     instance.installState = MacOSInstallState(
                         hasDownloadStep: true,
-                        currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 0, bytesPerSecond: 0)
+                        currentPhase: .downloading(DownloadProgress(fraction: 0, bytesWritten: 0, totalBytes: 0, bytesPerSecond: 0))
                     )
                     instance.status = .installing
 
@@ -172,13 +172,8 @@ final class VMLifecycleCoordinator {
                     try await ipswService.downloadRestoreImage(
                         from: remoteURL,
                         to: downloadDestination
-                    ) { progress, bytesWritten, totalBytes, bytesPerSecond in
-                        instance.installState?.currentPhase = .downloading(
-                            progress: progress,
-                            bytesWritten: bytesWritten,
-                            totalBytes: totalBytes,
-                            bytesPerSecond: bytesPerSecond
-                        )
+                    ) { progress in
+                        instance.installState?.currentPhase = .downloading(progress)
                     }
 
                     // Mark download complete, transition to install phase

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -163,7 +163,7 @@ final class VMLifecycleCoordinator {
                     // Set up two-step install state before changing status
                     instance.installState = MacOSInstallState(
                         hasDownloadStep: true,
-                        currentPhase: .downloading(DownloadProgress(fraction: 0, bytesWritten: 0, totalBytes: 0, bytesPerSecond: 0))
+                        currentPhase: .downloading(.zero)
                     )
                     instance.status = .installing
 

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -163,7 +163,7 @@ final class VMLifecycleCoordinator {
                     // Set up two-step install state before changing status
                     instance.installState = MacOSInstallState(
                         hasDownloadStep: true,
-                        currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 0)
+                        currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 0, bytesPerSecond: 0)
                     )
                     instance.status = .installing
 
@@ -172,11 +172,12 @@ final class VMLifecycleCoordinator {
                     try await ipswService.downloadRestoreImage(
                         from: remoteURL,
                         to: downloadDestination
-                    ) { progress, bytesWritten, totalBytes in
+                    ) { progress, bytesWritten, totalBytes, bytesPerSecond in
                         instance.installState?.currentPhase = .downloading(
                             progress: progress,
                             bytesWritten: bytesWritten,
-                            totalBytes: totalBytes
+                            totalBytes: totalBytes,
+                            bytesPerSecond: bytesPerSecond
                         )
                     }
 

--- a/Kernova/Views/Detail/MacOSInstallProgressView.swift
+++ b/Kernova/Views/Detail/MacOSInstallProgressView.swift
@@ -139,8 +139,8 @@ struct MacOSInstallProgressView: View {
     @ViewBuilder
     private var activeProgressBar: some View {
         switch installState.currentPhase {
-        case .downloading(let progress, _, _, _):
-            ProgressView(value: progress)
+        case .downloading(let dl):
+            ProgressView(value: dl.fraction)
                 .progressViewStyle(.linear)
 
         case .installing(let progress):
@@ -154,19 +154,18 @@ struct MacOSInstallProgressView: View {
     @ViewBuilder
     private var activeDetailText: some View {
         switch installState.currentPhase {
-        case .downloading(let progress, let bytesWritten, let totalBytes, let bytesPerSecond):
-            let written = DataFormatters.formatBytesFixedWidth(UInt64(bytesWritten))
-            let total = DataFormatters.formatBytesFixedWidth(UInt64(totalBytes))
-            let pct = String(format: "%3d", Int(progress * 100))
+        case .downloading(let dl):
+            let written = DataFormatters.formatBytesFixedWidth(UInt64(dl.bytesWritten))
+            let total = DataFormatters.formatBytesFixedWidth(UInt64(dl.totalBytes))
+            let pct = String(format: "%3d", Int(dl.fraction * 100))
                 .replacingOccurrences(of: " ", with: "\u{2007}")
             VStack(spacing: 4) {
                 Text("Downloading:\u{2007}\(written) / \(total) — \(pct)%")
-                if bytesPerSecond > 0 {
-                    let speed = DataFormatters.formatSpeed(bytesPerSecond)
-                    let remaining = totalBytes - bytesWritten
+                if dl.bytesPerSecond > 0 {
+                    let speed = DataFormatters.formatSpeed(dl.bytesPerSecond)
                     let eta = DataFormatters.formatETA(
-                        remainingBytes: remaining,
-                        bytesPerSecond: bytesPerSecond
+                        remainingBytes: dl.totalBytes - dl.bytesWritten,
+                        bytesPerSecond: dl.bytesPerSecond
                     )
                     if let eta {
                         Text("\(speed) — \(eta)\u{2007}remaining")

--- a/Kernova/Views/Detail/MacOSInstallProgressView.swift
+++ b/Kernova/Views/Detail/MacOSInstallProgressView.swift
@@ -139,7 +139,7 @@ struct MacOSInstallProgressView: View {
     @ViewBuilder
     private var activeProgressBar: some View {
         switch installState.currentPhase {
-        case .downloading(let progress, _, _):
+        case .downloading(let progress, _, _, _):
             ProgressView(value: progress)
                 .progressViewStyle(.linear)
 
@@ -154,12 +154,27 @@ struct MacOSInstallProgressView: View {
     @ViewBuilder
     private var activeDetailText: some View {
         switch installState.currentPhase {
-        case .downloading(let progress, let bytesWritten, let totalBytes):
+        case .downloading(let progress, let bytesWritten, let totalBytes, let bytesPerSecond):
             let written = DataFormatters.formatBytesFixedWidth(UInt64(bytesWritten))
             let total = DataFormatters.formatBytesFixedWidth(UInt64(totalBytes))
             let pct = String(format: "%3d", Int(progress * 100))
                 .replacingOccurrences(of: " ", with: "\u{2007}")
-            Text("Downloading:\u{2007}\(written) / \(total) — \(pct)%")
+            VStack(spacing: 4) {
+                Text("Downloading:\u{2007}\(written) / \(total) — \(pct)%")
+                if bytesPerSecond > 0 {
+                    let speed = DataFormatters.formatSpeed(bytesPerSecond)
+                    let remaining = totalBytes - bytesWritten
+                    let eta = DataFormatters.formatETA(
+                        remainingBytes: remaining,
+                        bytesPerSecond: bytesPerSecond
+                    )
+                    if let eta {
+                        Text("\(speed) — \(eta)\u{2007}remaining")
+                    } else {
+                        Text(speed)
+                    }
+                }
+            }
 
         case .installing(let progress):
             Text("Installing macOS: \(Int(progress * 100))%")

--- a/KernovaTests/DataFormattersTests.swift
+++ b/KernovaTests/DataFormattersTests.swift
@@ -142,6 +142,26 @@ struct DataFormattersTests {
         #expect(result!.contains("h"))
     }
 
+    @Test("formatETA returns nil when estimate exceeds upper bound")
+    func formatETAExceedsUpperBound() {
+        // 360_001 seconds at 1 KB/s
+        let result = DataFormatters.formatETA(remainingBytes: 360_001_000, bytesPerSecond: 1_000)
+        #expect(result == nil)
+    }
+
+    @Test("formatETA returns nil for negative remaining bytes")
+    func formatETANegativeRemaining() {
+        let result = DataFormatters.formatETA(remainingBytes: -1000, bytesPerSecond: 10_000_000)
+        #expect(result == nil)
+    }
+
+    @Test("formatSpeed handles zero input")
+    func formatSpeedZero() {
+        let result = DataFormatters.formatSpeed(0)
+        #expect(result.contains("KB/s"))
+        #expect(result.contains("0.0"))
+    }
+
     // MARK: - formatDiskSize
 
     @Test("formatDiskSize formats GB values with figure-space padding")

--- a/KernovaTests/DataFormattersTests.swift
+++ b/KernovaTests/DataFormattersTests.swift
@@ -82,6 +82,66 @@ struct DataFormattersTests {
         #expect(result.contains("GB"))
     }
 
+    // MARK: - formatSpeed
+
+    @Test("formatSpeed formats KB/s for low speeds")
+    func formatSpeedKB() {
+        let result = DataFormatters.formatSpeed(500_000)
+        #expect(result.contains("KB/s"))
+        #expect(result.contains("500.0"))
+    }
+
+    @Test("formatSpeed formats MB/s for typical download speeds")
+    func formatSpeedMB() {
+        let result = DataFormatters.formatSpeed(42_500_000)
+        #expect(result.contains("MB/s"))
+        #expect(result.contains("42.5"))
+    }
+
+    @Test("formatSpeed formats GB/s for very high speeds")
+    func formatSpeedGB() {
+        let result = DataFormatters.formatSpeed(2_500_000_000)
+        #expect(result.contains("GB/s"))
+        #expect(result.contains("2.5"))
+    }
+
+    @Test("formatSpeed uses figure spaces instead of regular spaces")
+    func formatSpeedFigureSpaces() {
+        let result = DataFormatters.formatSpeed(42_500_000)
+        #expect(!result.contains(" "))
+        #expect(result.contains("\u{2007}"))
+    }
+
+    // MARK: - formatETA
+
+    @Test("formatETA returns nil for zero speed")
+    func formatETAZeroSpeed() {
+        let result = DataFormatters.formatETA(remainingBytes: 1_000_000, bytesPerSecond: 0)
+        #expect(result == nil)
+    }
+
+    @Test("formatETA returns nil for negligible speed")
+    func formatETANegligibleSpeed() {
+        let result = DataFormatters.formatETA(remainingBytes: 1_000_000, bytesPerSecond: 500)
+        #expect(result == nil)
+    }
+
+    @Test("formatETA returns formatted duration for valid inputs")
+    func formatETAValid() {
+        // 100 MB remaining at 10 MB/s = 10 seconds
+        let result = DataFormatters.formatETA(remainingBytes: 100_000_000, bytesPerSecond: 10_000_000)
+        #expect(result != nil)
+        #expect(result!.contains("s"))
+    }
+
+    @Test("formatETA handles large remaining time")
+    func formatETALargeTime() {
+        // 10 GB remaining at 1 MB/s = ~10000 seconds
+        let result = DataFormatters.formatETA(remainingBytes: 10_000_000_000, bytesPerSecond: 1_000_000)
+        #expect(result != nil)
+        #expect(result!.contains("h"))
+    }
+
     // MARK: - formatDiskSize
 
     @Test("formatDiskSize formats GB values with figure-space padding")

--- a/KernovaTests/MacOSInstallStateTests.swift
+++ b/KernovaTests/MacOSInstallStateTests.swift
@@ -11,16 +11,16 @@ struct MacOSInstallStateTests {
     func initialStateWithDownload() {
         let state = MacOSInstallState(
             hasDownloadStep: true,
-            currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 0, bytesPerSecond: 0)
+            currentPhase: .downloading(DownloadProgress(fraction: 0, bytesWritten: 0, totalBytes: 0, bytesPerSecond: 0))
         )
 
         #expect(state.hasDownloadStep == true)
         #expect(state.downloadCompleted == false)
-        if case .downloading(let progress, let bytesWritten, let totalBytes, let bytesPerSecond) = state.currentPhase {
-            #expect(progress == 0)
-            #expect(bytesWritten == 0)
-            #expect(totalBytes == 0)
-            #expect(bytesPerSecond == 0)
+        if case .downloading(let dl) = state.currentPhase {
+            #expect(dl.fraction == 0)
+            #expect(dl.bytesWritten == 0)
+            #expect(dl.totalBytes == 0)
+            #expect(dl.bytesPerSecond == 0)
         } else {
             Issue.record("Expected downloading phase")
         }
@@ -48,7 +48,7 @@ struct MacOSInstallStateTests {
     func phaseTransition() {
         var state = MacOSInstallState(
             hasDownloadStep: true,
-            currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 1000, bytesPerSecond: 0)
+            currentPhase: .downloading(DownloadProgress(fraction: 0, bytesWritten: 0, totalBytes: 1000, bytesPerSecond: 0))
         )
 
         // Simulate download completion
@@ -69,21 +69,21 @@ struct MacOSInstallStateTests {
     func downloadProgress() {
         var state = MacOSInstallState(
             hasDownloadStep: true,
-            currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 1_000_000, bytesPerSecond: 0)
+            currentPhase: .downloading(DownloadProgress(fraction: 0, bytesWritten: 0, totalBytes: 1_000_000, bytesPerSecond: 0))
         )
 
-        state.currentPhase = .downloading(
-            progress: 0.5,
+        state.currentPhase = .downloading(DownloadProgress(
+            fraction: 0.5,
             bytesWritten: 500_000,
             totalBytes: 1_000_000,
             bytesPerSecond: 42_500_000
-        )
+        ))
 
-        if case .downloading(let progress, let bytesWritten, let totalBytes, let bytesPerSecond) = state.currentPhase {
-            #expect(progress == 0.5)
-            #expect(bytesWritten == 500_000)
-            #expect(totalBytes == 1_000_000)
-            #expect(bytesPerSecond == 42_500_000)
+        if case .downloading(let dl) = state.currentPhase {
+            #expect(dl.fraction == 0.5)
+            #expect(dl.bytesWritten == 500_000)
+            #expect(dl.totalBytes == 1_000_000)
+            #expect(dl.bytesPerSecond == 42_500_000)
         } else {
             Issue.record("Expected downloading phase")
         }

--- a/KernovaTests/MacOSInstallStateTests.swift
+++ b/KernovaTests/MacOSInstallStateTests.swift
@@ -11,7 +11,7 @@ struct MacOSInstallStateTests {
     func initialStateWithDownload() {
         let state = MacOSInstallState(
             hasDownloadStep: true,
-            currentPhase: .downloading(DownloadProgress(fraction: 0, bytesWritten: 0, totalBytes: 0, bytesPerSecond: 0))
+            currentPhase: .downloading(.zero)
         )
 
         #expect(state.hasDownloadStep == true)
@@ -48,7 +48,7 @@ struct MacOSInstallStateTests {
     func phaseTransition() {
         var state = MacOSInstallState(
             hasDownloadStep: true,
-            currentPhase: .downloading(DownloadProgress(fraction: 0, bytesWritten: 0, totalBytes: 1000, bytesPerSecond: 0))
+            currentPhase: .downloading(DownloadProgress(bytesWritten: 0, totalBytes: 1000, bytesPerSecond: 0))
         )
 
         // Simulate download completion
@@ -69,11 +69,10 @@ struct MacOSInstallStateTests {
     func downloadProgress() {
         var state = MacOSInstallState(
             hasDownloadStep: true,
-            currentPhase: .downloading(DownloadProgress(fraction: 0, bytesWritten: 0, totalBytes: 1_000_000, bytesPerSecond: 0))
+            currentPhase: .downloading(.zero)
         )
 
         state.currentPhase = .downloading(DownloadProgress(
-            fraction: 0.5,
             bytesWritten: 500_000,
             totalBytes: 1_000_000,
             bytesPerSecond: 42_500_000
@@ -87,6 +86,17 @@ struct MacOSInstallStateTests {
         } else {
             Issue.record("Expected downloading phase")
         }
+    }
+
+    @Test("Download progress fraction is derived from bytes")
+    func downloadProgressFraction() {
+        let dl = DownloadProgress(bytesWritten: 750_000, totalBytes: 1_000_000, bytesPerSecond: 0)
+        #expect(dl.fraction == 0.75)
+    }
+
+    @Test("Download progress fraction is zero when totalBytes is zero")
+    func downloadProgressFractionZeroTotal() {
+        #expect(DownloadProgress.zero.fraction == 0)
     }
 
     @Test("Install progress tracks completion percentage")

--- a/KernovaTests/MacOSInstallStateTests.swift
+++ b/KernovaTests/MacOSInstallStateTests.swift
@@ -11,15 +11,16 @@ struct MacOSInstallStateTests {
     func initialStateWithDownload() {
         let state = MacOSInstallState(
             hasDownloadStep: true,
-            currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 0)
+            currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 0, bytesPerSecond: 0)
         )
 
         #expect(state.hasDownloadStep == true)
         #expect(state.downloadCompleted == false)
-        if case .downloading(let progress, let bytesWritten, let totalBytes) = state.currentPhase {
+        if case .downloading(let progress, let bytesWritten, let totalBytes, let bytesPerSecond) = state.currentPhase {
             #expect(progress == 0)
             #expect(bytesWritten == 0)
             #expect(totalBytes == 0)
+            #expect(bytesPerSecond == 0)
         } else {
             Issue.record("Expected downloading phase")
         }
@@ -47,7 +48,7 @@ struct MacOSInstallStateTests {
     func phaseTransition() {
         var state = MacOSInstallState(
             hasDownloadStep: true,
-            currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 1000)
+            currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 1000, bytesPerSecond: 0)
         )
 
         // Simulate download completion
@@ -68,19 +69,21 @@ struct MacOSInstallStateTests {
     func downloadProgress() {
         var state = MacOSInstallState(
             hasDownloadStep: true,
-            currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 1_000_000)
+            currentPhase: .downloading(progress: 0, bytesWritten: 0, totalBytes: 1_000_000, bytesPerSecond: 0)
         )
 
         state.currentPhase = .downloading(
             progress: 0.5,
             bytesWritten: 500_000,
-            totalBytes: 1_000_000
+            totalBytes: 1_000_000,
+            bytesPerSecond: 42_500_000
         )
 
-        if case .downloading(let progress, let bytesWritten, let totalBytes) = state.currentPhase {
+        if case .downloading(let progress, let bytesWritten, let totalBytes, let bytesPerSecond) = state.currentPhase {
             #expect(progress == 0.5)
             #expect(bytesWritten == 500_000)
             #expect(totalBytes == 1_000_000)
+            #expect(bytesPerSecond == 42_500_000)
         } else {
             Issue.record("Expected downloading phase")
         }

--- a/KernovaTests/Mocks/MockIPSWService.swift
+++ b/KernovaTests/Mocks/MockIPSWService.swift
@@ -20,7 +20,7 @@ final class MockIPSWService: IPSWProviding, @unchecked Sendable {
     func downloadRestoreImage(
         from remoteURL: URL,
         to destinationURL: URL,
-        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64, Double) -> Void
+        progressHandler: @MainActor @Sendable @escaping (DownloadProgress) -> Void
     ) async throws {
         downloadCallCount += 1
         if let error = downloadError { throw error }

--- a/KernovaTests/Mocks/MockIPSWService.swift
+++ b/KernovaTests/Mocks/MockIPSWService.swift
@@ -20,7 +20,7 @@ final class MockIPSWService: IPSWProviding, @unchecked Sendable {
     func downloadRestoreImage(
         from remoteURL: URL,
         to destinationURL: URL,
-        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64) -> Void
+        progressHandler: @MainActor @Sendable @escaping (Double, Int64, Int64, Double) -> Void
     ) async throws {
         downloadCallCount += 1
         if let error = downloadError { throw error }


### PR DESCRIPTION
## Summary
- Display EWMA-smoothed download speed (e.g., "42.5 MB/s") and estimated time remaining during IPSW downloads
- Introduce `DownloadProgress` struct to replace positional parameter sprawl in the progress handler
- Add `formatSpeed()` and `formatETA()` formatters with fixed-width output to prevent UI jitter

Closes #96

## Changes
- Add `DownloadProgress` struct with computed `fraction`, `static let zero`, and EWMA-smoothed `bytesPerSecond`
- Add EWMA speed tracking (alpha=0.2) in `IPSWDownloadDelegate` with negative-delta guard
- Add `DataFormatters.formatSpeed()` (auto unit: KB/s, MB/s, GB/s) and `formatETA()` with upper-bound cap
- Cache `DateComponentsFormatter` as static (was allocating per call at 10 Hz)
- Update `MacOSInstallProgressView` to show speed + ETA below existing progress line
- Clamp completion-path byte counts against `NSURLSessionTransferSizeUnknown` (-1)
- Update `IPSWProviding` protocol, `MockIPSWService`, and `VMLifecycleCoordinator`
- Add 14 new tests for formatters, edge cases, and DownloadProgress derivation

## Test plan
- [x] Built successfully on macOS 26
- [x] All existing and new tests pass (68 total)
- [x] Speed line hidden at download start (bytesPerSecond == 0), appears after first sample
- [x] ETA hidden when speed is negligible or estimate exceeds 100 hours
- [x] Negative byte deltas logged and skipped (EWMA not corrupted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)