### PR TITLE
feat: Add agentLogForwardingEnabled config + UI toggle

### DIFF
--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -10,6 +10,13 @@ enum VMDisplayPreference: String, Codable, Sendable, Equatable {
 /// Persistent configuration for a virtual machine.
 ///
 /// This type is serialized to `config.json` inside each VM bundle directory.
+///
+/// > Important: This struct uses a custom `init(from:)` (see the `Codable`
+/// > section) instead of synthesized `Decodable` so newly added optional
+/// > defaults can be migrated cleanly. **Any new property must be added to
+/// > the custom `init(from:)` as well.** Optional properties decoded via
+/// > synthesized `init(from:)` would default to `nil` silently; the manual
+/// > initializer makes that decision explicit.
 struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
 
     // MARK: - Identity
@@ -261,6 +268,25 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     var memorySizeInBytes: UInt64 {
         UInt64(memorySizeInGB) * 1024 * 1024 * 1024
     }
+
+    // MARK: - Hot-Toggleable Fields
+
+    /// Fields the user may edit while the VM is running. Changes to these
+    /// bypass the read-only settings lock and are pushed to the live guest
+    /// agent via `PolicyUpdate` on the vsock control channel.
+    ///
+    /// Single source of truth — `VMSettingsView` uses this for change
+    /// detection, and the live-policy handler that applies these changes to
+    /// a running VM consumes the same list.
+    ///
+    /// RATIONALE: `KeyPath` does not conform to `Sendable` in Swift 6, so a
+    /// `static let` of `[KeyPath]` would be rejected. The values are
+    /// immutable (key paths captured at compile time) so concurrent reads
+    /// are safe — `nonisolated(unsafe)` is the appropriate escape hatch.
+    nonisolated(unsafe) static let hotToggleFields: [KeyPath<VMConfiguration, Bool>] = [
+        \.agentLogForwardingEnabled,
+        \.clipboardSharingEnabled,
+    ]
 }
 
 // MARK: - SharedDirectory

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -51,6 +51,18 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     /// listen to the host. Speaker output is always enabled regardless of this flag.
     var microphoneEnabled: Bool
 
+    // MARK: - Guest Agent
+
+    /// When `true`, the macOS guest agent forwards `os.Logger` records to the
+    /// host over vsock so they appear in Console.app under
+    /// `com.kernova.guest`. Defaults to `false` for new and existing VMs:
+    /// log forwarding is opt-in. Linux guests have no Kernova agent and ignore
+    /// this flag.
+    ///
+    /// Hot-toggleable while the VM is running — see `VsockControlService`'s
+    /// `PolicyUpdate` delivery.
+    var agentLogForwardingEnabled: Bool
+
     // MARK: - macOS-specific
 
     /// Serialized `VZMacHardwareModel.dataRepresentation`.
@@ -115,6 +127,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         macAddress: String? = nil,
         clipboardSharingEnabled: Bool = false,
         microphoneEnabled: Bool = false,
+        agentLogForwardingEnabled: Bool = false,
         hardwareModelData: Data? = nil,
         machineIdentifierData: Data? = nil,
         genericMachineIdentifierData: Data? = nil,
@@ -144,6 +157,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         self.macAddress = macAddress
         self.clipboardSharingEnabled = clipboardSharingEnabled
         self.microphoneEnabled = microphoneEnabled
+        self.agentLogForwardingEnabled = agentLogForwardingEnabled
         self.hardwareModelData = hardwareModelData
         self.machineIdentifierData = machineIdentifierData
         self.genericMachineIdentifierData = genericMachineIdentifierData
@@ -156,6 +170,45 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         self.additionalDisks = additionalDisks
         self.sharedDirectories = sharedDirectories
         self.createdAt = createdAt
