### PR TITLE
style: Use [DEBUG] tag in About panel version line

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -491,6 +491,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         viewModel.mountGuestAgentInstaller(on: instance)
     }
 
+    @objc func showAboutPanel(_ sender: Any?) {
+        #if DEBUG
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        let versionAnnotation = buildNumber.isEmpty ? "Debug" : "\(buildNumber) Debug"
+        NSApp.orderFrontStandardAboutPanel(options: [.version: versionAnnotation])
+        #else
+        NSApp.orderFrontStandardAboutPanel(sender)
+        #endif
+    }
+
     // MARK: - Display Window (Pop-Out / Fullscreen)
 
     @objc func togglePopOut(_ sender: Any?) {
@@ -765,7 +775,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // Application menu
         let appMenuItem = NSMenuItem()
         let appMenu = NSMenu()
-        appMenu.addItem(withTitle: "About Kernova", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(withTitle: "About Kernova", action: #selector(showAboutPanel(_:)), keyEquivalent: "")
         appMenu.addItem(.separator())
         let servicesItem = NSMenuItem(title: "Services", action: nil, keyEquivalent: "")
         let servicesMenu = NSMenu(title: "Services")

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -494,7 +494,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     @objc func showAboutPanel(_ sender: Any?) {
         #if DEBUG
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
-        let versionAnnotation = buildNumber.isEmpty ? "Debug" : "\(buildNumber) Debug"
+        let versionAnnotation = buildNumber.isEmpty ? "[DEBUG]" : "\(buildNumber) [DEBUG]"
         NSApp.orderFrontStandardAboutPanel(options: [.version: versionAnnotation])
         #else
         NSApp.orderFrontStandardAboutPanel(sender)


### PR DESCRIPTION
## Summary
- Tweak the Debug build indicator in the About panel from `(<build> Debug)` to `(<build> [DEBUG])` so the tag visually stands apart from the build number.
- Follow-up to #177.

## Changes
- Update the `versionAnnotation` string in `showAboutPanel(_:)` (`Kernova/App/AppDelegate.swift`) to wrap the tag in square brackets and uppercase the word.

## Test plan
- [ ] Open About panel from a Debug build → version line reads `Version <X.Y.Z> (<build> [DEBUG])`
- [ ] Open About panel from a Release build → version line is unchanged (no annotation)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjHawCSKt7LAL1UwoFJpzW)_