### PR TITLE
fix: Move serial input pipe writes off the main thread

### DIFF
--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -102,6 +102,10 @@ final class VMInstance: Identifiable {
     /// File handle for writing serial output to the on-disk log.
     private var serialLogFileHandle: FileHandle?
 
+    /// Serial queue for pipe writes, keeping the main thread free if the guest
+    /// stops reading and the kernel buffer fills up.
+    private let serialInputQueue = DispatchQueue(label: "com.kernova.serial-input", qos: .userInteractive)
+
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VMInstance")
 
     /// Maximum in-memory serial buffer size (1 MB).
@@ -318,13 +322,24 @@ final class VMInstance: Identifiable {
     }
 
     /// Sends a string to the guest via the serial input pipe.
+    ///
+    /// The write is dispatched to a dedicated serial queue so that a full
+    /// kernel pipe buffer (~64 KB on macOS) never blocks the main thread.
     func sendSerialInput(_ string: String) {
         guard let data = string.data(using: .utf8),
               let inputPipe = serialInputPipe else { return }
-        do {
-            try inputPipe.fileHandleForWriting.write(contentsOf: data)
-        } catch {
-            Self.logger.error("Failed to send serial input to VM '\(self.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
+        let fileHandle = inputPipe.fileHandleForWriting
+        let vmName = self.name
+        let logger = Self.logger
+        // inputPipe is captured strongly so its file descriptors remain valid
+        // even if tearDownSession() nils the instance property mid-write.
+        serialInputQueue.async { [inputPipe] in
+            do {
+                try fileHandle.write(contentsOf: data)
+            } catch {
+                logger.error("Failed to send serial input to VM '\(vmName, privacy: .public)': \(error.localizedDescription, privacy: .public)")
+            }
+            withExtendedLifetime(inputPipe) {}
         }
     }
 

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -269,16 +269,57 @@ struct VMInstanceTests {
         #expect(instance.serialOutputText.isEmpty)
     }
 
-    @Test("sendSerialInput writes to input pipe")
-    func sendSerialInputWritesToPipe() {
+    @Test("sendSerialInput writes to input pipe off main thread")
+    func sendSerialInputWritesToPipe() async {
         let instance = makeInstance()
         let pipe = Pipe()
         instance.serialInputPipe = pipe
 
         instance.sendSerialInput("hello")
 
-        let data = pipe.fileHandleForReading.availableData
-        #expect(String(data: data, encoding: .utf8) == "hello")
+        // availableData blocks until bytes arrive, so no arbitrary sleep needed.
+        let text = await Task.detached {
+            let expectedCount = "hello".utf8.count
+            var accumulated = Data()
+            while accumulated.count < expectedCount {
+                let chunk = pipe.fileHandleForReading.availableData
+                if chunk.isEmpty { break }
+                accumulated.append(chunk)
+            }
+            return String(data: accumulated, encoding: .utf8)
+        }.value
+
+        #expect(text == "hello")
+    }
+
+    @Test("sendSerialInput is a no-op when input pipe is nil")
+    func sendSerialInputNilPipe() {
+        let instance = makeInstance()
+        #expect(instance.serialInputPipe == nil)
+        instance.sendSerialInput("hello")
+    }
+
+    @Test("sendSerialInput preserves write ordering")
+    func sendSerialInputOrdering() async {
+        let instance = makeInstance()
+        let pipe = Pipe()
+        instance.serialInputPipe = pipe
+
+        instance.sendSerialInput("A")
+        instance.sendSerialInput("B")
+        instance.sendSerialInput("C")
+
+        let text = await Task.detached {
+            var accumulated = Data()
+            while accumulated.count < 3 {
+                let chunk = pipe.fileHandleForReading.availableData
+                if chunk.isEmpty { break }
+                accumulated.append(chunk)
+            }
+            return String(data: accumulated, encoding: .utf8)
+        }.value
+
+        #expect(text == "ABC")
     }
 
     @Test("resetToStopped clears serial pipes")


### PR DESCRIPTION
## Summary
- Dispatch serial console pipe writes to a dedicated background `DispatchQueue` to prevent UI freezes when the guest VM stops reading and the ~64 KB kernel pipe buffer fills
- Capture the `Pipe` strongly in the async closure so file descriptors remain valid even if `tearDownSession` runs before the write completes
- Add tests for async write delivery, nil-pipe guard, and FIFO ordering invariant

## Test plan
- [x] Built successfully on macOS 26
- [x] All VMInstanceTests pass (including 2 new tests: nil-pipe no-op, write ordering)
- [ ] Manual: open serial console, type while guest is running — keystrokes echo normally
- [ ] Manual: stop VM while typing in serial console — no crash or hang

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)