### PR TITLE
test: Harden vsock timing tests against macos-26 CI jitter

### DIFF
--- a/KernovaGuestAgentTests/TestHelpers.swift
+++ b/KernovaGuestAgentTests/TestHelpers.swift
@@ -37,7 +37,7 @@ func makeChannelPair() throws -> (VsockChannel, VsockChannel) {
 
 /// Polls `predicate` every 10 ms until it returns `true` or `timeout` elapses.
 func waitUntil(
-    timeout: Duration = .seconds(2),
+    timeout: Duration = .seconds(5),
     _ predicate: @Sendable () -> Bool
 ) async throws {
     let deadline = ContinuousClock.now.advanced(by: timeout)
@@ -58,7 +58,7 @@ func waitUntil(
 ///   producing a frame (EOF), so the two failure shapes are identifiable.
 func nextFrame(
     from channel: VsockChannel,
-    timeout: Duration = .seconds(2)
+    timeout: Duration = .seconds(5)
 ) async throws -> Frame {
     let receiver = Task<Frame?, Error> {
         var iterator = channel.incoming.makeAsyncIterator()
@@ -87,7 +87,7 @@ func nextFrame(
 /// - Throws: `TestFailure("Timed out…")` if no value arrives within `timeout`.
 func awaitFirst<T: Sendable>(
     _ stream: AsyncStream<T>,
-    timeout: Duration = .seconds(2)
+    timeout: Duration = .seconds(5)
 ) async throws -> T {
     let task = Task<T?, Never> {
         var iterator = stream.makeAsyncIterator()

--- a/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
@@ -86,27 +86,43 @@ struct VsockGuestControlAgentTests {
         host.start()
         defer { host.close() }
 
-        // Use a 100 ms cadence and a 1 s deadline so MainActor scheduling
-        // jitter on slow CI runners (the macOS-26 VMs see noticeably more
-        // latency than local hardware) doesn't squeeze the heartbeat count.
-        // 1 s / 100 ms = 10 expected cadences; demanding ≥ 3 leaves 7×
-        // headroom while still proving the timer fires repeatedly.
-        let agent = makeAgent(agentFd: agentFd, heartbeatInterval: .milliseconds(100))
+        // Property under test: heartbeats fire repeatedly on the cadence.
+        //
+        // Earlier shape — "≥ N heartbeats inside a fixed wall-clock window" —
+        // was brittle on macos-26 GitHub Actions runners (one prior failure
+        // recorded `count → 2 ≥ 3`). The window-based count fails when a
+        // single MainActor stall slides multiple ticks outside the window
+        // even though the timer is firing correctly.
+        //
+        // Gap-based assertion: read three consecutive heartbeats and check
+        // that the maximum inter-frame gap stays within a generous tolerance
+        // of the cadence. This proves "the timer fires repeatedly at roughly
+        // the configured rate" without coupling to absolute wall-clock time.
+        let cadence: Duration = .milliseconds(100)
+        let agent = makeAgent(agentFd: agentFd, heartbeatInterval: cadence)
         defer { agent.stop() }
         agent.start()
 
         // First frame is the agent Hello — discard.
         _ = try await nextFrame(from: host)
 
-        var count = 0
-        let deadline = ContinuousClock.now.advanced(by: .seconds(1))
-        while ContinuousClock.now < deadline && count < 3 {
-            let frame = try await nextFrame(from: host, timeout: .milliseconds(800))
+        var stamps: [ContinuousClock.Instant] = []
+        while stamps.count < 3 {
+            let frame = try await nextFrame(from: host, timeout: .seconds(2))
             if case .heartbeat = frame.payload {
-                count += 1
+                stamps.append(.now)
             }
         }
-        #expect(count >= 3, "Expected at least 3 heartbeats; got \(count)")
+
+        let gaps = zip(stamps.dropFirst(), stamps).map { $0 - $1 }
+        let maxGap = gaps.max() ?? .zero
+        // 10× cadence tolerance: catches "timer not running" / "cadence
+        // misconfigured" without flagging single-tick scheduling jitter.
+        let tolerance = cadence * 10
+        #expect(
+            maxGap < tolerance,
+            "Heartbeat cadence drift: max gap \(maxGap) exceeds \(tolerance) (10× cadence). Gaps: \(gaps)"
+        )
     }
 
     // MARK: - Inbound

--- a/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
@@ -115,7 +115,11 @@ struct VsockGuestControlAgentTests {
 
         var stamps: [ContinuousClock.Instant] = []
         while stamps.count < 3 {
-            let frame = try await nextFrame(from: host, timeout: .seconds(2))
+            // Use the shared 5 s default. If the timer is genuinely broken
+            // we'll still fail in bounded time (≤15 s); if it's just slow,
+            // returning the frame lets the maxGap assertion below produce a
+            // sharper "cadence drift" error than a generic timeout.
+            let frame = try await nextFrame(from: host)
             if case .heartbeat = frame.payload {
                 stamps.append(.now)
             }

--- a/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
@@ -98,6 +98,13 @@ struct VsockGuestControlAgentTests {
         // that the maximum inter-frame gap stays within a generous tolerance
         // of the cadence. This proves "the timer fires repeatedly at roughly
         // the configured rate" without coupling to absolute wall-clock time.
+        //
+        // Note: gaps are measured at receive time, not at the timer's fire
+        // time. If MainActor stalls and the kernel buffers heartbeats during
+        // the stall, the test reads them back-to-back with near-zero gaps and
+        // passes — which is correct for "is the timer running" but does NOT
+        // catch "MainActor → late delivery". A separate (likely clock-injected)
+        // test would be needed to assert end-to-end latency.
         let cadence: Duration = .milliseconds(100)
         let agent = makeAgent(agentFd: agentFd, heartbeatInterval: cadence)
         defer { agent.stop() }
@@ -114,8 +121,10 @@ struct VsockGuestControlAgentTests {
             }
         }
 
+        // Loop above guarantees stamps.count == 3, so gaps has exactly 2
+        // elements and reduce(.zero, max) is the natural non-optional form.
         let gaps = zip(stamps.dropFirst(), stamps).map { $0 - $1 }
-        let maxGap = gaps.max() ?? .zero
+        let maxGap = gaps.reduce(.zero, max)
         // 10× cadence tolerance: catches "timer not running" / "cadence
         // misconfigured" without flagging single-tick scheduling jitter.
         let tolerance = cadence * 10

--- a/KernovaTests/SpiceClipboardServiceTests.swift
+++ b/KernovaTests/SpiceClipboardServiceTests.swift
@@ -207,11 +207,7 @@ struct SpiceClipboardServiceTests {
 
         try outputPipe.fileHandleForWriting.close()
 
-        let deadline = Date().addingTimeInterval(5.0)
-        while service.isConnected && Date() < deadline {
-            try await Task.sleep(for: .milliseconds(20))
-        }
-
+        try await waitUntil { !service.isConnected }
         #expect(!service.isConnected)
         service.stop()
     }

--- a/KernovaTests/SpiceClipboardServiceTests.swift
+++ b/KernovaTests/SpiceClipboardServiceTests.swift
@@ -207,7 +207,7 @@ struct SpiceClipboardServiceTests {
 
         try outputPipe.fileHandleForWriting.close()
 
-        let deadline = Date().addingTimeInterval(1.0)
+        let deadline = Date().addingTimeInterval(5.0)
         while service.isConnected && Date() < deadline {
             try await Task.sleep(for: .milliseconds(20))
         }

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Darwin
+import KernovaProtocol
+
+// Shared timing/test primitives for the KernovaTests bundle. Mirrors the
+// shape of `KernovaGuestAgentTests/TestHelpers.swift` so the two bundles
+// give the same diagnostic detail (timeout vs EOF) when frame waits fail.
+//
+// Xcode 16 synchronized folders make each bundle's files target-private,
+// so a single file can't be shared across both — the duplication here is
+// deliberate. Keep these signatures aligned with the GuestAgent variant.
+
+// MARK: - TestFailure
+
+struct TestFailure: Error {
+    let message: String
+    init(_ m: String) { message = m }
+}
+
+// MARK: - Socket / channel factories
+
+/// Returns a connected AF_UNIX socketpair as two raw file descriptors.
+func makeRawSocketPair() throws -> (Int32, Int32) {
+    var fds: [Int32] = [-1, -1]
+    let rc = fds.withUnsafeMutableBufferPointer { buf in
+        socketpair(AF_UNIX, SOCK_STREAM, 0, buf.baseAddress)
+    }
+    guard rc == 0 else {
+        throw POSIXError(.init(rawValue: errno) ?? .EIO)
+    }
+    return (fds[0], fds[1])
+}
+
+// MARK: - waitUntil
+
+/// Polls `predicate` every 10 ms until it returns `true` or `timeout` elapses.
+///
+/// Default deadline is generous (5 s) to absorb MainActor scheduling jitter on
+/// CI runners. See feedback memory `feedback_ci_test_timings`.
+///
+/// `@MainActor`-isolated because every test in `KernovaTests` is MainActor and
+/// the predicates routinely close over MainActor-isolated state (services,
+/// view models). Keeping the helper on the same actor sidesteps Swift 6's
+/// non-Sendable-closure errors on MainActor → nonisolated boundaries.
+@MainActor
+func waitUntil(
+    timeout: Duration = .seconds(5),
+    _ predicate: () -> Bool
+) async throws {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while !predicate() && ContinuousClock.now < deadline {
+        try await Task.sleep(for: .milliseconds(10))
+    }
+    guard predicate() else {
+        throw TestFailure("Predicate did not become true within \(timeout)")
+    }
+}
+
+// MARK: - nextFrame
+
+/// Reads the next frame from `channel`, distinguishing timeout from EOF.
+///
+/// - Throws: `TestFailure("Timed out…")` when no frame arrives within `timeout`.
+/// - Throws: `TestFailure("Channel finished…")` when the channel closes without
+///   producing a frame (EOF), so the two failure shapes are identifiable in
+///   post-mortem logs. Conflating them once masked a CI flake as a
+///   peer-disconnect bug.
+@MainActor
+func nextFrame(
+    from channel: VsockChannel,
+    timeout: Duration = .seconds(5)
+) async throws -> Frame {
+    let receiver = Task<Frame?, Error> {
+        var iterator = channel.incoming.makeAsyncIterator()
+        return try await iterator.next()
+    }
+    let timeoutTask = Task<Void, Never> {
+        try? await Task.sleep(for: timeout)
+        receiver.cancel()
+    }
+    defer { timeoutTask.cancel() }
+
+    do {
+        guard let frame = try await receiver.value else {
+            throw TestFailure("Channel finished without producing a frame (EOF)")
+        }
+        return frame
+    } catch is CancellationError {
+        throw TestFailure("Timed out waiting for a frame after \(timeout)")
+    }
+}

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -74,6 +74,11 @@ func nextFrame(
         var iterator = channel.incoming.makeAsyncIterator()
         return try await iterator.next()
     }
+    // RATIONALE: `receiver` is not cancelled in `defer` because every exit path
+    // already awaits `receiver.value` (success, EOF, or timeout-induced
+    // CancellationError). By the time the function returns, the receiver task
+    // has completed; a redundant cancel would be a no-op and obscures intent.
+    // Cancelling the timeoutTask is necessary on the success path.
     let timeoutTask = Task<Void, Never> {
         try? await Task.sleep(for: timeout)
         receiver.cancel()

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -11,28 +11,15 @@ struct VsockClipboardServiceTests {
     // MARK: - Helpers
 
     private func makePair() throws -> (sender: VsockChannel, receiver: VsockChannel) {
-        var fds: [Int32] = [-1, -1]
-        let rc = fds.withUnsafeMutableBufferPointer { buf in
-            socketpair(AF_UNIX, SOCK_STREAM, 0, buf.baseAddress)
-        }
-        guard rc == 0 else {
-            throw POSIXError(.init(rawValue: errno) ?? .EIO)
-        }
-        return (VsockChannel(fileDescriptor: fds[0]),
-                VsockChannel(fileDescriptor: fds[1]))
+        let (a, b) = try makeRawSocketPair()
+        return (VsockChannel(fileDescriptor: a), VsockChannel(fileDescriptor: b))
     }
 
     /// Returns the raw fd pair alongside the channels so callers can set socket
     /// options (e.g. SO_NOSIGPIPE) on the fd before writes.
     private func makeRawPair() throws -> (hostFd: Int32, guestFd: Int32, host: VsockChannel, guest: VsockChannel) {
-        var fds: [Int32] = [-1, -1]
-        let rc = fds.withUnsafeMutableBufferPointer { buf in
-            socketpair(AF_UNIX, SOCK_STREAM, 0, buf.baseAddress)
-        }
-        guard rc == 0 else {
-            throw POSIXError(.init(rawValue: errno) ?? .EIO)
-        }
-        return (fds[0], fds[1], VsockChannel(fileDescriptor: fds[0]), VsockChannel(fileDescriptor: fds[1]))
+        let (hostFd, guestFd) = try makeRawSocketPair()
+        return (hostFd, guestFd, VsockChannel(fileDescriptor: hostFd), VsockChannel(fileDescriptor: guestFd))
     }
 
     /// MainActor-isolated buffer fed by a single iterator on the channel.
@@ -440,12 +427,7 @@ struct VsockClipboardServiceTests {
 
     @Test("handleOffer send failure leaves pendingInboundGeneration unchanged")
     func offerSendFailureDoesNotSetPendingGeneration() async throws {
-        var rawFds: [Int32] = [-1, -1]
-        let rc = rawFds.withUnsafeMutableBufferPointer { buf in
-            socketpair(AF_UNIX, SOCK_STREAM, 0, buf.baseAddress)
-        }
-        guard rc == 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
-        let (guestRawFd, hostRawFd) = (rawFds[0], rawFds[1])
+        let (guestRawFd, hostRawFd) = try makeRawSocketPair()
 
         // SO_NOSIGPIPE so the service's write to a closed peer surfaces as an
         // error rather than killing the test process with SIGPIPE.

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -35,30 +35,6 @@ struct VsockClipboardServiceTests {
         return (fds[0], fds[1], VsockChannel(fileDescriptor: fds[0]), VsockChannel(fileDescriptor: fds[1]))
     }
 
-    /// Drains the next frame from a channel within a generous deadline. Tests
-    /// that expect no frame must use `expectNoFrame` instead — this helper
-    /// throws on timeout.
-    private func nextFrame(
-        from channel: VsockChannel,
-        timeout: Duration = .seconds(2)
-    ) async throws -> Frame {
-        let receiver = Task<Frame?, Error> {
-            var iterator = channel.incoming.makeAsyncIterator()
-            return try await iterator.next()
-        }
-        let timeoutTask = Task<Void, Error> {
-            try await Task.sleep(for: timeout)
-            receiver.cancel()
-        }
-        defer { timeoutTask.cancel() }
-        guard let frame = try await receiver.value else {
-            throw TestFailure("Channel finished without producing a frame")
-        }
-        return frame
-    }
-
-    private struct TestFailure: Error { let message: String; init(_ m: String) { message = m } }
-
     /// MainActor-isolated buffer fed by a single iterator on the channel.
     /// Tests that need both "expect frame" and "expect no frame" assertions
     /// against the same channel must not hand-roll iterators per call —
@@ -91,7 +67,7 @@ struct VsockClipboardServiceTests {
     private func waitForFrameCount(
         _ recorder: FrameRecorder,
         equals expected: Int,
-        timeout: Duration = .seconds(2)
+        timeout: Duration = .seconds(5)
     ) async throws {
         try await waitUntil(timeout: timeout) {
             recorder.frames.count == expected
@@ -110,21 +86,6 @@ struct VsockClipboardServiceTests {
         if recorder.frames.count != before {
             let extras = Array(recorder.frames[before...])
             Issue.record("Expected no new frames over \(duration); got \(extras.count): \(extras.map { String(describing: $0.payload) })")
-        }
-    }
-
-    /// Spins until a service-side condition is true (or a deadline elapses).
-    /// Replaces ad-hoc `Task.sleep` waits in concurrency-sensitive tests.
-    private func waitUntil(
-        timeout: Duration = .seconds(2),
-        _ predicate: () -> Bool
-    ) async throws {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while !predicate() && ContinuousClock.now < deadline {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        if !predicate() {
-            throw TestFailure("Predicate did not become true within \(timeout)")
         }
     }
 

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -11,15 +11,8 @@ struct VsockControlServiceTests {
     // MARK: - Helpers
 
     private func makePair() throws -> (sender: VsockChannel, receiver: VsockChannel) {
-        var fds: [Int32] = [-1, -1]
-        let rc = fds.withUnsafeMutableBufferPointer { buf in
-            socketpair(AF_UNIX, SOCK_STREAM, 0, buf.baseAddress)
-        }
-        guard rc == 0 else {
-            throw POSIXError(.init(rawValue: errno) ?? .EIO)
-        }
-        return (VsockChannel(fileDescriptor: fds[0]),
-                VsockChannel(fileDescriptor: fds[1]))
+        let (a, b) = try makeRawSocketPair()
+        return (VsockChannel(fileDescriptor: a), VsockChannel(fileDescriptor: b))
     }
 
     /// Builds a guest-side Hello frame with the given agent version. Tests use
@@ -258,6 +251,11 @@ struct VsockControlServiceTests {
         // heartbeats and check that the maximum inter-frame gap stays within
         // a generous tolerance of the cadence. Mirrors the agent-side test
         // in VsockGuestControlAgentTests.
+        //
+        // Note: gaps are measured at receive time, not at the timer's fire
+        // time. A MainActor stall that buffers frames and drains them back-
+        // to-back will pass — correct for "is the timer running" but not a
+        // check on end-to-end latency.
         let cadence: Duration = .milliseconds(100)
         let service = makeService(channel: host, heartbeatInterval: cadence)
         service.start()
@@ -274,8 +272,10 @@ struct VsockControlServiceTests {
             }
         }
 
+        // Loop above guarantees stamps.count == 3, so gaps has exactly 2
+        // elements and reduce(.zero, max) is the natural non-optional form.
         let gaps = zip(stamps.dropFirst(), stamps).map { $0 - $1 }
-        let maxGap = gaps.max() ?? .zero
+        let maxGap = gaps.reduce(.zero, max)
         let tolerance = cadence * 10
         #expect(
             maxGap < tolerance,

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -22,40 +22,6 @@ struct VsockControlServiceTests {
                 VsockChannel(fileDescriptor: fds[1]))
     }
 
-    private func nextFrame(
-        from channel: VsockChannel,
-        timeout: Duration = .seconds(2)
-    ) async throws -> Frame {
-        let receiver = Task<Frame?, Error> {
-            var iterator = channel.incoming.makeAsyncIterator()
-            return try await iterator.next()
-        }
-        let timeoutTask = Task<Void, Error> {
-            try await Task.sleep(for: timeout)
-            receiver.cancel()
-        }
-        defer { timeoutTask.cancel() }
-        guard let frame = try await receiver.value else {
-            throw TestFailure("Channel finished without producing a frame")
-        }
-        return frame
-    }
-
-    private struct TestFailure: Error { let message: String; init(_ m: String) { message = m } }
-
-    private func waitUntil(
-        timeout: Duration = .seconds(2),
-        _ predicate: () -> Bool
-    ) async throws {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while !predicate() && ContinuousClock.now < deadline {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        if !predicate() {
-            throw TestFailure("Predicate did not become true within \(timeout)")
-        }
-    }
-
     /// Builds a guest-side Hello frame with the given agent version. Tests use
     /// this to drive the `agentStatus` numeric-comparison matrix.
     private func makeGuestHello(agentVersion: String) -> Frame {
@@ -285,25 +251,36 @@ struct VsockControlServiceTests {
         host.start()
         defer { guest.close() }
 
-        // Wider cadence (100 ms) and deadline (1 s) so MainActor scheduling
-        // jitter on slow CI runners doesn't squeeze the heartbeat count.
-        let service = makeService(channel: host, heartbeatInterval: .milliseconds(100))
+        // Property under test: heartbeats fire repeatedly on the cadence.
+        //
+        // Earlier shape — "≥ N heartbeats inside a fixed wall-clock window" —
+        // was brittle on macos-26 runners. Gap-based: read three consecutive
+        // heartbeats and check that the maximum inter-frame gap stays within
+        // a generous tolerance of the cadence. Mirrors the agent-side test
+        // in VsockGuestControlAgentTests.
+        let cadence: Duration = .milliseconds(100)
+        let service = makeService(channel: host, heartbeatInterval: cadence)
         service.start()
         defer { service.stop() }
 
-        // Frame 0 is the host Hello. After that, ≥3 heartbeats with a 100ms
-        // cadence inside a 1 s window — 7× headroom over the assertion.
+        // Frame 0 is the host Hello — discard.
         _ = try await nextFrame(from: guest)
 
-        var heartbeatCount = 0
-        let deadline = ContinuousClock.now.advanced(by: .seconds(1))
-        while heartbeatCount < 3, ContinuousClock.now < deadline {
-            let frame = try await nextFrame(from: guest, timeout: .milliseconds(800))
+        var stamps: [ContinuousClock.Instant] = []
+        while stamps.count < 3 {
+            let frame = try await nextFrame(from: guest, timeout: .seconds(2))
             if case .heartbeat = frame.payload {
-                heartbeatCount += 1
+                stamps.append(.now)
             }
         }
-        #expect(heartbeatCount >= 3, "Expected at least 3 heartbeats; got \(heartbeatCount)")
+
+        let gaps = zip(stamps.dropFirst(), stamps).map { $0 - $1 }
+        let maxGap = gaps.max() ?? .zero
+        let tolerance = cadence * 10
+        #expect(
+            maxGap < tolerance,
+            "Heartbeat cadence drift: max gap \(maxGap) exceeds \(tolerance) (10× cadence). Gaps: \(gaps)"
+        )
     }
 
     @Test("Inbound heartbeat keeps agentStatus .current past unresponsiveAfter")

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -266,7 +266,11 @@ struct VsockControlServiceTests {
 
         var stamps: [ContinuousClock.Instant] = []
         while stamps.count < 3 {
-            let frame = try await nextFrame(from: guest, timeout: .seconds(2))
+            // Use the shared 5 s default. If the timer is genuinely broken
+            // we'll still fail in bounded time (≤15 s); if it's just slow,
+            // returning the frame lets the maxGap assertion below produce a
+            // sharper "cadence drift" error than a generic timeout.
+            let frame = try await nextFrame(from: guest)
             if case .heartbeat = frame.payload {
                 stamps.append(.now)
             }

--- a/KernovaTests/VsockGuestLogServiceTests.swift
+++ b/KernovaTests/VsockGuestLogServiceTests.swift
@@ -11,15 +11,8 @@ struct VsockGuestLogServiceTests {
     // MARK: - Helpers
 
     private func makePair() throws -> (sender: VsockChannel, receiver: VsockChannel) {
-        var fds: [Int32] = [-1, -1]
-        let rc = fds.withUnsafeMutableBufferPointer { buf in
-            socketpair(AF_UNIX, SOCK_STREAM, 0, buf.baseAddress)
-        }
-        guard rc == 0 else {
-            throw POSIXError(.init(rawValue: errno) ?? .EIO)
-        }
-        return (VsockChannel(fileDescriptor: fds[0]),
-                VsockChannel(fileDescriptor: fds[1]))
+        let (a, b) = try makeRawSocketPair()
+        return (VsockChannel(fileDescriptor: a), VsockChannel(fileDescriptor: b))
     }
 
     // Generous default — multi-frame tests on slower CI runners were


### PR DESCRIPTION
## Summary
- Bump `nextFrame` / `waitUntil` deadlines from 2 s to 5 s across the vsock test helpers — one prior post-merge failure (`VsockClipboardServiceTests/dropsUnsupportedProtocolVersion`) was a 2 s timeout firing on a slow macos-26 GitHub runner.
- Redesign `heartbeatOutboundCadence` to assert on inter-frame gap rather than count-in-window — that shape was the most jitter-sensitive in the suite and produced one prior `count → 2 ≥ 3` flake.
- Consolidate per-file `nextFrame` / `waitUntil` / `TestFailure` copies into a shared `TestHelpers.swift` per test bundle so both bundles emit the same diagnostic (`Timed out…` vs `EOF`) on any future flake.

## Changes
- Add `KernovaTests/TestHelpers.swift` with `@MainActor`-isolated `waitUntil` and `nextFrame`, plus shared `TestFailure` / `makeRawSocketPair` primitives. Mirrors the shape of the existing `KernovaGuestAgentTests/TestHelpers.swift`.
- Bump `waitUntil` / `nextFrame` / `awaitFirst` defaults in `KernovaGuestAgentTests/TestHelpers.swift` from 2 s to 5 s.
- Replace the count-in-window heartbeat assertion with a max-gap-over-3-consecutive-frames assertion (10× cadence tolerance) in both `VsockControlServiceTests.heartbeatOutboundCadence` and `VsockGuestControlAgentTests.heartbeatOutboundCadence`.
- Remove duplicate private `nextFrame` / `waitUntil` / `TestFailure` from `VsockClipboardServiceTests` and `VsockControlServiceTests`; tests now resolve to the bundle-shared `TestHelpers` definitions.
- Bump `SpiceClipboardServiceTests` pipe-EOF deadline from 1 s to 5 s.

## Test plan
- [x] `xcodebuild test` passes locally on macOS 26
- [ ] CI green on this PR
- [ ] `/gemini review` triaged

## Notes — deferred follow-ups
1. **Hardcoded post-action `Task.sleep` waits** in `VsockClipboardServiceTests` (lines 408 and 533): on closer reading, both test *negative state* (no crash; no spurious mutation). There's no positive event to poll for, so replacing with `waitUntil` would be a no-op or require invasive test seams.
2. **Injecting a `Clock` into `VsockControlService`** for fully deterministic liveness tests: Swift's `Clock` protocol has an associated `Instant` type, so doing this right needs either a generic class (invasive across call sites) or a custom mock clock that emits `ContinuousClock.Instant`. Saved for a focused refactor PR — the gap-based heartbeat assertion already removes the most-flaky shape.
3. **`VsockGuestControlAgentTests/inboundFramesAccepted` SIGPIPE crashes** seen in two pre-merge runs of #181: investigated and confirmed already fixed by the process-wide `signal(SIGPIPE, SIG_IGN)` static init added in `VsockChannel.swift:55-57` in the same PR. No code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)