### PR TITLE
feat: Implement text-only SPICE clipboard in KernovaGuestAgent

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -89,7 +89,7 @@ KernovaRelaunchHelper/
 KernovaGuestAgent/                      # Guest-side SPICE agent for macOS VMs + DMG packaging resources
 ├── main.swift                          # Entry point: signal handling, device discovery, reconnect loop
 ├── GuestClipboardAgent.swift           # SPICE clipboard protocol state machine + NSPasteboard polling
-├── SerialPortDiscovery.swift           # Discovers /dev/cu.virtio* console port character device
+├── SerialPortDiscovery.swift           # Opens the SPICE agent console port character device
 ├── Info.plist                          # Explicit Info.plist with preprocessor macro for CFBundleVersion
 ├── install.command                     # Guest-side installer: copies binary, registers LaunchAgent
 ├── uninstall.command                   # Guest-side uninstaller: stops agent, removes files

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,8 +86,10 @@ DiskTemplates/                             # Bundled ASIF disk image templates (
 KernovaRelaunchHelper/
 └── main.swift                          # Lightweight CLI watchdog for TCC-forced restarts
 
-KernovaGuestAgent/                      # Guest-side agent stub + DMG packaging resources
-├── main.swift                          # Stub binary: blocks via dispatchMain() (placeholder for SPICE agent)
+KernovaGuestAgent/                      # Guest-side SPICE agent for macOS VMs + DMG packaging resources
+├── main.swift                          # Entry point: signal handling, device discovery, reconnect loop
+├── GuestClipboardAgent.swift           # SPICE clipboard protocol state machine + NSPasteboard polling
+├── SerialPortDiscovery.swift           # Discovers /dev/cu.virtio* console port character device
 ├── Info.plist                          # Explicit Info.plist with preprocessor macro for CFBundleVersion
 ├── install.command                     # Guest-side installer: copies binary, registers LaunchAgent
 ├── uninstall.command                   # Guest-side uninstaller: stops agent, removes files
@@ -177,7 +179,7 @@ Services are split by concurrency requirements:
 
 - **`ConfigurationBuilder`** — Translates a `VMConfiguration` into a `VZVirtualMachineConfiguration`. Handles three boot paths: `VZMacOSBootLoader` (macOS), `VZEFIBootLoader` (EFI/UEFI), and `VZLinuxBootLoader` (direct kernel boot). Configures CPU, memory, storage, network, display, keyboard, trackpad, and audio devices. When `clipboardSharingEnabled` is set, configures a `VZVirtioConsoleDeviceConfiguration` with a SPICE-named port using raw `VZFileHandleSerialPortAttachment` pipes (not `VZSpiceAgentPortAttachment`). Resolves symlinks on user-supplied paths (shared directories, kernel/initrd, ISO images) and validates them before passing to VZ. File paths (kernel, initrd, ISO) are checked for existence and rejected if they point to directories. Shared directory validation checks existence, is-directory, readability, and writability (for read-write shares) against the resolved path.
 
-- **`SpiceAgentProtocol`** — Pure data types and parsing for the SPICE agent wire format. Defines VDI chunk headers, VDAgent message headers, clipboard message types, and capability bitmasks. Includes `SpiceMessageBuilder` (builds wire-ready messages) and `SpiceAgentParser` (incremental parser handling fragmented data across multiple pipe reads). Fully `Sendable`, no I/O.
+- **`SpiceAgentProtocol`** — Pure data types and parsing for the SPICE agent wire format. Defines VDI chunk headers, VDAgent message headers, clipboard message types, and capability bitmasks. Includes `SpiceMessageBuilder` (builds wire-ready messages with a `port` parameter defaulting to `serverPort` for host-side use; guest-side code passes `clientPort`) and `SpiceAgentParser` (incremental parser handling fragmented data across multiple pipe reads). Fully `Sendable`, no I/O. Shared between the Kernova app and KernovaGuestAgent targets via multi-target membership.
 
 - **`SpiceClipboardService`** — `@MainActor` service that manages SPICE clipboard sharing for a single VM. Reads from the guest pipe on a background GCD queue, parses messages via `SpiceAgentParser`, and exposes `clipboardText` (observable, editable by the UI) and `isConnected`. When the clipboard window loses focus, `grabIfChanged()` sends a `CLIPBOARD_GRAB` if the text was edited. Uses raw pipes rather than `VZSpiceAgentPortAttachment` so clipboard data flows through the gated UI instead of the host `NSPasteboard`.
 
@@ -327,7 +329,7 @@ Two standalone command-line tool targets are built alongside the main app:
 
 - **KernovaRelaunchHelper** — Embedded in `Contents/MacOS/`. A watchdog that monitors the main app's PID and relaunches it after TCC-forced terminations. Launched by `AppDelegate` during quit when a TCC revocation is detected.
 
-- **KernovaGuestAgent** — Not embedded directly. A stub binary (blocks via `dispatchMain()` for launchd supervision) that is packaged into a disk image at build time by the "Package Guest Agent DMG" Run Script build phase. The disk image (containing the binary, `install.command`, `uninstall.command`, and a LaunchAgent plist) is placed in `Contents/Resources/KernovaGuestAgent.dmg`. At runtime, the "Install Guest Agent..." menu item in the Virtual Machine menu attaches it to a guest VM as USB mass storage. The guest user runs `install.command` to install the agent as a LaunchAgent in user-space (`~/Library/Application Support/Kernova/`). The build number is injected via `INFOPLIST_PREPROCESS`: a pre-Sources build phase ("Set Build Number from Git") writes `#define AGENT_BUILD_NUMBER` (set to the git commit count scoped to `KernovaGuestAgent/`) to a header in `DERIVED_FILE_DIR`, and the explicit `Info.plist` references that macro for `CFBundleVersion`. The preprocessed plist is embedded in the binary via `CREATE_INFOPLIST_SECTION_IN_BINARY`. This is a pipeline stub — the real agent will implement host-guest communication via SPICE.
+- **KernovaGuestAgent** — Not embedded directly. A SPICE guest agent that runs inside macOS VMs and speaks the VDAgent clipboard protocol over the virtio console port (`com.redhat.spice.0`), enabling bidirectional text clipboard sharing with the host-side `SpiceClipboardService`. Packaged into a disk image at build time by the "Package Guest Agent DMG" Run Script build phase. The disk image (containing the binary, `install.command`, `uninstall.command`, and a LaunchAgent plist) is placed in `Contents/Resources/KernovaGuestAgent.dmg`. At runtime, the "Install Guest Agent..." menu item in the Virtual Machine menu attaches it to a guest VM as USB mass storage. The guest user runs `install.command` to install the agent as a LaunchAgent in user-space (`~/Library/Application Support/Kernova/`). The agent discovers the serial device via `/dev/` scan, performs a capabilities handshake, polls `NSPasteboard.general` for clipboard changes (500ms interval), and reconnects automatically if the device disappears. Shares `SpiceAgentProtocol.swift` with the host app via multi-target membership. The build number is injected via `INFOPLIST_PREPROCESS`: a pre-Sources build phase ("Set Build Number from Git") writes `#define AGENT_BUILD_NUMBER` (set to the git commit count scoped to `KernovaGuestAgent/`) to a header in `DERIVED_FILE_DIR`, and the explicit `Info.plist` references that macro for `CFBundleVersion`. The preprocessed plist is embedded in the binary via `CREATE_INFOPLIST_SECTION_IN_BINARY`.
 
 ## Dependencies
 
@@ -364,7 +366,7 @@ No external package dependencies. No Swift Package Manager, CocoaPods, or Cartha
 | `VMToolbarManager` | 22 tests | Item creation, state updates, configuration flags, label toggling |
 | `DataFormatters` | Yes | Byte formatting, CPU count formatting |
 | `NSImageExtensions` | Yes | SF Symbol loading with known symbol validation |
-| `SpiceAgentProtocol` | Yes | VDI chunk/message serialization round-trips, parser with multi-message feeds, partial data, unknown types |
+| `SpiceAgentProtocol` | Yes | VDI chunk/message serialization round-trips, parser with multi-message feeds, partial data, unknown types, clientPort constant, port-parameterized builders |
 
 ### Mocked but Not Directly Tested
 
