### PR TITLE
feat: Add PolicyUpdate protocol message

### DIFF
--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -210,10 +210,11 @@ final class VsockClipboardService: ClipboardServicing {
             Self.logger.warning(
                 "Guest clipboard error for '\(self.label, privacy: .public)': \(error.code, privacy: .public) — \(error.message, privacy: .public)"
             )
-        case .hello, .heartbeat, .logRecord, .none:
-            // Hello and Heartbeat belong on the control channel, LogRecord on
-            // the log channel. .none means a frame with no payload. Any of
-            // these arriving here means the peer crossed wires — log and ignore.
+        case .hello, .heartbeat, .policyUpdate, .logRecord, .none:
+            // Hello, Heartbeat, and PolicyUpdate belong on the control
+            // channel, LogRecord on the log channel. .none means a frame with
+            // no payload. Any of these arriving here means the peer crossed
+            // wires — log and ignore.
             Self.logger.warning(
                 "Unexpected payload on clipboard channel for '\(self.label, privacy: .public)' — wrong port"
             )

--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -303,8 +303,10 @@ final class VsockControlService {
             Self.logger.warning(
                 "Guest control error for '\(self.label, privacy: .public)': \(error.code, privacy: .public) — \(error.message, privacy: .public)"
             )
-        case .clipboardOffer, .clipboardRequest, .clipboardData, .clipboardRelease, .logRecord, .none:
-            // These payloads belong on other channels. Log and ignore.
+        case .policyUpdate, .clipboardOffer, .clipboardRequest, .clipboardData, .clipboardRelease, .logRecord, .none:
+            // PolicyUpdate is a host→guest message and never arrives on the
+            // host side; other payloads belong on other channels. Log and
+            // ignore.
             Self.logger.warning(
                 "Unexpected payload on control channel for '\(self.label, privacy: .public)' — wrong port"
             )

--- a/Kernova/Services/VsockGuestLogService.swift
+++ b/Kernova/Services/VsockGuestLogService.swift
@@ -90,10 +90,11 @@ final class VsockGuestLogService {
             logger.warning(
                 "Guest agent error for '\(label, privacy: .public)': \(error.code, privacy: .public) — \(error.message, privacy: .public)"
             )
-        case .hello, .heartbeat, .clipboardOffer, .clipboardRequest, .clipboardData, .clipboardRelease:
-            // Hello and Heartbeat belong on the control channel; clipboard
-            // payloads belong on the clipboard channel. Anything other than
-            // LogRecord/Error reaching here means the peer crossed wires.
+        case .hello, .heartbeat, .policyUpdate, .clipboardOffer, .clipboardRequest, .clipboardData, .clipboardRelease:
+            // Hello, Heartbeat, and PolicyUpdate belong on the control
+            // channel; clipboard payloads belong on the clipboard channel.
+            // Anything other than LogRecord/Error reaching here means the peer
+            // crossed wires.
             logger.warning("Unexpected payload on log channel for '\(label, privacy: .public)' — wrong port")
         case .none:
             logger.debug("Frame with no payload for '\(label, privacy: .public)'")

--- a/KernovaGuestAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaGuestAgent/VsockGuestClipboardAgent.swift
@@ -275,7 +275,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             Self.logger.warning(
                 "Host clipboard error: \(error.code, privacy: .public) — \(error.message, privacy: .public)"
             )
-        case .hello, .heartbeat, .logRecord, .none:
+        case .hello, .heartbeat, .policyUpdate, .logRecord, .none:
             Self.logger.warning("Unexpected payload on clipboard channel — wrong port")
         }
     }

--- a/KernovaGuestAgent/VsockGuestControlAgent.swift
+++ b/KernovaGuestAgent/VsockGuestControlAgent.swift
@@ -171,6 +171,11 @@ final class VsockGuestControlAgent: @unchecked Sendable {
             Self.logger.warning(
                 "Host control error: \(error.code, privacy: .public) — \(error.message, privacy: .public)"
             )
+        case .policyUpdate:
+            // PolicyUpdate is the right channel and the right direction
+            // (host→guest), but routing to the log + clipboard agents is
+            // wired up in a follow-up change. For now, log and drop.
+            Self.logger.debug("PolicyUpdate received but routing not yet wired")
         case .clipboardOffer, .clipboardRequest, .clipboardData, .clipboardRelease, .logRecord, .none:
             Self.logger.warning("Unexpected payload on control channel — wrong port")
         }

--- a/KernovaProtocol/Proto/kernova.proto
+++ b/KernovaProtocol/Proto/kernova.proto
@@ -24,10 +24,12 @@ message Frame {
 
     // Service payloads occupy reserved number ranges so each service can grow
     // independently without colliding:
-    //   12..19 reserved for control plane (heartbeat, future control payloads)
+    //   12..19 reserved for control plane (heartbeat, policy, future control)
     //   20..29 reserved for clipboard
     //   30..39 reserved for logging
     //   40..49 reserved for drag/drop
+    PolicyUpdate policy_update = 13;
+
     ClipboardOffer clipboard_offer = 20;
     ClipboardRequest clipboard_request = 21;
     ClipboardData clipboard_data = 22;
@@ -148,6 +150,27 @@ message ClipboardRelease {
 // sampling) without bumping `Frame.protocol_version`.
 message Heartbeat {
   uint64 nonce = 1;
+}
+
+// Sent by the host on the control channel to tell the guest agent which
+// optional capabilities are currently enabled for this VM. The guest agent
+// uses it to actually stop work for disabled capabilities (close channels,
+// stop pasteboard polling, drop buffered records) rather than just having
+// the host ignore inbound traffic.
+//
+// The host sends one `PolicyUpdate` immediately after the control-plane
+// `Hello` exchange and one each time the user toggles a capability while
+// the VM is running. Each message carries the full current policy snapshot;
+// receivers compare against their last applied state and act on diffs.
+message PolicyUpdate {
+  // Whether the guest's log-forwarding agent should connect on the log port
+  // and stream `LogRecord` frames to the host.
+  bool log_forwarding_enabled = 1;
+
+  // Whether the guest's clipboard agent should poll `NSPasteboard.general`
+  // and exchange `ClipboardOffer`/`ClipboardRequest`/`ClipboardData` with
+  // the host on the clipboard port.
+  bool clipboard_sharing_enabled = 2;
 }
 
 // Reported by either side when a request cannot be fulfilled, or as an

--- a/KernovaProtocol/Sources/KernovaProtocol/Generated/kernova.pb.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/Generated/kernova.pb.swift
@@ -110,10 +110,18 @@ public struct Kernova_V1_Frame: Sendable {
 
   /// Service payloads occupy reserved number ranges so each service can grow
   /// independently without colliding:
-  ///   12..19 reserved for control plane (heartbeat, future control payloads)
+  ///   12..19 reserved for control plane (heartbeat, policy, future control)
   ///   20..29 reserved for clipboard
   ///   30..39 reserved for logging
   ///   40..49 reserved for drag/drop
+  public var policyUpdate: Kernova_V1_PolicyUpdate {
+    get {
+      if case .policyUpdate(let v)? = payload {return v}
+      return Kernova_V1_PolicyUpdate()
+    }
+    set {payload = .policyUpdate(newValue)}
+  }
+
   public var clipboardOffer: Kernova_V1_ClipboardOffer {
     get {
       if case .clipboardOffer(let v)? = payload {return v}
@@ -162,10 +170,11 @@ public struct Kernova_V1_Frame: Sendable {
     case heartbeat(Kernova_V1_Heartbeat)
     /// Service payloads occupy reserved number ranges so each service can grow
     /// independently without colliding:
-    ///   12..19 reserved for control plane (heartbeat, future control payloads)
+    ///   12..19 reserved for control plane (heartbeat, policy, future control)
     ///   20..29 reserved for clipboard
     ///   30..39 reserved for logging
     ///   40..49 reserved for drag/drop
+    case policyUpdate(Kernova_V1_PolicyUpdate)
     case clipboardOffer(Kernova_V1_ClipboardOffer)
     case clipboardRequest(Kernova_V1_ClipboardRequest)
     case clipboardData(Kernova_V1_ClipboardData)
@@ -409,6 +418,35 @@ public struct Kernova_V1_Heartbeat: Sendable {
   public init() {}
 }
 
+/// Sent by the host on the control channel to tell the guest agent which
+/// optional capabilities are currently enabled for this VM. The guest agent
+/// uses it to actually stop work for disabled capabilities (close channels,
+/// stop pasteboard polling, drop buffered records) rather than just having
+/// the host ignore inbound traffic.
+///
+/// The host sends one `PolicyUpdate` immediately after the control-plane
+/// `Hello` exchange and one each time the user toggles a capability while
+/// the VM is running. Each message carries the full current policy snapshot;
+/// receivers compare against their last applied state and act on diffs.
+public struct Kernova_V1_PolicyUpdate: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Whether the guest's log-forwarding agent should connect on the log port
+  /// and stream `LogRecord` frames to the host.
+  public var logForwardingEnabled: Bool = false
+
+  /// Whether the guest's clipboard agent should poll `NSPasteboard.general`
+  /// and exchange `ClipboardOffer`/`ClipboardRequest`/`ClipboardData` with
+  /// the host on the clipboard port.
+  public var clipboardSharingEnabled: Bool = false
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 /// Reported by either side when a request cannot be fulfilled, or as an
 /// asynchronous notification of a problem (e.g. malformed request, capability
 /// mismatch). The receiver may log and continue; it should not assume the
@@ -454,7 +492,7 @@ extension Kernova_V1_ClipboardFormat: SwiftProtobuf._ProtoNameProviding {
 
 extension Kernova_V1_Frame: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Frame"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}protocol_version\0\u{2}\u{9}hello\0\u{1}error\0\u{1}heartbeat\0\u{4}\u{8}clipboard_offer\0\u{3}clipboard_request\0\u{3}clipboard_data\0\u{3}clipboard_release\0\u{4}\u{7}log_record\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}protocol_version\0\u{2}\u{9}hello\0\u{1}error\0\u{1}heartbeat\0\u{3}policy_update\0\u{4}\u{7}clipboard_offer\0\u{3}clipboard_request\0\u{3}clipboard_data\0\u{3}clipboard_release\0\u{4}\u{7}log_record\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -500,6 +538,19 @@ extension Kernova_V1_Frame: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
         if let v = v {
           if hadOneofValue {try decoder.handleConflictingOneOf()}
           self.payload = .heartbeat(v)
+        }
+      }()
+      case 13: try {
+        var v: Kernova_V1_PolicyUpdate?
+        var hadOneofValue = false
+        if let current = self.payload {
+          hadOneofValue = true
+          if case .policyUpdate(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payload = .policyUpdate(v)
         }
       }()
       case 20: try {
@@ -592,6 +643,10 @@ extension Kernova_V1_Frame: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     case .heartbeat?: try {
       guard case .heartbeat(let v)? = self.payload else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+    }()
+    case .policyUpdate?: try {
+      guard case .policyUpdate(let v)? = self.payload else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
     }()
     case .clipboardOffer?: try {
       guard case .clipboardOffer(let v)? = self.payload else { preconditionFailure() }
@@ -929,6 +984,41 @@ extension Kernova_V1_Heartbeat: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
   public static func ==(lhs: Kernova_V1_Heartbeat, rhs: Kernova_V1_Heartbeat) -> Bool {
     if lhs.nonce != rhs.nonce {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Kernova_V1_PolicyUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".PolicyUpdate"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}log_forwarding_enabled\0\u{3}clipboard_sharing_enabled\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.logForwardingEnabled) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.clipboardSharingEnabled) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.logForwardingEnabled != false {
+      try visitor.visitSingularBoolField(value: self.logForwardingEnabled, fieldNumber: 1)
+    }
+    if self.clipboardSharingEnabled != false {
+      try visitor.visitSingularBoolField(value: self.clipboardSharingEnabled, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Kernova_V1_PolicyUpdate, rhs: Kernova_V1_PolicyUpdate) -> Bool {
+    if lhs.logForwardingEnabled != rhs.logForwardingEnabled {return false}
+    if lhs.clipboardSharingEnabled != rhs.clipboardSharingEnabled {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/KernovaProtocol/Tests/KernovaProtocolTests/VsockChannelTests.swift
+++ b/KernovaProtocol/Tests/KernovaProtocolTests/VsockChannelTests.swift
@@ -86,6 +86,31 @@ struct VsockChannelTests {
         }
     }
 
+    @Test("Round-trips a PolicyUpdate frame")
+    func roundTripPolicyUpdate() async throws {
+        let (a, b) = try makePair()
+        a.start()
+        b.start()
+        defer { a.close(); b.close() }
+
+        var sent = Frame()
+        sent.protocolVersion = 1
+        sent.policyUpdate = Kernova_V1_PolicyUpdate.with {
+            $0.logForwardingEnabled = true
+            $0.clipboardSharingEnabled = false
+        }
+        try a.send(sent)
+
+        let received = try await waitForNextFrame(on: b)
+        #expect(received?.protocolVersion == 1)
+        guard case .policyUpdate(let policy) = received?.payload else {
+            Issue.record("Expected policyUpdate payload, got \(String(describing: received?.payload))")
+            return
+        }
+        #expect(policy.logForwardingEnabled == true)
+        #expect(policy.clipboardSharingEnabled == false)
+    }
+
     @Test("Delivers multiple frames in order")
     func multipleFramesPreserveOrder() async throws {
         let (a, b) = try makePair()


### PR DESCRIPTION
## Summary
- Lay the wire-format groundwork for hot-toggleable agent capabilities by adding a `PolicyUpdate` payload to the host↔guest protocol.
- This is wire-only; no behavior changes. Subsequent PRs will use it to gate log forwarding and clipboard sync at runtime.

## Changes
- Add `PolicyUpdate` message (`bool log_forwarding_enabled`, `bool clipboard_sharing_enabled`) to `KernovaProtocol/Proto/kernova.proto` at field 13 in the control-plane reservation (12..19).
- Regenerate `kernova.pb.swift` (`protoc --swift_opt=Visibility=Public`).
- Update existing `Frame.payload` switches to include `.policyUpdate`:
  - Host log/control/clipboard services treat it as wrong-port and warn (the host doesn't receive `PolicyUpdate` — it's a host→guest message).
  - Guest control agent logs at `.debug` for now; routing is wired up in a follow-up PR.
- Add a `roundTripPolicyUpdate` test in `KernovaProtocolTests/VsockChannelTests.swift`.

## Test plan
- [x] `swift test` in `KernovaProtocol` passes (28 tests)
- [x] `xcodebuild test` for the Kernova app passes
- [x] New `roundTripPolicyUpdate` test passes locally

## Notes
First of five planned PRs to add hot-toggleable log forwarding and clipboard sync. This one is intentionally minimal so the protocol surface lands cleanly before any consumers exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)