### PR TITLE
fix: Keep toolbar observation alive across main-window hide/re-show

### DIFF
--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -11,7 +11,6 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
     private let toolbarManager: VMToolbarManager
     private let splitViewController = NSSplitViewController()
     private let sidebarItem: NSSplitViewItem
-    private var observingToolbar = false
     private var sidebarCollapseObservation: NSKeyValueObservation?
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "MainWindowController")
@@ -85,13 +84,6 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
         window?.orderBack(nil)
     }
 
-    // MARK: - NSWindowDelegate
-
-    func windowWillClose(_ notification: Notification) {
-        observingToolbar = false
-        Self.logger.debug("Main window closing, toolbar observation stopped")
-    }
-
     // MARK: - Sidebar Collapse Observation
 
     private func observeSidebarCollapse() {
@@ -122,7 +114,6 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
     // MARK: - Toolbar State Observation
 
     private func observeToolbarState() {
-        observingToolbar = true
         withObservationTracking {
             _ = self.viewModel.selectedID
             _ = self.viewModel.selectedInstance?.status
@@ -132,7 +123,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
             _ = self.viewModel.selectedInstance?.configuration.clipboardSharingEnabled
         } onChange: {
             Task { @MainActor [weak self] in
-                guard let self, self.observingToolbar else { return }
+                guard let self else { return }
                 self.updateToolbarItems()
                 self.observeToolbarState()
             }

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -113,6 +113,12 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
 
     // MARK: - Toolbar State Observation
 
+    // RATIONALE: No `observing` gate flag here. A previous `observingToolbar`
+    // flag cleared in windowWillClose stranded the toolbar on stale state after
+    // the main window was hidden and re-shown from the Dock (one-shot
+    // re-registration never resumed). [weak self] already handles the only real
+    // teardown case (controller deallocation); writes against a hidden toolbar
+    // are harmless no-ops.
     private func observeToolbarState() {
         withObservationTracking {
             _ = self.viewModel.selectedID


### PR DESCRIPTION
## Summary
- Main window toolbar stopped reflecting sidebar selection after the user closed and re-opened the main window from the Dock while a running VM kept the app alive in the background.
- Start/Pause/Stop buttons stayed frozen on the previously-selected VM's state; the menubar and sidebar context menu were unaffected (both are pull-based and read live state on open).

## Root cause
`MainWindowController.windowWillClose` set `observingToolbar = false`, and nothing re-enabled it when the window was re-shown from the Dock. The one-shot `withObservationTracking` re-registration chain relied on that flag being `true` inside the `onChange` Task's guard — with it permanently `false`, the chain tore itself down on first invocation after re-open, and the toolbar was never pushed another state update.

Diagnosis was confirmed with temporary instrumentation that showed `observer fired` log entries stopped appearing after the close/re-open sequence while `lifecycle write` entries continued (coming from `VMDisplayWindowController`'s independent observer for VM state transitions, not from selection changes).

## Changes
- Remove the `observingToolbar` flag from `MainWindowController`.
- Remove the now-empty `windowWillClose(_:)` handler whose only effect was clearing the flag.
- Simplify the `onChange` Task's guard to `guard let self else { return }`. The `[weak self]` already handles controller deallocation; observation running against a hidden window's toolbar is a harmless no-op (the guards in `updateToolbarItems` and the `VMToolbarManager` lookups short-circuit on missing items).

This converges the site on the same trust-`[weak self]` idiom already used in `ClipboardContentViewController`, `SerialConsoleContentViewController`, and `AppDelegate.observeForTermination`.

## Test plan
- [x] `xcodebuild ... build` → `** BUILD SUCCEEDED **`
- [x] `xcodebuild ... test` → `** TEST SUCCEEDED **`
- [ ] Manual repro: start a VM fullscreen → close main window → pop VM out to a floating window → re-open main window from Dock → cycle sidebar selection. Toolbar should now reflect each VM's state.
- [ ] Regression check: selection cycling with main window open still updates the toolbar correctly across stopped / running / paused VMs.

## Follow-up
Filed #137 to audit the same `observing*`-flag pattern in `VMDisplayWindowController`, `ClipboardWindowController`, and `SerialConsoleWindowController`. Those sites are benign today (`AppDelegate` creates fresh controllers per open), but would regress into this bug class if any of them were ever cached.