### PR TITLE
fix: Abort serve on Hello send failure in VsockGuestClipboardAgent

### DIFF
--- a/KernovaGuestAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaGuestAgent/VsockGuestClipboardAgent.swift
@@ -131,7 +131,18 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         // so any offer the timer dispatches is guaranteed to land on the host
         // after Hello — the host doesn't otherwise gate offer handling on
         // hello completion, but ordering keeps the wire trace coherent.
-        sendHello(on: channel)
+        do {
+            try sendHello(on: channel)
+        } catch {
+            // Don't publish liveChannel — VsockGuestClient will retry the
+            // connection. channel.close() is belt-and-braces; VsockChannel.send
+            // already tears down on .write errors.
+            Self.logger.warning(
+                "Failed to send clipboard Hello — aborting serve: \(error.localizedDescription, privacy: .public)"
+            )
+            channel.close()
+            return
+        }
 
         DispatchQueue.main.async { [weak self] in
             self?.liveChannel = channel
@@ -360,7 +371,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
 
     // MARK: - Hello
 
-    private func sendHello(on channel: VsockChannel) {
+    private func sendHello(on channel: VsockChannel) throws {
         var hello = Frame()
         hello.protocolVersion = 1
         hello.hello = Kernova_V1_Hello.with {
@@ -372,12 +383,6 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                 $0.agentVersion = (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "unknown"
             }
         }
-        do {
-            try channel.send(hello)
-        } catch {
-            Self.logger.warning(
-                "Failed to send clipboard Hello: \(error.localizedDescription, privacy: .public)"
-            )
-        }
+        try channel.send(hello)
     }
 }

--- a/KernovaGuestAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaGuestAgent/VsockGuestClipboardAgent.swift
@@ -134,11 +134,11 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         do {
             try sendHello(on: channel)
         } catch {
-            // Don't publish liveChannel — VsockGuestClient will retry the
-            // connection. channel.close() is belt-and-braces; VsockChannel.send
-            // already tears down on .write errors.
+            // Don't publish liveChannel — VsockGuestClient.runReconnectLoop will retry
+            // the connection. channel.close() is idempotent and ensures the fd is
+            // released regardless of which sendHello error path we took.
             Self.logger.warning(
-                "Failed to send clipboard Hello — aborting serve: \(error.localizedDescription, privacy: .public)"
+                "Failed to send clipboard Hello on port \(KernovaVsockPort.clipboard, privacy: .public) — aborting serve, VsockGuestClient will reconnect: \(String(describing: error), privacy: .public)"
             )
             channel.close()
             return

--- a/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
@@ -242,6 +242,53 @@ struct VsockGuestClipboardAgentTests {
         #expect(pasteboard.string(forType: .string) == nil)
     }
 
+    @Test("Hello send failure aborts serve without publishing liveChannel; client retries")
+    func helloFailureAbortsAndRetries() async throws {
+        let pasteboard = FakePasteboard()
+
+        // First attempt: close the peer fd before the agent writes Hello so the
+        // first send() hits EPIPE / .closed. Second attempt: a healthy pair.
+        let (agentFd0, remoteFd0) = try makeRawSocketPair()
+        close(remoteFd0)  // peer gone before agent writes Hello
+
+        let (agentFd1, remoteFd1) = try makeRawSocketPair()
+        let host1 = VsockChannel(fileDescriptor: remoteFd1)
+        host1.start()
+        defer { host1.close() }
+
+        let fdBox = FdBox(fds: [agentFd0, agentFd1])
+        let provideCount = AtomicInt()
+
+        let client = VsockGuestClient(
+            port: 49152,
+            label: "clipboard-hello-fail-test",
+            retryInterval: .milliseconds(50)
+        ) { _, _ in
+            let n = provideCount.increment()
+            return fdBox.fd(at: n - 1)
+        }
+
+        let agent = VsockGuestClipboardAgent(pasteboard: pasteboard, client: client)
+        defer { agent.stop() }
+
+        agent.start()
+
+        // The retry should reach the second (healthy) connection and Hello should
+        // arrive on host1. liveChannel must only become non-nil for the second
+        // connection — never for the first (broken) one.
+        let hello = try await nextFrame(from: host1, timeout: .seconds(3))
+        guard case .hello = hello.payload else {
+            throw TestFailure("Expected Hello on retry connection, got \(String(describing: hello.payload))")
+        }
+        // Reply with host Hello so liveChannel is published.
+        try host1.send(makeHelloFrame())
+        try await waitUntil { agent.liveChannelForTesting != nil }
+
+        // Socket provider was called at least twice (once for the failed fd,
+        // once for the healthy fd).
+        #expect(provideCount.value >= 2)
+    }
+
     @Test("full inbound offer/request/data round-trip writes pasteboard")
     func inboundRoundTripWritesPasteboard() async throws {
         let pasteboard = FakePasteboard()

--- a/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
@@ -249,6 +249,12 @@ struct VsockGuestClipboardAgentTests {
         // First attempt: close the peer fd before the agent writes Hello so the
         // first send() hits EPIPE / .closed. Second attempt: a healthy pair.
         let (agentFd0, remoteFd0) = try makeRawSocketPair()
+
+        // SO_NOSIGPIPE so writing to a peer-closed socket surfaces as an
+        // error rather than killing the test process with SIGPIPE.
+        var noSigpipe: Int32 = 1
+        _ = setsockopt(agentFd0, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size))
+
         close(remoteFd0)  // peer gone before agent writes Hello
 
         let (agentFd1, remoteFd1) = try makeRawSocketPair()
@@ -259,12 +265,29 @@ struct VsockGuestClipboardAgentTests {
         let fdBox = FdBox(fds: [agentFd0, agentFd1])
         let provideCount = AtomicInt()
 
+        // Gate: signals when the reconnect loop asks for the second fd (i.e.,
+        // after the first connection has already failed and been cleaned up).
+        let firstFailedGate = DispatchSemaphore(value: 0)
+        // Gate: released by the test body after it has asserted liveChannel==nil,
+        // allowing the reconnect loop to continue with the healthy fd.
+        let secondProvideGate = DispatchSemaphore(value: 0)
+
         let client = VsockGuestClient(
             port: 49152,
             label: "clipboard-hello-fail-test",
             retryInterval: .milliseconds(50)
         ) { _, _ in
             let n = provideCount.increment()
+            if n == 2 {
+                // The reconnect loop has already (a) called serve with fd0,
+                // (b) had serve return due to Hello failure, (c) cleared
+                // currentChannel, (d) slept retryInterval, and (e) re-entered
+                // runReconnectLoop to ask for the next fd. Signal the test body
+                // so it can assert liveChannel is still nil (the fix under test),
+                // then wait for the test to give the go-ahead.
+                firstFailedGate.signal()
+                secondProvideGate.wait()
+            }
             return fdBox.fd(at: n - 1)
         }
 
@@ -272,6 +295,23 @@ struct VsockGuestClipboardAgentTests {
         defer { agent.stop() }
 
         agent.start()
+
+        // Wait (on a background thread) until the provider is entered for the
+        // second time, then assert liveChannel is nil before releasing the gate.
+        // Must not block the cooperative thread pool — bridge via a detached thread.
+        // AtomicInt stores the snapshot: 1 = liveChannel was nil (fix worked), 0 = non-nil (regression).
+        let liveChannelWasNilSnapshot = AtomicInt()
+        DispatchQueue.global(qos: .userInitiated).async {
+            firstFailedGate.wait()
+            // By the time the provider is called a second time, serve() for
+            // the broken connection has already returned without publishing
+            // liveChannel (that is exactly what the fix under test enforces).
+            let isNil = DispatchQueue.main.sync {
+                agent.liveChannelForTesting == nil
+            }
+            if isNil { liveChannelWasNilSnapshot.increment() }
+            secondProvideGate.signal()
+        }
 
         // The retry should reach the second (healthy) connection and Hello should
         // arrive on host1. liveChannel must only become non-nil for the second
@@ -287,6 +327,10 @@ struct VsockGuestClipboardAgentTests {
         // Socket provider was called at least twice (once for the failed fd,
         // once for the healthy fd).
         #expect(provideCount.value >= 2)
+
+        // The snapshot taken between first failure and second provide must be nil —
+        // this is the load-bearing assertion that the fix prevents premature publish.
+        #expect(liveChannelWasNilSnapshot.value == 1, "liveChannel was non-nil during the failed Hello connection: fix did not abort before publish")
     }
 
     @Test("full inbound offer/request/data round-trip writes pasteboard")


### PR DESCRIPTION
## Summary
- `sendHello(on:)` previously swallowed send errors silently; `serve(channel:)` would then unconditionally publish `liveChannel` and enter the drain loop regardless of whether Hello reached the host
- If Hello fails, the polling timer could send `ClipboardOffer` frames on a channel whose peer has no handshake context, leaving the host in a confused state until EOF
- `sendHello` now throws; `serve` wraps the call in `do/catch` and returns early on failure (closing the channel defensively), preventing the half-open channel from being published and letting `VsockGuestClient` retry the connection

## Changes
- `KernovaGuestAgent/VsockGuestClipboardAgent.swift`: `sendHello(on:)` now throws instead of swallowing errors; `serve(channel:)` aborts early on Hello failure before publishing `liveChannel`
- `KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift`: Add `helloFailureAbortsAndRetries` regression test

## Test plan
- [x] Built successfully on macOS 26
- [x] `helloFailureAbortsAndRetries` passes: Hello send failure logs "aborting serve", `liveChannel` only published for the second (healthy) connection, `provideCount >= 2`
- [x] All 5 existing `VsockGuestClipboardAgent` tests continue to pass
- [x] Full test suite passes

Closes #152