### PR TITLE
refactor: Live-policy cleanups from post-merge review

### DIFF
--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -278,12 +278,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     /// Single source of truth — `VMSettingsView` uses this for change
     /// detection, and the live-policy handler that applies these changes to
     /// a running VM consumes the same list.
-    ///
-    /// RATIONALE: `KeyPath` does not conform to `Sendable` in Swift 6, so a
-    /// `static let` of `[KeyPath]` would be rejected. The values are
-    /// immutable (key paths captured at compile time) so concurrent reads
-    /// are safe — `nonisolated(unsafe)` is the appropriate escape hatch.
-    nonisolated(unsafe) static let hotToggleFields: [KeyPath<VMConfiguration, Bool>] = [
+    static let hotToggleFields: [KeyPath<VMConfiguration, Bool> & Sendable] = [
         \.agentLogForwardingEnabled,
         \.clipboardSharingEnabled,
     ]

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -592,6 +592,24 @@ final class VMInstance: Identifiable {
             oldConfig.clipboardSharingEnabled != newConfig.clipboardSharingEnabled
         guard logChanged || clipboardChanged else { return }
 
+        // Push the policy snapshot to the guest BEFORE manipulating host
+        // listeners. On a disable transition, this lets the guest pause its
+        // reconnect loop first; if we tore down the listener first, the guest
+        // would see EOF on its existing channel and pound the host with
+        // reconnects (up to one per `retryInterval`) until the policy frame
+        // arrives. On enable, the guest's `resume()` waits up to
+        // `retryInterval` before its next connect, so the host has time to
+        // install the listener after the policy send returns. The control
+        // service may be nil during the brief window between accepting the
+        // listener connection and receiving the guest's Hello — `?` keeps
+        // that state safe; the next Hello-driven send will catch it up.
+        vsockControlService?.sendPolicyUpdate(
+            AgentPolicySnapshot(
+                logForwardingEnabled: newConfig.agentLogForwardingEnabled,
+                clipboardSharingEnabled: newConfig.clipboardSharingEnabled
+            )
+        )
+
         if logChanged {
             applyLiveLogPolicy(enabled: newConfig.agentLogForwardingEnabled, on: socketDevice)
         }
@@ -603,17 +621,6 @@ final class VMInstance: Identifiable {
                 on: socketDevice
             )
         }
-
-        // Push the resulting policy snapshot to the guest. The control
-        // service may be nil during the brief window between accepting the
-        // listener connection and receiving the guest's Hello — `?` keeps
-        // that state safe; the next Hello-driven send will catch it up.
-        vsockControlService?.sendPolicyUpdate(
-            AgentPolicySnapshot(
-                logForwardingEnabled: newConfig.agentLogForwardingEnabled,
-                clipboardSharingEnabled: newConfig.clipboardSharingEnabled
-            )
-        )
 
         Self.logger.notice(
             "Applied live policy for '\(self.name, privacy: .public)' (logForwarding=\(newConfig.agentLogForwardingEnabled, privacy: .public), clipboard=\(newConfig.clipboardSharingEnabled, privacy: .public))"
@@ -660,10 +667,11 @@ final class VMInstance: Identifiable {
             clipHost.attach(to: socketDevice)
             vsockClipboardListenerHost = clipHost
         } else {
-            if clipboardService is VsockClipboardService {
-                clipboardService?.stop()
-                clipboardService = nil
-            }
+            // Caller (`applyLivePolicy`) gates this branch on `isMacOSGuest`,
+            // so any `clipboardService` here is a `VsockClipboardService` —
+            // SPICE-backed services live exclusively on Linux guests.
+            clipboardService?.stop()
+            clipboardService = nil
             vsockClipboardListenerHost = nil
         }
     }

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -665,6 +665,80 @@ struct VMConfigurationTests {
 
     // MARK: - Missing Required Fields
 
+    // MARK: - Full-field round-trip
+
+    /// Populates every property with a non-default value, encodes to JSON,
+    /// decodes back, and asserts equality. Tripwire for the custom
+    /// `init(from:)`: if a new field is added to `VMConfiguration` but the
+    /// decoder is not updated, the missed field will silently default-
+    /// initialize on decode and the round-trip equality will fail.
+    ///
+    /// When this test fires, also update `init(from:)` in `VMConfiguration`
+    /// to read the new key.
+    @Test("Configuration with all fields populated round-trips identically through JSON")
+    func fullFieldRoundTrip() throws {
+        let original = VMConfiguration(
+            id: UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!,
+            name: "Comprehensive VM",
+            guestOS: .macOS,
+            bootMode: .macOS,
+            cpuCount: 12,
+            memorySizeInGB: 24,
+            diskSizeInGB: 256,
+            displayWidth: 2560,
+            displayHeight: 1440,
+            displayPPI: 192,
+            displayPreference: .popOut,
+            lastFullscreenDisplayID: 0xDEAD_BEEF,
+            networkEnabled: false,
+            macAddress: "aa:bb:cc:dd:ee:ff",
+            clipboardSharingEnabled: true,
+            microphoneEnabled: true,
+            agentLogForwardingEnabled: true,
+            hardwareModelData: Data([0x01, 0x02, 0x03]),
+            machineIdentifierData: Data([0x04, 0x05]),
+            genericMachineIdentifierData: Data([0x06]),
+            discImagePath: "/path/to/disc.iso",
+            discImageReadOnly: false,
+            bootFromDiscImage: true,
+            kernelPath: "/path/to/kernel",
+            initrdPath: "/path/to/initrd",
+            kernelCommandLine: "console=ttyS0",
+            additionalDisks: [
+                AdditionalDisk(
+                    id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+                    path: "/disk2.img",
+                    readOnly: true,
+                    label: "data",
+                    isInternal: false
+                ),
+            ],
+            sharedDirectories: [
+                SharedDirectory(
+                    id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+                    path: "/host/shared",
+                    readOnly: true
+                ),
+            ],
+            // Whole-second timestamp so .iso8601 (no fractional seconds)
+            // round-trips without precision loss.
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: data)
+
+        #expect(
+            decoded == original,
+            "Round-trip mismatch — likely an unhandled field in `init(from:)`"
+        )
+    }
+
     @Test("Decoding JSON missing a required field throws DecodingError")
     func missingRequiredFieldThrows() {
         // Intentionally omits: displayPreference, clipboardSharingEnabled,

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -663,8 +663,6 @@ struct VMConfigurationTests {
         #expect(decoded.microphoneEnabled == true)
     }
 
-    // MARK: - Missing Required Fields
-
     // MARK: - Full-field round-trip
 
     /// Populates every property with a non-default value, encodes to JSON,
@@ -738,6 +736,8 @@ struct VMConfigurationTests {
             "Round-trip mismatch — likely an unhandled field in `init(from:)`"
         )
     }
+
+    // MARK: - Missing Required Fields
 
     @Test("Decoding JSON missing a required field throws DecodingError")
     func missingRequiredFieldThrows() {


### PR DESCRIPTION
## Summary
- Send `PolicyUpdate` to the guest before manipulating host listeners so disable transitions pause the guest's reconnect loop before its existing channel sees EOF — eliminates a brief reconnect storm against a dead port.
- Drop dead defensive code and an unnecessary `nonisolated(unsafe)` annotation surfaced in review of #185–#188.
- Add a tripwire test that catches future fields added to `VMConfiguration` but missed in the custom `init(from:)` decoder.

## Changes

| Area | Change |
|------|--------|
| `VMInstance.applyLivePolicy` | Move `vsockControlService?.sendPolicyUpdate(...)` before the listener install/teardown calls. Comment expanded to explain the ordering invariant in both directions. |
| `VMInstance.applyLiveClipboardPolicy` | Drop the redundant `clipboardService is VsockClipboardService` guard — the caller already gates on `isMacOSGuest` so the type is guaranteed. Replaced with a comment naming the invariant. |
| `VMConfiguration.hotToggleFields` | Replace `nonisolated(unsafe) static let ...: [KeyPath<...>]` with `static let ...: [KeyPath<VMConfiguration, Bool> & Sendable]`. The escape hatch was unnecessary; the existential `& Sendable` constraint makes the array `Sendable` cleanly. Removed the obsolete `RATIONALE`. |
| `VMConfigurationTests.fullFieldRoundTrip` | New test: build a fully-populated `VMConfiguration`, JSON-encode, decode, assert struct equality. Tripwire for fields added to the struct but missed in `init(from:)`. |

## Why the reorder matters

`applyLivePolicy` is invoked when the user toggles a hot-toggleable setting while a VM is running. Before this PR, the order was: tear down the host listener → close the active service → send `PolicyUpdate`. On a disable transition, that meant the guest saw EOF on its existing channel and its reconnect loop pounded the (now-absent) host listener with connect attempts (one per `retryInterval`) until the policy frame finally arrived and paused the loop. Logs were noisy; functionality wasn't broken.

After this PR: send `PolicyUpdate` first → guest pauses → host tears down. On enable, the inverse holds: the guest's `resume()` doesn't wake the loop immediately — it waits up to `retryInterval` (5 s in production) before the next connect, which is plenty of time for the host to install the listener.

## Test plan
- [x] Build succeeds on macOS 26 / Xcode 26
- [x] New `VMConfigurationTests/fullFieldRoundTrip` passes
- [x] Pre-existing `VMInstanceTests/hotToggleFieldsCovered`, `applyLivePolicyNoopWhenStopped`, `applyLivePolicyNoopWithoutDiff` still pass
- [x] Full test suite green locally