### PR TITLE
fix: Correct window frame persistence for console and clipboard windows

### DIFF
--- a/Kernova/App/ClipboardWindowController.swift
+++ b/Kernova/App/ClipboardWindowController.swift
@@ -14,10 +14,12 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
     private static let logger = Logger(subsystem: "com.kernova.app", category: "ClipboardWindowController")
 
     let instance: VMInstance
+    private let frameName: NSWindow.FrameAutosaveName
     private var observingStatus = false
 
     init(instance: VMInstance) {
         self.instance = instance
+        self.frameName = "Clipboard-\(instance.instanceID.uuidString)"
 
         let viewController = ClipboardContentViewController(instance: instance)
 
@@ -28,12 +30,14 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
             defer: false
         )
         window.contentViewController = viewController
+        window.setContentSize(NSSize(width: 480, height: 300))
         window.title = "\(instance.name) — Clipboard"
         window.minSize = NSSize(width: 320, height: 250)
-        window.setFrameAutosaveName("Clipboard-\(instance.instanceID.uuidString)")
+        window.setFrameUsingName(frameName)
 
         super.init(window: window)
         window.delegate = self
+        window.setFrameAutosaveName(frameName)
     }
 
     required init?(coder: NSCoder) {

--- a/Kernova/App/ClipboardWindowController.swift
+++ b/Kernova/App/ClipboardWindowController.swift
@@ -14,12 +14,10 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
     private static let logger = Logger(subsystem: "com.kernova.app", category: "ClipboardWindowController")
 
     let instance: VMInstance
-    private let frameName: NSWindow.FrameAutosaveName
     private var observingStatus = false
 
     init(instance: VMInstance) {
         self.instance = instance
-        self.frameName = "Clipboard-\(instance.instanceID.uuidString)"
 
         let viewController = ClipboardContentViewController(instance: instance)
 
@@ -33,11 +31,9 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
         window.setContentSize(NSSize(width: 480, height: 300))
         window.title = "\(instance.name) — Clipboard"
         window.minSize = NSSize(width: 320, height: 250)
-        window.setFrameUsingName(frameName)
-
         super.init(window: window)
         window.delegate = self
-        window.setFrameAutosaveName(frameName)
+        window.setFrameAutosaveName("Clipboard-\(instance.instanceID.uuidString)")
     }
 
     required init?(coder: NSCoder) {

--- a/Kernova/App/ClipboardWindowController.swift
+++ b/Kernova/App/ClipboardWindowController.swift
@@ -20,15 +20,19 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
         self.instance = instance
 
         let viewController = ClipboardContentViewController(instance: instance)
+        let initialSize = NSSize(width: 480, height: 300)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 300),
+            contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
         window.contentViewController = viewController
-        window.setContentSize(NSSize(width: 480, height: 300))
+        // RATIONALE: contentViewController assignment resizes the window to fit
+        // the content view's auto layout, which allows near-zero height.
+        // Re-establish the intended initial size before setFrameAutosaveName.
+        window.setContentSize(initialSize)
         window.title = "\(instance.name) — Clipboard"
         window.minSize = NSSize(width: 320, height: 250)
         super.init(window: window)

--- a/Kernova/App/SerialConsoleWindowController.swift
+++ b/Kernova/App/SerialConsoleWindowController.swift
@@ -14,10 +14,12 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "SerialConsoleWindowController")
 
     let instance: VMInstance
+    private let frameName: NSWindow.FrameAutosaveName
     private var observingStatus = false
 
     init(instance: VMInstance) {
         self.instance = instance
+        self.frameName = "SerialConsole-\(instance.instanceID.uuidString)"
 
         let viewController = SerialConsoleContentViewController(instance: instance)
 
@@ -28,12 +30,14 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
             defer: false
         )
         window.contentViewController = viewController
+        window.setContentSize(NSSize(width: 720, height: 480))
         window.title = "\(instance.name) — Serial Console"
         window.minSize = NSSize(width: 400, height: 200)
