### PR TITLE
fix: Remove SPICE clipboard heartbeat

### DIFF
--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -48,17 +48,6 @@ final class SpiceClipboardService {
     /// instead of waiting for a REQUEST.
     private var guestSupportsByDemand = false
 
-    // MARK: - Heartbeat
-
-    private static let heartbeatInterval: Duration = .seconds(5)
-    private static let heartbeatTimeout: Duration = .seconds(5)
-
-    /// Set to `true` whenever a valid message arrives from the guest; reset by
-    /// the heartbeat loop after each check. Avoids wall-clock comparisons.
-    private var receivedSinceLastProbe = false
-
-    private var heartbeatTask: Task<Void, Never>?
-
     private static let logger = Logger(subsystem: "com.kernova.app", category: "SpiceClipboardService")
 
     // MARK: - Init
@@ -77,7 +66,7 @@ final class SpiceClipboardService {
         Self.logger.info("SPICE clipboard service started")
     }
 
-    /// Stops reading, cancels the heartbeat, and releases resources.
+    /// Stops reading, marks the connection inactive, and releases resources.
     func stop() {
         disconnect()
         outputPipe.fileHandleForReading.readabilityHandler = nil
@@ -154,10 +143,6 @@ final class SpiceClipboardService {
             Self.logger.error("SPICE parser buffer reset — stream may be corrupted")
         }
 
-        if !messages.isEmpty {
-            receivedSinceLastProbe = true
-        }
-
         for message in messages {
             switch message {
             case .announceCapabilities(let request, let caps):
@@ -200,7 +185,6 @@ final class SpiceClipboardService {
 
         isConnected = true
         guestSupportsByDemand = byDemand
-        startHeartbeat()
 
         // If the guest requested our capabilities, send them back (non-requesting)
         if request {
@@ -286,53 +270,9 @@ final class SpiceClipboardService {
         }
     }
 
-    // MARK: - Heartbeat
-
-    /// Monitors guest agent liveness. Skips probing when the agent was recently
-    /// active; otherwise sends a capabilities request and waits for a reply.
-    /// Marks the connection as dead and stops if no response arrives.
-    private func startHeartbeat() {
-        heartbeatTask?.cancel()
-        Self.logger.debug("Starting heartbeat monitor")
-        heartbeatTask = Task { [weak self] in
-            do {
-                while true {
-                    try await Task.sleep(for: Self.heartbeatInterval)
-                    guard let self, self.isConnected else { return }
-
-                    // Agent was active during the interval — no probe needed
-                    if self.receivedSinceLastProbe {
-                        self.receivedSinceLastProbe = false
-                        continue
-                    }
-
-                    // No recent activity — send a probe and wait for response
-                    self.sendCapabilities()
-
-                    try await Task.sleep(for: Self.heartbeatTimeout)
-                    guard self.isConnected else { return }
-
-                    if self.receivedSinceLastProbe {
-                        self.receivedSinceLastProbe = false
-                        continue
-                    }
-
-                    self.disconnect()
-                    Self.logger.notice("Heartbeat timeout — guest agent not responding")
-                    return
-                }
-            } catch {
-                // CancellationError from stop() — normal teardown
-            }
-        }
-    }
-
-    /// Cancels the heartbeat and marks the connection as inactive.
+    /// Marks the connection as inactive.
     private func disconnect() {
-        heartbeatTask?.cancel()
-        heartbeatTask = nil
         isConnected = false
-        receivedSinceLastProbe = false
     }
 
     // MARK: - Capability Helpers

--- a/KernovaTests/SpiceClipboardServiceTests.swift
+++ b/KernovaTests/SpiceClipboardServiceTests.swift
@@ -182,6 +182,25 @@ struct SpiceClipboardServiceTests {
         #expect(!service.isConnected)
     }
 
+    @Test("Pipe EOF disconnects the service")
+    func pipeEOFDisconnects() async throws {
+        let (service, inputPipe, outputPipe) = makeService()
+        service.start()
+        drainPipe(inputPipe)
+        connect(service)
+        #expect(service.isConnected)
+
+        try outputPipe.fileHandleForWriting.close()
+
+        let deadline = Date().addingTimeInterval(1.0)
+        while service.isConnected && Date() < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        #expect(!service.isConnected)
+        service.stop()
+    }
+
     // MARK: - Inbound Message Handling
 
     @Test("Guest clipboard data updates text and resets grab tracking")


### PR DESCRIPTION
## Summary
- Remove the periodic ANNOUNCE_CAPABILITIES probe and timeout-based disconnect from `SpiceClipboardService`
- The heartbeat falsely flipped the connection to disconnected during VM pause and added protocol noise on the guest side; SPICE vdagent has no protocol-level keepalive
- Connection death is now detected only on real signals: pipe EOF and host-side write failures

## Changes
- Drop `heartbeatInterval` / `heartbeatTimeout` statics, `receivedSinceLastProbe` flag, and `heartbeatTask` from `SpiceClipboardService`
- Remove `startHeartbeat()` and the call from `handleCapabilities`
- Drop the `receivedSinceLastProbe` write in `handleIncomingData`
- Strip heartbeat-cancel logic from `disconnect()`, keeping only the `isConnected` flip
- Update `stop()` doc comment to match

## Test plan
- [ ] Build succeeds on macOS 26
- [ ] `KernovaTests` SpiceClipboardService suite passes
- [ ] Clipboard sync still works after a VM pause/resume cycle on a Linux guest
- [ ] Connection recovers after restarting the in-VM guest agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)