### PR TITLE
fix: Show lock icon on locked sections of VM Settings while running

### DIFF
--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -103,7 +103,7 @@ struct VMSettingsView: View {
         HStack(spacing: 10) {
             Image(systemName: "lock.fill")
                 .foregroundStyle(.orange)
-            Text("Settings are read-only while the VM is running. Stop the VM to make changes.")
+            Text("Sections marked with \(Image(systemName: "lock.fill")) are locked while the VM is running. Stop the VM to change them. Other sections can be edited live.")
                 .font(.callout)
             Spacer()
         }
@@ -116,11 +116,29 @@ struct VMSettingsView: View {
         }
     }
 
+    /// Section header that appends a lock SF Symbol when `isReadOnly` is
+    /// `true`, signaling that the section's controls are locked while the
+    /// VM is running. Hot-toggleable sections (Guest Agent, Clipboard) keep
+    /// their plain headers so the absence of the lock is itself the signal
+    /// that those sections remain editable.
+    @ViewBuilder
+    private func lockableHeader(_ title: String) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+            if isReadOnly {
+                Image(systemName: "lock.fill")
+                    .foregroundStyle(.orange)
+                    .imageScale(.small)
+                    .help("Locked while the VM is running")
+            }
+        }
+    }
+
     // MARK: - Sections
 
     @ViewBuilder
     private var generalSection: some View {
-        Section("General") {
+        Section(header: lockableHeader("General")) {
             if isRenaming {
                 TextField("Name", text: $editingName)
                     .focused($isNameFieldFocused)
@@ -158,7 +176,7 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var removableMediaSection: some View {
-        Section("Removable Media") {
+        Section(header: lockableHeader("Removable Media")) {
             if let discImagePath = instance.configuration.discImagePath {
                 HStack {
                     Image(systemName: "opticaldisc")
@@ -289,7 +307,7 @@ struct VMSettingsView: View {
                 }
             }
         } header: {
-            Text("Storage Disks")
+            lockableHeader("Storage Disks")
         }
     }
 
@@ -346,7 +364,7 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var resourcesSection: some View {
-        Section("Resources") {
+        Section(header: lockableHeader("Resources")) {
             let os = instance.configuration.guestOS
 
             Stepper(
@@ -397,7 +415,7 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var networkSection: some View {
-        Section("Network") {
+        Section(header: lockableHeader("Network")) {
             Toggle("Networking Enabled", isOn: $instance.configuration.networkEnabled)
             if let mac = instance.configuration.macAddress {
                 LabeledContent("MAC Address", value: mac)
@@ -407,7 +425,7 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var audioSection: some View {
-        Section("Audio") {
+        Section(header: lockableHeader("Audio")) {
             Toggle("Microphone", isOn: $instance.configuration.microphoneEnabled)
                 .disabled(isReadOnly)
             Text("Allows the guest to access the host microphone. Speaker output is always enabled.")
@@ -567,7 +585,7 @@ struct VMSettingsView: View {
                     .foregroundStyle(.secondary)
             }
         } header: {
-            Text("Shared Directories")
+            lockableHeader("Shared Directories")
         }
     }
 

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -103,7 +103,7 @@ struct VMSettingsView: View {
         HStack(spacing: 10) {
             Image(systemName: "lock.fill")
                 .foregroundStyle(.orange)
-            Text("Sections marked with \(Image(systemName: "lock.fill")) are locked while the VM is running. Stop the VM to change them. Other sections can be edited live.")
+            Text("Sections marked with \(Text(Image(systemName: "lock.fill")).foregroundStyle(.orange)) are locked while the VM is running. Stop the VM to change them. Other sections can be edited live.")
                 .font(.callout)
             Spacer()
         }
@@ -121,8 +121,12 @@ struct VMSettingsView: View {
     /// VM is running. Hot-toggleable sections (Guest Agent, Clipboard) keep
     /// their plain headers so the absence of the lock is itself the signal
     /// that those sections remain editable.
+    ///
+    /// `LocalizedStringKey` matches SwiftUI's built-in `Section("...")`
+    /// initializer behavior so passing a literal participates in the same
+    /// localization lookup as the rest of the app's titles would.
     @ViewBuilder
-    private func lockableHeader(_ title: String) -> some View {
+    private func lockableHeader(_ title: LocalizedStringKey) -> some View {
         HStack(spacing: 6) {
             Text(title)
             if isReadOnly {


### PR DESCRIPTION
## Summary
- When a VM is running, hot-editable toggles (Forward guest logs, Clipboard Sharing) looked visually identical to the disabled read-only rows when their toggles were OFF — SwiftUI's toggle styling doesn't differentiate enabled-off from disabled-off enough to read at a glance.
- Inverts the signal: mark **locked** sections with a lock icon, leave hot-editable sections with plain headers. The absence of a lock becomes the cue that the section is editable live.

## Changes
- New \`lockableHeader(_:)\` helper that conditionally appends a \`lock.fill\` SF Symbol (orange tint, \`.help\` tooltip "Locked while the VM is running") to a section header when \`isReadOnly\` is true.
- Applied to the 7 sections that lock when running: General, Resources, Storage Disks, Removable Media, Shared Directories, Network, Audio.
- Guest Agent and Clipboard sections keep their plain headers — no lock — so users can tell at a glance they're still interactive.
- Updated the read-only banner copy: clarifies that only sections with the lock icon are read-only; other sections can be edited live.

## Test plan
- [x] \`xcodebuild test\` passes (no test changes; UI-only refactor)
- [ ] **Visual verification still needed**: I can build but can't simulate the running-VM state from the test harness. Please reload the app and confirm:
  - With a VM running, lock icons appear next to General/Resources/Storage/Removable Media/Shared Directories/Network/Audio headers
  - Guest Agent and Clipboard headers have no lock and their toggles remain interactive
  - With the VM stopped, no lock icons appear on any section header

## Notes
Follow-up to the hot-toggleable agent capability series (#183 → #187). The series shipped the wiring; this addresses an affordance gap pointed out post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)