### PR TITLE
fix: Use typed-error Result return in VsockSocketProvider to halt on permanent failures (#150)

### DIFF
--- a/KernovaGuestAgent/VsockGuestClient.swift
+++ b/KernovaGuestAgent/VsockGuestClient.swift
@@ -128,7 +128,13 @@ final class VsockGuestClient: @unchecked Sendable {
     private func runReconnectLoop(serve: @Sendable @escaping (VsockChannel) async -> Void) async {
         while !Task.isCancelled {
             let outcome = await connectAndServe(serve: serve)
-            if outcome == .terminate { break }
+            switch outcome {
+            case .terminate:
+                lock.withLock { stopped = true }
+                return
+            case .retry:
+                break
+            }
             guard !Task.isCancelled else { break }
             try? await Task.sleep(for: retryInterval)
         }
@@ -141,13 +147,14 @@ final class VsockGuestClient: @unchecked Sendable {
         switch socketProvider(port, label) {
         case .success(let f):
             fd = f
-        case .failure(.transient(let reason)):
-            Self.logger.warning("\(reason, privacy: .public)")
+        case .failure(.transient):
+            // Logged at the call site closest to errno context (openVsockToHost /
+            // classifySocketErrno). No re-log here — the typed error is purely a
+            // control-flow signal at this level.
             return .retry
-        case .failure(.permanent(let reason)):
-            Self.logger.error(
-                "\(reason, privacy: .public). Halting reconnect loop for '\(self.label, privacy: .public)'."
-            )
+        case .failure(.permanent):
+            // Logged at error level inside classifySocketErrno. Halt the loop.
+            Self.logger.error("Halting reconnect loop for '\(self.label, privacy: .public)' after permanent failure.")
             return .terminate
         }
 
@@ -210,13 +217,13 @@ final class VsockGuestClient: @unchecked Sendable {
         guard originalFlags >= 0 else {
             let err = errno
             close(fd)
-            logger.warning("fcntl(F_GETFL) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+            logger.error("fcntl(F_GETFL) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
             return .failure(.transient("fcntl(F_GETFL) failed for '\(label)': errno=\(err)"))
         }
         guard fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK) >= 0 else {
             let err = errno
             close(fd)
-            logger.warning("fcntl(F_SETFL, O_NONBLOCK) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+            logger.error("fcntl(F_SETFL, O_NONBLOCK) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
             return .failure(.transient("fcntl(F_SETFL, O_NONBLOCK) failed for '\(label)': errno=\(err)"))
         }
 
@@ -251,7 +258,7 @@ final class VsockGuestClient: @unchecked Sendable {
         guard fcntl(fd, F_SETFL, originalFlags) >= 0 else {
             let err = errno
             close(fd)
-            logger.warning("fcntl(F_SETFL) restore failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+            logger.error("fcntl(F_SETFL) restore failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
             return .failure(.transient("fcntl(F_SETFL) restore failed for '\(label)': errno=\(err)"))
         }
 
@@ -264,7 +271,7 @@ final class VsockGuestClient: @unchecked Sendable {
     /// indicate the kernel does not support AF_VSOCK at all and will never
     /// succeed; all other values (resource exhaustion, access control) may
     /// clear up and are classified as transient.
-    private static func classifySocketErrno(_ err: Int32, label: String) -> VsockProviderError {
+    static func classifySocketErrno(_ err: Int32, label: String) -> VsockProviderError {
         switch err {
         case EAFNOSUPPORT, EPROTONOSUPPORT:
             logger.error("socket(AF_VSOCK) unsupported for '\(label, privacy: .public)': errno=\(err, privacy: .public)")

--- a/KernovaGuestAgent/VsockGuestClient.swift
+++ b/KernovaGuestAgent/VsockGuestClient.swift
@@ -24,8 +24,31 @@ import os
 /// another send through the broken channel.
 final class VsockGuestClient: @unchecked Sendable {
 
-    /// Opens a SOCK_STREAM fd for the given port and label; returns nil on failure.
-    typealias VsockSocketProvider = @Sendable (_ port: UInt32, _ label: String) -> Int32?
+    /// Outcome of a `VsockSocketProvider` failure. `.transient` failures cause
+    /// the reconnect loop to sleep and retry; `.permanent` failures cause the
+    /// loop to exit and the client to enter its terminal "cannot be restarted"
+    /// state.
+    enum VsockProviderError: Error, Sendable, Equatable {
+        /// Retry-able — peer not ready, transient kernel resource pressure, etc.
+        case transient(String)
+        /// Not retry-able — kernel doesn't support AF_VSOCK, sandbox prohibits
+        /// the syscall, etc. Logging once at error level is sufficient.
+        case permanent(String)
+    }
+
+    /// Opens a SOCK_STREAM fd for the given port and label; returns `.success`
+    /// with the connected fd, or `.failure` with a `.transient` or `.permanent`
+    /// error indicating whether the loop should retry or halt.
+    typealias VsockSocketProvider =
+        @Sendable (_ port: UInt32, _ label: String) -> Result<Int32, VsockProviderError>
+
+    /// Outcome produced by `connectAndServe` to control the reconnect loop.
+    private enum LoopOutcome: Equatable {
+        /// Sleep `retryInterval`, then try again.
+        case retry
+        /// Exit the loop; client is now permanently inert.
+        case terminate
+    }
 
     private static let logger = Logger(subsystem: "com.kernova.agent", category: "VsockGuestClient")
     private static let socketTimeoutSeconds: Int = 30
@@ -66,8 +89,9 @@ final class VsockGuestClient: @unchecked Sendable {
     // MARK: - Lifecycle
 
     /// Begins the connect/serve/reconnect loop. Idempotent — repeated calls
-    /// after the first are no-ops. Once stopped, the client cannot be
-    /// restarted; create a new instance.
+    /// after the first are no-ops. Once stopped (or permanently terminated by a
+    /// permanent provider failure), the client cannot be restarted; create a
+    /// new instance.
     func start(serve: @escaping @Sendable (VsockChannel) async -> Void) {
         lock.withLock {
             guard reconnectTask == nil, !stopped else { return }
@@ -103,19 +127,38 @@ final class VsockGuestClient: @unchecked Sendable {
 
     private func runReconnectLoop(serve: @Sendable @escaping (VsockChannel) async -> Void) async {
         while !Task.isCancelled {
-            await connectAndServe(serve: serve)
+            let outcome = await connectAndServe(serve: serve)
+            if outcome == .terminate { break }
             guard !Task.isCancelled else { break }
             try? await Task.sleep(for: retryInterval)
         }
     }
 
-    private func connectAndServe(serve: @Sendable @escaping (VsockChannel) async -> Void) async {
-        guard let fd = socketProvider(port, label) else { return }
-        guard fd >= 0 else {
-            Self.logger.fault("socketProvider returned invalid fd \(fd, privacy: .public) for '\(self.label, privacy: .public)'")
-            assertionFailure("socketProvider returned invalid fd \(fd) for '\(self.label)'")
-            return
+    private func connectAndServe(
+        serve: @Sendable @escaping (VsockChannel) async -> Void
+    ) async -> LoopOutcome {
+        let fd: Int32
+        switch socketProvider(port, label) {
+        case .success(let f):
+            fd = f
+        case .failure(.transient(let reason)):
+            Self.logger.warning("\(reason, privacy: .public)")
+            return .retry
+        case .failure(.permanent(let reason)):
+            Self.logger.error(
+                "\(reason, privacy: .public). Halting reconnect loop for '\(self.label, privacy: .public)'."
+            )
+            return .terminate
         }
+
+        guard fd >= 0 else {
+            Self.logger.fault(
+                "socketProvider returned invalid fd \(fd, privacy: .public) for '\(self.label, privacy: .public)'"
+            )
+            assertionFailure("socketProvider returned invalid fd \(fd) for '\(self.label)'")
+            return .retry
+        }
+
         let channel = VsockChannel(fileDescriptor: fd)
         channel.start()
 
@@ -126,7 +169,7 @@ final class VsockGuestClient: @unchecked Sendable {
         }
         if aborted {
             channel.close()
-            return
+            return .retry
         }
 
         Self.logger.notice("Connected '\(self.label, privacy: .public)' to host vsock port \(self.port, privacy: .public)")
@@ -136,6 +179,7 @@ final class VsockGuestClient: @unchecked Sendable {
         lock.withLock {
             if currentChannel === channel { currentChannel = nil }
         }
+        return .retry
     }
 
     // MARK: - Socket helpers (static — no instance state read)
@@ -149,27 +193,31 @@ final class VsockGuestClient: @unchecked Sendable {
     /// connect phase; blocking mode is restored afterwards so subsequent
     /// `recv`/`send` calls continue to observe the socket-level timeouts.
     ///
-    /// Returns the connected fd on success, nil on failure. Used as the
-    /// default `socketProvider` in the production convenience init.
-    private static func openVsockToHost(port: UInt32, label: String) -> Int32? {
+    /// Returns `.success(fd)` on success, `.failure(.permanent(...))` when
+    /// `AF_VSOCK` is unsupported, or `.failure(.transient(...))` for all other
+    /// failures. Used as the default `socketProvider` in the production
+    /// convenience init.
+    private static func openVsockToHost(
+        port: UInt32, label: String
+    ) -> Result<Int32, VsockProviderError> {
         let fd = socket(AF_VSOCK, SOCK_STREAM, 0)
         guard fd >= 0 else {
-            logger.warning("socket(AF_VSOCK) failed for '\(label, privacy: .public)': errno=\(errno, privacy: .public)")
-            return nil
+            let err = errno
+            return .failure(classifySocketErrno(err, label: label))
         }
 
         let originalFlags = fcntl(fd, F_GETFL, 0)
         guard originalFlags >= 0 else {
             let err = errno
             close(fd)
-            logger.error("fcntl(F_GETFL) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
-            return nil
+            logger.warning("fcntl(F_GETFL) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+            return .failure(.transient("fcntl(F_GETFL) failed for '\(label)': errno=\(err)"))
         }
         guard fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK) >= 0 else {
             let err = errno
             close(fd)
-            logger.error("fcntl(F_SETFL, O_NONBLOCK) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
-            return nil
+            logger.warning("fcntl(F_SETFL, O_NONBLOCK) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+            return .failure(.transient("fcntl(F_SETFL, O_NONBLOCK) failed for '\(label)': errno=\(err)"))
         }
 
         var addr = sockaddr_vm()
@@ -192,23 +240,39 @@ final class VsockGuestClient: @unchecked Sendable {
             guard connectErr == EINPROGRESS else {
                 close(fd)
                 logger.warning("connect() to '\(label, privacy: .public)' port \(port, privacy: .public) failed: errno=\(connectErr, privacy: .public)")
-                return nil
+                return .failure(.transient("connect() to '\(label)' port \(port) failed: errno=\(connectErr)"))
             }
             guard awaitConnectCompletion(fd: fd, label: label, port: port) else {
                 close(fd)
-                return nil
+                return .failure(.transient("connect() to '\(label)' port \(port) did not complete"))
             }
         }
 
         guard fcntl(fd, F_SETFL, originalFlags) >= 0 else {
             let err = errno
             close(fd)
-            logger.error("fcntl(F_SETFL) restore failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
-            return nil
+            logger.warning("fcntl(F_SETFL) restore failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+            return .failure(.transient("fcntl(F_SETFL) restore failed for '\(label)': errno=\(err)"))
         }
 
         applySocketTimeouts(fd: fd, label: label)
-        return fd
+        return .success(fd)
+    }
+
+    /// Classifies a `socket(AF_VSOCK)` errno value into a `.permanent` or
+    /// `.transient` provider error. `EAFNOSUPPORT` and `EPROTONOSUPPORT`
+    /// indicate the kernel does not support AF_VSOCK at all and will never
+    /// succeed; all other values (resource exhaustion, access control) may
+    /// clear up and are classified as transient.
+    private static func classifySocketErrno(_ err: Int32, label: String) -> VsockProviderError {
+        switch err {
+        case EAFNOSUPPORT, EPROTONOSUPPORT:
+            logger.error("socket(AF_VSOCK) unsupported for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+            return .permanent("socket(AF_VSOCK) unsupported for '\(label)': errno=\(err)")
+        default:
+            logger.warning("socket(AF_VSOCK) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+            return .transient("socket(AF_VSOCK) failed for '\(label)': errno=\(err)")
+        }
     }
 
     /// Waits up to `connectTimeoutSeconds` for an in-flight non-blocking connect

--- a/KernovaGuestAgentTests/VsockGuestClientTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClientTests.swift
@@ -22,7 +22,7 @@ struct VsockGuestClientTests {
             port: 12345,
             label: "test",
             retryInterval: fastRetry
-        ) { _, _ in localFd }
+        ) { _, _ in .success(localFd) }
         defer { client.stop() }
 
         client.start { channel in
@@ -40,15 +40,15 @@ struct VsockGuestClientTests {
         let remote = VsockChannel(fileDescriptor: remoteFd)
         remote.start()
 
-        // Return localFd on first call, nil thereafter — prevents reuse of a
-        // closed fd if the client retries after the remote closes.
+        // Return localFd on first call, transient failure thereafter — prevents
+        // reuse of a closed fd if the client retries after the remote closes.
         let callCount = AtomicInt()
         let client = VsockGuestClient(
             port: 12345,
             label: "test",
             retryInterval: fastRetry
         ) { _, _ in
-            callCount.increment() == 1 ? localFd : nil
+            callCount.increment() == 1 ? .success(localFd) : .failure(.transient("test: no fd"))
         }
         defer { client.stop() }
 
@@ -92,7 +92,7 @@ struct VsockGuestClientTests {
             // Signal we've entered, then block until the test releases us.
             providerEnteredGate.signal()
             providerReleaseGate.wait()  // Legal: called synchronously, not from async context
-            return localFd
+            return .success(localFd)
         }
 
         client.start { _ in
@@ -110,7 +110,7 @@ struct VsockGuestClientTests {
             stopDone.signal()
         }
 
-        // Await the background work by sleeping; the provider returns localFd
+        // Await the background work by sleeping; the provider returns .success(localFd)
         // but aborted==true so serve is not invoked.
         try await Task.sleep(for: .milliseconds(300))
 
@@ -130,7 +130,7 @@ struct VsockGuestClientTests {
             port: 12345,
             label: "test",
             retryInterval: fastRetry
-        ) { _, _ in localFd }
+        ) { _, _ in .success(localFd) }
 
         let (enteredStream, continuation) = AsyncStream<Void>.makeStream()
 
@@ -161,7 +161,7 @@ struct VsockGuestClientTests {
             retryInterval: fastRetry
         ) { _, _ in
             provideCounter.increment()
-            return nil
+            return .failure(.transient("test: no fd"))
         }
 
         client.stop()
@@ -188,7 +188,7 @@ struct VsockGuestClientTests {
             retryInterval: fastRetry
         ) { _, _ in
             provideCounter.increment()
-            return localFd
+            return .success(localFd)
         }
         defer { client.stop() }
 
@@ -207,8 +207,8 @@ struct VsockGuestClientTests {
         #expect(provideCounter.value == 1)
     }
 
-    @Test("socketProvider returning nil triggers retry until a real fd arrives")
-    func providerNilTriggersRetry() async throws {
+    @Test("socketProvider returning transient failure triggers retry until a real fd arrives")
+    func providerTransientFailureTriggersRetry() async throws {
         let fastRetry: Duration = .milliseconds(50)
         let targetAttempt = 3
 
@@ -226,7 +226,7 @@ struct VsockGuestClientTests {
             retryInterval: fastRetry
         ) { _, _ in
             let n = attemptCounter.increment()
-            return n < targetAttempt ? nil : localFd
+            return n < targetAttempt ? .failure(.transient("attempt \(n)")) : .success(localFd)
         }
         defer { client.stop() }
 
@@ -239,6 +239,30 @@ struct VsockGuestClientTests {
 
         #expect(attemptCounter.value >= targetAttempt)
         #expect(client.liveChannel != nil)
+    }
+
+    @Test("permanent socket-provider failure halts the reconnect loop")
+    func permanentFailureHaltsLoop() async throws {
+        let fastRetry: Duration = .milliseconds(50)
+        let provideCounter = AtomicInt()
+
+        let client = VsockGuestClient(
+            port: 12345,
+            label: "test",
+            retryInterval: fastRetry
+        ) { _, _ in
+            provideCounter.increment()
+            return .failure(.permanent("AF_VSOCK not supported"))
+        }
+        defer { client.stop() }
+
+        client.start { _ in }
+
+        // Wait several retry intervals — if the loop kept retrying we'd see >1 calls.
+        try await Task.sleep(for: .milliseconds(300))
+
+        #expect(provideCounter.value == 1)
+        #expect(client.liveChannel == nil)
     }
 }
 

--- a/KernovaGuestAgentTests/VsockGuestClientTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClientTests.swift
@@ -264,6 +264,83 @@ struct VsockGuestClientTests {
         #expect(provideCounter.value == 1)
         #expect(client.liveChannel == nil)
     }
+
+    /// Pins the docstring contract: once permanently terminated, subsequent
+    /// `start` calls are no-ops — the client cannot be restarted.
+    @Test("start after permanent termination is a no-op — provider is never called again")
+    func startAfterPermanentTerminationIsNoOp() async throws {
+        let fastRetry: Duration = .milliseconds(50)
+        let provideCounter = AtomicInt()
+
+        let client = VsockGuestClient(
+            port: 12345,
+            label: "test",
+            retryInterval: fastRetry
+        ) { _, _ in
+            provideCounter.increment()
+            return .failure(.permanent("AF_VSOCK not supported"))
+        }
+
+        client.start { _ in }
+
+        // Wait for the loop to reach terminal state.
+        try await Task.sleep(for: .milliseconds(300))
+        #expect(provideCounter.value == 1)
+
+        // Re-start — must be a no-op because stopped == true.
+        client.start { _ in }
+
+        // Wait another retry window; provider count must remain 1.
+        try await Task.sleep(for: .milliseconds(300))
+        #expect(provideCounter.value == 1)
+        #expect(client.liveChannel == nil)
+    }
+}
+
+// MARK: - classifySocketErrno tests
+
+@Suite("VsockGuestClient.classifySocketErrno classification")
+struct ClassifySocketErrnoTests {
+
+    @Test("EAFNOSUPPORT classifies as permanent")
+    func eafnosupportIsPermanent() {
+        let result = VsockGuestClient.classifySocketErrno(EAFNOSUPPORT, label: "test")
+        if case .permanent = result { } else {
+            Issue.record("Expected .permanent for EAFNOSUPPORT, got \(result)")
+        }
+    }
+
+    @Test("EPROTONOSUPPORT classifies as permanent")
+    func eprotonosupportIsPermanent() {
+        let result = VsockGuestClient.classifySocketErrno(EPROTONOSUPPORT, label: "test")
+        if case .permanent = result { } else {
+            Issue.record("Expected .permanent for EPROTONOSUPPORT, got \(result)")
+        }
+    }
+
+    @Test("EMFILE (resource exhaustion) classifies as transient")
+    func emfileIsTransient() {
+        let result = VsockGuestClient.classifySocketErrno(EMFILE, label: "test")
+        if case .transient = result { } else {
+            Issue.record("Expected .transient for EMFILE, got \(result)")
+        }
+    }
+
+    @Test("EACCES (access control) classifies as transient — sandbox may clear")
+    func eaccesIsTransient() {
+        let result = VsockGuestClient.classifySocketErrno(EACCES, label: "test")
+        if case .transient = result { } else {
+            Issue.record("Expected .transient for EACCES, got \(result)")
+        }
+    }
+
+    @Test("errno 0 (unknown/default) classifies as transient")
+    func zeroErrnoIsTransient() {
+        let result = VsockGuestClient.classifySocketErrno(0, label: "test")
+        if case .transient = result { } else {
+            Issue.record("Expected .transient for errno=0, got \(result)")
+        }
+    }
 }
 
 // MARK: - Concurrency helpers

--- a/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
@@ -51,8 +51,8 @@ struct VsockGuestClipboardAgentTests {
     // MARK: - Agent factory helpers
 
     /// Sets up an agent with the given pasteboard and a socket provider that
-    /// returns the given fd on first call, nil thereafter. Does NOT retry
-    /// (long retry interval) so tests don't interfere with each other.
+    /// returns the given fd on first call, transient failure thereafter. Does
+    /// NOT retry (long retry interval) so tests don't interfere with each other.
     private func makeAgent(pasteboard: FakePasteboard, agentFd: Int32) -> VsockGuestClipboardAgent {
         let provided = AtomicInt()
         let client = VsockGuestClient(
@@ -60,7 +60,7 @@ struct VsockGuestClipboardAgentTests {
             label: "clipboard-test",
             retryInterval: .seconds(60)
         ) { _, _ in
-            provided.increment() == 1 ? agentFd : nil
+            provided.increment() == 1 ? .success(agentFd) : .failure(.transient("test: no fd"))
         }
         return VsockGuestClipboardAgent(pasteboard: pasteboard, client: client)
     }
@@ -174,7 +174,11 @@ struct VsockGuestClipboardAgentTests {
             retryInterval: .milliseconds(50)
         ) { _, _ in
             let n = provideCount.increment()
-            return fdBox.fd(at: n - 1)
+            if let fd = fdBox.fd(at: n - 1) {
+                return .success(fd)
+            } else {
+                return .failure(.transient("test: no fd at index \(n - 1)"))
+            }
         }
 
         let agent = VsockGuestClipboardAgent(pasteboard: pasteboard, client: client)
@@ -288,7 +292,11 @@ struct VsockGuestClipboardAgentTests {
                 firstFailedGate.signal()
                 secondProvideGate.wait()
             }
-            return fdBox.fd(at: n - 1)
+            if let fd = fdBox.fd(at: n - 1) {
+                return .success(fd)
+            } else {
+                return .failure(.transient("test: no fd at index \(n - 1)"))
+            }
         }
 
         let agent = VsockGuestClipboardAgent(pasteboard: pasteboard, client: client)


### PR DESCRIPTION
## Summary
- Replaces the `Int32?` return of `VsockSocketProvider` with `Result<Int32, VsockProviderError>` where `VsockProviderError` discriminates `.transient(String)` from `.permanent(String)`
- Permanent failures (`EAFNOSUPPORT`, `EPROTONOSUPPORT` from `socket()`) now exit the reconnect loop immediately with a single `.error`-level log, eliminating the one-warning-per-5s spam on kernels without AF_VSOCK support
- Transient failures (resource exhaustion, connect refused, poll/fcntl errors) preserve the existing sleep-and-retry behavior

## Changes
- `VsockGuestClient.swift`: add `VsockProviderError` enum and `LoopOutcome` private enum; update `VsockSocketProvider` typealias; rewrite `openVsockToHost` to return `Result`; add `classifySocketErrno` helper; reshape `connectAndServe` to return `LoopOutcome`; honor `.terminate` in `runReconnectLoop`
- `VsockGuestClientTests.swift`: update 7 provider closures to return `Result`; rename nil-retry test to reflect transient failure; add `permanentFailureHaltsLoop` test
- `VsockGuestClipboardAgentTests.swift`: update 3 provider closures (including `FdBox`-backed ones) to return `Result`

## Test plan
- [x] Built successfully on macOS 26
- [x] All existing tests pass (`** TEST SUCCEEDED **`)
- [x] `permanentFailureHaltsLoop` new test confirms provider called exactly once when permanent failure is returned, verifying the loop halts

Closes #150