### PR TITLE
perf: Switch VsockFrameDecoder to a read-offset model

### DIFF
--- a/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
@@ -122,7 +122,8 @@ public struct VsockFrameDecoder: Sendable {
         }
     }
 
-    /// Drops the consumed prefix when worthwhile. Cheap if no work is needed.
+    /// Two-tier compaction: drained buffers reset for free; partial buffers
+    /// shift only after the threshold to keep the per-byte copy cost amortized.
     private mutating func compactIfNeeded() {
         guard readOffset > 0 else { return }
         if readOffset == buffer.count {

--- a/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
@@ -59,7 +59,14 @@ public enum VsockFrameError: Error, Sendable, Equatable {
 /// queue at a time.
 public struct VsockFrameDecoder: Sendable {
 
+    /// Compact the consumed prefix once the read offset crosses this many
+    /// bytes. Sized to amortize the shift cost (each byte is copied at most
+    /// once before being dropped) without keeping more than ~64 KiB of stale
+    /// storage live per decoder.
+    private static let compactionThreshold: Int = 64 * 1024
+
     private var buffer: Data = Data()
+    private var readOffset: Int = 0
 
     public init() {}
 
@@ -77,7 +84,8 @@ public struct VsockFrameDecoder: Sendable {
     ///   should be discarded — the buffer is left in place but the stream is
     ///   considered corrupt.
     public mutating func nextFrame() throws -> Data? {
-        guard buffer.count >= VsockFrame.lengthPrefixSize else { return nil }
+        let unread = buffer.count - readOffset
+        guard unread >= VsockFrame.lengthPrefixSize else { return nil }
 
         let payloadSize = Int(readLengthPrefix())
 
@@ -89,24 +97,43 @@ public struct VsockFrameDecoder: Sendable {
         }
 
         let totalFrameSize = VsockFrame.lengthPrefixSize + payloadSize
-        guard buffer.count >= totalFrameSize else { return nil }
+        guard unread >= totalFrameSize else { return nil }
 
-        let start = buffer.startIndex + VsockFrame.lengthPrefixSize
-        let end = buffer.startIndex + totalFrameSize
-        let payload = Data(buffer[start..<end])
-        buffer.removeSubrange(buffer.startIndex..<end)
+        let payloadStart = buffer.startIndex + readOffset + VsockFrame.lengthPrefixSize
+        let payloadEnd = buffer.startIndex + readOffset + totalFrameSize
+        let payload = Data(buffer[payloadStart..<payloadEnd])
+        readOffset += totalFrameSize
+
+        compactIfNeeded()
         return payload
     }
 
     /// `true` when no buffered bytes remain.
-    public var isEmpty: Bool { buffer.isEmpty }
+    public var isEmpty: Bool { buffer.count == readOffset }
 
     /// Number of buffered bytes not yet consumed.
-    public var bufferedByteCount: Int { buffer.count }
+    public var bufferedByteCount: Int { buffer.count - readOffset }
 
     private func readLengthPrefix() -> UInt32 {
-        buffer.prefix(VsockFrame.lengthPrefixSize).withUnsafeBytes { raw in
+        let start = buffer.startIndex + readOffset
+        let end = start + VsockFrame.lengthPrefixSize
+        return buffer[start..<end].withUnsafeBytes { raw in
             UInt32(bigEndian: raw.loadUnaligned(as: UInt32.self))
+        }
+    }
+
+    /// Drops the consumed prefix when worthwhile. Cheap if no work is needed.
+    private mutating func compactIfNeeded() {
+        guard readOffset > 0 else { return }
+        if readOffset == buffer.count {
+            buffer.removeAll(keepingCapacity: true)
+            readOffset = 0
+            return
+        }
+        if readOffset >= VsockFrameDecoder.compactionThreshold {
+            let unreadStart = buffer.startIndex + readOffset
+            buffer.removeSubrange(buffer.startIndex..<unreadStart)
+            readOffset = 0
         }
     }
 }

--- a/KernovaProtocol/Tests/KernovaProtocolTests/VsockFrameTests.swift
+++ b/KernovaProtocol/Tests/KernovaProtocolTests/VsockFrameTests.swift
@@ -126,8 +126,8 @@ struct VsockFrameTests {
         let payload = Data(repeating: 0xAB, count: 1024)
         let framed = try VsockFrame.encode(payload)
 
-        // Feed and consume enough frames to cross 64 KiB consumed bytes several times.
-        let frameCount = 256  // ~256 KiB of data
+        // Enough frames to cross the compaction threshold several times.
+        let frameCount = 256
         for _ in 0..<frameCount {
             decoder.feed(framed)
             let got = try decoder.nextFrame()
@@ -147,16 +147,85 @@ struct VsockFrameTests {
         // Push enough frames to trip compaction, but leave a partial frame at the tail.
         let smallPayload = Data(repeating: 0x55, count: 4096)
         let smallFramed = try VsockFrame.encode(smallPayload)
-        for _ in 0..<32 {  // ~128 KiB consumed
+        // Cross the compaction threshold at least twice before leaving a partial frame.
+        for _ in 0..<32 {
             decoder.feed(smallFramed)
             _ = try decoder.nextFrame()
         }
 
-        // Feed a half-frame to leave unread bytes hanging.
         let halfFrame = smallFramed.prefix(smallFramed.count / 2)
         decoder.feed(halfFrame)
         #expect(try decoder.nextFrame() == nil)
         #expect(decoder.bufferedByteCount == halfFrame.count)
+    }
+
+    @Test("decoder preserves payload bytes of a frame straddling the compaction boundary")
+    func decoderPayloadIntegrityAcrossCompaction() throws {
+        var decoder = VsockFrameDecoder()
+        // Use a recognisable payload so byte corruption is immediately obvious.
+        let smallPayload = Data((0..<128).map { UInt8($0 & 0xFF) })
+        let smallFramed = try VsockFrame.encode(smallPayload)
+
+        // Cross the compaction threshold at least once.
+        for _ in 0..<32 {
+            decoder.feed(smallFramed)
+            _ = try decoder.nextFrame()
+        }
+
+        // Feed just past the threshold but mid-payload of the next frame.
+        let splitAt = smallFramed.count / 2
+        decoder.feed(Data(smallFramed.prefix(splitAt)))
+        #expect(try decoder.nextFrame() == nil)
+
+        // Deliver the remainder — the decoder must reconstruct the exact bytes.
+        decoder.feed(Data(smallFramed.suffix(smallFramed.count - splitAt)))
+        let recovered = try decoder.nextFrame()
+        #expect(recovered == smallPayload)
+    }
+
+    @Test("decoder yields correct payloads while draining across a compaction boundary")
+    func decoderDrainsAcrossCompactionBoundary() throws {
+        var decoder = VsockFrameDecoder()
+        // Build a single chunk large enough to trigger compaction mid-drain.
+        let payload = Data((0..<64).map { UInt8($0 & 0xFF) })
+        let framed = try VsockFrame.encode(payload)
+        // Enough frames to cross the compaction threshold several times in one feed.
+        let frameCount = 1100
+        var bulk = Data()
+        bulk.reserveCapacity(framed.count * frameCount)
+        for _ in 0..<frameCount { bulk.append(framed) }
+
+        decoder.feed(bulk)
+
+        for i in 0..<frameCount {
+            let got = try decoder.nextFrame()
+            #expect(got == payload, "payload mismatch at frame \(i)")
+        }
+        #expect(try decoder.nextFrame() == nil)
+    }
+
+    @Test("decoder handles a partial length prefix split at the compaction boundary")
+    func decoderPartialLengthPrefixAcrossCompaction() throws {
+        var decoder = VsockFrameDecoder()
+        let warmPayload = Data(repeating: 0xAA, count: 4096)
+        let warmFramed = try VsockFrame.encode(warmPayload)
+
+        // Cross the compaction threshold at least twice before leaving a partial prefix.
+        for _ in 0..<32 {
+            decoder.feed(warmFramed)
+            _ = try decoder.nextFrame()
+        }
+
+        // Build the next frame but deliver only 1 byte of its length prefix.
+        let nextPayload = Data([0x10, 0x20, 0x30, 0x40, 0x50])
+        let nextFramed = try VsockFrame.encode(nextPayload)
+        decoder.feed(Data(nextFramed.prefix(1)))
+        #expect(try decoder.nextFrame() == nil)
+
+        // Deliver the rest — decoder must reconstruct the full frame correctly.
+        decoder.feed(Data(nextFramed.dropFirst(1)))
+        #expect(try decoder.nextFrame() == nextPayload)
+        #expect(decoder.isEmpty)
     }
 
     // MARK: - round trip

--- a/KernovaProtocol/Tests/KernovaProtocolTests/VsockFrameTests.swift
+++ b/KernovaProtocol/Tests/KernovaProtocolTests/VsockFrameTests.swift
@@ -118,6 +118,47 @@ struct VsockFrameTests {
         }
     }
 
+    // MARK: - compaction
+
+    @Test("decoder remains correct after consuming more than the compaction threshold")
+    func decoderSurvivesCompaction() throws {
+        var decoder = VsockFrameDecoder()
+        let payload = Data(repeating: 0xAB, count: 1024)
+        let framed = try VsockFrame.encode(payload)
+
+        // Feed and consume enough frames to cross 64 KiB consumed bytes several times.
+        let frameCount = 256  // ~256 KiB of data
+        for _ in 0..<frameCount {
+            decoder.feed(framed)
+            let got = try decoder.nextFrame()
+            #expect(got == payload)
+        }
+        #expect(decoder.isEmpty)
+        #expect(decoder.bufferedByteCount == 0)
+
+        // Decoder is still usable for new frames after compaction cycles.
+        decoder.feed(try VsockFrame.encode(Data([0x01, 0x02, 0x03])))
+        #expect(try decoder.nextFrame() == Data([0x01, 0x02, 0x03]))
+    }
+
+    @Test("decoder reports correct bufferedByteCount mid-stream after compaction")
+    func decoderBufferedByteCountAfterCompaction() throws {
+        var decoder = VsockFrameDecoder()
+        // Push enough frames to trip compaction, but leave a partial frame at the tail.
+        let smallPayload = Data(repeating: 0x55, count: 4096)
+        let smallFramed = try VsockFrame.encode(smallPayload)
+        for _ in 0..<32 {  // ~128 KiB consumed
+            decoder.feed(smallFramed)
+            _ = try decoder.nextFrame()
+        }
+
+        // Feed a half-frame to leave unread bytes hanging.
+        let halfFrame = smallFramed.prefix(smallFramed.count / 2)
+        decoder.feed(halfFrame)
+        #expect(try decoder.nextFrame() == nil)
+        #expect(decoder.bufferedByteCount == halfFrame.count)
+    }
+
     // MARK: - round trip
 
     @Test("encode/decode round-trip preserves arbitrary bytes")


### PR DESCRIPTION
## Summary
- Replaces the `removeSubrange`-per-frame pattern in `VsockFrameDecoder` with a `readOffset` cursor that advances through the buffer on each successful extraction, turning per-frame extraction from O(unread) into O(1)
- Compaction is deferred and amortized: the consumed prefix is dropped at most once per 64 KiB consumed (or immediately when the buffer is fully drained via `removeAll(keepingCapacity: true)`, which is a count-reset with no copy)
- All public API (`feed`, `nextFrame`, `isEmpty`, `bufferedByteCount`) and their semantics are unchanged; the decoder is ready for MB-scale clipboard payloads in Phase 4
- Two new tests cover the compaction path: one verifies correctness across many compaction cycles (256 KiB), one verifies `bufferedByteCount` accuracy when a partial frame is left mid-stream after compaction

## Test plan
- [x] Built successfully on macOS 26
- [x] `swift test --package-path KernovaProtocol` passes (20/20 tests including 2 new)
- [x] Full Xcode test suite passes (`** TEST SUCCEEDED **`)

Closes #147