### PR TITLE
fix: Send error frames on handleRequest failures in clipboard agents

### DIFF
--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -52,6 +52,11 @@ final class VsockClipboardService: ClipboardServicing {
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VsockClipboardService")
 
+    // Error codes for outbound `Kernova_V1_Error` frames on `handleRequest` failures.
+    private static let errorCodeFormatUnavailable = "clipboard.format.unavailable"
+    private static let errorCodeEncodingFailure = "clipboard.transfer.encoding.failure"
+    private static let errorCodeTransferFailure = "clipboard.transfer.send.failure"
+
     // MARK: - Init
 
     init(channel: VsockChannel, label: String) {
@@ -124,7 +129,29 @@ final class VsockClipboardService: ClipboardServicing {
         }
     }
 
-    // MARK: - Hello
+    // MARK: - Hello / Error helpers
+
+    /// Best-effort emission of an `Error` frame on the clipboard channel.
+    ///
+    /// If `channel.send` fails (typically because the channel just tore down
+    /// for the same reason we're reporting), the failure is logged at `.debug`
+    /// and swallowed — we have nothing better to do at that point.
+    private func sendErrorFrame(code: String, message: String, inReplyTo: String?) {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.error = Kernova_V1_Error.with {
+            $0.code = code
+            $0.message = message
+            if let inReplyTo { $0.inReplyTo = inReplyTo }
+        }
+        do {
+            try channel.send(frame)
+        } catch {
+            Self.logger.debug(
+                "Failed to send error frame (code=\(code, privacy: .public)) for '\(self.label, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
 
     private func sendHello() {
         var hello = Frame()
@@ -235,20 +262,32 @@ final class VsockClipboardService: ClipboardServicing {
 
     private func handleRequest(_ request: Kernova_V1_ClipboardRequest) {
         guard let pending = pendingOutbound, pending.generation == request.generation else {
+            // Stale: the guest has already replaced or dropped the offer this targets.
+            // Don't burden it with an error — silence is correct here.
             Self.logger.debug(
                 "Stale clipboard request gen=\(request.generation, privacy: .public) (pending=\(self.pendingOutbound?.generation ?? 0, privacy: .public))"
             )
             return
         }
         guard request.format == .textUtf8 else {
-            Self.logger.debug(
-                "Unsupported clipboard format requested: \(request.format.rawValue, privacy: .public)"
+            Self.logger.warning(
+                "Unsupported clipboard format requested gen=\(request.generation, privacy: .public) format=\(request.format.rawValue, privacy: .public)"
+            )
+            sendErrorFrame(
+                code: Self.errorCodeFormatUnavailable,
+                message: "Host only carries TEXT_UTF8 (gen=\(request.generation), requested format=\(request.format.rawValue))",
+                inReplyTo: "clipboard.request"
             )
             return
         }
         guard let bytes = pending.text.data(using: .utf8) else {
             Self.logger.warning(
-                "Failed to encode clipboard text as UTF-8 (\(pending.text.count, privacy: .public) chars)"
+                "Failed to encode clipboard text as UTF-8 gen=\(pending.generation, privacy: .public) chars=\(pending.text.count, privacy: .public)"
+            )
+            sendErrorFrame(
+                code: Self.errorCodeEncodingFailure,
+                message: "Host could not encode \(pending.text.count) characters as UTF-8 (gen=\(pending.generation))",
+                inReplyTo: "clipboard.request"
             )
             return
         }
@@ -266,8 +305,18 @@ final class VsockClipboardService: ClipboardServicing {
                 "Sent clipboard data to '\(self.label, privacy: .public)' (gen=\(pending.generation, privacy: .public), \(bytes.count, privacy: .public) bytes)"
             )
         } catch {
+            // Escalate severity: this is user-visible (paste from host produces
+            // nothing on the guest). Generation + size in the log so post-mortems
+            // can match the failure against the guest's "request sent" line.
             Self.logger.error(
-                "Failed to send clipboard data: \(error.localizedDescription, privacy: .public)"
+                "Failed to send clipboard data to '\(self.label, privacy: .public)' gen=\(pending.generation, privacy: .public) bytes=\(bytes.count, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            // Best-effort error frame. If the channel died on the data send,
+            // this will also fail and be swallowed — guest learns via EOF.
+            sendErrorFrame(
+                code: Self.errorCodeTransferFailure,
+                message: "Host failed to deliver clipboard data (gen=\(pending.generation), \(bytes.count) bytes): \(error.localizedDescription)",
+                inReplyTo: "clipboard.request"
             )
         }
     }

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -52,7 +52,6 @@ final class VsockClipboardService: ClipboardServicing {
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VsockClipboardService")
 
-    // Error codes for outbound `Kernova_V1_Error` frames on `handleRequest` failures.
     private static let errorCodeFormatUnavailable = "clipboard.format.unavailable"
     private static let errorCodeEncodingFailure = "clipboard.transfer.encoding.failure"
     private static let errorCodeTransferFailure = "clipboard.transfer.send.failure"
@@ -131,8 +130,6 @@ final class VsockClipboardService: ClipboardServicing {
 
     // MARK: - Hello / Error helpers
 
-    /// Best-effort emission of an `Error` frame on the clipboard channel.
-    ///
     /// If `channel.send` fails (typically because the channel just tore down
     /// for the same reason we're reporting), the failure is logged at `.debug`
     /// and swallowed — we have nothing better to do at that point.
@@ -305,14 +302,12 @@ final class VsockClipboardService: ClipboardServicing {
                 "Sent clipboard data to '\(self.label, privacy: .public)' (gen=\(pending.generation, privacy: .public), \(bytes.count, privacy: .public) bytes)"
             )
         } catch {
-            // Escalate severity: this is user-visible (paste from host produces
-            // nothing on the guest). Generation + size in the log so post-mortems
-            // can match the failure against the guest's "request sent" line.
+            // Logged at .error: this failure is user-visible (paste produces nothing).
+            // Include gen + size so post-mortems can pair this with the peer's "request sent" log.
             Self.logger.error(
                 "Failed to send clipboard data to '\(self.label, privacy: .public)' gen=\(pending.generation, privacy: .public) bytes=\(bytes.count, privacy: .public): \(error.localizedDescription, privacy: .public)"
             )
-            // Best-effort error frame. If the channel died on the data send,
-            // this will also fail and be swallowed — guest learns via EOF.
+            // If the channel is dead, the peer will learn via EOF — no further fallback needed.
             sendErrorFrame(
                 code: Self.errorCodeTransferFailure,
                 message: "Host failed to deliver clipboard data (gen=\(pending.generation), \(bytes.count) bytes): \(error.localizedDescription)",

--- a/KernovaGuestAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaGuestAgent/VsockGuestClipboardAgent.swift
@@ -43,7 +43,6 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     private static let logger = KernovaLogger(subsystem: "com.kernova.agent", category: "VsockGuestClipboardAgent")
     private static let pollingInterval: TimeInterval = 0.5
 
-    // Error codes for outbound `Kernova_V1_Error` frames on `handleRequest` failures.
     private static let errorCodeFormatUnavailable = "clipboard.format.unavailable"
     private static let errorCodeEncodingFailure = "clipboard.transfer.encoding.failure"
     private static let errorCodeTransferFailure = "clipboard.transfer.send.failure"
@@ -346,14 +345,12 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                 "Sent clipboard data (gen=\(pending.generation, privacy: .public), \(bytes.count, privacy: .public) bytes)"
             )
         } catch {
-            // Escalate severity: this is user-visible (paste from guest produces
-            // nothing). Generation + size in the log so post-mortems can match
-            // the failure against the host's "request sent" line.
+            // Logged at .error: this failure is user-visible (paste produces nothing).
+            // Include gen + size so post-mortems can pair this with the peer's "request sent" log.
             Self.logger.error(
                 "Failed to send clipboard data gen=\(pending.generation, privacy: .public) bytes=\(bytes.count, privacy: .public): \(error.localizedDescription, privacy: .public)"
             )
-            // Best-effort error frame. If the channel died on the data send,
-            // this will also fail and be swallowed — host learns via EOF.
+            // If the channel is dead, the peer will learn via EOF — no further fallback needed.
             sendErrorFrame(
                 on: channel,
                 code: Self.errorCodeTransferFailure,
@@ -401,8 +398,6 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
 
     // MARK: - Hello / Error helpers
 
-    /// Best-effort emission of an `Error` frame on the clipboard channel.
-    ///
     /// If `channel.send` fails (typically because the channel just tore down
     /// for the same reason we're reporting), the failure is logged at `.debug`
     /// and swallowed — we have nothing better to do at that point.

--- a/KernovaGuestAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaGuestAgent/VsockGuestClipboardAgent.swift
@@ -43,6 +43,11 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     private static let logger = KernovaLogger(subsystem: "com.kernova.agent", category: "VsockGuestClipboardAgent")
     private static let pollingInterval: TimeInterval = 0.5
 
+    // Error codes for outbound `Kernova_V1_Error` frames on `handleRequest` failures.
+    private static let errorCodeFormatUnavailable = "clipboard.format.unavailable"
+    private static let errorCodeEncodingFailure = "clipboard.transfer.encoding.failure"
+    private static let errorCodeTransferFailure = "clipboard.transfer.send.failure"
+
     private let client: VsockGuestClient
     private let pasteboard: Pasteboard
 
@@ -296,20 +301,34 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
 
     private func handleRequest(_ request: Kernova_V1_ClipboardRequest, channel: VsockChannel) {
         guard let pending = pendingOutbound, pending.generation == request.generation else {
+            // Stale: the host has already replaced or dropped the offer this targets.
+            // Don't burden it with an error — silence is correct here.
             Self.logger.debug(
                 "Stale clipboard request gen=\(request.generation, privacy: .public) (pending=\(self.pendingOutbound?.generation ?? 0, privacy: .public))"
             )
             return
         }
         guard request.format == .textUtf8 else {
-            Self.logger.debug(
-                "Unsupported clipboard format requested: \(request.format.rawValue, privacy: .public)"
+            Self.logger.warning(
+                "Unsupported clipboard format requested gen=\(request.generation, privacy: .public) format=\(request.format.rawValue, privacy: .public)"
+            )
+            sendErrorFrame(
+                on: channel,
+                code: Self.errorCodeFormatUnavailable,
+                message: "Guest agent only carries TEXT_UTF8 (gen=\(request.generation), requested format=\(request.format.rawValue))",
+                inReplyTo: "clipboard.request"
             )
             return
         }
         guard let bytes = pending.text.data(using: .utf8) else {
             Self.logger.warning(
-                "Failed to encode clipboard text as UTF-8 (\(pending.text.count, privacy: .public) chars)"
+                "Failed to encode clipboard text as UTF-8 gen=\(pending.generation, privacy: .public) chars=\(pending.text.count, privacy: .public)"
+            )
+            sendErrorFrame(
+                on: channel,
+                code: Self.errorCodeEncodingFailure,
+                message: "Guest agent could not encode \(pending.text.count) characters as UTF-8 (gen=\(pending.generation))",
+                inReplyTo: "clipboard.request"
             )
             return
         }
@@ -327,8 +346,19 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                 "Sent clipboard data (gen=\(pending.generation, privacy: .public), \(bytes.count, privacy: .public) bytes)"
             )
         } catch {
-            Self.logger.warning(
-                "Failed to send clipboard data: \(error.localizedDescription, privacy: .public)"
+            // Escalate severity: this is user-visible (paste from guest produces
+            // nothing). Generation + size in the log so post-mortems can match
+            // the failure against the host's "request sent" line.
+            Self.logger.error(
+                "Failed to send clipboard data gen=\(pending.generation, privacy: .public) bytes=\(bytes.count, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            // Best-effort error frame. If the channel died on the data send,
+            // this will also fail and be swallowed — host learns via EOF.
+            sendErrorFrame(
+                on: channel,
+                code: Self.errorCodeTransferFailure,
+                message: "Guest agent failed to deliver clipboard data (gen=\(pending.generation), \(bytes.count) bytes): \(error.localizedDescription)",
+                inReplyTo: "clipboard.request"
             )
         }
     }
@@ -369,7 +399,34 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         }
     }
 
-    // MARK: - Hello
+    // MARK: - Hello / Error helpers
+
+    /// Best-effort emission of an `Error` frame on the clipboard channel.
+    ///
+    /// If `channel.send` fails (typically because the channel just tore down
+    /// for the same reason we're reporting), the failure is logged at `.debug`
+    /// and swallowed — we have nothing better to do at that point.
+    private func sendErrorFrame(
+        on channel: VsockChannel,
+        code: String,
+        message: String,
+        inReplyTo: String?
+    ) {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.error = Kernova_V1_Error.with {
+            $0.code = code
+            $0.message = message
+            if let inReplyTo { $0.inReplyTo = inReplyTo }
+        }
+        do {
+            try channel.send(frame)
+        } catch {
+            Self.logger.debug(
+                "Failed to send error frame (code=\(code, privacy: .public)): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
 
     private func sendHello(on channel: VsockChannel) throws {
         var hello = Frame()

--- a/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
@@ -354,7 +354,6 @@ struct VsockGuestClipboardAgentTests {
 
         try await startAgentAndWaitForHello(agent: agent, hostChannel: hostChannel)
 
-        // Guest puts text on the clipboard; agent sends an offer.
         pasteboard.setString("guest content", forType: .string)
         await MainActor.run { agent.checkClipboardChange() }
 
@@ -363,7 +362,6 @@ struct VsockGuestClipboardAgentTests {
             throw TestFailure("Expected ClipboardOffer, got \(String(describing: offerFrame.payload))")
         }
 
-        // Host sends a request with an unsupported format.
         var request = Frame()
         request.protocolVersion = 1
         request.clipboardRequest = Kernova_V1_ClipboardRequest.with {
@@ -379,6 +377,53 @@ struct VsockGuestClipboardAgentTests {
         }
         #expect(err.code == "clipboard.format.unavailable")
         #expect(err.inReplyTo == "clipboard.request")
+        #expect(err.message.contains("gen=\(offer.generation)"))
+    }
+
+    @Test("handleRequest data-send failure is logged without crashing and leaves state coherent")
+    func dataSendFailureIsHandledGracefully() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+
+        // SO_NOSIGPIPE so a write to a peer-closed socket returns EPIPE rather
+        // than delivering SIGPIPE to the test process.
+        var noSigpipe: Int32 = 1
+        _ = setsockopt(agentFd, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size))
+
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+
+        try await startAgentAndWaitForHello(agent: agent, hostChannel: hostChannel)
+
+        pasteboard.setString("guest data", forType: .string)
+        await MainActor.run { agent.checkClipboardChange() }
+
+        let offerFrame = try await nextFrame(from: hostChannel)
+        guard case .clipboardOffer(let offer) = offerFrame.payload else {
+            throw TestFailure("Expected ClipboardOffer, got \(String(describing: offerFrame.payload))")
+        }
+
+        // Queue the request in the kernel buffer, then close the host end so
+        // the agent's data-send reply arrives at a dead peer.
+        var request = Frame()
+        request.protocolVersion = 1
+        request.clipboardRequest = Kernova_V1_ClipboardRequest.with {
+            $0.generation = offer.generation
+            $0.format = .textUtf8
+        }
+        try hostChannel.send(request)
+        hostChannel.close()
+
+        // The agent reads the request, tries to send data, fails (peer gone),
+        // logs .error, and attempts a best-effort error frame (also fails,
+        // swallowed). It must not crash and liveChannel must be cleared once
+        // the receive loop observes EOF.
+        try await waitUntil(timeout: .seconds(3)) { agent.liveChannelForTesting == nil }
+        #expect(agent.liveChannelForTesting == nil, "liveChannel should be nil after peer EOF")
     }
 
     @Test("full inbound offer/request/data round-trip writes pasteboard")

--- a/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
@@ -341,6 +341,46 @@ struct VsockGuestClipboardAgentTests {
         #expect(liveChannelWasNilSnapshot.value == 1, "liveChannel was non-nil during the failed Hello connection: fix did not abort before publish")
     }
 
+    @Test("handleRequest with unsupported format replies with an Error frame")
+    func unsupportedFormatRepliesWithError() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+
+        try await startAgentAndWaitForHello(agent: agent, hostChannel: hostChannel)
+
+        // Guest puts text on the clipboard; agent sends an offer.
+        pasteboard.setString("guest content", forType: .string)
+        await MainActor.run { agent.checkClipboardChange() }
+
+        let offerFrame = try await nextFrame(from: hostChannel)
+        guard case .clipboardOffer(let offer) = offerFrame.payload else {
+            throw TestFailure("Expected ClipboardOffer, got \(String(describing: offerFrame.payload))")
+        }
+
+        // Host sends a request with an unsupported format.
+        var request = Frame()
+        request.protocolVersion = 1
+        request.clipboardRequest = Kernova_V1_ClipboardRequest.with {
+            $0.generation = offer.generation
+            $0.format = .unspecified  // any non-textUtf8 value
+        }
+        try hostChannel.send(request)
+
+        // Expect an Error frame — not silence.
+        let response = try await nextFrame(from: hostChannel)
+        guard case .error(let err) = response.payload else {
+            throw TestFailure("Expected Error frame, got \(String(describing: response.payload))")
+        }
+        #expect(err.code == "clipboard.format.unavailable")
+        #expect(err.inReplyTo == "clipboard.request")
+    }
+
     @Test("full inbound offer/request/data round-trip writes pasteboard")
     func inboundRoundTripWritesPasteboard() async throws {
         let pasteboard = FakePasteboard()

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -355,6 +355,48 @@ struct VsockClipboardServiceTests {
         #expect(data.generation == offer.generation)
     }
 
+    @Test("handleRequest with unsupported format replies with an Error frame")
+    func unsupportedFormatRepliesWithError() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let service = VsockClipboardService(channel: host, label: "test")
+        service.start()
+        defer { service.stop() }
+
+        _ = try await nextFrame(from: guest)        // host hello
+        try guest.send(makeHello())
+        try await waitUntil { service.isConnected }
+
+        service.clipboardText = "host content"
+        service.grabIfChanged()
+        let offerFrame = try await nextFrame(from: guest)
+        guard case .clipboardOffer(let offer) = offerFrame.payload else {
+            Issue.record("Expected clipboardOffer, got \(String(describing: offerFrame.payload))")
+            return
+        }
+
+        // Guest requests with an unsupported format.
+        var badRequest = Frame()
+        badRequest.protocolVersion = 1
+        badRequest.clipboardRequest = Kernova_V1_ClipboardRequest.with {
+            $0.generation = offer.generation
+            $0.format = .unspecified  // any non-textUtf8 value
+        }
+        try guest.send(badRequest)
+
+        // Expect an Error frame — not silence.
+        let response = try await nextFrame(from: guest)
+        guard case .error(let err) = response.payload else {
+            Issue.record("Expected error frame, got \(String(describing: response.payload))")
+            return
+        }
+        #expect(err.code == "clipboard.format.unavailable")
+        #expect(err.inReplyTo == "clipboard.request")
+    }
+
     @Test("Inbound offer triggers a request and incoming data updates clipboardText")
     func inboundFlowPopulatesClipboard() async throws {
         let (guest, host) = try makePair()

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -22,6 +22,19 @@ struct VsockClipboardServiceTests {
                 VsockChannel(fileDescriptor: fds[1]))
     }
 
+    /// Returns the raw fd pair alongside the channels so callers can set socket
+    /// options (e.g. SO_NOSIGPIPE) on the fd before writes.
+    private func makeRawPair() throws -> (hostFd: Int32, guestFd: Int32, host: VsockChannel, guest: VsockChannel) {
+        var fds: [Int32] = [-1, -1]
+        let rc = fds.withUnsafeMutableBufferPointer { buf in
+            socketpair(AF_UNIX, SOCK_STREAM, 0, buf.baseAddress)
+        }
+        guard rc == 0 else {
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+        return (fds[0], fds[1], VsockChannel(fileDescriptor: fds[0]), VsockChannel(fileDescriptor: fds[1]))
+    }
+
     /// Drains the next frame from a channel within a generous deadline. Tests
     /// that expect no frame must use `expectNoFrame` instead — this helper
     /// throws on timeout.
@@ -378,7 +391,6 @@ struct VsockClipboardServiceTests {
             return
         }
 
-        // Guest requests with an unsupported format.
         var badRequest = Frame()
         badRequest.protocolVersion = 1
         badRequest.clipboardRequest = Kernova_V1_ClipboardRequest.with {
@@ -395,6 +407,47 @@ struct VsockClipboardServiceTests {
         }
         #expect(err.code == "clipboard.format.unavailable")
         #expect(err.inReplyTo == "clipboard.request")
+        #expect(err.message.contains("gen=\(offer.generation)"))
+    }
+
+    @Test("handleRequest data-send failure is logged without crashing and leaves service connected")
+    func dataSendFailureIsHandledGracefully() async throws {
+        let (hostFd, _, host, guest) = try makeRawPair()
+        host.start()
+        guest.start()
+
+        // SO_NOSIGPIPE on the host channel's fd so a write to a peer-closed
+        // socket surfaces as an error rather than delivering SIGPIPE.
+        var noSigpipe: Int32 = 1
+        _ = setsockopt(hostFd, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size))
+
+        let service = VsockClipboardService(channel: host, label: "test")
+        service.start()
+        defer { service.stop() }
+
+        _ = try await nextFrame(from: guest)        // host hello
+        try guest.send(makeHello())
+        try await waitUntil { service.isConnected }
+
+        service.clipboardText = "host data"
+        service.grabIfChanged()
+        let offerFrame = try await nextFrame(from: guest)
+        guard case .clipboardOffer(let offer) = offerFrame.payload else {
+            Issue.record("Expected clipboardOffer, got \(String(describing: offerFrame.payload))")
+            return
+        }
+
+        // Queue the request in the kernel buffer, then close the guest end so
+        // the service's data-send reply arrives at a dead peer.
+        try guest.send(makeRequest(generation: offer.generation))
+        guest.close()
+
+        // The service reads the request, tries to send data, fails (peer gone),
+        // logs .error, and attempts a best-effort error frame (also fails,
+        // swallowed). The service must not crash (no SIGPIPE) and isConnected
+        // must remain true because only stop() clears it.
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(service.isConnected, "isConnected should remain true — only stop() clears it")
     }
 
     @Test("Inbound offer triggers a request and incoming data updates clipboardText")


### PR DESCRIPTION
## Summary
- Silent failure paths in `handleRequest` now reply with a `Kernova_V1_Error` frame so the peer knows the data transfer failed rather than waiting forever for data that will never arrive
- Escalates the data-send failure log from `.warning` to `.error` (this failure is user-visible: paste produces nothing)
- Both the guest agent (`VsockGuestClipboardAgent`) and the host service (`VsockClipboardService`) are fixed symmetrically — the host had the same four silent-failure shapes as the guest

## Failure paths fixed

| Path | Guest | Host |
|------|-------|------|
| Stale generation | Debug log only (silence is correct — peer has moved on) | Same |
| Unsupported format | `.debug` → `.warning` + error frame | Same |
| UTF-8 encoding failure | `.warning` + error frame | Same |
| `channel.send(dataFrame)` throws | `.warning` → `.error` (gen+bytes) + best-effort error frame | Same (was already `.error`, now also sends error frame) |

The `sendErrorFrame` helper is best-effort: if the channel died on the data send, the error frame attempt also fails and is swallowed with a `.debug` log. The peer learns via EOF in that case.

## Test plan
- [x] Built successfully on macOS 26
- [x] `KernovaGuestAgentTests/VsockGuestClipboardAgentTests` — 7 tests pass (new: `unsupportedFormatRepliesWithError`)
- [x] `KernovaTests/VsockClipboardServiceTests` — 10 tests pass (new: `unsupportedFormatRepliesWithError`)

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)