-        window.setFrameAutosaveName("SerialConsole-\(instance.instanceID.uuidString)")
+        window.setFrameUsingName(frameName)
 
         super.init(window: window)
         window.delegate = self
+        window.setFrameAutosaveName(frameName)
     }
 
     required init?(coder: NSCoder) {

--- a/Kernova/App/SerialConsoleWindowController.swift
+++ b/Kernova/App/SerialConsoleWindowController.swift
@@ -20,15 +20,19 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
         self.instance = instance
 
         let viewController = SerialConsoleContentViewController(instance: instance)
+        let initialSize = NSSize(width: 720, height: 480)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 720, height: 480),
+            contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
         window.contentViewController = viewController
-        window.setContentSize(NSSize(width: 720, height: 480))
+        // RATIONALE: contentViewController assignment resizes the window to fit
+        // the content view's auto layout, which allows near-zero height.
+        // Re-establish the intended initial size before setFrameAutosaveName.
+        window.setContentSize(initialSize)
         window.title = "\(instance.name) — Serial Console"
         window.minSize = NSSize(width: 400, height: 200)
         super.init(window: window)

--- a/Kernova/App/SerialConsoleWindowController.swift
+++ b/Kernova/App/SerialConsoleWindowController.swift
@@ -14,12 +14,10 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "SerialConsoleWindowController")
 
     let instance: VMInstance
-    private let frameName: NSWindow.FrameAutosaveName
     private var observingStatus = false
 
     init(instance: VMInstance) {
         self.instance = instance
-        self.frameName = "SerialConsole-\(instance.instanceID.uuidString)"
 
         let viewController = SerialConsoleContentViewController(instance: instance)
 
@@ -33,11 +31,9 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
         window.setContentSize(NSSize(width: 720, height: 480))
         window.title = "\(instance.name) — Serial Console"
         window.minSize = NSSize(width: 400, height: 200)
-        window.setFrameUsingName(frameName)
-
         super.init(window: window)
         window.delegate = self
-        window.setFrameAutosaveName(frameName)
+        window.setFrameAutosaveName("SerialConsole-\(instance.instanceID.uuidString)")
     }
 
     required init?(coder: NSCoder) {

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -61,10 +61,10 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
         window.title = "\(instance.name) — Display"
         window.minSize = NSSize(width: 640, height: 400)
         window.collectionBehavior = [.fullScreenPrimary]
-        window.setFrameAutosaveName("VMDisplay-\(instance.instanceID)")
 
         super.init(window: window)
         window.delegate = self
+        window.setFrameAutosaveName("VMDisplay-\(instance.instanceID)")
 
         let toolbar = NSToolbar(identifier: "VMDisplayToolbar-\(instance.instanceID)")
         toolbar.delegate = self


### PR DESCRIPTION
## Summary
- Fix serial console and clipboard windows opening collapsed instead of at their intended size
- Fix window position/size not persisting across open/close cycles
- Move `setFrameAutosaveName` after `super.init` in all auxiliary window controllers for consistency

Closes #126

## Changes
- Add `setContentSize` after `contentViewController` assignment in `SerialConsoleWindowController` and `ClipboardWindowController` to override the auto-layout collapse that occurs when AppKit sizes the window to fit the content view's constraints
- Move `setFrameAutosaveName` after `super.init(window:)` in `SerialConsoleWindowController`, `ClipboardWindowController`, and `VMDisplayWindowController` so the controller is fully initialized before frame auto-save registration (matches existing `MainWindowController` pattern)
- Extract `initialSize` constants and add `RATIONALE:` comments explaining the non-obvious `setContentSize` calls

## Test plan
- [ ] Serial console opens at 720x480, not collapsed
- [ ] Clipboard window opens at 480x300, not collapsed
- [ ] Resize/move either window, close, reopen — frame is restored
- [ ] Display window frame persistence still works
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)