### PR TITLE
refactor: Consolidate withObservationTracking loops into observeRecurring helper

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -75,7 +75,8 @@ Kernova/
 │   ├── DataFormatters.swift            # Human-readable formatting for bytes, CPU counts, etc.
 │   ├── FileManagerExtensions.swift     # FileManager convenience methods
 │   ├── NSImageExtensions.swift         # Nil-safe SF Symbol image loading
-│   └── NSViewExtensions.swift          # Full-size subview constraint helper
+│   ├── NSViewExtensions.swift          # Full-size subview constraint helper
+│   └── ObservationLoop.swift           # observeRecurring(track:apply:) helper wrapping withObservationTracking
 └── Resources/
     ├── Assets.xcassets/                # App icons and image assets
     └── Kernova.entitlements            # com.apple.security.virtualization entitlement
@@ -257,11 +258,12 @@ SystemSleepWatcher ──sleep/wake──→ VMLibraryViewModel ──pause/resu
 
 ### Utilities
 
-**Files:** `DataFormatters.swift`, `FileManagerExtensions.swift`, `NSImageExtensions.swift`, `NSViewExtensions.swift`
+**Files:** `DataFormatters.swift`, `FileManagerExtensions.swift`, `NSImageExtensions.swift`, `NSViewExtensions.swift`, `ObservationLoop.swift`
 
 - `DataFormatters` — human-readable formatting for bytes (e.g., "107.4 GB"), CPU counts, etc.
 - `FileManagerExtensions` — convenience methods on `FileManager`
 - `NSImageExtensions` — `NSImage.systemSymbol(_:accessibilityDescription:)` for nil-safe SF Symbol loading with error logging
+- `ObservationLoop` — `observeRecurring(track:apply:) -> ObservationLoop` helper that encapsulates the `withObservationTracking` + `Task { @MainActor }` + recursive re-register dance. Returns a cancel token stored by the caller; the loop stops when the token is deallocated or `cancel()` is called. Used by all 8 observation sites (`MainWindowController`, `VMDisplayWindowController`, `ClipboardWindowController`, `SerialConsoleWindowController`, `DetailContainerViewController`, `ClipboardContentViewController`, `SerialConsoleContentViewController`, `AppDelegate.observeForTermination`) so each site only declares *what* to track and *what* to do — not how to sustain the loop.
 
 ## Key Design Decisions
 
@@ -317,9 +319,9 @@ SystemSleepWatcher ──sleep/wake──→ VMLibraryViewModel ──pause/resu
 
 ### 7. Native NSToolbar with observation-driven validation
 
-**What:** The main window and display window use `NSToolbar` with `NSToolbarDelegate` creating native `NSToolbarItem`s. Shared toolbar groups (lifecycle, suspend, display) are managed by `VMToolbarManager`, a `@MainActor` `NSObject` subclass that handles item creation, state updates, and action routing for both controllers. Each controller configures it with an `instanceProvider` closure and a `Configuration` struct that captures per-controller differences (identifier strings, `isPreparing` checks, display capability gating). Toolbar state is driven by `withObservationTracking` on the view model, directly setting `isEnabled` on subitems on change. All toolbar item groups use `autovalidates = false` to prevent AppKit's automatic validation from overriding the observation-driven state.
+**What:** The main window and display window use `NSToolbar` with `NSToolbarDelegate` creating native `NSToolbarItem`s. Shared toolbar groups (lifecycle, suspend, display) are managed by `VMToolbarManager`, a `@MainActor` `NSObject` subclass that handles item creation, state updates, and action routing for both controllers. Each controller configures it with an `instanceProvider` closure and a `Configuration` struct that captures per-controller differences (identifier strings, `isPreparing` checks, display capability gating). Toolbar state is driven by the shared `observeRecurring` helper (see Utilities), directly setting `isEnabled` on subitems on change. All toolbar item groups use `autovalidates = false` to prevent AppKit's automatic validation from overriding the observation-driven state.
 
