### PR TITLE
refactor: Promote sendErrorFrame to shared VsockChannel helper

### DIFF
--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -148,19 +148,12 @@ final class VsockClipboardService: ClipboardServicing {
 
     // MARK: - Hello / Error helpers
 
-    /// If `channel.send` fails (typically because the channel just tore down
+    /// If `channel.sendErrorFrame` fails (typically because the channel just tore down
     /// for the same reason we're reporting), the failure is logged at `.debug`
     /// and swallowed — we have nothing better to do at that point.
     private func sendErrorFrame(code: String, message: String, inReplyTo: String?) {
-        var frame = Frame()
-        frame.protocolVersion = 1
-        frame.error = Kernova_V1_Error.with {
-            $0.code = code
-            $0.message = message
-            if let inReplyTo { $0.inReplyTo = inReplyTo }
-        }
         do {
-            try channel.send(frame)
+            try channel.sendErrorFrame(code: code, message: message, inReplyTo: inReplyTo)
         } catch {
             Self.logger.debug(
                 "Failed to send error frame (code=\(code, privacy: .public)) for '\(self.label, privacy: .public)': \(error.localizedDescription, privacy: .public)"

--- a/KernovaGuestAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaGuestAgent/VsockGuestClipboardAgent.swift
@@ -430,7 +430,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
 
     // MARK: - Hello / Error helpers
 
-    /// If `channel.send` fails (typically because the channel just tore down
+    /// If `channel.sendErrorFrame` fails (typically because the channel just tore down
     /// for the same reason we're reporting), the failure is logged at `.debug`
     /// and swallowed — we have nothing better to do at that point.
     private func sendErrorFrame(
@@ -439,15 +439,8 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         message: String,
         inReplyTo: String?
     ) {
-        var frame = Frame()
-        frame.protocolVersion = 1
-        frame.error = Kernova_V1_Error.with {
-            $0.code = code
-            $0.message = message
-            if let inReplyTo { $0.inReplyTo = inReplyTo }
-        }
         do {
-            try channel.send(frame)
+            try channel.sendErrorFrame(code: code, message: message, inReplyTo: inReplyTo)
         } catch {
             Self.logger.debug(
                 "Failed to send error frame (code=\(code, privacy: .public)): \(error.localizedDescription, privacy: .public)"

--- a/KernovaProtocol/Sources/KernovaProtocol/VsockChannel.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/VsockChannel.swift
@@ -177,16 +177,20 @@ extension VsockChannel {
     /// Constructs and sends a Kernova V1 Error frame on this channel.
     ///
     /// Convenience wrapper around `send` that centralizes the protocol-version
-    /// pin and the optional `inReplyTo` plumbing. Throws on send failure;
-    /// callers that treat error reporting as best-effort (the typical case —
-    /// the channel is usually torn down for the same reason being reported)
-    /// catch and log at `.debug`.
+    /// pin and the optional `inReplyTo` plumbing. Callers that treat error
+    /// reporting as best-effort (the typical case — the channel is usually
+    /// torn down for the same reason being reported) catch and log at `.debug`.
+    ///
+    /// Throws any error documented on `send(_:)` — `VsockChannelError.closed`,
+    /// `VsockChannelError.write(_)`, or a serialization error from
+    /// `Frame.serializedData()` / `VsockFrame.encode(_:)`.
     ///
     /// - Parameters:
     ///   - code: stable machine-readable code, e.g. `"clipboard.format.unavailable"`
     ///   - message: human-readable detail; surfaced in logs
     ///   - inReplyTo: optional ref to the request type this error replies to,
-    ///     e.g. `"clipboard.request"`. When `nil`, `hasInReplyTo` is false on the wire.
+    ///     e.g. `"clipboard.request"`. When `nil`, the field is omitted from
+    ///     the encoded frame and `hasInReplyTo` reads `false` on the receiving side.
     public func sendErrorFrame(code: String, message: String, inReplyTo: String?) throws {
         var frame = Frame()
         frame.protocolVersion = 1

--- a/KernovaProtocol/Sources/KernovaProtocol/VsockChannel.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/VsockChannel.swift
@@ -170,3 +170,31 @@ extension VsockChannelError: Equatable {
         }
     }
 }
+
+// MARK: - Convenience helpers
+
+extension VsockChannel {
+    /// Constructs and sends a Kernova V1 Error frame on this channel.
+    ///
+    /// Convenience wrapper around `send` that centralizes the protocol-version
+    /// pin and the optional `inReplyTo` plumbing. Throws on send failure;
+    /// callers that treat error reporting as best-effort (the typical case —
+    /// the channel is usually torn down for the same reason being reported)
+    /// catch and log at `.debug`.
+    ///
+    /// - Parameters:
+    ///   - code: stable machine-readable code, e.g. `"clipboard.format.unavailable"`
+    ///   - message: human-readable detail; surfaced in logs
+    ///   - inReplyTo: optional ref to the request type this error replies to,
+    ///     e.g. `"clipboard.request"`. When `nil`, `hasInReplyTo` is false on the wire.
+    public func sendErrorFrame(code: String, message: String, inReplyTo: String?) throws {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.error = Kernova_V1_Error.with {
+            $0.code = code
+            $0.message = message
+            if let inReplyTo { $0.inReplyTo = inReplyTo }
+        }
+        try send(frame)
+    }
+}

--- a/KernovaProtocol/Tests/KernovaProtocolTests/VsockChannelTests.swift
+++ b/KernovaProtocol/Tests/KernovaProtocolTests/VsockChannelTests.swift
@@ -176,6 +176,57 @@ struct VsockChannelTests {
         }
     }
 
+    @Test("sendErrorFrame round-trips an Error payload with inReplyTo set")
+    func sendErrorFrameRoundTrips() async throws {
+        let (a, b) = try makePair()
+        a.start()
+        b.start()
+        defer { a.close(); b.close() }
+
+        try a.sendErrorFrame(code: "test.code", message: "test message", inReplyTo: "test.reply")
+
+        let received = try await waitForNextFrame(on: b)
+        #expect(received?.protocolVersion == 1)
+        guard case .error(let err) = received?.payload else {
+            Issue.record("Expected error payload, got \(String(describing: received?.payload))")
+            return
+        }
+        #expect(err.code == "test.code")
+        #expect(err.message == "test message")
+        #expect(err.hasInReplyTo)
+        #expect(err.inReplyTo == "test.reply")
+    }
+
+    @Test("sendErrorFrame omits inReplyTo when nil")
+    func sendErrorFrameOmitsInReplyTo() async throws {
+        let (a, b) = try makePair()
+        a.start()
+        b.start()
+        defer { a.close(); b.close() }
+
+        try a.sendErrorFrame(code: "test.code", message: "test", inReplyTo: nil)
+
+        let received = try await waitForNextFrame(on: b)
+        guard case .error(let err) = received?.payload else {
+            Issue.record("Expected error payload")
+            return
+        }
+        #expect(err.hasInReplyTo == false)
+    }
+
+    @Test("sendErrorFrame on a closed channel throws .closed")
+    func sendErrorFrameOnClosedChannelThrows() async throws {
+        let (a, b) = try makePair()
+        a.start()
+        b.start()
+        defer { b.close() }
+        a.close()
+
+        #expect(throws: VsockChannelError.closed) {
+            try a.sendErrorFrame(code: "x", message: "y", inReplyTo: nil)
+        }
+    }
+
     @Test("send throws .write when the underlying FileHandle write fails")
     func sendThrowsWriteOnUnderlyingFailure() async throws {
         var fds: [Int32] = [-1, -1]

--- a/KernovaProtocol/Tests/KernovaProtocolTests/VsockChannelTests.swift
+++ b/KernovaProtocol/Tests/KernovaProtocolTests/VsockChannelTests.swift
@@ -207,10 +207,13 @@ struct VsockChannelTests {
         try a.sendErrorFrame(code: "test.code", message: "test", inReplyTo: nil)
 
         let received = try await waitForNextFrame(on: b)
+        #expect(received?.protocolVersion == 1)
         guard case .error(let err) = received?.payload else {
             Issue.record("Expected error payload")
             return
         }
+        #expect(err.code == "test.code")
+        #expect(err.message == "test")
         #expect(err.hasInReplyTo == false)
     }
 
@@ -224,6 +227,37 @@ struct VsockChannelTests {
 
         #expect(throws: VsockChannelError.closed) {
             try a.sendErrorFrame(code: "x", message: "y", inReplyTo: nil)
+        }
+    }
+
+    @Test("sendErrorFrame throws .write when the underlying FileHandle write fails")
+    func sendErrorFrameThrowsWriteOnUnderlyingFailure() async throws {
+        var fds: [Int32] = [-1, -1]
+        let rc = fds.withUnsafeMutableBufferPointer { buf in
+            socketpair(AF_UNIX, SOCK_STREAM, 0, buf.baseAddress)
+        }
+        guard rc == 0 else {
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+
+        var enable: Int32 = 1
+        _ = setsockopt(fds[0], SOL_SOCKET, SO_NOSIGPIPE, &enable, socklen_t(MemoryLayout<Int32>.size))
+
+        Darwin.close(fds[1])
+
+        // RATIONALE: deliberately do NOT call `start()`. The readability
+        // handler would otherwise observe EOF and tear the channel down
+        // (flipping `closed` to true) before we can attempt the write —
+        // and the test would then see `.closed` instead of `.write`.
+        let a = VsockChannel(fileDescriptor: fds[0])
+        defer { a.close() }
+
+        #expect {
+            try a.sendErrorFrame(code: "x", message: "y", inReplyTo: nil)
+        } throws: { error in
+            guard let channelError = error as? VsockChannelError else { return false }
+            if case .write = channelError { return true }
+            return false
         }
     }
 


### PR DESCRIPTION
## Summary
- Eliminates duplicated error-frame construction logic between `VsockClipboardService` (host) and `VsockGuestClipboardAgent` (guest)
- Adds `sendErrorFrame(code:message:inReplyTo:)` as a public extension on `VsockChannel` in `KernovaProtocol`, centralizing the protocol-version pin and optional `inReplyTo` plumbing
- Host and guest wrapper methods are preserved — they carry logger context (e.g. `self.label`) that is unavailable inside `KernovaProtocol` — but now delegate frame construction entirely to the shared helper

Fixes #165

## Changes
- `KernovaProtocol/Sources/KernovaProtocol/VsockChannel.swift`: Add `sendErrorFrame(code:message:inReplyTo:)` public extension
- `Kernova/Services/VsockClipboardService.swift`: Shrink host `sendErrorFrame` wrapper to delegate to `channel.sendErrorFrame`
- `KernovaGuestAgent/VsockGuestClipboardAgent.swift`: Shrink guest `sendErrorFrame(on:...)` wrapper to delegate to `channel.sendErrorFrame`
- `KernovaProtocol/Tests/KernovaProtocolTests/VsockChannelTests.swift`: Add three tests: round-trip with `inReplyTo`, `nil inReplyTo` omission, closed-channel throw

## Test plan
- [x] Built successfully on macOS 26
- [x] All 74 tests pass
- [x] `sendErrorFrame` round-trips an Error payload with `inReplyTo` set
- [x] `sendErrorFrame` omits `inReplyTo` when `nil`
- [x] `sendErrorFrame` on a closed channel throws `.closed`
- [x] Existing `VsockClipboardServiceTests` and `VsockGuestClipboardAgentTests` continue to pass, providing regression coverage for the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)