@@ -374,6 +376,7 @@ These services interact with system processes, the network, or VZ installer inte
 - `IPSWService` — makes network requests to Apple
 - `MacOSInstallService` — requires a real `VZVirtualMachine` and restore image
 - `SpiceClipboardService` — requires active SPICE pipe I/O (protocol parsing tested via `SpiceAgentProtocol` suite)
+- `GuestClipboardAgent` — runs inside guest VMs; mirrors `SpiceClipboardService` logic (protocol layer tested via shared `SpiceAgentProtocol` suite)
 
 ### Not Tested
 

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		A100010B /* KernovaRelaunchHelper in Embed Helpers */ = {isa = PBXBuildFile; fileRef = A1000100 /* KernovaRelaunchHelper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		A10000F1 /* DiskTemplates in Resources */ = {isa = PBXBuildFile; fileRef = A10000F0 /* DiskTemplates */; };
+		A100010B /* KernovaRelaunchHelper in Embed Helpers */ = {isa = PBXBuildFile; fileRef = A1000100 /* KernovaRelaunchHelper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,12 +35,26 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		A100010A /* Embed Helpers */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 6;
+			files = (
+				A100010B /* KernovaRelaunchHelper in Embed Helpers */,
+			);
+			name = "Embed Helpers";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		A1000004 /* Kernova.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Kernova.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1000005 /* KernovaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KernovaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000F0 /* DiskTemplates */ = {isa = PBXFileReference; lastKnownFileType = folder; path = DiskTemplates; sourceTree = "<group>"; };
 		A1000100 /* KernovaRelaunchHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = KernovaRelaunchHelper; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1000200 /* KernovaGuestAgent */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = KernovaGuestAgent; sourceTree = BUILT_PRODUCTS_DIR; };
-		A10000F0 /* DiskTemplates */ = {isa = PBXFileReference; lastKnownFileType = folder; path = DiskTemplates; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -50,16 +64,6 @@
 				App/Info.plist,
 			);
 			target = A1000003 /* Kernova */;
-		};
-		A100020B /* Exceptions for "KernovaGuestAgent" folder in "KernovaGuestAgent" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Info.plist,
-				com.kernova.agent.plist,
-				install.command,
-				uninstall.command,
-			);
-			target = A1000204 /* KernovaGuestAgent */;
 		};
 		A1000300 /* Exceptions for "Kernova" folder in "KernovaGuestAgent" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
@@ -92,9 +96,6 @@
 		};
 		A1000201 /* KernovaGuestAgent */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				A100020B /* Exceptions for "KernovaGuestAgent" folder in "KernovaGuestAgent" target */,
-			);
 			path = KernovaGuestAgent;
 			sourceTree = "<group>";
 		};
@@ -185,6 +186,29 @@
 			productReference = A1000004 /* Kernova.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A1000060 /* KernovaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1000031 /* Build configuration list for PBXNativeTarget "KernovaTests" */;
+			buildPhases = (
+				A1000041 /* Sources */,
+				A1000011 /* Frameworks */,
+				A1000051 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A1000070 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A1000007 /* KernovaTests */,
+			);
+			name = KernovaTests;
+			packageProductDependencies = (
+			);
+			productName = KernovaTests;
+			productReference = A1000005 /* KernovaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		A1000102 /* KernovaRelaunchHelper */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A1000107 /* Build configuration list for PBXNativeTarget "KernovaRelaunchHelper" */;
@@ -228,29 +252,6 @@
 			productReference = A1000200 /* KernovaGuestAgent */;
 			productType = "com.apple.product-type.tool";
 		};
-		A1000060 /* KernovaTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = A1000031 /* Build configuration list for PBXNativeTarget "KernovaTests" */;
-			buildPhases = (
-				A1000041 /* Sources */,
-				A1000011 /* Frameworks */,
-				A1000051 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				A1000070 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				A1000007 /* KernovaTests */,
-			);
-			name = KernovaTests;
-			packageProductDependencies = (
-			);
-			productName = KernovaTests;
-			productReference = A1000005 /* KernovaTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -263,15 +264,15 @@
 					A1000003 = {
 						CreatedOnToolsVersion = 16.0;
 					};
+					A1000060 = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = A1000003;
+					};
 					A1000102 = {
 						CreatedOnToolsVersion = 16.0;
 					};
 					A1000204 = {
 						CreatedOnToolsVersion = 16.0;
-					};
-					A1000060 = {
-						CreatedOnToolsVersion = 16.0;
-						TestTargetID = A1000003;
 					};
 				};
 			};
@@ -296,20 +297,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		A100010A /* Embed Helpers */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 6;
-			files = (
-				A100010B /* KernovaRelaunchHelper in Embed Helpers */,
-			);
-			name = "Embed Helpers";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXResourcesBuildPhase section */
 		A1000050 /* Resources */ = {
@@ -349,26 +336,6 @@
 			shellPath = /bin/sh;
 			shellScript = "BUILD_NUMBER=$(git rev-list --count HEAD)\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $BUILD_NUMBER\" \"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"\n";
 		};
-		A100020C /* Set Build Number from Git */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Set Build Number from Git";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/AgentBuildNumber.h",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\nBUILD_NUMBER=$(git rev-list --count HEAD -- KernovaGuestAgent/)\nif [ -z \"${BUILD_NUMBER}\" ]; then\n    echo \"error: Could not determine agent build number from git history\" >&2\n    exit 1\nfi\nmkdir -p \"${DERIVED_FILE_DIR}\"\necho \"#define AGENT_BUILD_NUMBER ${BUILD_NUMBER}\" > \"${DERIVED_FILE_DIR}/AgentBuildNumber.h\"\n";
-		};
 		A100020A /* Package Guest Agent DMG */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -391,6 +358,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
 			shellScript = "set -euo pipefail\n\nSTAGING_DIR=$(mktemp -d \"${DERIVED_FILE_DIR}/guest-agent-dmg-staging.XXXXXX\")\nTEMP_DMG=$(mktemp \"${DERIVED_FILE_DIR}/guest-agent-temp.XXXXXX.dmg\")\ntrap 'rm -rf \"${STAGING_DIR}\" \"${TEMP_DMG}\"' EXIT\n\nRAW_PREFIX=\"${DERIVED_FILE_DIR}/guest-agent-raw\"\nDMG_OUTPUT=\"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Resources/KernovaGuestAgent.dmg\"\n\ncp \"${BUILT_PRODUCTS_DIR}/KernovaGuestAgent\" \"${STAGING_DIR}/kernova-agent\"\ncp \"${SRCROOT}/KernovaGuestAgent/install.command\" \"${STAGING_DIR}/install.command\"\ncp \"${SRCROOT}/KernovaGuestAgent/uninstall.command\" \"${STAGING_DIR}/uninstall.command\"\nchmod +x \"${STAGING_DIR}/install.command\" \"${STAGING_DIR}/uninstall.command\"\ncp \"${SRCROOT}/KernovaGuestAgent/com.kernova.agent.plist\" \"${STAGING_DIR}/com.kernova.agent.plist\"\n\nmkdir -p \"$(dirname \"${DMG_OUTPUT}\")\"\n\n# Create a UDRW DMG then convert to DVD/CD-R master (UDTO/.cdr).\n# VZDiskImageStorageDeviceAttachment needs a format it can present as a\n# USB block device — the .cdr export works reliably for guest-mountable volumes.\nhdiutil create \\\n    -volname \"Kernova Guest Agent\" \\\n    -srcfolder \"${STAGING_DIR}\" \\\n    -ov -format UDRW \\\n    \"${TEMP_DMG}\"\nhdiutil convert \"${TEMP_DMG}\" -format UDTO -ov -o \"${RAW_PREFIX}\"\nmv \"${RAW_PREFIX}.cdr\" \"${DMG_OUTPUT}\"\n\n# Strip extended attributes that break code signing\nxattr -cr \"${DMG_OUTPUT}\"\n";
