### PR TITLE
fix: Confirmation sheet when stopping a paused VM

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -273,6 +273,16 @@ final class VMLibraryViewModel {
             Self.logger.error("Failed to resume-and-stop '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
+        instanceToStopPaused = nil
+        showStopPausedConfirmation = false
+    }
+
+    /// Force-stops a paused VM via the stop-paused confirmation sheet's "Force Stop" action.
+    /// Wrapper around `forceStop` that clears the alert state, matching `deleteConfirmed`'s pattern.
+    func forceStopFromPaused(_ instance: VMInstance) async {
+        await forceStop(instance)
+        instanceToStopPaused = nil
+        showStopPausedConfirmation = false
     }
 
     func forceStop(_ instance: VMInstance) async {

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -259,6 +259,12 @@ final class VMLibraryViewModel {
 
     /// Resumes a paused VM then requests a graceful ACPI shutdown. Used by the
     /// stop-paused confirmation sheet's "Resume and Shut Down" action.
+    ///
+    /// Note: `lifecycle.resume` is serialized through the lifecycle coordinator,
+    /// but `lifecycle.stop` deliberately bypasses serialization (so users can
+    /// always interrupt a hung op). The two calls are therefore not atomic; in
+    /// practice the UI gates lifecycle buttons during transitions, so an
+    /// interleaved op is not reachable through normal user input.
     func resumeAndStop(_ instance: VMInstance) async {
         do {
             try await lifecycle.resume(instance)

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -40,6 +40,8 @@ final class VMLibraryViewModel {
     var preparingInstanceToCancel: VMInstance?
     var showForceStopConfirmation = false
     var instanceToForceStop: VMInstance?
+    var showStopPausedConfirmation = false
+    var instanceToStopPaused: VMInstance?
 
     /// `true` when any instance is mid-clone or mid-import.
     var hasPreparing: Bool { instances.contains(where: \.isPreparing) }
@@ -240,10 +242,29 @@ final class VMLibraryViewModel {
     }
 
     func stop(_ instance: VMInstance) {
+        // VZ rejects requestStop() on paused VMs ("Invalid virtual machine state").
+        // Surface a confirmation sheet offering resume-and-shutdown or force-stop instead.
+        if instance.status == .paused && !instance.isColdPaused {
+            instanceToStopPaused = instance
+            showStopPausedConfirmation = true
+            return
+        }
         do {
             try lifecycle.stop(instance)
         } catch {
             Self.logger.error("Failed to stop '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
+            presentError(error)
+        }
+    }
+
+    /// Resumes a paused VM then requests a graceful ACPI shutdown. Used by the
+    /// stop-paused confirmation sheet's "Resume and Shut Down" action.
+    func resumeAndStop(_ instance: VMInstance) async {
+        do {
+            try await lifecycle.resume(instance)
+            try lifecycle.stop(instance)
+        } catch {
+            Self.logger.error("Failed to resume-and-stop '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
     }

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -131,7 +131,7 @@ private struct LifecycleAlerts: ViewModifier {
                 // alert. The message text below makes the destructive nature
                 // explicit so one confirmation is sufficient.
                 Button("Force Stop", role: .destructive) {
-                    Task { await viewModel.forceStop(vm) }
+                    Task { await viewModel.forceStopFromPaused(vm) }
                 }
                 Button("Cancel", role: .cancel) {}
             } message: { vm in

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -102,7 +102,9 @@ private struct LifecycleAlerts: ViewModifier {
                 Button(vm.isColdPaused ? "Discard" : "Force Stop", role: .destructive) {
                     Task { await viewModel.forceStopConfirmed(vm) }
                 }
-                if vm.canStop {
+                // Paused VMs route through the dedicated "Stop Paused" alert instead;
+                // showing "Shut Down" here would chain a second alert on top of this one.
+                if vm.canStop && vm.status != .paused {
                     Button("Shut Down") {
                         viewModel.stop(vm)
                     }
@@ -123,6 +125,11 @@ private struct LifecycleAlerts: ViewModifier {
                 Button("Resume and Shut Down") {
                     Task { await viewModel.resumeAndStop(vm) }
                 }
+                // RATIONALE: This alert is itself a confirmation step, so
+                // "Force Stop" intentionally calls forceStop directly rather
+                // than routing through confirmForceStop and stacking a second
+                // alert. The message text below makes the destructive nature
+                // explicit so one confirmation is sufficient.
                 Button("Force Stop", role: .destructive) {
                     Task { await viewModel.forceStop(vm) }
                 }

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -6,87 +6,44 @@ struct VMDetailView: View {
     @Bindable var viewModel: VMLibraryViewModel
 
     var body: some View {
-        Group {
-            if let preparing = instance.preparingState {
-                VStack(spacing: 12) {
-                    ProgressView()
-                        .controlSize(.large)
-                    Text(preparing.operation.displayLabel)
-                        .font(.headline)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                switch instance.status {
-                case .stopped, .error:
-                    VMSettingsView(instance: instance, viewModel: viewModel, isReadOnly: false)
+        content
+            .modifier(LifecycleAlerts(viewModel: viewModel))
+    }
 
-                case .installing:
-                    if let installState = instance.installState {
-                        MacOSInstallProgressView(installState: installState) {
-                            viewModel.cancelInstallation(instance)
-                        }
-                    } else {
-                        transitionView
+    @ViewBuilder
+    private var content: some View {
+        if let preparing = instance.preparingState {
+            VStack(spacing: 12) {
+                ProgressView()
+                    .controlSize(.large)
+                Text(preparing.operation.displayLabel)
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            switch instance.status {
+            case .stopped, .error:
+                VMSettingsView(instance: instance, viewModel: viewModel, isReadOnly: false)
+
+            case .installing:
+                if let installState = instance.installState {
+                    MacOSInstallProgressView(installState: installState) {
+                        viewModel.cancelInstallation(instance)
                     }
-
-                case _ where instance.status.hasActiveDisplay:
-                    if instance.detailPaneMode == .settings {
-                        VMSettingsView(instance: instance, viewModel: viewModel, isReadOnly: true)
-                    } else {
-                        VMConsoleView(instance: instance)
-                    }
-
-                default:
+                } else {
                     transitionView
                 }
-            }
-        }
-        .alert(
-            "Delete Virtual Machine",
-            isPresented: $viewModel.showDeleteConfirmation,
-            presenting: viewModel.instanceToDelete
-        ) { vm in
-            Button("Move to Trash", role: .destructive) {
-                viewModel.deleteConfirmed(vm)
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: { vm in
-            Text("\"\(vm.name)\" will be moved to the Trash. You can restore it using Finder's Put Back command. Empty the Trash to permanently delete the VM and reclaim disk space.")
-        }
-        .alert(
-            viewModel.preparingInstanceToCancel?.preparingState?.operation.cancelAlertTitle ?? "",
-            isPresented: $viewModel.showCancelPreparingConfirmation,
-            presenting: viewModel.preparingInstanceToCancel
-        ) { instance in
-            Button(instance.preparingState?.operation.cancelLabel ?? "Cancel", role: .destructive) {
-                viewModel.cancelPreparingConfirmed(instance)
-            }
-            Button("Continue", role: .cancel) {}
-        } message: { _ in
-            Text("The operation will be stopped and any partially copied files will be removed.")
-        }
-        .alert(
-            viewModel.instanceToForceStop?.isColdPaused == true
-                ? "Discard Saved State"
-                : "Force Stop Virtual Machine",
-            isPresented: $viewModel.showForceStopConfirmation,
-            presenting: viewModel.instanceToForceStop
-        ) { vm in
-            Button(vm.isColdPaused ? "Discard" : "Force Stop", role: .destructive) {
-                Task { await viewModel.forceStopConfirmed(vm) }
-            }
-            if vm.canStop {
-                Button("Shut Down") {
-                    viewModel.stop(vm)
+
+            case _ where instance.status.hasActiveDisplay:
+                if instance.detailPaneMode == .settings {
+                    VMSettingsView(instance: instance, viewModel: viewModel, isReadOnly: true)
+                } else {
+                    VMConsoleView(instance: instance)
                 }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: { vm in
-            if vm.isColdPaused {
-                Text("\"\(vm.name)\" has its state saved to disk. Discarding will permanently delete the saved state.")
-            } else {
-                Text("\"\(vm.name)\" will be immediately terminated. Any unsaved data inside the guest will be lost.")
+
+            default:
+                transitionView
             }
         }
     }
@@ -100,5 +57,78 @@ struct VMDetailView: View {
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Lifecycle confirmation alerts (delete, cancel preparing, force stop, stop paused).
+/// Extracted into a separate modifier to keep the parent `body` expression within
+/// the Swift type-checker's complexity budget.
+private struct LifecycleAlerts: ViewModifier {
+    @Bindable var viewModel: VMLibraryViewModel
+
+    func body(content: Content) -> some View {
+        content
+            .alert(
+                "Delete Virtual Machine",
+                isPresented: $viewModel.showDeleteConfirmation,
+                presenting: viewModel.instanceToDelete
+            ) { vm in
+                Button("Move to Trash", role: .destructive) {
+                    viewModel.deleteConfirmed(vm)
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: { vm in
+                Text("\"\(vm.name)\" will be moved to the Trash. You can restore it using Finder's Put Back command. Empty the Trash to permanently delete the VM and reclaim disk space.")
+            }
+            .alert(
+                viewModel.preparingInstanceToCancel?.preparingState?.operation.cancelAlertTitle ?? "",
+                isPresented: $viewModel.showCancelPreparingConfirmation,
+                presenting: viewModel.preparingInstanceToCancel
+            ) { instance in
+                Button(instance.preparingState?.operation.cancelLabel ?? "Cancel", role: .destructive) {
+                    viewModel.cancelPreparingConfirmed(instance)
+                }
+                Button("Continue", role: .cancel) {}
+            } message: { _ in
+                Text("The operation will be stopped and any partially copied files will be removed.")
+            }
+            .alert(
+                viewModel.instanceToForceStop?.isColdPaused == true
+                    ? "Discard Saved State"
+                    : "Force Stop Virtual Machine",
+                isPresented: $viewModel.showForceStopConfirmation,
+                presenting: viewModel.instanceToForceStop
+            ) { vm in
+                Button(vm.isColdPaused ? "Discard" : "Force Stop", role: .destructive) {
+                    Task { await viewModel.forceStopConfirmed(vm) }
+                }
+                if vm.canStop {
+                    Button("Shut Down") {
+                        viewModel.stop(vm)
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: { vm in
+                if vm.isColdPaused {
+                    Text("\"\(vm.name)\" has its state saved to disk. Discarding will permanently delete the saved state.")
+                } else {
+                    Text("\"\(vm.name)\" will be immediately terminated. Any unsaved data inside the guest will be lost.")
+                }
+            }
+            .alert(
+                "Stop Paused Virtual Machine",
+                isPresented: $viewModel.showStopPausedConfirmation,
+                presenting: viewModel.instanceToStopPaused
+            ) { vm in
+                Button("Resume and Shut Down") {
+                    Task { await viewModel.resumeAndStop(vm) }
+                }
+                Button("Force Stop", role: .destructive) {
+                    Task { await viewModel.forceStop(vm) }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: { vm in
+                Text("\"\(vm.name)\" is paused and cannot be shut down directly. Resume it to send a graceful shutdown, or force stop to terminate it immediately (any unsaved data inside the guest will be lost).")
+            }
     }
 }

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -381,6 +381,37 @@ struct VMLibraryViewModelTests {
         #expect(virtService.stopCallCount == 1)
     }
 
+    @Test("resumeAndStop clears confirmation state after dispatch")
+    func resumeAndStopClearsConfirmationState() async {
+        let (viewModel, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .paused
+        viewModel.instances.append(instance)
+        viewModel.instanceToStopPaused = instance
+        viewModel.showStopPausedConfirmation = true
+
+        await viewModel.resumeAndStop(instance)
+
+        #expect(viewModel.instanceToStopPaused == nil)
+        #expect(viewModel.showStopPausedConfirmation == false)
+    }
+
+    @Test("forceStopFromPaused dispatches forceStop and clears state")
+    func forceStopFromPausedDispatches() async {
+        let (viewModel, _, _, virtService) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .paused
+        viewModel.instances.append(instance)
+        viewModel.instanceToStopPaused = instance
+        viewModel.showStopPausedConfirmation = true
+
+        await viewModel.forceStopFromPaused(instance)
+
+        #expect(virtService.forceStopCallCount == 1)
+        #expect(viewModel.instanceToStopPaused == nil)
+        #expect(viewModel.showStopPausedConfirmation == false)
+    }
+
     @Test("resumeAndStop presents error if resume fails")
     func resumeAndStopPresentsErrorOnResumeFailure() async {
         let virtService = MockVirtualizationService()

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -359,6 +359,15 @@ struct VMLibraryViewModelTests {
 
     // MARK: - Stop Paused Confirmation
 
+    // Note: the `stop()` branch that diverts a *live-paused* instance to the
+    // confirmation sheet (status == .paused && virtualMachine != nil) is not
+    // directly unit-tested here. Triggering it requires a non-nil
+    // VZVirtualMachine, which the existing test infrastructure cannot
+    // construct (matching VMInstanceTests.swift:82 / VMStatusSerialConsoleTests.swift:25).
+    // The branch is exercised at integration time. Tests below cover the
+    // surrounding behavior: resumeAndStop dispatch, error surfacing, and
+    // confirming `.running` instances skip the confirmation flow.
+
     @Test("resumeAndStop dispatches resume then stop")
     func resumeAndStopDispatches() async {
         let (viewModel, _, _, virtService) = makeViewModel()

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -357,6 +357,49 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.errorMessage != nil)
     }
 
+    // MARK: - Stop Paused Confirmation
+
+    @Test("resumeAndStop dispatches resume then stop")
+    func resumeAndStopDispatches() async {
+        let (viewModel, _, _, virtService) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .paused
+        viewModel.instances.append(instance)
+
+        await viewModel.resumeAndStop(instance)
+
+        #expect(virtService.resumeCallCount == 1)
+        #expect(virtService.stopCallCount == 1)
+    }
+
+    @Test("resumeAndStop presents error if resume fails")
+    func resumeAndStopPresentsErrorOnResumeFailure() async {
+        let virtService = MockVirtualizationService()
+        virtService.resumeError = VirtualizationError.noVirtualMachine
+        let (viewModel, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let instance = makeInstance()
+        instance.status = .paused
+
+        await viewModel.resumeAndStop(instance)
+
+        #expect(viewModel.showError == true)
+        #expect(virtService.stopCallCount == 0)
+    }
+
+    @Test("stop on running VM still delegates directly without confirmation")
+    func stopRunningSkipsConfirmation() {
+        let (viewModel, _, _, virtService) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .running
+        viewModel.instances.append(instance)
+
+        viewModel.stop(instance)
+
+        #expect(virtService.stopCallCount == 1)
+        #expect(viewModel.showStopPausedConfirmation == false)
+        #expect(viewModel.instanceToStopPaused == nil)
+    }
+
     @Test("pause presents error on service failure")
     func pausePresentsError() async {
         let virtService = MockVirtualizationService()


### PR DESCRIPTION
## Summary
- Pressing Stop on a paused VM previously surfaced the raw VZ error ("Invalid virtual machine state. Virtual machine state 'paused' is invalid for requesting a stop.") because Apple's `requestStop()` only accepts running VMs.
- Replace the dead-end with a sheet offering **Resume and Shut Down** / **Force Stop** / **Cancel** so the user can recover with one click instead of having to manually click Resume → Stop.

## Changes
- `VMLibraryViewModel.stop(_:)` now diverts live-paused instances to a confirmation flow (`showStopPausedConfirmation` / `instanceToStopPaused`) instead of calling `lifecycle.stop` and bubbling up the VZ error.
- Add `VMLibraryViewModel.resumeAndStop(_:)` which awaits resume then delegates to the existing graceful stop path.
- `VMDetailView`: extract the existing alerts into a `LifecycleAlerts` ViewModifier — the parent `body` exceeded the Swift type-checker's expression-complexity budget once a fourth alert was added — and add the new "Stop Paused Virtual Machine" alert there.
- Tests: cover `resumeAndStop` happy path, resume-failure error surfacing, and confirm `stop` on a `.running` VM still delegates directly without triggering the new sheet.

## Notes
- This is an Apple VZ framework limitation, not a Kernova bug — `VZVirtualMachine.requestStop()` is only valid when the VM is `.running`. We've moved the response from "show raw framework error" to "let the user pick the right transition."
- The new "Stop Paused" sheet's destructive button is **Force Stop** (immediate termination, may lose unsaved data); **Resume and Shut Down** is the non-destructive default.

## Test plan
- [x] `xcodebuild build` on macOS 26 / Xcode 26
- [x] `xcodebuild test` — all suites pass (including 3 new tests)
- [ ] Manual: pause a Linux guest → press Stop → choose "Resume and Shut Down" → guest shuts down gracefully
- [ ] Manual: pause a Linux guest → press Stop → choose "Force Stop" → VM terminates immediately
- [ ] Manual: pressing Stop on a running VM still shuts down directly (no sheet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)