### PR TITLE
fix: Remove overly broad isPreparing menu validation guard

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -677,37 +677,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     // MARK: - Menu Validation
 
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        // Preparing instances disable all VM menu bar actions (cancel is only available via sidebar context menu)
-        if let instance = activeInstance, instance.isPreparing {
-            switch menuItem.action {
-            case #selector(showLibrary(_:)), #selector(newVM(_:)):
-                return true
-            default:
-                return false
-            }
-        }
-
         switch menuItem.action {
         case #selector(startVM(_:)):
-            return activeInstance?.status.canStart ?? false
+            guard let instance = activeInstance else { return false }
+            return instance.status.canStart && !instance.isPreparing
         case #selector(pauseVM(_:)):
             return activeInstance?.status.canPause ?? false
         case #selector(resumeVM(_:)):
-            return activeInstance?.status.canResume ?? false
+            guard let instance = activeInstance else { return false }
+            return instance.status.canResume && !instance.isPreparing
         case #selector(stopVM(_:)):
             guard let instance = activeInstance else { return false }
-            return instance.canStop || instance.isColdPaused
+            return (instance.canStop || instance.isColdPaused) && !instance.isPreparing
         case #selector(forceStopVM(_:)):
-            return activeInstance?.status.canForceStop ?? false
+            guard let instance = activeInstance else { return false }
+            return instance.status.canForceStop && !instance.isPreparing
         case #selector(saveVM(_:)):
             return activeInstance?.canSave ?? false
         case #selector(renameVM(_:)):
-            return activeInstance?.status.canRename ?? false
+            guard let instance = activeInstance else { return false }
+            return instance.status.canRename && !instance.isPreparing
         case #selector(cloneVM(_:)):
             guard let instance = activeInstance else { return false }
             return instance.status.canEditSettings && !viewModel.hasPreparing
         case #selector(deleteVM(_:)):
-            return activeInstance?.status.canEditSettings ?? false
+            guard let instance = activeInstance else { return false }
+            return instance.status.canEditSettings && !instance.isPreparing
         // AppKit bypasses NSMenuItemValidation for windowsMenu items, so
         // menuNeedsUpdate(_:) handles visual state. This case covers keyboard
         // shortcut validation, which still routes through validateMenuItem(_:).


### PR DESCRIPTION
## Summary
- Fix ⌘Q and other system menu shortcuts being blocked during VM preparation
- The `isPreparing` guard used a catch-all `default: return false` that disabled every menu item (including Quit, Close, Hide) except two whitelisted actions
- Replace with targeted `\!instance.isPreparing` checks on only the six actions whose status predicates would incorrectly return true for preparing instances

Closes #122

## Changes
- Remove the blanket `isPreparing` guard block from `validateMenuItem`
- Add `\!instance.isPreparing` to: `startVM`, `resumeVM`, `stopVM`, `forceStopVM`, `renameVM`, `deleteVM`
- Remaining actions (pause, save, serial console, clipboard, display, USB) are naturally disabled because they require a running/paused status with a live `VZVirtualMachine`, which preparing instances lack

## Test plan
- [ ] Built successfully on macOS 26
- [ ] All existing tests pass
- [ ] ⌘Q quits the app while a VM is preparing (clone/import in progress)
- [ ] VM menu actions remain disabled during preparation
- [ ] Standard app menu items (Quit, Close, Hide) work in all states

🤖 Generated with [Claude Code](https://claude.com/claude-code)