### PR TITLE
feat: Show build configuration in About panel

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -328,6 +328,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         }
     }
 
+    @objc func showAboutPanel(_ sender: Any?) {
+        #if DEBUG
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        let versionAnnotation = buildNumber.isEmpty ? "Debug" : "\(buildNumber) | Debug"
+        NSApp.orderFrontStandardAboutPanel(options: [.version: versionAnnotation])
+        #else
+        NSApp.orderFrontStandardAboutPanel(sender)
+        #endif
+    }
+
     // MARK: - VM Actions
 
     @objc func startVM(_ sender: Any?) {
@@ -489,16 +499,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // window button. The viewModel already handles the missing-DMG case
         // with a fault + assertionFailure.
         viewModel.mountGuestAgentInstaller(on: instance)
-    }
-
-    @objc func showAboutPanel(_ sender: Any?) {
-        #if DEBUG
-        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
-        let versionAnnotation = buildNumber.isEmpty ? "Debug" : "\(buildNumber) | Debug"
-        NSApp.orderFrontStandardAboutPanel(options: [.version: versionAnnotation])
-        #else
-        NSApp.orderFrontStandardAboutPanel(sender)
-        #endif
     }
 
     // MARK: - Display Window (Pop-Out / Fullscreen)

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -491,6 +491,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         viewModel.mountGuestAgentInstaller(on: instance)
     }
 
+    @objc func showAboutPanel(_ sender: Any?) {
+        #if DEBUG
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        let versionAnnotation = buildNumber.isEmpty ? "Debug" : "\(buildNumber) | Debug"
+        NSApp.orderFrontStandardAboutPanel(options: [.version: versionAnnotation])
+        #else
+        NSApp.orderFrontStandardAboutPanel(sender)
+        #endif
+    }
+
     // MARK: - Display Window (Pop-Out / Fullscreen)
 
     @objc func togglePopOut(_ sender: Any?) {
@@ -765,7 +775,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // Application menu
         let appMenuItem = NSMenuItem()
         let appMenu = NSMenu()
-        appMenu.addItem(withTitle: "About Kernova", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(withTitle: "About Kernova", action: #selector(showAboutPanel(_:)), keyEquivalent: "")
         appMenu.addItem(.separator())
         let servicesItem = NSMenuItem(title: "Services", action: nil, keyEquivalent: "")
         let servicesMenu = NSMenu(title: "Services")


### PR DESCRIPTION
## Summary
- Show \`Debug\` alongside the build number in the About panel for Debug builds, formatted as \`<build> | Debug\`. Makes it obvious at a glance which configuration is running.
- Release builds are unchanged (system-supplied About panel).

## Changes
- Add \`showAboutPanel(_:)\` in \`AppDelegate.swift\` that overrides the standard About panel for Debug builds via \`NSApp.orderFrontStandardAboutPanel(options: [.version: ...])\`. The \`#else\` branch falls through to the system-supplied panel.
- Wire the application menu's "About Kernova" item to the new selector.

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Debug build: About panel reads \`Version <X.Y.Z> (<build> | Debug)\`
- [ ] Release build: About panel reads \`Version <X.Y.Z> (<build>)\` (unchanged)