### PR TITLE
feat: Show build configuration in About panel

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -491,6 +491,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         viewModel.mountGuestAgentInstaller(on: instance)
     }
 
+    @objc func showAboutPanel(_ sender: Any?) {
+        #if DEBUG
+        let buildConfiguration = "Debug Build"
+        #else
+        let buildConfiguration = "Release Build"
+        #endif
+
+        let credits = NSAttributedString(
+            string: buildConfiguration,
+            attributes: [
+                .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize),
+                .foregroundColor: NSColor.secondaryLabelColor,
+            ]
+        )
+        NSApp.orderFrontStandardAboutPanel(options: [.credits: credits])
+    }
+
     // MARK: - Display Window (Pop-Out / Fullscreen)
 
     @objc func togglePopOut(_ sender: Any?) {
@@ -765,7 +782,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // Application menu
         let appMenuItem = NSMenuItem()
         let appMenu = NSMenu()
-        appMenu.addItem(withTitle: "About Kernova", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(withTitle: "About Kernova", action: #selector(showAboutPanel(_:)), keyEquivalent: "")
         appMenu.addItem(.separator())
         let servicesItem = NSMenuItem(title: "Services", action: nil, keyEquivalent: "")
         let servicesMenu = NSMenu(title: "Services")

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -494,7 +494,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     @objc func showAboutPanel(_ sender: Any?) {
         #if DEBUG
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
-        let versionAnnotation = buildNumber.isEmpty ? "Debug" : "\(buildNumber), Debug"
+        let versionAnnotation = buildNumber.isEmpty ? "Debug" : "\(buildNumber) Debug"
         NSApp.orderFrontStandardAboutPanel(options: [.version: versionAnnotation])
         #else
         NSApp.orderFrontStandardAboutPanel(sender)

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -493,17 +493,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     @objc func showAboutPanel(_ sender: Any?) {
         #if DEBUG
-        let buildConfiguration = "Debug"
-        #else
-        let buildConfiguration = "Release"
-        #endif
-
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
-        let versionAnnotation = buildNumber.isEmpty
-            ? buildConfiguration
-            : "\(buildNumber), \(buildConfiguration)"
-
+        let versionAnnotation = buildNumber.isEmpty ? "Debug" : "\(buildNumber), Debug"
         NSApp.orderFrontStandardAboutPanel(options: [.version: versionAnnotation])
+        #else
+        NSApp.orderFrontStandardAboutPanel(sender)
+        #endif
     }
 
     // MARK: - Display Window (Pop-Out / Fullscreen)

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -493,19 +493,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     @objc func showAboutPanel(_ sender: Any?) {
         #if DEBUG
-        let buildConfiguration = "Debug Build"
+        let buildConfiguration = "Debug"
         #else
-        let buildConfiguration = "Release Build"
+        let buildConfiguration = "Release"
         #endif
 
-        let credits = NSAttributedString(
-            string: buildConfiguration,
-            attributes: [
-                .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize),
-                .foregroundColor: NSColor.secondaryLabelColor,
-            ]
-        )
-        NSApp.orderFrontStandardAboutPanel(options: [.credits: credits])
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        let versionAnnotation = buildNumber.isEmpty
+            ? buildConfiguration
+            : "\(buildNumber), \(buildConfiguration)"
+
+        NSApp.orderFrontStandardAboutPanel(options: [.version: versionAnnotation])
     }
 
     // MARK: - Display Window (Pop-Out / Fullscreen)


### PR DESCRIPTION
## Summary
- Indicate whether the running app was compiled as Debug or Release directly in the standard About panel, making the build flavor obvious at a glance.

## Changes
- Replace the About menu item's default `orderFrontStandardAboutPanel(_:)` action with a custom `showAboutPanel(_:)` action in `AppDelegate`.
- The new action populates the panel's credits with a styled "Debug Build" / "Release Build" line, gated on `#if DEBUG`.

## Test plan
- [ ] Open the About panel from a Debug build and confirm "Debug Build" appears below the version
- [ ] Open the About panel from a Release build and confirm "Release Build" appears below the version