+		};
+		A100020C /* Set Build Number from Git */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Set Build Number from Git";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/AgentBuildNumber.h",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\nBUILD_NUMBER=$(git rev-list --count HEAD -- KernovaGuestAgent/)\nif [ -z \"${BUILD_NUMBER}\" ]; then\n    echo \"error: Could not determine agent build number from git history\" >&2\n    exit 1\nfi\nmkdir -p \"${DERIVED_FILE_DIR}\"\necho \"#define AGENT_BUILD_NUMBER ${BUILD_NUMBER}\" > \"${DERIVED_FILE_DIR}/AgentBuildNumber.h\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -61,6 +61,13 @@
 			);
 			target = A1000204 /* KernovaGuestAgent */;
 		};
+		A1000300 /* Exceptions for "Kernova" folder in "KernovaGuestAgent" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Services/SpiceAgentProtocol.swift,
+			);
+			target = A1000204 /* KernovaGuestAgent */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -68,6 +75,7 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				A10000E0 /* Exceptions for "Kernova" folder in "Kernova" target */,
+				A1000300 /* Exceptions for "Kernova" folder in "KernovaGuestAgent" target */,
 			);
 			path = Kernova;
 			sourceTree = "<group>";

--- a/Kernova/Services/SpiceAgentProtocol.swift
+++ b/Kernova/Services/SpiceAgentProtocol.swift
@@ -205,6 +205,14 @@ enum SpiceMessageBuilder {
     private static func setCapability(_ caps: inout UInt32, _ cap: SpiceAgentCapability) {
         caps |= 1 << UInt32(cap.rawValue)
     }
+
+    /// Checks whether a capability bit is set in a capabilities array.
+    static func hasCapability(_ caps: [UInt32], _ cap: SpiceAgentCapability) -> Bool {
+        let wordIndex = cap.rawValue / 32
+        let bitIndex = cap.rawValue % 32
+        guard wordIndex < caps.count else { return false }
+        return (caps[wordIndex] & (1 << UInt32(bitIndex))) != 0
+    }
 }
 
 // MARK: - Message Parser

--- a/Kernova/Services/SpiceAgentProtocol.swift
+++ b/Kernova/Services/SpiceAgentProtocol.swift
@@ -12,6 +12,10 @@ enum SpiceConstants {
     /// Destination port for host → guest messages (`VDP_SERVER_PORT`).
     /// The guest agent reads from this port.
     static let serverPort: UInt32 = 2
+
+    /// Destination port for guest → host messages (`VDP_CLIENT_PORT`).
+    /// The host reads from this port.
+    static let clientPort: UInt32 = 1
 }
 
 // MARK: - VDI Chunk Header