+    }
+
+    // MARK: - Codable
+
+    // RATIONALE: Custom `init(from:)` so a newly added field
+    // (`agentLogForwardingEnabled`) defaults to `false` when decoding configs
+    // that pre-date its introduction. Other fields keep their existing
+    // required/optional decoding semantics.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(UUID.self, forKey: .id)
+        self.name = try c.decode(String.self, forKey: .name)
+        self.guestOS = try c.decode(VMGuestOS.self, forKey: .guestOS)
+        self.bootMode = try c.decode(VMBootMode.self, forKey: .bootMode)
+        self.cpuCount = try c.decode(Int.self, forKey: .cpuCount)
+        self.memorySizeInGB = try c.decode(Int.self, forKey: .memorySizeInGB)
+        self.diskSizeInGB = try c.decode(Int.self, forKey: .diskSizeInGB)
+        self.displayWidth = try c.decode(Int.self, forKey: .displayWidth)
+        self.displayHeight = try c.decode(Int.self, forKey: .displayHeight)
+        self.displayPPI = try c.decode(Int.self, forKey: .displayPPI)
+        self.displayPreference = try c.decode(VMDisplayPreference.self, forKey: .displayPreference)
+        self.lastFullscreenDisplayID = try c.decodeIfPresent(UInt32.self, forKey: .lastFullscreenDisplayID)
+        self.networkEnabled = try c.decode(Bool.self, forKey: .networkEnabled)
+        self.macAddress = try c.decodeIfPresent(String.self, forKey: .macAddress)
+        self.clipboardSharingEnabled = try c.decode(Bool.self, forKey: .clipboardSharingEnabled)
+        self.microphoneEnabled = try c.decode(Bool.self, forKey: .microphoneEnabled)
+        self.agentLogForwardingEnabled = try c.decodeIfPresent(Bool.self, forKey: .agentLogForwardingEnabled) ?? false
+        self.hardwareModelData = try c.decodeIfPresent(Data.self, forKey: .hardwareModelData)
+        self.machineIdentifierData = try c.decodeIfPresent(Data.self, forKey: .machineIdentifierData)
+        self.genericMachineIdentifierData = try c.decodeIfPresent(Data.self, forKey: .genericMachineIdentifierData)
+        self.discImagePath = try c.decodeIfPresent(String.self, forKey: .discImagePath)
+        self.discImageReadOnly = try c.decode(Bool.self, forKey: .discImageReadOnly)
+        self.bootFromDiscImage = try c.decode(Bool.self, forKey: .bootFromDiscImage)
+        self.kernelPath = try c.decodeIfPresent(String.self, forKey: .kernelPath)
+        self.initrdPath = try c.decodeIfPresent(String.self, forKey: .initrdPath)
+        self.kernelCommandLine = try c.decodeIfPresent(String.self, forKey: .kernelCommandLine)
+        self.additionalDisks = try c.decodeIfPresent([AdditionalDisk].self, forKey: .additionalDisks)
+        self.sharedDirectories = try c.decodeIfPresent([SharedDirectory].self, forKey: .sharedDirectories)
+        self.createdAt = try c.decode(Date.self, forKey: .createdAt)
     }
 
     // MARK: - Cloning

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -62,6 +62,9 @@ struct VMSettingsView: View {
                     // `resourcesSection` and `audioSection` (which handle their own
                     // disabling per-control) remain interactive in read-only mode —
                     // SwiftUI's disabled state propagates irreversibly to descendants.
+                    // `guestAgentSection` and `clipboardSection` carry hot-toggle
+                    // fields that remain editable while the VM is running, so they
+                    // are NOT wrapped with `.disabled(isReadOnly)`.
                     generalSection.disabled(isReadOnly)
                     resourcesSection
                     storageDiskSection.disabled(isReadOnly)
@@ -69,17 +72,25 @@ struct VMSettingsView: View {
                     sharedDirectoriesSection.disabled(isReadOnly)
                     networkSection.disabled(isReadOnly)
                     audioSection
-                    clipboardSection.disabled(isReadOnly)
+                    if instance.configuration.guestOS == .macOS {
+                        guestAgentSection
+                    }
+                    clipboardSection
                 }
                 .formStyle(.grouped)
                 .padding()
             }
         }
-        .onChange(of: instance.configuration) { _, _ in
-            // RATIONALE: In read-only mode no control can mutate the configuration, but
-            // SwiftUI may still invoke onChange when the instance itself is swapped in.
-            // Guarding here avoids a spurious write during that transition.
-            guard !isReadOnly else { return }
+        .onChange(of: instance.configuration) { old, new in
+            // RATIONALE: hot-toggleable fields (agent log forwarding, clipboard
+            // sharing) can change while `isReadOnly` is true because their
+            // toggles stay interactive. Save when they change; for everything
+            // else, the read-only guard protects against spurious writes
+            // during instance swap-in transitions.
+            let hotFieldsChanged =
+                old.agentLogForwardingEnabled != new.agentLogForwardingEnabled
+                || old.clipboardSharingEnabled != new.clipboardSharingEnabled
+            guard !isReadOnly || hotFieldsChanged else { return }
             viewModel.saveConfiguration(for: instance)
         }
     }
@@ -450,12 +461,30 @@ struct VMSettingsView: View {
     }
 
     @ViewBuilder
