### PR TITLE
feat: Allow renaming VMs while running or suspended

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -149,7 +149,7 @@ The model layer has two key types:
 
 `VMBundleLayout` is a `Sendable` struct that takes a bundle root path and provides all derived file paths (disk image, aux storage, save file, serial log, etc.), keeping path logic centralized.
 
-The remaining models are enums: `VMStatus` (stopped/starting/running/paused/saving/restoring/installing/error), `VMBootMode` (macOS/efi/linuxKernel), `VMGuestOS` (macOS/linux), and `MacOSInstallState` (tracking download and install phases with progress). `VMStatus` provides computed properties for state checks (`canStart`, `canStop`, `canForceStop`, `canPause`, `canResume`, `canSave`, `canEditSettings`, `isTransitioning`, `isActive`). `canForceStop` covers all states where a `VZVirtualMachine` may exist and need forceful termination (running, paused, starting, saving, restoring).
+The remaining models are enums: `VMStatus` (stopped/starting/running/paused/saving/restoring/installing/error), `VMBootMode` (macOS/efi/linuxKernel), `VMGuestOS` (macOS/linux), and `MacOSInstallState` (tracking download and install phases with progress). `VMStatus` provides computed properties for state checks (`canStart`, `canStop`, `canForceStop`, `canPause`, `canResume`, `canSave`, `canEditSettings`, `canRename`, `isTransitioning`, `isActive`). `canForceStop` covers all states where a `VZVirtualMachine` may exist and need forceful termination (running, paused, starting, saving, restoring).
 
 ### Services
 

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -681,7 +681,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         case #selector(saveVM(_:)):
             return activeInstance?.canSave ?? false
         case #selector(renameVM(_:)):
-            return activeInstance?.status.canEditSettings ?? false
+            return activeInstance?.status.canRename ?? false
         case #selector(cloneVM(_:)):
             guard let instance = activeInstance else { return false }
             return instance.status.canEditSettings && !viewModel.hasPreparing

--- a/Kernova/Models/VMStatus.swift
+++ b/Kernova/Models/VMStatus.swift
@@ -62,6 +62,7 @@ enum VMStatus: String, Codable, Sendable {
     /// prefer `VMInstance.canSave` for runtime checks.
     var canSave: Bool { self == .running || self == .paused }
     var canEditSettings: Bool { self == .stopped || self == .error }
+    var canRename: Bool { !isTransitioning }
 
     /// Whether the VM has a live display session that a backing view should present.
     var hasActiveDisplay: Bool {

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -83,6 +83,7 @@ struct VMSettingsView: View {
                     }
                 }
                 .buttonStyle(.plain)
+                .disabled(!instance.status.canRename)
             }
             LabeledContent("Type", value: instance.configuration.guestOS.displayName)
             LabeledContent("Boot Mode", value: instance.configuration.bootMode.displayName)

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -124,7 +124,7 @@ struct SidebarView: View {
             Button("Rename") {
                 viewModel.renameVMInSidebar(instance)
             }
-            .disabled(!instance.status.canEditSettings)
+            .disabled(!instance.status.canRename)
 
             Button("Clone") {
                 viewModel.cloneVM(instance)

--- a/KernovaTests/VMStatusTests.swift
+++ b/KernovaTests/VMStatusTests.swift
@@ -79,6 +79,18 @@ struct VMStatusTests {
         #expect(VMStatus.installing.canEditSettings == false)
     }
 
+    @Test("canRename returns true for all non-transitioning states")
+    func canRename() {
+        #expect(VMStatus.stopped.canRename == true)
+        #expect(VMStatus.running.canRename == true)
+        #expect(VMStatus.paused.canRename == true)
+        #expect(VMStatus.error.canRename == true)
+        #expect(VMStatus.starting.canRename == false)
+        #expect(VMStatus.saving.canRename == false)
+        #expect(VMStatus.restoring.canRename == false)
+        #expect(VMStatus.installing.canRename == false)
+    }
+
     @Test("canForceStop returns true for running, paused, starting, saving, restoring")
     func canForceStop() {
         #expect(VMStatus.running.canForceStop == true)


### PR DESCRIPTION
## Summary
- Decouple rename from `canEditSettings` so users can rename VMs in any non-transient state (running, paused, stopped, error)
- Rename only updates a display string and writes config JSON — no reason to block it while a VM is active

Closes #103

## Changes
- Add `canRename` computed property to `VMStatus` (`\!isTransitioning`)
- Replace `canEditSettings` with `canRename` for rename gates in SidebarView and AppDelegate
- Add `.disabled(\!instance.status.canRename)` to VMSettingsView name button (previously ungated)
- Add unit test covering all 8 states for `canRename`
- Update ARCHITECTURE.md VMStatus property listing

## Test plan
- [x] Build succeeds on macOS 26
- [x] All VMStatus tests pass (including new `canRename` test)
- [ ] Rename enabled in sidebar context menu and VM menu for running/paused VMs
- [ ] Rename disabled during transient states (starting, saving, restoring, installing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)