@@ -135,7 +139,7 @@ enum SpiceAgentCapability: Int, Sendable {
 enum SpiceMessageBuilder {
 
     /// Builds an `ANNOUNCE_CAPABILITIES` message advertising clipboard support.
-    static func buildAnnounceCapabilities(request: Bool) -> Data {
+    static func buildAnnounceCapabilities(request: Bool, port: UInt32 = SpiceConstants.serverPort) -> Data {
         // Capabilities payload: request (uint32) + caps array (1 × uint32)
         var caps: UInt32 = 0
         setCapability(&caps, .clipboard)
@@ -145,44 +149,44 @@ enum SpiceMessageBuilder {
         payload.appendLittleEndian(request ? UInt32(1) : UInt32(0))
         payload.appendLittleEndian(caps)
 
-        return wrapMessage(type: .announceCapabilities, payload: payload)
+        return wrapMessage(type: .announceCapabilities, payload: payload, port: port)
     }
 
     /// Builds a `CLIPBOARD_GRAB` message announcing available clipboard types.
     ///
     /// Without `VD_AGENT_CAP_CLIPBOARD_SELECTION`, the grab payload is simply
     /// an array of `uint32_t` type values.
-    static func buildClipboardGrab(types: [SpiceClipboardType]) -> Data {
+    static func buildClipboardGrab(types: [SpiceClipboardType], port: UInt32 = SpiceConstants.serverPort) -> Data {
         var payload = Data(capacity: types.count * 4)
         for type in types {
             payload.appendLittleEndian(type.rawValue)
         }
-        return wrapMessage(type: .clipboardGrab, payload: payload)
+        return wrapMessage(type: .clipboardGrab, payload: payload, port: port)
     }
 
     /// Builds a `CLIPBOARD_REQUEST` message asking the peer for clipboard data.
-    static func buildClipboardRequest(type: SpiceClipboardType) -> Data {
+    static func buildClipboardRequest(type: SpiceClipboardType, port: UInt32 = SpiceConstants.serverPort) -> Data {
         var payload = Data(capacity: 4)
         payload.appendLittleEndian(type.rawValue)
-        return wrapMessage(type: .clipboardRequest, payload: payload)
+        return wrapMessage(type: .clipboardRequest, payload: payload, port: port)
     }
 
     /// Builds a `CLIPBOARD` message delivering clipboard data to the peer.
-    static func buildClipboardData(type: SpiceClipboardType, data clipboardData: Data) -> Data {
+    static func buildClipboardData(type: SpiceClipboardType, data clipboardData: Data, port: UInt32 = SpiceConstants.serverPort) -> Data {
         var payload = Data(capacity: 4 + clipboardData.count)
         payload.appendLittleEndian(type.rawValue)
         payload.append(clipboardData)
-        return wrapMessage(type: .clipboard, payload: payload)
+        return wrapMessage(type: .clipboard, payload: payload, port: port)
     }
 
     /// Builds a `CLIPBOARD_RELEASE` message.
-    static func buildClipboardRelease() -> Data {
-        wrapMessage(type: .clipboardRelease, payload: Data())
+    static func buildClipboardRelease(port: UInt32 = SpiceConstants.serverPort) -> Data {
+        wrapMessage(type: .clipboardRelease, payload: Data(), port: port)
     }
 
     // MARK: - Private
 
-    private static func wrapMessage(type: SpiceAgentMessageType, payload: Data) -> Data {
+    private static func wrapMessage(type: SpiceAgentMessageType, payload: Data, port: UInt32) -> Data {
         let header = VDAgentMessageHeader(
             type: type,
             opaque: 0,
@@ -190,10 +194,8 @@ enum SpiceMessageBuilder {
         )
 
         let chunkPayload = header.serialize() + payload
-        // Use serverPort (2): the port field indicates the destination, and
-        // the guest agent reads from VDP_SERVER_PORT.
         let chunk = VDIChunkHeader(
-            port: SpiceConstants.serverPort,
+            port: port,
             dataSize: UInt32(chunkPayload.count)
         )
 

--- a/Kernova/Services/SpiceAgentProtocol.swift
+++ b/Kernova/Services/SpiceAgentProtocol.swift
@@ -134,8 +134,8 @@ enum SpiceAgentCapability: Int, Sendable {
 
 /// Builds complete wire-ready messages (VDI chunk header + VDAgent message header + data).
 ///
-/// All messages are sent from the host (client) to the guest (agent), so the chunk
-/// port is always `VDP_SERVER_PORT` (the destination port the guest agent reads from).
+/// Shared between the host app and guest agent. The `port` parameter defaults to
+/// `serverPort` for host-side callers; guest-side code passes `clientPort` explicitly.
 enum SpiceMessageBuilder {
 
     /// Builds an `ANNOUNCE_CAPABILITIES` message advertising clipboard support.
@@ -245,7 +245,7 @@ struct SpiceAgentParser: Sendable {
     private static let maxChunkDataSize: UInt32 = 1_048_576  // 1 MB
 
     /// `true` when the buffer was reset due to overflow or corruption.
-    /// Checked by `SpiceClipboardService` to log at the appropriate level.
+    /// Consumers should check this after each `feed()` call to log appropriately.
     private(set) var didReset = false
 
     /// Feed raw bytes from the pipe into the parser.

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -190,8 +190,8 @@ final class SpiceClipboardService {
     // (bit 5) — the legacy VD_AGENT_CAP_CLIPBOARD (bit 3) is the old "always-sync" mode that
     // no current agent advertises. We accept either bit as proof of clipboard support.
     private func handleCapabilities(request: Bool, caps: [UInt32]) {
-        let hasClipboard = hasCapability(caps, .clipboard)
-        let byDemand = hasCapability(caps, .clipboardByDemand)
+        let hasClipboard = SpiceMessageBuilder.hasCapability(caps, .clipboard)
+        let byDemand = SpiceMessageBuilder.hasCapability(caps, .clipboardByDemand)
 
         guard hasClipboard || byDemand else {
             Self.logger.warning("Guest agent does not support clipboard (caps: \(caps.map { String($0, radix: 16) }, privacy: .public))")
@@ -343,10 +343,4 @@ final class SpiceClipboardService {
         Self.logger.debug("Sent ANNOUNCE_CAPABILITIES (requesting guest reply)")
     }
 
-    private func hasCapability(_ caps: [UInt32], _ cap: SpiceAgentCapability) -> Bool {
-        let wordIndex = cap.rawValue / 32
-        let bitIndex = cap.rawValue % 32
-        guard wordIndex < caps.count else { return false }
-        return (caps[wordIndex] & (1 << UInt32(bitIndex))) != 0
-    }
 }

--- a/KernovaGuestAgent/GuestClipboardAgent.swift
+++ b/KernovaGuestAgent/GuestClipboardAgent.swift
@@ -45,8 +45,6 @@ final class GuestClipboardAgent: @unchecked Sendable {
 
     init(deviceHandle: FileHandle) {
         self.deviceHandle = deviceHandle
-        // Snapshot the current pasteboard change count so we don't immediately
-        // re-grab whatever is already on the clipboard at launch.
         self.lastPasteboardChangeCount = NSPasteboard.general.changeCount
     }
 
@@ -62,6 +60,7 @@ final class GuestClipboardAgent: @unchecked Sendable {
     }
 
     /// Stops polling, reading, and releases the device.
+    /// Does not invoke `onDisconnect` — used for intentional shutdown, not device loss.
     func stop() {
         pollingTimer?.cancel()
         pollingTimer = nil
@@ -73,7 +72,6 @@ final class GuestClipboardAgent: @unchecked Sendable {
     // MARK: - Reading
 
     private func startReading() {
-        // Capture for the closure (runs on a background GCD queue)
         let logger = Self.logger
 
         deviceHandle.readabilityHandler = { [weak self] handle in
@@ -98,9 +96,15 @@ final class GuestClipboardAgent: @unchecked Sendable {
 
     private func handleDeviceEOF() {
         Self.logger.notice("SPICE device closed (EOF)")
-        isConnected = false
+        disconnect()
+    }
+
+    /// Cancels polling, marks the connection as inactive, and notifies the caller.
+    private func disconnect() {
         pollingTimer?.cancel()
         pollingTimer = nil
+        deviceHandle.readabilityHandler = nil
+        isConnected = false
         onDisconnect?()
     }
 
@@ -140,8 +144,8 @@ final class GuestClipboardAgent: @unchecked Sendable {
     // MARK: - Message Handlers
 
     private func handleCapabilities(request: Bool, caps: [UInt32]) {
-        let hasClipboard = hasCapability(caps, .clipboard)
-        let byDemand = hasCapability(caps, .clipboardByDemand)
+        let hasClipboard = SpiceMessageBuilder.hasCapability(caps, .clipboard)
+        let byDemand = SpiceMessageBuilder.hasCapability(caps, .clipboardByDemand)
 
         guard hasClipboard || byDemand else {
             Self.logger.warning("Host does not support clipboard (caps: \(caps.map { String($0, radix: 16) }, privacy: .public))")
@@ -230,13 +234,13 @@ final class GuestClipboardAgent: @unchecked Sendable {
     }
 
     private func checkClipboardChange() {
+        guard isConnected else { return }
+
         let pasteboard = NSPasteboard.general
         let currentCount = pasteboard.changeCount
 
         guard currentCount != lastPasteboardChangeCount else { return }
         lastPasteboardChangeCount = currentCount
-
-        guard isConnected else { return }
 
         guard let text = pasteboard.string(forType: .string),
               !text.isEmpty else { return }
@@ -286,10 +290,7 @@ final class GuestClipboardAgent: @unchecked Sendable {
             return true
         } catch {
             Self.logger.error("Write to SPICE device failed: \(error.localizedDescription, privacy: .public)")
-            isConnected = false
-            pollingTimer?.cancel()
-            pollingTimer = nil
-            onDisconnect?()
+            disconnect()
             return false
         }
     }
@@ -303,12 +304,5 @@ final class GuestClipboardAgent: @unchecked Sendable {
         )
         writeToHost(message)
         Self.logger.debug("Sent ANNOUNCE_CAPABILITIES (request: \(request, privacy: .public))")
-    }
-
-    private func hasCapability(_ caps: [UInt32], _ cap: SpiceAgentCapability) -> Bool {
-        let wordIndex = cap.rawValue / 32
-        let bitIndex = cap.rawValue % 32
-        guard wordIndex < caps.count else { return false }
-        return (caps[wordIndex] & (1 << UInt32(bitIndex))) != 0
     }
 }

--- a/KernovaGuestAgent/GuestClipboardAgent.swift
+++ b/KernovaGuestAgent/GuestClipboardAgent.swift
@@ -9,9 +9,9 @@ import os
 /// - Reads messages sent by the host on `SpiceConstants.serverPort` (VDP_SERVER_PORT = 2)
 ///
 /// All mutable state is accessed exclusively on the main dispatch queue.
-// RATIONALE: @unchecked Sendable with DispatchQueue.main serialization mirrors the host-side
-// SpiceClipboardService pattern. @MainActor is impractical here because the entry point is
-// main.swift top-level code (nonisolated in Swift 6), not an @main app.
+// RATIONALE: @unchecked Sendable with DispatchQueue.main serialization is used because
+// @MainActor is impractical here — the entry point is main.swift top-level code
+// (nonisolated in Swift 6), not an @main app.
 final class GuestClipboardAgent: @unchecked Sendable {
 
     // MARK: - Callback

--- a/KernovaGuestAgent/GuestClipboardAgent.swift
+++ b/KernovaGuestAgent/GuestClipboardAgent.swift
@@ -62,10 +62,7 @@ final class GuestClipboardAgent: @unchecked Sendable {
     /// Stops polling, reading, and releases the device.
     /// Does not invoke `onDisconnect` — used for intentional shutdown, not device loss.
     func stop() {
-        pollingTimer?.cancel()
-        pollingTimer = nil
-        deviceHandle.readabilityHandler = nil
-        isConnected = false
+        tearDown()
         Self.logger.notice("Guest clipboard agent stopped")
     }
 
@@ -99,12 +96,16 @@ final class GuestClipboardAgent: @unchecked Sendable {
         disconnect()
     }
 
-    /// Cancels polling, marks the connection as inactive, and notifies the caller.
-    private func disconnect() {
+    private func tearDown() {
         pollingTimer?.cancel()
         pollingTimer = nil
         deviceHandle.readabilityHandler = nil
         isConnected = false
+    }
+
+    /// Tears down and notifies the caller to trigger reconnection.
+    private func disconnect() {
+        tearDown()
         onDisconnect?()
     }
 

--- a/KernovaGuestAgent/GuestClipboardAgent.swift
+++ b/KernovaGuestAgent/GuestClipboardAgent.swift
@@ -241,13 +241,18 @@ final class GuestClipboardAgent: @unchecked Sendable {
         let currentCount = pasteboard.changeCount
 
         guard currentCount != lastPasteboardChangeCount else { return }
-        lastPasteboardChangeCount = currentCount
 
         guard let text = pasteboard.string(forType: .string),
-              !text.isEmpty else { return }
+              !text.isEmpty else {
+            lastPasteboardChangeCount = currentCount
+            return
+        }
 
         // Avoid echoing back text we just wrote to the pasteboard from the host
-        guard text != lastGrabbedText else { return }
+        guard text != lastGrabbedText else {
+            lastPasteboardChangeCount = currentCount
+            return
+        }
 
         pendingOutboundText = text
         lastGrabbedText = text
@@ -262,8 +267,12 @@ final class GuestClipboardAgent: @unchecked Sendable {
             // Legacy mode: host won't send REQUEST, deliver data immediately.
             if !sendClipboardText(text) {
                 lastGrabbedText = nil
+                return
             }
         }
+
+        // Update change count only after successfully initiating the sync
+        lastPasteboardChangeCount = currentCount
 
         Self.logger.debug("Sent clipboard grab (\(text.utf8.count, privacy: .public) bytes pending, byDemand: \(self.hostSupportsByDemand, privacy: .public))")
     }

--- a/KernovaGuestAgent/GuestClipboardAgent.swift
+++ b/KernovaGuestAgent/GuestClipboardAgent.swift
@@ -1,0 +1,314 @@
+import AppKit
+import Foundation
+import os
+
+/// Guest-side SPICE clipboard agent that communicates with the host's `SpiceClipboardService`.
+///
+/// Mirrors the host-side `SpiceClipboardService` but with reversed message direction:
+/// - Sends messages with `SpiceConstants.clientPort` (VDP_CLIENT_PORT = 1)
+/// - Reads messages sent by the host on `SpiceConstants.serverPort` (VDP_SERVER_PORT = 2)
+///
+/// All mutable state is accessed exclusively on the main dispatch queue.
+// RATIONALE: @unchecked Sendable with DispatchQueue.main serialization mirrors the host-side
+// SpiceClipboardService pattern. @MainActor is impractical here because the entry point is
+// main.swift top-level code (nonisolated in Swift 6), not an @main app.
+final class GuestClipboardAgent: @unchecked Sendable {
+
+    // MARK: - Callback
+
+    /// Called when the device becomes unavailable (EOF or write error).
+    /// The caller (main.swift) uses this to trigger a reconnect cycle.
+    var onDisconnect: (() -> Void)?
+
+    // MARK: - Private State (main queue only)
+
+    private var parser = SpiceAgentParser()
+    private var isConnected = false
+    private var hostSupportsByDemand = false
+
+    private var lastPasteboardChangeCount: Int = 0
+    private var pendingOutboundText: String?
+    private var lastGrabbedText: String?
+
+    // MARK: - I/O
+
+    private let deviceHandle: FileHandle
+    private var pollingTimer: DispatchSourceTimer?
+
+    // MARK: - Constants
+
+    private static let pollingInterval: TimeInterval = 0.5
+
+    private static let logger = Logger(subsystem: "com.kernova.agent", category: "GuestClipboardAgent")
+
+    // MARK: - Init
+
+    init(deviceHandle: FileHandle) {
+        self.deviceHandle = deviceHandle
+        // Snapshot the current pasteboard change count so we don't immediately
+        // re-grab whatever is already on the clipboard at launch.
+        self.lastPasteboardChangeCount = NSPasteboard.general.changeCount
+    }
+
+    // MARK: - Lifecycle
+
+    /// Begins reading from the device, sends the initial capabilities handshake,
+    /// and starts clipboard polling.
+    func start() {
+        startReading()
+        sendCapabilities(request: true)
+        startClipboardPolling()
+        Self.logger.notice("Guest clipboard agent started")
+    }
+
+    /// Stops polling, reading, and releases the device.
+    func stop() {
+        pollingTimer?.cancel()
+        pollingTimer = nil
+        deviceHandle.readabilityHandler = nil
+        isConnected = false
+        Self.logger.notice("Guest clipboard agent stopped")
+    }
+
+    // MARK: - Reading
+
+    private func startReading() {
+        // Capture for the closure (runs on a background GCD queue)
+        let logger = Self.logger
+
+        deviceHandle.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else {
+                // EOF — device closed (VM paused, device removed, etc.)
+                // Nil-out immediately to prevent GCD spin loop.
+                handle.readabilityHandler = nil
+                DispatchQueue.main.async { [weak self] in
+                    self?.handleDeviceEOF()
+                }
+                return
+            }
+
+            logger.debug("Read \(data.count, privacy: .public) bytes from SPICE device")
+
+            DispatchQueue.main.async { [weak self] in
+                self?.handleIncomingData(data)
+            }
+        }
+    }
+
+    private func handleDeviceEOF() {
+        Self.logger.notice("SPICE device closed (EOF)")
+        isConnected = false
+        pollingTimer?.cancel()
+        pollingTimer = nil
+        onDisconnect?()
+    }
+
+    private func handleIncomingData(_ data: Data) {
+        let messages = parser.feed(data)
+
+        if parser.didReset {
+            Self.logger.error("SPICE parser buffer reset — stream may be corrupted")
+        }
+
+        for message in messages {
+            switch message {
+            case .announceCapabilities(let request, let caps):
+                handleCapabilities(request: request, caps: caps)
+
+            case .clipboardGrab(let types):
+                handleClipboardGrab(types: types)
+
+            case .clipboardRequest(let type):
+                handleClipboardRequest(type: type)
+
+            case .clipboardData(let type, let data):
+                handleClipboardData(type: type, data: data)
+
+            case .clipboardRelease:
+                Self.logger.debug("Host released clipboard")
+
+            case .other(let type):
+                Self.logger.debug("Ignoring unhandled SPICE message type: \(type.rawValue, privacy: .public)")
+
+            case .malformedChunk:
+                Self.logger.warning("Skipping malformed SPICE chunk")
+            }
+        }
+    }
+
+    // MARK: - Message Handlers
+
+    private func handleCapabilities(request: Bool, caps: [UInt32]) {
+        let hasClipboard = hasCapability(caps, .clipboard)
+        let byDemand = hasCapability(caps, .clipboardByDemand)
+
+        guard hasClipboard || byDemand else {
+            Self.logger.warning("Host does not support clipboard (caps: \(caps.map { String($0, radix: 16) }, privacy: .public))")
+            return
+        }
+
+        isConnected = true
+        hostSupportsByDemand = byDemand
+
+        // If the host requested our capabilities, send them back (non-requesting)
+        if request {
+            sendCapabilities(request: false)
+        }
+
+        Self.logger.notice(
+            "Host connected (caps: \(caps.map { String($0, radix: 16) }, privacy: .public), byDemand: \(byDemand, privacy: .public))"
+        )
+    }
+
+    /// Host announced it has new clipboard data — request it.
+    private func handleClipboardGrab(types: [SpiceClipboardType]) {
+        Self.logger.debug("Host clipboard grab: types=\(types.map(\.rawValue), privacy: .public)")
+
+        guard types.contains(.utf8Text) else {
+            Self.logger.debug("Host clipboard has no UTF-8 text type, ignoring")
+            return
+        }
+
+        let request = SpiceMessageBuilder.buildClipboardRequest(
+            type: .utf8Text,
+            port: SpiceConstants.clientPort
+        )
+        writeToHost(request)
+    }
+
+    /// Host is requesting clipboard data from us (response to our GRAB).
+    private func handleClipboardRequest(type: SpiceClipboardType) {
+        Self.logger.debug("Host requested clipboard data (type: \(type.rawValue, privacy: .public))")
+
+        guard type == .utf8Text else {
+            Self.logger.debug("Host requested non-text type, ignoring")
+            return
+        }
+
+        guard let text = pendingOutboundText else {
+            Self.logger.debug("No pending outbound text for clipboard request")
+            return
+        }
+
+        sendClipboardText(text)
+    }
+
+    /// Host delivered clipboard data — write to the guest pasteboard.
+    private func handleClipboardData(type: SpiceClipboardType, data: Data) {
+        guard type == .utf8Text else {
+            Self.logger.debug("Received non-text clipboard data (type: \(type.rawValue, privacy: .public)), ignoring")
+            return
+        }
+
+        guard let text = String(data: data, encoding: .utf8) else {
+            Self.logger.warning("Failed to decode host clipboard data as UTF-8 (\(data.count, privacy: .public) bytes)")
+            return
+        }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+
+        // Record the change count and text to suppress echo detection in the polling timer
+        lastPasteboardChangeCount = pasteboard.changeCount
+        lastGrabbedText = text
+
+        Self.logger.debug("Wrote host clipboard to pasteboard (\(text.count, privacy: .public) chars)")
+    }
+
+    // MARK: - Clipboard Polling
+
+    private func startClipboardPolling() {
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + Self.pollingInterval, repeating: Self.pollingInterval)
+        timer.setEventHandler { [weak self] in
+            self?.checkClipboardChange()
+        }
+        timer.resume()
+        pollingTimer = timer
+    }
+
+    private func checkClipboardChange() {
+        let pasteboard = NSPasteboard.general
+        let currentCount = pasteboard.changeCount
+
+        guard currentCount != lastPasteboardChangeCount else { return }
+        lastPasteboardChangeCount = currentCount
+
+        guard isConnected else { return }
+
+        guard let text = pasteboard.string(forType: .string),
+              !text.isEmpty else { return }
+
+        // Avoid echoing back text we just wrote to the pasteboard from the host
+        guard text != lastGrabbedText else { return }
+
+        pendingOutboundText = text
+        lastGrabbedText = text
+
+        let grabMessage = SpiceMessageBuilder.buildClipboardGrab(
+            types: [.utf8Text],
+            port: SpiceConstants.clientPort
+        )
+        guard writeToHost(grabMessage) else { return }
+
+        if !hostSupportsByDemand {
+            // Legacy mode: host won't send REQUEST, deliver data immediately.
+            if !sendClipboardText(text) {
+                lastGrabbedText = nil
+            }
+        }
+
+        Self.logger.debug("Sent clipboard grab (\(text.utf8.count, privacy: .public) bytes pending, byDemand: \(self.hostSupportsByDemand, privacy: .public))")
+    }
+
+    // MARK: - Writing
+
+    @discardableResult
+    private func sendClipboardText(_ text: String) -> Bool {
+        guard let textData = text.data(using: .utf8) else {
+            Self.logger.warning("Failed to encode clipboard text as UTF-8 (\(text.count, privacy: .public) characters)")
+            return false
+        }
+        let dataMessage = SpiceMessageBuilder.buildClipboardData(
+            type: .utf8Text,
+            data: textData,
+            port: SpiceConstants.clientPort
+        )
+        return writeToHost(dataMessage)
+    }
+
+    @discardableResult
+    private func writeToHost(_ data: Data) -> Bool {
+        do {
+            try deviceHandle.write(contentsOf: data)
+            return true
+        } catch {
+            Self.logger.error("Write to SPICE device failed: \(error.localizedDescription, privacy: .public)")
+            isConnected = false
+            pollingTimer?.cancel()
+            pollingTimer = nil
+            onDisconnect?()
+            return false
+        }
+    }
+
+    // MARK: - Capability Helpers
+
+    private func sendCapabilities(request: Bool) {
+        let message = SpiceMessageBuilder.buildAnnounceCapabilities(
+            request: request,
+            port: SpiceConstants.clientPort
+        )
+        writeToHost(message)
+        Self.logger.debug("Sent ANNOUNCE_CAPABILITIES (request: \(request, privacy: .public))")
+    }
+
+    private func hasCapability(_ caps: [UInt32], _ cap: SpiceAgentCapability) -> Bool {
+        let wordIndex = cap.rawValue / 32
+        let bitIndex = cap.rawValue % 32
+        guard wordIndex < caps.count else { return false }
+        return (caps[wordIndex] & (1 << UInt32(bitIndex))) != 0
+    }
+}

--- a/KernovaGuestAgent/SerialPortDiscovery.swift
+++ b/KernovaGuestAgent/SerialPortDiscovery.swift
@@ -10,12 +10,10 @@ enum SerialPortDiscovery {
 
     private static let logger = Logger(subsystem: "com.kernova.agent", category: "SerialPortDiscovery")
 
-    /// Known device path patterns for the SPICE agent console port.
-    /// The port is configured at index 0 of a `VZVirtioConsoleDeviceConfiguration`.
-    private static let candidatePaths = [
-        "/dev/cu.virtio-port0",
-        "/dev/cu.virtio",
-    ]
+    /// Device path for the SPICE agent console port.
+    /// The host names the port `VZSpiceAgentPortAttachment.spiceAgentPortName`
+    /// ("com.redhat.spice.0"); the guest kernel exposes it as `/dev/cu.<name>`.
+    private static let devicePath = "/dev/cu.com.redhat.spice.0"
 
     // RATIONALE: nonisolated(unsafe) is safe here because openDevice() is only called
     // from the main dispatch queue in main.swift's connection retry loop.
@@ -33,16 +31,13 @@ enum SerialPortDiscovery {
             hasLoggedDevices = true
         }
 
-        for path in candidatePaths {
-            let fd = open(path, O_RDWR | O_NOCTTY | O_NONBLOCK)
-            if fd >= 0 {
-                logger.notice("Opened SPICE device at '\(path, privacy: .public)' (fd=\(fd, privacy: .public))")
-                return FileHandle(fileDescriptor: fd, closeOnDealloc: true)
-            }
+        let fd = open(devicePath, O_RDWR | O_NOCTTY | O_NONBLOCK)
+        guard fd >= 0 else {
+            logger.debug("SPICE device not available at '\(devicePath, privacy: .public)'")
+            return nil
         }
-
-        logger.debug("No SPICE serial device found")
-        return nil
+        logger.notice("Opened SPICE device at '\(devicePath, privacy: .public)' (fd=\(fd, privacy: .public))")
+        return FileHandle(fileDescriptor: fd, closeOnDealloc: true)
     }
 
     /// Logs all `/dev/cu.*` devices at debug level to aid device path discovery during development.

--- a/KernovaGuestAgent/SerialPortDiscovery.swift
+++ b/KernovaGuestAgent/SerialPortDiscovery.swift
@@ -1,0 +1,59 @@
+import Foundation
+import os
+
+/// Discovers and opens the SPICE agent serial device inside a macOS guest VM.
+///
+/// The host creates a `VZVirtioConsoleDeviceConfiguration` with a port named
+/// `com.redhat.spice.0`. Inside the guest this appears as a character device
+/// under `/dev/`. This enum scans known candidate paths and opens the first match.
+enum SerialPortDiscovery {
+
+    private static let logger = Logger(subsystem: "com.kernova.agent", category: "SerialPortDiscovery")
+
+    /// Known device path patterns for the SPICE agent console port.
+    /// The port is configured at index 0 of a `VZVirtioConsoleDeviceConfiguration`.
+    private static let candidatePaths = [
+        "/dev/cu.virtio-port0",
+        "/dev/cu.virtio",
+    ]
+
+    /// Discovers and opens the SPICE agent serial device.
+    ///
+    /// Scans candidate paths, opens the first matching device with `O_RDWR | O_NOCTTY | O_NONBLOCK`,
+    /// and returns a `FileHandle` for bidirectional communication.
+    ///
+    /// - Returns: A `FileHandle` wrapping the opened device, or `nil` if no device was found.
+    static func openDevice() -> FileHandle? {
+        logAvailableSerialDevices()
+
+        for path in candidatePaths {
+            guard FileManager.default.fileExists(atPath: path) else { continue }
+
+            let fd = open(path, O_RDWR | O_NOCTTY | O_NONBLOCK)
+            if fd >= 0 {
+                logger.notice("Opened SPICE device at '\(path, privacy: .public)' (fd=\(fd, privacy: .public))")
+                return FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+            } else {
+                logger.warning("Found '\(path, privacy: .public)' but open() failed: \(String(cString: strerror(errno)), privacy: .public)")
+            }
+        }
+
+        logger.debug("No SPICE serial device found")
+        return nil
+    }
+
+    /// Logs all `/dev/cu.*` devices at debug level to aid device path discovery during development.
+    private static func logAvailableSerialDevices() {
+        do {
+            let devContents = try FileManager.default.contentsOfDirectory(atPath: "/dev")
+            let serialDevices = devContents.filter { $0.hasPrefix("cu.") }.sorted()
+            if serialDevices.isEmpty {
+                logger.debug("No /dev/cu.* serial devices found")
+            } else {
+                logger.debug("Available serial devices: \(serialDevices, privacy: .public)")
+            }
+        } catch {
+            logger.debug("Failed to enumerate /dev: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/KernovaGuestAgent/SerialPortDiscovery.swift
+++ b/KernovaGuestAgent/SerialPortDiscovery.swift
@@ -1,11 +1,11 @@
 import Foundation
 import os
 
-/// Discovers and opens the SPICE agent serial device inside a macOS guest VM.
+/// Opens the SPICE agent serial device inside a macOS guest VM.
 ///
 /// The host creates a `VZVirtioConsoleDeviceConfiguration` with a port named
-/// `com.redhat.spice.0`. Inside the guest this appears as a character device
-/// under `/dev/`. This enum scans known candidate paths and opens the first match.
+/// `com.redhat.spice.0` (via `VZSpiceAgentPortAttachment.spiceAgentPortName`).
+/// Inside the guest this appears as a character device at `/dev/cu.<name>`.
 enum SerialPortDiscovery {
 
     private static let logger = Logger(subsystem: "com.kernova.agent", category: "SerialPortDiscovery")
@@ -19,12 +19,9 @@ enum SerialPortDiscovery {
     // from the main dispatch queue in main.swift's connection retry loop.
     nonisolated(unsafe) private static var hasLoggedDevices = false
 
-    /// Discovers and opens the SPICE agent serial device.
+    /// Attempts to open the SPICE agent serial device at the known path.
     ///
-    /// Scans candidate paths, opens the first matching device with `O_RDWR | O_NOCTTY | O_NONBLOCK`,
-    /// and returns a `FileHandle` for bidirectional communication.
-    ///
-    /// - Returns: A `FileHandle` wrapping the opened device, or `nil` if no device was found.
+    /// - Returns: A `FileHandle` wrapping the opened device, or `nil` if unavailable.
     static func openDevice() -> FileHandle? {
         if !hasLoggedDevices {
             logAvailableSerialDevices()
@@ -33,7 +30,12 @@ enum SerialPortDiscovery {
 
         let fd = open(devicePath, O_RDWR | O_NOCTTY | O_NONBLOCK)
         guard fd >= 0 else {
-            logger.debug("SPICE device not available at '\(devicePath, privacy: .public)'")
+            let code = errno
+            if code == ENOENT || code == ENXIO {
+                logger.debug("SPICE device not available at '\(devicePath, privacy: .public)'")
+            } else {
+                logger.warning("Failed to open SPICE device at '\(devicePath, privacy: .public)': \(String(cString: strerror(code)), privacy: .public) (errno=\(code, privacy: .public))")
+            }
             return nil
         }
         logger.notice("Opened SPICE device at '\(devicePath, privacy: .public)' (fd=\(fd, privacy: .public))")

--- a/KernovaGuestAgent/SerialPortDiscovery.swift
+++ b/KernovaGuestAgent/SerialPortDiscovery.swift
@@ -17,6 +17,10 @@ enum SerialPortDiscovery {
         "/dev/cu.virtio",
     ]
 
+    // RATIONALE: nonisolated(unsafe) is safe here because openDevice() is only called
+    // from the main dispatch queue in main.swift's connection retry loop.
+    nonisolated(unsafe) private static var hasLoggedDevices = false
+
     /// Discovers and opens the SPICE agent serial device.
     ///
     /// Scans candidate paths, opens the first matching device with `O_RDWR | O_NOCTTY | O_NONBLOCK`,
@@ -24,17 +28,16 @@ enum SerialPortDiscovery {
     ///
     /// - Returns: A `FileHandle` wrapping the opened device, or `nil` if no device was found.
     static func openDevice() -> FileHandle? {
-        logAvailableSerialDevices()
+        if !hasLoggedDevices {
+            logAvailableSerialDevices()
+            hasLoggedDevices = true
+        }
 
         for path in candidatePaths {
-            guard FileManager.default.fileExists(atPath: path) else { continue }
-
             let fd = open(path, O_RDWR | O_NOCTTY | O_NONBLOCK)
             if fd >= 0 {
                 logger.notice("Opened SPICE device at '\(path, privacy: .public)' (fd=\(fd, privacy: .public))")
                 return FileHandle(fileDescriptor: fd, closeOnDealloc: true)
-            } else {
-                logger.warning("Found '\(path, privacy: .public)' but open() failed: \(String(cString: strerror(errno)), privacy: .public)")
             }
         }
 

--- a/KernovaGuestAgent/SerialPortDiscovery.swift
+++ b/KernovaGuestAgent/SerialPortDiscovery.swift
@@ -15,18 +15,15 @@ enum SerialPortDiscovery {
     /// ("com.redhat.spice.0"); the guest kernel exposes it as `/dev/cu.<name>`.
     private static let devicePath = "/dev/cu.com.redhat.spice.0"
 
-    // RATIONALE: nonisolated(unsafe) is safe here because openDevice() is only called
-    // from the main dispatch queue in main.swift's connection retry loop.
-    nonisolated(unsafe) private static var hasLoggedDevices = false
+    private static let logOnce: () = {
+        logAvailableSerialDevices()
+    }()
 
     /// Attempts to open the SPICE agent serial device at the known path.
     ///
     /// - Returns: A `FileHandle` wrapping the opened device, or `nil` if unavailable.
     static func openDevice() -> FileHandle? {
-        if !hasLoggedDevices {
-            logAvailableSerialDevices()
-            hasLoggedDevices = true
-        }
+        _ = logOnce
 
         let fd = open(devicePath, O_RDWR | O_NOCTTY | O_NONBLOCK)
         guard fd >= 0 else {

--- a/KernovaGuestAgent/main.swift
+++ b/KernovaGuestAgent/main.swift
@@ -89,7 +89,6 @@ func attemptConnection() {
     currentAgent = agent
     agent.onDisconnect = {
         logger.notice("Device disconnected, scheduling reconnect in \(retryInterval, privacy: .public)s")
-        currentAgent?.stop()
         currentAgent = nil
         DispatchQueue.main.asyncAfter(deadline: .now() + retryInterval) {
             attemptConnection()

--- a/KernovaGuestAgent/main.swift
+++ b/KernovaGuestAgent/main.swift
@@ -1,16 +1,20 @@
+import AppKit
 import Foundation
 import os
 
 // KernovaGuestAgent
 //
-// A guest-side agent that runs inside macOS virtual machines managed by Kernova.
-// This is currently a stub that validates the build-package-install pipeline.
-// The real agent will implement host-guest communication via SPICE.
+// A guest-side SPICE agent that runs inside macOS virtual machines managed by Kernova.
+// Speaks the VDAgent clipboard protocol over the virtio console port, enabling
+// bidirectional text clipboard sharing with the host.
 //
 // Usage: kernova-agent [--version]
-// When run without flags, blocks indefinitely via dispatchMain() for launchd supervision.
+// When run without flags, discovers the SPICE serial device and begins clipboard sharing.
+// Designed to run as a macOS LaunchAgent (auto-start on login, auto-restart on crash).
 
 private let logger = Logger(subsystem: "com.kernova.agent", category: "GuestAgent")
+
+// MARK: - Version
 
 private let version: String = {
     guard let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
@@ -40,5 +44,59 @@ if CommandLine.arguments.contains("--version") {
     exit(0)
 }
 
-logger.notice("Kernova Guest Agent v\(version, privacy: .public) (\(buildNumber, privacy: .public)) started (stub — waiting for termination)")
+logger.notice("Kernova Guest Agent v\(version, privacy: .public) (\(buildNumber, privacy: .public)) started")
+
+// MARK: - Signal Handling
+
+// RATIONALE: nonisolated(unsafe) is correct here because all access to currentAgent occurs
+// on the main dispatch queue (signal handlers, attemptConnection, onDisconnect callback).
+// main.swift top-level code is nonisolated in Swift 6, making @MainActor impractical.
+nonisolated(unsafe) var currentAgent: GuestClipboardAgent?
+
+signal(SIGINT, SIG_IGN)
+signal(SIGTERM, SIG_IGN)
+
+let sigintSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+let sigtermSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+
+let shutdownHandler: () -> Void = {
+    logger.notice("Received termination signal, shutting down")
+    currentAgent?.stop()
+    currentAgent = nil
+    exit(0)
+}
+
+sigintSource.setEventHandler(handler: shutdownHandler)
+sigtermSource.setEventHandler(handler: shutdownHandler)
+sigintSource.resume()
+sigtermSource.resume()
+
+// MARK: - Device Discovery and Connect Loop
+
+/// Retry interval when the device is not yet available or after a disconnect.
+private let retryInterval: TimeInterval = 5.0
+
+func attemptConnection() {
+    guard let deviceHandle = SerialPortDiscovery.openDevice() else {
+        logger.debug("SPICE device not available, retrying in \(retryInterval, privacy: .public)s")
+        DispatchQueue.main.asyncAfter(deadline: .now() + retryInterval) {
+            attemptConnection()
+        }
+        return
+    }
+
+    let agent = GuestClipboardAgent(deviceHandle: deviceHandle)
+    currentAgent = agent
+    agent.onDisconnect = {
+        logger.notice("Device disconnected, scheduling reconnect in \(retryInterval, privacy: .public)s")
+        currentAgent?.stop()
+        currentAgent = nil
+        DispatchQueue.main.asyncAfter(deadline: .now() + retryInterval) {
+            attemptConnection()
+        }
+    }
+    agent.start()
+}
+
+attemptConnection()
 dispatchMain()

--- a/KernovaTests/SpiceAgentProtocolTests.swift
+++ b/KernovaTests/SpiceAgentProtocolTests.swift
@@ -477,6 +477,35 @@ struct SpiceAgentProtocolTests {
         #expect(port == SpiceConstants.serverPort)
     }
 
+    // MARK: - Capability Checking
+
+    @Test("hasCapability detects set capability bits")
+    func hasCapabilityDetectsSetBits() {
+        // clipboard = bit 3, clipboardByDemand = bit 5
+        let caps: [UInt32] = [(1 << 3) | (1 << 5)]
+        #expect(SpiceMessageBuilder.hasCapability(caps, .clipboard))
+        #expect(SpiceMessageBuilder.hasCapability(caps, .clipboardByDemand))
+    }
+
+    @Test("hasCapability returns false for unset bits")
+    func hasCapabilityReturnsFalseForUnsetBits() {
+        let caps: [UInt32] = [(1 << 3)]  // only clipboard set
+        #expect(!SpiceMessageBuilder.hasCapability(caps, .clipboardByDemand))
+        #expect(!SpiceMessageBuilder.hasCapability(caps, .monitorsConfig))
+    }
+
+    @Test("hasCapability returns false for empty caps array")
+    func hasCapabilityEmptyCaps() {
+        #expect(!SpiceMessageBuilder.hasCapability([], .clipboard))
+    }
+
+    @Test("hasCapability returns false when word index exceeds array length")
+    func hasCapabilityOutOfBounds() {
+        // clipboardNoReleaseOnRegrab = bit 16 (word 0, bit 16) — fits in single word
+        // But if we pass an empty array, wordIndex 0 exceeds bounds
+        #expect(!SpiceMessageBuilder.hasCapability([], .clipboardNoReleaseOnRegrab))
+    }
+
     // MARK: - Test Helpers
 
     /// Builds a fake guest→host message with the given type and payload.

--- a/KernovaTests/SpiceAgentProtocolTests.swift
+++ b/KernovaTests/SpiceAgentProtocolTests.swift
@@ -426,6 +426,57 @@ struct SpiceAgentProtocolTests {
         #expect(data.readLittleEndianUInt64(at: 0) == 0x0102030405060708)
     }
 
+    // MARK: - Client Port and Port Parameter
+
+    @Test("Client port constant equals VDP_CLIENT_PORT (1)")
+    func clientPortValue() {
+        #expect(SpiceConstants.clientPort == 1)
+        #expect(SpiceConstants.clientPort != SpiceConstants.serverPort)
+    }
+
+    @Test("Builder with explicit clientPort produces chunk header with port 1")
+    func buildCapabilitiesWithClientPort() {
+        let message = SpiceMessageBuilder.buildAnnounceCapabilities(
+            request: true,
+            port: SpiceConstants.clientPort
+        )
+
+        let port = message.readLittleEndianUInt32(at: 0)
+        #expect(port == SpiceConstants.clientPort)
+
+        // Message structure should be identical except for the port field
+        #expect(message.count == 36)
+        let msgType = message.readLittleEndianUInt32(at: VDIChunkHeader.size + 4)
+        #expect(msgType == SpiceAgentMessageType.announceCapabilities.rawValue)
+    }
+
+    @Test("All builder methods respect explicit port parameter",
+          arguments: [SpiceConstants.clientPort, SpiceConstants.serverPort])
+    func buildersRespectPortParameter(port: UInt32) {
+        let capabilities = SpiceMessageBuilder.buildAnnounceCapabilities(request: false, port: port)
+        #expect(capabilities.readLittleEndianUInt32(at: 0) == port)
+
+        let grab = SpiceMessageBuilder.buildClipboardGrab(types: [.utf8Text], port: port)
+        #expect(grab.readLittleEndianUInt32(at: 0) == port)
+
+        let request = SpiceMessageBuilder.buildClipboardRequest(type: .utf8Text, port: port)
+        #expect(request.readLittleEndianUInt32(at: 0) == port)
+
+        let data = SpiceMessageBuilder.buildClipboardData(type: .utf8Text, data: Data([0x41]), port: port)
+        #expect(data.readLittleEndianUInt32(at: 0) == port)
+
+        let release = SpiceMessageBuilder.buildClipboardRelease(port: port)
+        #expect(release.readLittleEndianUInt32(at: 0) == port)
+    }
+
+    @Test("Default port parameter produces serverPort for backward compatibility")
+    func defaultPortIsServerPort() {
+        // Call without explicit port — should default to serverPort (2)
+        let message = SpiceMessageBuilder.buildClipboardGrab(types: [.utf8Text])
+        let port = message.readLittleEndianUInt32(at: 0)
+        #expect(port == SpiceConstants.serverPort)
+    }
+
     // MARK: - Test Helpers
 
     /// Builds a fake guest→host message with the given type and payload.


### PR DESCRIPTION
## Summary
- Replace the stub KernovaGuestAgent binary with a real SPICE agent that speaks the VDAgent clipboard protocol over the virtio console port, enabling bidirectional text clipboard sharing between macOS guests and the host
- The agent discovers the serial device, performs a capabilities handshake, polls NSPasteboard for clipboard changes, and reconnects automatically on device disconnection

Closes #116

## Changes
- Add `SpiceConstants.clientPort` and `port` parameter to all `SpiceMessageBuilder` methods for guest-side message direction (backward-compatible defaults)
- Add `SpiceMessageBuilder.hasCapability` as shared utility (extracted from `SpiceClipboardService`)
- Add cross-target membership in pbxproj so KernovaGuestAgent compiles `SpiceAgentProtocol.swift`
- Create `GuestClipboardAgent`: protocol state machine, 500ms pasteboard polling, echo suppression, by-demand and legacy clipboard modes
- Create `SerialPortDiscovery`: opens `/dev/cu.com.redhat.spice.0` with errno-differentiated logging
- Replace `main.swift` stub with signal handling (SIGINT/SIGTERM), device discovery retry loop, and agent lifecycle management
- Add 8 new tests: 4 for port parameter, 4 for hasCapability
- Update ARCHITECTURE.md directory structure and component descriptions

## Test plan
- [x] Built successfully on macOS 26
- [x] All 496 tests pass
- [x] Mount DMG in macOS guest, install agent, verify bidirectional text clipboard with host ClipboardContentView

🤖 Generated with [Claude Code](https://claude.com/claude-code)