### PR TITLE
fix: Add error logging for clipboard pipe handle close

### DIFF
--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -215,9 +215,10 @@ final class VMInstance: Identifiable {
 
     // MARK: - State Helpers
 
-    /// Tears down the live VM session: stops serial I/O, releases pipes, and
-    /// clears the `VZVirtualMachine` reference. Does **not** change `status` —
-    /// callers set the appropriate status after calling this.
+    /// Tears down the live VM session: stops clipboard and serial I/O, releases
+    /// pipes, clears attached USB devices, and nils the delegate adapter and
+    /// `VZVirtualMachine` reference. Does **not** change `status` — callers set
+    /// the appropriate status after calling this.
     func tearDownSession() {
         stopClipboardService()
         stopSerialReading()
@@ -361,10 +362,28 @@ final class VMInstance: Identifiable {
     func stopClipboardService() {
         clipboardService?.stop()
         clipboardService = nil
-        try? clipboardInputPipe?.fileHandleForReading.close()
-        try? clipboardInputPipe?.fileHandleForWriting.close()
-        try? clipboardOutputPipe?.fileHandleForReading.close()
-        try? clipboardOutputPipe?.fileHandleForWriting.close()
+
+        do {
+            try clipboardInputPipe?.fileHandleForReading.close()
+        } catch {
+            Self.logger.warning("Failed to close clipboard input read handle for VM '\(self.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
+        }
+        do {
+            try clipboardInputPipe?.fileHandleForWriting.close()
+        } catch {
+            Self.logger.warning("Failed to close clipboard input write handle for VM '\(self.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
+        }
+        do {
+            try clipboardOutputPipe?.fileHandleForReading.close()
+        } catch {
+            Self.logger.warning("Failed to close clipboard output read handle for VM '\(self.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
+        }
+        do {
+            try clipboardOutputPipe?.fileHandleForWriting.close()
+        } catch {
+            Self.logger.warning("Failed to close clipboard output write handle for VM '\(self.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
+        }
+
         clipboardInputPipe = nil
         clipboardOutputPipe = nil
     }


### PR DESCRIPTION
## Summary
- Replace silent `try?` expressions in `stopClipboardService()` with `do/catch` blocks that log at `.warning` level, matching the existing pattern in `stopSerialReading()`
- Provides diagnostic trails for file descriptor leaks or double-close bugs

Closes #129

## Test plan
- [x] Built successfully on macOS 26
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)