### PR TITLE
fix: Resolve compiler warnings across four files

### DIFF
--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -476,7 +476,7 @@ struct ConfigurationBuilder: Sendable {
             let resolved = try PathValidation.resolveFile(at: path, requireWritable: requireWritable)
             resolved.logResolution(logger: logger, context: context)
             return resolved
-        } catch let error as PathValidation.Failure {
+        } catch {
             switch error {
             case .notFound:
                 logger.error("\(context, privacy: .public) not found at '\(path, privacy: .public)'")
@@ -516,7 +516,7 @@ struct ConfigurationBuilder: Sendable {
                 at: path, requireReadable: requireReadable, requireWritable: requireWritable)
             resolved.logResolution(logger: logger, context: context)
             return resolved
-        } catch let error as PathValidation.Failure {
+        } catch {
             switch error {
             case .notFound:
                 logger.error("\(context, privacy: .public) not found at '\(path, privacy: .public)'")

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -339,7 +339,7 @@ final class SpiceClipboardService {
 
     private func sendCapabilities() {
         let message = SpiceMessageBuilder.buildAnnounceCapabilities(request: true)
-        writeToGuest(message)
+        _ = writeToGuest(message)
         Self.logger.debug("Sent ANNOUNCE_CAPABILITIES (requesting guest reply)")
     }
 

--- a/Kernova/Services/USBDeviceService.swift
+++ b/Kernova/Services/USBDeviceService.swift
@@ -26,7 +26,7 @@ final class USBDeviceService: USBDeviceProviding {
         do {
             resolved = try PathValidation.resolveFile(at: diskImagePath, requireWritable: !readOnly)
             resolved.logResolution(logger: Self.logger, context: "USB disk image")
-        } catch let error as PathValidation.Failure {
+        } catch {
             switch error {
             case .notFound:
                 Self.logger.error("USB disk image not found at '\(diskImagePath, privacy: .public)'")

--- a/Kernova/Utilities/DataFormatters.swift
+++ b/Kernova/Utilities/DataFormatters.swift
@@ -87,9 +87,7 @@ enum DataFormatters {
         count == 1 ? "1 core" : "\(count) cores"
     }
 
-    // RATIONALE: nonisolated(unsafe) is safe because all callers of DataFormatters
-    // are @MainActor-isolated (SwiftUI view bodies). Matches the existing byteFormatter pattern.
-    private nonisolated(unsafe) static let durationFormatter: DateComponentsFormatter = {
+    private static let durationFormatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.unitsStyle = .abbreviated


### PR DESCRIPTION
## Summary
- Eliminate five compiler warnings: redundant typed-throw casts, unused return value, and unnecessary `nonisolated(unsafe)` qualifier
- Removes `as PathValidation.Failure` casts that are always true due to typed throws (`throws(Failure)`)
- Explicitly discards `writeToGuest` return value in `SpiceClipboardService.sendCapabilities()`
- Removes unnecessary `nonisolated(unsafe)` from `DataFormatters.durationFormatter` (`DateComponentsFormatter` is `Sendable`)

## Changes
- `ConfigurationBuilder.swift`: Remove redundant `as PathValidation.Failure` in `resolveFile` and `resolveDirectory` catch blocks
- `SpiceClipboardService.swift`: Add `_ =` to explicitly discard `writeToGuest` result in `sendCapabilities()`
- `USBDeviceService.swift`: Remove redundant `as PathValidation.Failure` in catch block
- `DataFormatters.swift`: Remove `nonisolated(unsafe)` and stale `RATIONALE:` comment from `durationFormatter`

## Test plan
- [x] Built successfully on macOS 26 with zero warnings from these files
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)