+    private var guestAgentSection: some View {
+        Section("Guest Agent") {
+            Toggle(
+                "Forward guest logs",
+                isOn: $instance.configuration.agentLogForwardingEnabled
+            )
+            Text("Streams `os.Logger` records from the macOS guest agent to the host so they appear in Console.app under `com.kernova.guest`. Off by default; can be toggled while the VM is running.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
     private var clipboardSection: some View {
         Section("Clipboard") {
             Toggle("Clipboard Sharing", isOn: $instance.configuration.clipboardSharingEnabled)
             Text("Exchanges clipboard text between host and guest. macOS guests use the bundled Kernova guest agent — Kernova will offer to install or update it from the clipboard window. Linux guests need spice-vdagent installed via the guest's package manager.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+            if isReadOnly && instance.configuration.guestOS == .linux {
+                Text("Takes effect on next start — Linux guests configure SPICE at VM start time.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
         }
     }
 

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -82,14 +82,14 @@ struct VMSettingsView: View {
             }
         }
         .onChange(of: instance.configuration) { old, new in
-            // RATIONALE: hot-toggleable fields (agent log forwarding, clipboard
-            // sharing) can change while `isReadOnly` is true because their
-            // toggles stay interactive. Save when they change; for everything
-            // else, the read-only guard protects against spurious writes
-            // during instance swap-in transitions.
-            let hotFieldsChanged =
-                old.agentLogForwardingEnabled != new.agentLogForwardingEnabled
-                || old.clipboardSharingEnabled != new.clipboardSharingEnabled
+            // RATIONALE: fields in `VMConfiguration.hotToggleFields` can
+            // change while `isReadOnly` is true because their toggles stay
+            // interactive. Save when they change; for everything else, the
+            // read-only guard protects against spurious writes during
+            // instance swap-in transitions.
+            let hotFieldsChanged = VMConfiguration.hotToggleFields.contains {
+                old[keyPath: $0] != new[keyPath: $0]
+            }
             guard !isReadOnly || hotFieldsChanged else { return }
             viewModel.saveConfiguration(for: instance)
         }

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -587,6 +587,50 @@ struct VMConfigurationTests {
         #expect(decoded.clipboardSharingEnabled == true)
     }
 
+    // MARK: - agentLogForwardingEnabled Tests
+
+    @Test("Default agentLogForwardingEnabled is false")
+    func defaultAgentLogForwardingEnabled() {
+        let config = VMConfiguration(
+            name: "Test VM",
+            guestOS: .macOS,
+            bootMode: .macOS
+        )
+        #expect(config.agentLogForwardingEnabled == false)
+    }
+
+    @Test("Configuration preserves agentLogForwardingEnabled flag")
+    func agentLogForwardingEnabledRoundTrip() throws {
+        let config = VMConfiguration(
+            name: "Logging VM",
+            guestOS: .macOS,
+            bootMode: .macOS,
+            agentLogForwardingEnabled: true
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(config)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: data)
+
+        #expect(decoded.agentLogForwardingEnabled == true)
+    }
+
+    @Test("Missing agentLogForwardingEnabled decodes as false (existing-VM migration)")
+    func missingAgentLogForwardingEnabledDecodesFalse() throws {
+        // Older configs predate the field — they must still decode, with the
+        // new flag defaulting to off so existing VMs don't suddenly forward
+        // logs without the user opting in.
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let config = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
+
+        #expect(config.agentLogForwardingEnabled == false)
+    }
+
     // MARK: - microphoneEnabled Tests
 
     @Test("Default microphoneEnabled is false")


### PR DESCRIPTION
## Summary
- Introduce a per-VM toggle for guest-agent log forwarding, defaulting **off** so existing VMs don't surprise users by suddenly streaming logs after upgrade.
- Surface the toggle (macOS-only) and unlock the existing clipboard toggle so both can be edited while a VM is running. The runtime effect lands in subsequent PRs (#183 has already added the protocol piece).

## Changes
- `Kernova/Models/VMConfiguration.swift`:
  - Add `agentLogForwardingEnabled: Bool` (default `false`).
  - Custom `init(from:)` so older configs missing the field decode as `false` (existing-VM migration). Other fields keep their existing required/optional decoding semantics.
- `Kernova/Views/Detail/VMSettingsView.swift`:
  - New \"Guest Agent\" section, rendered only for macOS guests.
  - Drop `.disabled(isReadOnly)` on the clipboard section and the new guest-agent section so both stay editable while the VM is running.
  - Update the `onChange` save handler to bypass the read-only guard when the diff is in a hot-toggleable field.
  - Linux-specific \"takes effect on next start\" hint on the clipboard toggle when running, since the SPICE port must be declared at config-build time.
- `KernovaTests/VMConfigurationTests.swift`: add default-value, round-trip, and missing-field migration tests.

## Test plan
- [x] `xcodebuild test` (full Kernova suite) passes locally
- [x] `VMConfigurationTests` — `defaultAgentLogForwardingEnabled`, `agentLogForwardingEnabledRoundTrip`, `missingAgentLogForwardingEnabledDecodesFalse` all pass

## Notes
This PR is intentionally cosmetic at the runtime level — toggling the new field only persists to disk. The host-side gating, guest-side enforcement, and hot-toggle wiring land in three follow-up PRs. Builds on top of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)