### PR TITLE
fix: Set SO_NOSIGPIPE in flushReenqueuesOnPartialSendFailure test

### DIFF
--- a/KernovaGuestAgentTests/VsockHostConnectionTests.swift
+++ b/KernovaGuestAgentTests/VsockHostConnectionTests.swift
@@ -143,6 +143,11 @@ struct VsockHostConnectionTests {
 
         let (senderFd, receiverFd) = try makeRawSocketPair()
 
+        // SO_NOSIGPIPE so writing to a peer-closed socket surfaces as an
+        // error rather than killing the test process with SIGPIPE.
+        var noSigpipe: Int32 = 1
+        _ = setsockopt(senderFd, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size))
+
         // Constrain the send buffer to ~8 KB so the kernel queue fills quickly.
         var sndbuf: Int32 = 8192
         setsockopt(senderFd, SOL_SOCKET, SO_SNDBUF, &sndbuf, socklen_t(MemoryLayout<Int32>.size))


### PR DESCRIPTION
## Summary
- The `VsockHostConnectionTests/flushReenqueuesOnPartialSendFailure` test was crashing in CI with `signal pipe` (SIGPIPE), causing every Build & Test run on `main` to fail (exit 65)
- The test deliberately closes the receiver fd to force EPIPE on the sender, but didn't set `SO_NOSIGPIPE` — so the kernel delivered SIGPIPE to the test process before `FileHandle.write` could surface it as a Swift error
- The two other peer-close tests in the codebase (`VsockChannelTests.sendThrowsWriteOnUnderlyingFailure`, `VsockGuestClipboardAgentTests.helloFailureAbortsAndRetries`) already set this option; this brings the new test in line with that pattern

## Changes
- `KernovaGuestAgentTests/VsockHostConnectionTests.swift` — apply `setsockopt(SOL_SOCKET, SO_NOSIGPIPE)` on the sender fd before closing the receiver, matching the existing convention

## Test plan
- [x] `xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=macOS' -derivedDataPath DerivedData test -only-testing:KernovaGuestAgentTests` — all 38 guest-agent tests pass, including the previously-crashing case
- [ ] CI Build & Test passes on this branch

## Notes
The crash didn't reproduce on a local Apple Silicon dev machine — likely because Xcode's local test runner masks SIGPIPE for the xctest process by default, while the GitHub Actions macOS runner doesn't. The fix is robust to both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)