-**Why:** Native `NSToolbarItem`s provide reliable layout, proper `.sidebarTrackingSeparator` support, and standard macOS toolbar appearance. The `withObservationTracking` pattern (used in all three window controllers) re-evaluates on any observed property change and re-registers itself, providing reactive updates without SwiftUI. The shared `VMToolbarManager` eliminates ~150 lines of duplicated toolbar logic between `MainWindowController` and `VMDisplayWindowController`, ensuring toolbar changes are applied in one place.
+**Why:** Native `NSToolbarItem`s provide reliable layout, proper `.sidebarTrackingSeparator` support, and standard macOS toolbar appearance. The `observeRecurring` helper handles re-registration after each change and `[weak self]` teardown uniformly across every window controller, so toolbar updates stay reactive without SwiftUI and without duplicating the observation-loop boilerplate at each site. The shared `VMToolbarManager` eliminates ~150 lines of duplicated toolbar logic between `MainWindowController` and `VMDisplayWindowController`, ensuring toolbar changes are applied in one place.
 
 **Alternatives:** SwiftUI `.toolbar` modifiers on a hosting controller — simpler declarative API but caused persistent layout issues with grouped items and sidebar tracking.
 

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -15,6 +15,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private var clipboardObservers: [UUID: Any] = [:]
     private var displayWindows: [UUID: VMDisplayWindowController] = [:]
     private var displayWindowObservers: [UUID: Any] = [:]
+    private var terminationObservation: ObservationLoop?
     private var serialConsoleMenuItem: NSMenuItem!
     private var clipboardMenuItem: NSMenuItem!
     /// Set in `applicationWillBecomeActive` and read in `applicationShouldHandleReopen`
@@ -655,23 +656,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         NSApp.terminate(nil)
     }
 
-    /// Registers a one-shot observation on the instances list and each instance's
-    /// `isKeepingAppAlive` state. Re-subscribes after each change for continuous observation.
+    /// Observes each instance's `isKeepingAppAlive` state so the app can terminate
+    /// when the last one flips to inactive.
     private func observeForTermination() {
-        withObservationTracking {
-            for instance in viewModel.instances {
-                _ = instance.isKeepingAppAlive
-            }
-        } onChange: {
-            Task { @MainActor [weak self] in
-                guard let self else {
-                    Self.logger.warning("observeForTermination: observation chain ended (self deallocated)")
-                    return
+        terminationObservation = observeRecurring(
+            track: { [weak self] in
+                guard let self else { return }
+                for instance in self.viewModel.instances {
+                    _ = instance.isKeepingAppAlive
                 }
-                self.terminateIfIdle()
-                self.observeForTermination()
+            },
+            apply: { [weak self] in
+                self?.terminateIfIdle()
             }
-        }
+        )
     }
 
     // MARK: - Menu Validation

--- a/Kernova/App/ClipboardContentViewController.swift
+++ b/Kernova/App/ClipboardContentViewController.swift
@@ -16,6 +16,7 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
     private var statusCircle: NSView!
     private var statusLabel: NSTextField!
     private var isUpdatingFromService = false
+    private var serviceObservation: ObservationLoop?
 
     init(instance: VMInstance) {
         self.instance = instance
@@ -89,18 +90,17 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
     // MARK: - Observation
 
     private func observeServiceChanges() {
-        withObservationTracking {
-            // Read clipboardService itself so observation re-fires when it transitions nil → non-nil
-            let service = self.instance.clipboardService
-            _ = service?.clipboardText
-            _ = service?.isConnected
-        } onChange: {
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.updateUI()
-                self.observeServiceChanges()
+        serviceObservation = observeRecurring(
+            track: { [weak self] in
+                // Read clipboardService itself so observation re-fires when it transitions nil → non-nil
+                let service = self?.instance.clipboardService
+                _ = service?.clipboardText
+                _ = service?.isConnected
+            },
+            apply: { [weak self] in
+                self?.updateUI()
             }
-        }
+        )
     }
 
     private func updateUI() {

--- a/Kernova/App/ClipboardWindowController.swift
+++ b/Kernova/App/ClipboardWindowController.swift
@@ -14,7 +14,7 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
     private static let logger = Logger(subsystem: "com.kernova.app", category: "ClipboardWindowController")
 
     let instance: VMInstance
-    private var observingStatus = false
+    private var statusObservation: ObservationLoop?
 
     init(instance: VMInstance) {
         self.instance = instance
@@ -48,7 +48,7 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
 
     override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
-        if !observingStatus { observeStatus() }
+        if statusObservation == nil { observeStatus() }
         Self.logger.debug("Clipboard window shown for VM '\(self.instance.name, privacy: .public)'")
     }
 
@@ -59,7 +59,7 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
         if instance.status == .running || instance.status == .paused {
             instance.clipboardService?.grabIfChanged()
         }
-        observingStatus = false
+        statusObservation?.cancel()
         Self.logger.debug("Clipboard window closing for VM '\(self.instance.name, privacy: .public)'")
     }
 
@@ -71,20 +71,18 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
 
     /// Automatically closes the clipboard window when the VM stops or errors out.
     private func observeStatus() {
-        observingStatus = true
-        withObservationTracking {
-            _ = self.instance.status
-        } onChange: {
-            Task { @MainActor [weak self] in
-                guard let self, self.observingStatus else { return }
+        statusObservation = observeRecurring(
+            track: { [weak self] in
+                _ = self?.instance.status
+            },
+            apply: { [weak self] in
+                guard let self else { return }
                 let status = self.instance.status
                 if status == .stopped || status == .error {
                     Self.logger.notice("Auto-closing clipboard window for VM '\(self.instance.name, privacy: .public)' (status: \(status.displayName, privacy: .public))")
                     self.window?.close()
-                } else {
-                    self.observeStatus()
                 }
             }
-        }
+        )
     }
 }

--- a/Kernova/App/ClipboardWindowController.swift
+++ b/Kernova/App/ClipboardWindowController.swift
@@ -60,6 +60,7 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
             instance.clipboardService?.grabIfChanged()
         }
         statusObservation?.cancel()
+        statusObservation = nil
         Self.logger.debug("Clipboard window closing for VM '\(self.instance.name, privacy: .public)'")
     }
 

--- a/Kernova/App/DetailContainerViewController.swift
+++ b/Kernova/App/DetailContainerViewController.swift
@@ -17,7 +17,7 @@ final class DetailContainerViewController: NSViewController {
     private var backingViews: [UUID: VMDisplayBackingView] = [:]
     private var activeBackingViewID: UUID?
     private let swiftUIHost: NSHostingController<MainDetailView>
-    private var observing = false
+    private var stateObservation: ObservationLoop?
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "DetailContainerVC")
 
@@ -51,12 +51,13 @@ final class DetailContainerViewController: NSViewController {
     override func viewDidAppear() {
         super.viewDidAppear()
         updateDisplayState()
-        if !observing { observeState() }
+        if stateObservation == nil { observeState() }
     }
 
     override func viewWillDisappear() {
         super.viewWillDisappear()
-        observing = false
+        stateObservation?.cancel()
+        stateObservation = nil
         for id in Array(backingViews.keys) {
             removeBackingView(for: id)
         }
@@ -103,32 +104,28 @@ final class DetailContainerViewController: NSViewController {
     // MARK: - State Observation
 
     private func observeState() {
-        observing = true
-        withObservationTracking {
-            _ = self.viewModel.selectedInstance
-            _ = self.viewModel.selectedInstance?.status
-            _ = self.viewModel.selectedInstance?.displayMode
-            _ = self.viewModel.selectedInstance?.virtualMachine
-            // Track instances with backing views so we detect when they stop or leave inline mode.
-            // Also track the instances array itself so we detect additions/removals.
-            _ = self.viewModel.instances.count
-            for id in self.backingViews.keys {
-                if let inst = self.viewModel.instances.first(where: { $0.id == id }) {
-                    _ = inst.status
-                    _ = inst.virtualMachine
-                    _ = inst.displayMode
+        stateObservation = observeRecurring(
+            track: { [weak self] in
+                guard let self else { return }
+                _ = self.viewModel.selectedInstance
+                _ = self.viewModel.selectedInstance?.status
+                _ = self.viewModel.selectedInstance?.displayMode
+                _ = self.viewModel.selectedInstance?.virtualMachine
+                // Track instances with backing views so we detect when they stop or leave inline mode.
+                // Also track the instances array itself so we detect additions/removals.
+                _ = self.viewModel.instances.count
+                for id in self.backingViews.keys {
+                    if let inst = self.viewModel.instances.first(where: { $0.id == id }) {
+                        _ = inst.status
+                        _ = inst.virtualMachine
+                        _ = inst.displayMode
+                    }
                 }
+            },
+            apply: { [weak self] in
+                self?.updateDisplayState()
             }
-        } onChange: {
-            Task { @MainActor [weak self] in
-                guard let self, self.observing else {
-                    Self.logger.debug("observeState: observation chain ended (self deallocated or observing stopped)")
-                    return
-                }
-                self.updateDisplayState()
-                self.observeState()
-            }
-        }
+        )
     }
 
     private func updateDisplayState() {

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -12,6 +12,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
     private let splitViewController = NSSplitViewController()
     private let sidebarItem: NSSplitViewItem
     private var sidebarCollapseObservation: NSKeyValueObservation?
+    private var toolbarObservation: ObservationLoop?
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "MainWindowController")
     private static let toolbarNewVM = NSToolbarItem.Identifier("newVM")
@@ -113,27 +114,21 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
 
     // MARK: - Toolbar State Observation
 
-    // RATIONALE: No `observing` gate flag here. A previous `observingToolbar`
-    // flag cleared in windowWillClose stranded the toolbar on stale state after
-    // the main window was hidden and re-shown from the Dock (one-shot
-    // re-registration never resumed). [weak self] already handles the only real
-    // teardown case (controller deallocation); writes against a hidden toolbar
-    // are harmless no-ops.
     private func observeToolbarState() {
-        withObservationTracking {
-            _ = self.viewModel.selectedID
-            _ = self.viewModel.selectedInstance?.status
-            _ = self.viewModel.selectedInstance?.isPreparing
-            _ = self.viewModel.selectedInstance?.displayMode
-            _ = self.viewModel.selectedInstance?.virtualMachine
-            _ = self.viewModel.selectedInstance?.configuration.clipboardSharingEnabled
-        } onChange: {
-            Task { @MainActor [weak self] in
+        toolbarObservation = observeRecurring(
+            track: { [weak self] in
                 guard let self else { return }
-                self.updateToolbarItems()
-                self.observeToolbarState()
+                _ = self.viewModel.selectedID
+                _ = self.viewModel.selectedInstance?.status
+                _ = self.viewModel.selectedInstance?.isPreparing
+                _ = self.viewModel.selectedInstance?.displayMode
+                _ = self.viewModel.selectedInstance?.virtualMachine
+                _ = self.viewModel.selectedInstance?.configuration.clipboardSharingEnabled
+            },
+            apply: { [weak self] in
+                self?.updateToolbarItems()
             }
-        }
+        )
     }
 
     private func updateToolbarItems() {

--- a/Kernova/App/SerialConsoleContentViewController.swift
+++ b/Kernova/App/SerialConsoleContentViewController.swift
@@ -15,6 +15,7 @@ final class SerialConsoleContentViewController: NSViewController {
     private var statusCircle: NSView!
     private var statusLabel: NSTextField!
     private var characterCountLabel: NSTextField!
+    private var instanceObservation: ObservationLoop?
 
     init(instance: VMInstance) {
         self.instance = instance
@@ -77,16 +78,16 @@ final class SerialConsoleContentViewController: NSViewController {
     // MARK: - Observation
 
     private func observeInstanceChanges() {
-        withObservationTracking {
-            _ = self.instance.serialOutputText
-            _ = self.instance.status
-        } onChange: {
-            Task { @MainActor [weak self] in
+        instanceObservation = observeRecurring(
+            track: { [weak self] in
                 guard let self else { return }
-                self.updateUI()
-                self.observeInstanceChanges()
+                _ = self.instance.serialOutputText
+                _ = self.instance.status
+            },
+            apply: { [weak self] in
+                self?.updateUI()
             }
-        }
+        )
     }
 
     private func updateUI() {

--- a/Kernova/App/SerialConsoleWindowController.swift
+++ b/Kernova/App/SerialConsoleWindowController.swift
@@ -14,7 +14,7 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "SerialConsoleWindowController")
 
     let instance: VMInstance
-    private var observingStatus = false
+    private var statusObservation: ObservationLoop?
 
     init(instance: VMInstance) {
         self.instance = instance
@@ -48,14 +48,14 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
 
     override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
-        if !observingStatus { observeStatus() }
+        if statusObservation == nil { observeStatus() }
         Self.logger.debug("Serial console window shown for VM '\(self.instance.name, privacy: .public)'")
     }
 
     // MARK: - NSWindowDelegate
 
     func windowWillClose(_ notification: Notification) {
-        observingStatus = false
+        statusObservation?.cancel()
         Self.logger.debug("Serial console window closing for VM '\(self.instance.name, privacy: .public)'")
     }
 
@@ -63,20 +63,18 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
 
     /// Automatically closes the serial console window when the VM stops or errors out.
     private func observeStatus() {
-        observingStatus = true
-        withObservationTracking {
-            _ = self.instance.status
-        } onChange: {
-            Task { @MainActor [weak self] in
-                guard let self, self.observingStatus else { return }
+        statusObservation = observeRecurring(
+            track: { [weak self] in
+                _ = self?.instance.status
+            },
+            apply: { [weak self] in
+                guard let self else { return }
                 let status = self.instance.status
                 if status == .stopped || status == .error {
                     Self.logger.notice("Auto-closing serial console for VM '\(self.instance.name, privacy: .public)' (status: \(status.displayName, privacy: .public))")
                     self.window?.close()
-                } else {
-                    self.observeStatus()
                 }
             }
-        }
+        )
     }
 }

--- a/Kernova/App/SerialConsoleWindowController.swift
+++ b/Kernova/App/SerialConsoleWindowController.swift
@@ -56,6 +56,7 @@ final class SerialConsoleWindowController: NSWindowController, NSWindowDelegate 
 
     func windowWillClose(_ notification: Notification) {
         statusObservation?.cancel()
+        statusObservation = nil
         Self.logger.debug("Serial console window closing for VM '\(self.instance.name, privacy: .public)'")
     }
 

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -20,7 +20,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     private let enterFullscreen: Bool
     private let onSaveConfiguration: () -> Void
     private let backingView: VMDisplayBackingView
-    private var observingInstance = false
+    private var instanceObservation: ObservationLoop?
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VMDisplayWindowController")
 
@@ -96,7 +96,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
         if lastDisplayID == nil {
             lastDisplayID = window?.screen?.displayID
         }
-        observingInstance = false
+        instanceObservation?.cancel()
         window?.toolbar?.isVisible = true
         instance.displayMode = .inline
     }
@@ -129,14 +129,15 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     /// Observes VM state changes to auto-close the window when the VM stops/errors/saves,
     /// keep toolbar items in sync, and update the backing view's overlay state.
     private func observeInstance() {
-        observingInstance = true
-        withObservationTracking {
-            _ = self.instance.status
-            _ = self.instance.virtualMachine
-            _ = self.instance.displayMode
-        } onChange: {
-            Task { @MainActor [weak self] in
-                guard let self, self.observingInstance else { return }
+        instanceObservation = observeRecurring(
+            track: { [weak self] in
+                guard let self else { return }
+                _ = self.instance.status
+                _ = self.instance.virtualMachine
+                _ = self.instance.displayMode
+            },
+            apply: { [weak self] in
+                guard let self else { return }
                 let status = self.instance.status
                 if status == .stopped || status == .error || self.instance.isColdPaused {
                     self.lastDisplayID = self.window?.screen?.displayID
@@ -149,10 +150,9 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
                         transitionText: status.transitionLabel
                     )
                     self.updateToolbarItems()
-                    self.observeInstance()
                 }
             }
-        }
+        )
     }
 
     // MARK: - Toolbar State

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -97,6 +97,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
             lastDisplayID = window?.screen?.displayID
         }
         instanceObservation?.cancel()
+        instanceObservation = nil
         window?.toolbar?.isVisible = true
         instance.displayMode = .inline
     }

--- a/Kernova/Utilities/ObservationLoop.swift
+++ b/Kernova/Utilities/ObservationLoop.swift
@@ -69,7 +69,6 @@ final class ObservationLoop {
 /// }
 /// ```
 @MainActor
-@discardableResult
 func observeRecurring(
     track: @escaping () -> Void,
     apply: @escaping () -> Void

--- a/Kernova/Utilities/ObservationLoop.swift
+++ b/Kernova/Utilities/ObservationLoop.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Handle to a recurring observation started by ``observeRecurring(track:apply:)``.
+///
+/// The observation runs until this handle is deallocated OR ``cancel()`` is
+/// called, whichever comes first. Callers typically store the handle as a
+/// stored property on the object whose state is being observed and drop it or
+/// cancel it during teardown.
+@MainActor
+final class ObservationLoop {
+    fileprivate var isCancelled = false
+    private let track: () -> Void
+    private let apply: () -> Void
+
+    fileprivate init(track: @escaping () -> Void, apply: @escaping () -> Void) {
+        self.track = track
+        self.apply = apply
+        register()
+    }
+
+    /// Stops the observation loop. Idempotent; safe to call multiple times.
+    func cancel() {
+        isCancelled = true
+    }
+
+    private func register() {
+        guard !isCancelled else { return }
+        withObservationTracking {
+            track()
+        } onChange: {
+            Task { @MainActor [weak self] in
+                guard let self, !self.isCancelled else { return }
+                self.apply()
+                self.register()
+            }
+        }
+    }
+}
+
+/// Observes any `@Observable` properties read inside `track`, invoking `apply`
+/// each time one of them changes, and automatically re-registering after each
+/// fire so the loop continues indefinitely.
+///
+/// Prefer this helper over hand-rolling the `withObservationTracking` +
+/// `Task { @MainActor }` + recursive re-register dance at each call site. Both
+/// closures run on the main actor. Callers should use `[weak self]` captures
+/// inside both closures to avoid retain cycles and to short-circuit gracefully
+/// after the observing object is deallocated.
+///
+/// The returned ``ObservationLoop`` must be retained by the caller — typically
+/// as a stored property. When the caller drops the reference or calls
+/// ``ObservationLoop/cancel()``, the loop stops at (or before) the next
+/// scheduled fire.
+///
+/// Example:
+/// ```swift
+/// private var toolbarObservation: ObservationLoop?
+///
+/// private func startToolbarObservation() {
+///     toolbarObservation = observeRecurring(
+///         track: { [weak self] in
+///             guard let self else { return }
+///             _ = self.viewModel.selectedInstance?.status
+///         },
+///         apply: { [weak self] in
+///             self?.updateToolbarItems()
+///         }
+///     )
+/// }
+/// ```
+@MainActor
+@discardableResult
+func observeRecurring(
+    track: @escaping () -> Void,
+    apply: @escaping () -> Void
+) -> ObservationLoop {
+    ObservationLoop(track: track, apply: apply)
+}

--- a/KernovaTests/ObservationLoopTests.swift
+++ b/KernovaTests/ObservationLoopTests.swift
@@ -1,0 +1,180 @@
+import Testing
+import Foundation
+@testable import Kernova
+
+@Suite("ObservationLoop Tests")
+@MainActor
+struct ObservationLoopTests {
+
+    @Observable
+    @MainActor
+    final class Subject {
+        var value: Int = 0
+        var other: Int = 0
+    }
+
+    @MainActor
+    final class Counter {
+        var count = 0
+        func increment() { count += 1 }
+    }
+
+    /// Yields the main actor multiple times so any queued `Task { @MainActor ... }`
+    /// enqueued by the observation helper has an opportunity to run before assertions.
+    private func drain() async {
+        for _ in 0..<5 { await Task.yield() }
+    }
+
+    @Test("apply fires when a tracked property changes")
+    func applyFiresOnChange() async {
+        let subject = Subject()
+        let counter = Counter()
+
+        let loop = observeRecurring(
+            track: { _ = subject.value },
+            apply: { counter.increment() }
+        )
+
+        #expect(counter.count == 0)
+
+        subject.value = 1
+        await drain()
+
+        #expect(counter.count == 1)
+        _ = loop
+    }
+
+    @Test("apply re-fires on subsequent changes (re-registration works)")
+    func applyReRegistersAfterFire() async {
+        let subject = Subject()
+        let counter = Counter()
+
+        let loop = observeRecurring(
+            track: { _ = subject.value },
+            apply: { counter.increment() }
+        )
+
+        subject.value = 1
+        await drain()
+        #expect(counter.count == 1)
+
+        subject.value = 2
+        await drain()
+        #expect(counter.count == 2)
+
+        subject.value = 3
+        await drain()
+        #expect(counter.count == 3)
+
+        _ = loop
+    }
+
+    @Test("apply does not fire for properties not read in track")
+    func applyIgnoresUntrackedProperties() async {
+        let subject = Subject()
+        let counter = Counter()
+
+        let loop = observeRecurring(
+            track: { _ = subject.value },
+            apply: { counter.increment() }
+        )
+
+        subject.other = 42
+        await drain()
+
+        #expect(counter.count == 0)
+        _ = loop
+    }
+
+    @Test("cancel stops the loop")
+    func cancelStopsLoop() async {
+        let subject = Subject()
+        let counter = Counter()
+
+        let loop = observeRecurring(
+            track: { _ = subject.value },
+            apply: { counter.increment() }
+        )
+
+        subject.value = 1
+        await drain()
+        #expect(counter.count == 1)
+
+        loop.cancel()
+
+        subject.value = 2
+        await drain()
+        #expect(counter.count == 1)
+
+        subject.value = 3
+        await drain()
+        #expect(counter.count == 1)
+    }
+
+    @Test("cancel is idempotent")
+    func cancelIsIdempotent() async {
+        let subject = Subject()
+        let counter = Counter()
+
+        let loop = observeRecurring(
+            track: { _ = subject.value },
+            apply: { counter.increment() }
+        )
+
+        loop.cancel()
+        loop.cancel()
+        loop.cancel()
+
+        subject.value = 1
+        await drain()
+        #expect(counter.count == 0)
+    }
+
+    @Test("dropping the handle after cancel stops the loop even before any fire")
+    func cancelBeforeAnyFire() async {
+        let subject = Subject()
+        let counter = Counter()
+
+        let loop = observeRecurring(
+            track: { _ = subject.value },
+            apply: { counter.increment() }
+        )
+
+        loop.cancel()
+
+        subject.value = 1
+        await drain()
+
+        #expect(counter.count == 0)
+    }
+
+    @Test("multiple independent loops can observe the same subject")
+    func independentLoops() async {
+        let subject = Subject()
+        let counterA = Counter()
+        let counterB = Counter()
+
+        let loopA = observeRecurring(
+            track: { _ = subject.value },
+            apply: { counterA.increment() }
+        )
+        let loopB = observeRecurring(
+            track: { _ = subject.value },
+            apply: { counterB.increment() }
+        )
+
+        subject.value = 1
+        await drain()
+        #expect(counterA.count == 1)
+        #expect(counterB.count == 1)
+
+        loopA.cancel()
+
+        subject.value = 2
+        await drain()
+        #expect(counterA.count == 1)
+        #expect(counterB.count == 2)
+
+        _ = loopB
+    }
+}


### PR DESCRIPTION
## Summary
- Replace eight hand-rolled `withObservationTracking` + `Task { @MainActor }` + recursive re-register patterns with a single shared helper.
- Eliminates the `observing*`-flag lifecycle design that caused the toolbar-stale bug fixed in #138 — if any of the three other flag-using controllers had ever been cached, they'd have regressed into the same bug class.
- Each call site now declares only *what* to track and *what* to do on change. The sustain-the-loop plumbing (`withObservationTracking`, the `Task`, the recursive re-register, the `[weak self]` teardown) lives once, in a tested helper.

Closes #137.

## The helper

`Kernova/Utilities/ObservationLoop.swift` introduces:

```swift
@MainActor
@discardableResult
func observeRecurring(
    track: @escaping () -> Void,
    apply: @escaping () -> Void
) -> ObservationLoop
```

- `track` is invoked inside `withObservationTracking` — it must read the `@Observable` properties the caller wants to observe.
- `apply` is invoked each time any of those properties changes, on the main actor.
- Returns an `ObservationLoop` handle. The loop runs until the handle is deallocated OR `cancel()` is called.
- Callers use `[weak self]` captures inside both closures.

Prior to this refactor the codebase had **three distinct lifecycle designs** spread across nine call sites:

- **Design A** — `[weak self]`-only, no gate flag (`ClipboardContentViewController`, `SerialConsoleContentViewController`, `AppDelegate.observeForTermination`, and — after #138 — `MainWindowController`). Robust.
- **Design B** — flag + paired `viewWillAppear` / `viewWillDisappear` lifecycle hooks (`DetailContainerViewController`). Correct but bespoke.
- **Design C** — flag cleared in `windowWillClose` with no re-start hook (`VMDisplayWindowController`, `ClipboardWindowController`, `SerialConsoleWindowController`). This is the variant that broke in `MainWindowController` and was fixed in #138. Benign in these three today only because `AppDelegate` creates fresh controllers per open.

All nine sites now use Design A-via-helper.

## Migration per site

- `MainWindowController.observeToolbarState` → stores `toolbarObservation: ObservationLoop?`; the RATIONALE comment added in #138 is gone (the helper makes the "no gate flag" pattern self-documenting).
- `VMDisplayWindowController.observeInstance` → stores `instanceObservation`; `windowWillClose` now calls `instanceObservation?.cancel()` instead of clearing a bool.
- `ClipboardWindowController.observeStatus` → stores `statusObservation`; `windowWillClose` cancels; `showWindow` starts the observation only if nil.
- `SerialConsoleWindowController.observeStatus` → same pattern as clipboard.
- `DetailContainerViewController.observeState` → stores `stateObservation`; `viewWillDisappear` cancels + nils the token; `viewDidAppear` starts only if nil (preserving the view-lifecycle gating that was the whole point of Design B).
- `ClipboardContentViewController.observeServiceChanges` → stores `serviceObservation`.
- `SerialConsoleContentViewController.observeInstanceChanges` → stores `instanceObservation`.
- `AppDelegate.observeForTermination` → stores `terminationObservation`.

## Tests

`KernovaTests/ObservationLoopTests.swift` (7 tests, all passing):

- `applyFiresOnChange` — fires on first tracked-property mutation
- `applyReRegistersAfterFire` — fires again on subsequent mutations (helper re-registers correctly)
- `applyIgnoresUntrackedProperties` — no fire when an untracked property changes
- `cancelStopsLoop` — no further fires after `cancel()`
- `cancelIsIdempotent` — multiple `cancel()` calls are safe
- `cancelBeforeAnyFire` — cancelling pre-fire prevents the initial fire too
- `independentLoops` — two separately-cancellable loops on the same subject

## Verification

- [x] `xcodebuild ... build` → **BUILD SUCCEEDED**
- [x] `xcodebuild ... test` → **TEST SUCCEEDED** (including the 7 new tests)
- [ ] Manual: main window toolbar still updates on sidebar selection, including after Dock close/reopen (the #138 regression scenario)
- [ ] Manual: clipboard + serial console windows still auto-close when the VM stops/errors
- [ ] Manual: display window still auto-closes on VM stop/error/cold-pause; toolbar tracks state transitions
- [ ] Manual: `DetailContainerViewController` inline display still swaps correctly when switching between running VMs
- [ ] Manual: the app still terminates cleanly when the last `isKeepingAppAlive` instance flips inactive

## Docs

`ARCHITECTURE.md` updated in the Utilities section and design decision #7 (NSToolbar with observation-driven validation) to reference the helper.