### PR TITLE
feat: Sidebar guest-agent UX upgrades

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -741,14 +741,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                 menuItem.title = "Update Guest Agent…"
             case .expectedMissing:
                 menuItem.title = "Reinstall Guest Agent…"
-            case .waiting, .current, .unresponsive:
+            case .waiting, .current, .unresponsive, .connecting:
                 menuItem.title = "Install Guest Agent…"
             }
             switch status {
-            case .current, .unresponsive:
+            case .current, .unresponsive, .connecting:
                 // Agent is already installed; no install/update action helps.
-                // `.unresponsive` will reset itself once the heartbeat timeout
-                // fires.
+                // `.unresponsive` resets itself once the heartbeat timeout
+                // fires; `.connecting` resolves to `.current` or
+                // `.expectedMissing` on its own.
                 return false
             case .waiting, .outdated, .expectedMissing:
                 return true

--- a/Kernova/App/ClipboardContentViewController.swift
+++ b/Kernova/App/ClipboardContentViewController.swift
@@ -150,6 +150,14 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
             statusLabel.stringValue = "Update available (\(installed) → \(bundled))"
             actionButton.isHidden = !canInstallKernovaAgent
             actionButton.title = "Update Guest Agent…"
+        case .connecting(let expected):
+            // Live session for a previously-installed agent that hasn't
+            // said Hello yet. No install/reinstall affordance — the agent
+            // is expected to reconnect; the watchdog will surface
+            // `.expectedMissing` if it doesn't.
+            statusCircle.layer?.backgroundColor = NSColor.secondaryLabelColor.cgColor
+            statusLabel.stringValue = "Connecting (was \(expected))"
+            actionButton.isHidden = true
         case .current(let version):
             statusCircle.layer?.backgroundColor = NSColor.systemGreen.cgColor
             statusLabel.stringValue = "Connected (\(version))"

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -86,6 +86,14 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     /// new version (e.g. user-side update or downgrade inside the VM).
     var lastSeenAgentVersion: String?
 
+    /// When `true`, the user has explicitly dismissed the sidebar "install
+    /// guest agent" nudge for this VM. Suppresses only the gentle `.waiting`
+    /// affordance — the `.outdated`, `.unresponsive`, and `.expectedMissing`
+    /// states still surface because they imply something more urgent than
+    /// "you could install this." Defaults to `false` for new and migrated
+    /// configs.
+    var agentInstallNudgeDismissed: Bool
+
     // MARK: - macOS-specific
 
     /// Serialized `VZMacHardwareModel.dataRepresentation`.
@@ -152,6 +160,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         microphoneEnabled: Bool = false,
         agentLogForwardingEnabled: Bool = false,
         lastSeenAgentVersion: String? = nil,
+        agentInstallNudgeDismissed: Bool = false,
         hardwareModelData: Data? = nil,
         machineIdentifierData: Data? = nil,
         genericMachineIdentifierData: Data? = nil,
@@ -183,6 +192,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         self.microphoneEnabled = microphoneEnabled
         self.agentLogForwardingEnabled = agentLogForwardingEnabled
         self.lastSeenAgentVersion = lastSeenAgentVersion
+        self.agentInstallNudgeDismissed = agentInstallNudgeDismissed
         self.hardwareModelData = hardwareModelData
         self.machineIdentifierData = machineIdentifierData
         self.genericMachineIdentifierData = genericMachineIdentifierData
@@ -202,8 +212,9 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     // RATIONALE: Custom `init(from:)` so newly added fields default cleanly
     // when decoding configs that pre-date their introduction
     // (`agentLogForwardingEnabled` defaults to `false`,
-    // `lastSeenAgentVersion` defaults to `nil`). Other fields keep their
-    // existing required/optional decoding semantics.
+    // `lastSeenAgentVersion` defaults to `nil`,
+    // `agentInstallNudgeDismissed` defaults to `false`). Other fields keep
+    // their existing required/optional decoding semantics.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try c.decode(UUID.self, forKey: .id)
@@ -224,6 +235,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         self.microphoneEnabled = try c.decode(Bool.self, forKey: .microphoneEnabled)
         self.agentLogForwardingEnabled = try c.decodeIfPresent(Bool.self, forKey: .agentLogForwardingEnabled) ?? false
         self.lastSeenAgentVersion = try c.decodeIfPresent(String.self, forKey: .lastSeenAgentVersion)
+        self.agentInstallNudgeDismissed = try c.decodeIfPresent(Bool.self, forKey: .agentInstallNudgeDismissed) ?? false
         self.hardwareModelData = try c.decodeIfPresent(Data.self, forKey: .hardwareModelData)
         self.machineIdentifierData = try c.decodeIfPresent(Data.self, forKey: .machineIdentifierData)
         self.genericMachineIdentifierData = try c.decodeIfPresent(Data.self, forKey: .genericMachineIdentifierData)

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -304,15 +304,19 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     // MARK: - Hot-Toggleable Fields
 
     /// Fields the user may edit while the VM is running. Changes to these
-    /// bypass the read-only settings lock and are pushed to the live guest
-    /// agent via `PolicyUpdate` on the vsock control channel.
+    /// bypass the `VMSettingsView` read-only settings lock so the user can
+    /// flip them mid-session.
     ///
-    /// Single source of truth — `VMSettingsView` uses this for change
-    /// detection, and the live-policy handler that applies these changes to
-    /// a running VM consumes the same list.
+    /// Most also affect runtime guest behavior and are pushed to the live
+    /// guest agent via `PolicyUpdate` on the vsock control channel — but the
+    /// `applyLivePolicy` handler checks each such field directly rather than
+    /// iterating this list, so a host-only UI preference like
+    /// `agentInstallNudgeDismissed` (which suppresses a sidebar nudge but
+    /// has no guest-side effect) is safe to include.
     static let hotToggleFields: [KeyPath<VMConfiguration, Bool> & Sendable] = [
         \.agentLogForwardingEnabled,
         \.clipboardSharingEnabled,
+        \.agentInstallNudgeDismissed,
     ]
 }
 

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -632,6 +632,15 @@ final class VMInstance: Identifiable {
                     "Guest agent expected (last seen \(self.configuration.lastSeenAgentVersion ?? "?", privacy: .public)) but never reconnected for '\(self.name, privacy: .public)' — surfacing reinstall affordance"
                 )
                 self.agentExpectedButMissing = true
+                // A previously-installed agent disappearing is a louder
+                // event than the gentle install nudge the user once chose
+                // to silence. Reset the dismissal so any future `.waiting`
+                // (e.g. user wipes the VM and starts fresh, or
+                // `lastSeenAgentVersion` clears) surfaces normally.
+                if self.configuration.agentInstallNudgeDismissed {
+                    self.configuration.agentInstallNudgeDismissed = false
+                    self.onConfigurationDidChange?(self)
+                }
             }
             self.agentPostStartTask = nil
         }

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -177,7 +177,19 @@ final class VMInstance: Identifiable {
                let expected = configuration.lastSeenAgentVersion {
                 return .expectedMissing(expected: expected)
             }
-            return vsockControlService?.agentStatus ?? .waiting
+            let upstream = vsockControlService?.agentStatus ?? .waiting
+            // Live session for a VM with a known prior agent that hasn't
+            // said Hello yet → `.connecting`. The UI uses this to show a
+            // softer rotating indicator instead of the install nudge while
+            // the agent is expected to reconnect. Resolves to `.current`
+            // once Hello arrives, or `.expectedMissing` if the post-start
+            // watchdog fires (handled above).
+            if case .waiting = upstream,
+               let lastSeen = configuration.lastSeenAgentVersion,
+               virtualMachine != nil {
+                return .connecting(expected: lastSeen)
+            }
+            return upstream
         case .linux:
             return (clipboardService as? SpiceClipboardService)?.agentStatus ?? .waiting
         }

--- a/Kernova/Services/AgentStatus.swift
+++ b/Kernova/Services/AgentStatus.swift
@@ -45,4 +45,24 @@ enum AgentStatus: Equatable, Sendable {
     /// (which has no access to persisted state) never returns it.
     /// `expected` is the last-known agent version we have on record.
     case expectedMissing(expected: String)
+
+    /// Live session for a VM that has previously had a guest agent connect
+    /// (`VMConfiguration.lastSeenAgentVersion` is set), but no `Hello` has
+    /// arrived yet on this session. Distinct from `.waiting` (no prior
+    /// install) so the UI can surface a softer "connecting…" indicator
+    /// instead of the install nudge while the agent is expected to
+    /// reconnect. Resolves to `.current` once the handshake completes, or
+    /// to `.expectedMissing` if the post-start watchdog fires.
+    ///
+    /// Synthesized only at `VMInstance.agentStatus`; `VsockControlService`
+    /// never returns it. `expected` is the last-known agent version.
+    case connecting(expected: String)
+
+    /// True when this case carries the "actively trying to reconnect"
+    /// semantic. Convenience for UI code that wants to attach a continuous
+    /// rotation `.symbolEffect` to the icon.
+    var isConnecting: Bool {
+        if case .connecting = self { return true }
+        return false
+    }
 }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -647,6 +647,18 @@ final class VMLibraryViewModel {
         }
     }
 
+    /// Marks this VM's `.waiting` install nudge as dismissed and persists
+    /// the choice. The sidebar icon for `.waiting` will no longer surface;
+    /// `.outdated`, `.unresponsive`, and `.expectedMissing` continue to
+    /// surface (those imply something more urgent than "you could install
+    /// this").
+    func dismissAgentInstallNudge(for instance: VMInstance) {
+        guard !instance.configuration.agentInstallNudgeDismissed else { return }
+        Self.logger.notice("User dismissed install-agent nudge for '\(instance.name, privacy: .public)'")
+        instance.configuration.agentInstallNudgeDismissed = true
+        saveConfiguration(for: instance)
+    }
+
     /// Detaches the bundled guest agent installer if currently mounted.
     /// Identified by path equality with `KernovaGuestAgentInfo.installerDiskImageURL`.
     func unmountGuestAgentInstaller(from instance: VMInstance) {

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -503,7 +503,7 @@ struct VMSettingsView: View {
                     set: { instance.configuration.agentInstallNudgeDismissed = !$0 }
                 )
             )
-            Text("Surfaces the orange install icon in the sidebar when the guest agent has not yet connected. Turn off to suppress the nudge for this VM. The more urgent indicators (update available, didn't reconnect, unresponsive) are not affected.")
+            Text("Surfaces the install icon in the sidebar when the guest agent has not yet connected. Turn off to suppress the nudge for this VM. The more urgent indicators (update available, didn't reconnect, unresponsive) are not affected.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -495,6 +495,17 @@ struct VMSettingsView: View {
             Text("Streams `os.Logger` records from the macOS guest agent to the host so they appear in Console.app under `com.kernova.guest`. Off by default; can be toggled while the VM is running.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+            Toggle(
+                "Show install reminder",
+                isOn: Binding(
+                    get: { !instance.configuration.agentInstallNudgeDismissed },
+                    set: { instance.configuration.agentInstallNudgeDismissed = !$0 }
+                )
+            )
+            Text("Surfaces the orange install icon in the sidebar when the guest agent has not yet connected. Turn off to suppress the nudge for this VM. The more urgent indicators (update available, didn't reconnect, unresponsive) are not affected.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
@@ -32,6 +32,7 @@ struct SidebarAgentStatusButton: View {
     /// install this."
     let onDismiss: (() -> Void)?
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPopoverPresented = false
 
     var body: some View {
@@ -45,8 +46,16 @@ struct SidebarAgentStatusButton: View {
                 // grace window for a previously-installed agent. The
                 // rotation stops automatically once `.connecting` resolves
                 // to `.current` (icon hidden) or `.expectedMissing` (icon
-                // becomes the warning triangle).
-                .symbolEffect(.rotate, options: .repeat(.continuous), isActive: status.isConnecting)
+                // becomes the warning triangle). Gated on
+                // `accessibilityReduceMotion` so users who've disabled
+                // motion in System Settings see a static icon — the gray
+                // color (vs. orange `.outdated`) still differentiates the
+                // state, and the popover/help text carry the meaning.
+                .symbolEffect(
+                    .rotate,
+                    options: .repeat(.continuous),
+                    isActive: status.isConnecting && !reduceMotion
+                )
         }
         .buttonStyle(.plain)
         .help(helpText)
@@ -389,9 +398,16 @@ struct WrappingNSTextLabel: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSTextField, context: Context) {
+        // Guard `stringValue` and `preferredMaxLayoutWidth` because they
+        // trigger layout invalidation when set; `font` and `textColor` are
+        // unconditionally assigned because their `!=` comparison uses
+        // pointer equality on `NSColor` / `NSFont`, and dynamic system
+        // colors (e.g. `.secondaryLabelColor` adapts to dark mode) can
+        // resolve to the same pointer across appearance changes — the
+        // guard would skip a needed update.
         if nsView.stringValue != text { nsView.stringValue = text }
-        if nsView.font != font { nsView.font = font }
-        if nsView.textColor != textColor { nsView.textColor = textColor }
+        nsView.font = font
+        nsView.textColor = textColor
         if nsView.preferredMaxLayoutWidth != maxWidth {
             nsView.preferredMaxLayoutWidth = maxWidth
         }

--- a/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
@@ -392,6 +392,10 @@ struct WrappingNSTextLabel: NSViewRepresentable {
         field.font = font
         field.textColor = textColor
         field.preferredMaxLayoutWidth = maxWidth
+        // Default for `wrappingLabelWithString:` is non-selectable. Enable
+        // selection so users can copy specific strings out of the body
+        // (e.g. `install.command`, version numbers).
+        field.isSelectable = true
         field.setContentHuggingPriority(.required, for: .vertical)
         field.setContentCompressionResistancePriority(.required, for: .vertical)
         return field

--- a/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
@@ -411,12 +411,6 @@ struct WrappingNSTextLabel: NSViewRepresentable {
         if nsView.preferredMaxLayoutWidth != maxWidth {
             nsView.preferredMaxLayoutWidth = maxWidth
         }
-        // Notify the layout system that the intrinsic size may have
-        // changed (text/font/maxWidth all affect it). The current popover
-        // pins its outer frame to a pre-measured size and ignores the
-        // intrinsic value, so this is effectively a no-op there — but it
-        // keeps the component correct if reused in a flexible container.
-        nsView.invalidateIntrinsicContentSize()
     }
 }
 

--- a/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
@@ -41,6 +41,12 @@ struct SidebarAgentStatusButton: View {
             Image(systemName: symbolName)
                 .foregroundStyle(symbolColor)
                 .font(.system(size: 12, weight: .semibold))
+                // Spin the refresh symbol while we're in the post-start
+                // grace window for a previously-installed agent. The
+                // rotation stops automatically once `.connecting` resolves
+                // to `.current` (icon hidden) or `.expectedMissing` (icon
+                // becomes the warning triangle).
+                .symbolEffect(.rotate, options: .repeat(.continuous), isActive: status.isConnecting)
         }
         .buttonStyle(.plain)
         .help(helpText)
@@ -58,10 +64,11 @@ struct SidebarAgentStatusButton: View {
                     status: status,
                     onAction: {
                         switch status {
-                        case .current, .unresponsive:
+                        case .current, .unresponsive, .connecting:
                             // Done — just close. Nothing to install or update;
                             // an unresponsive agent will reset itself once the
-                            // heartbeat timeout fires.
+                            // heartbeat timeout fires, and a connecting agent
+                            // is already on the way.
                             break
                         case .waiting, .outdated, .expectedMissing:
                             onMount()
@@ -85,6 +92,10 @@ struct SidebarAgentStatusButton: View {
         switch status {
         case .waiting: "exclamationmark.circle.fill"
         case .outdated: "arrow.triangle.2.circlepath.circle.fill"
+        // Same refresh symbol as `.outdated`; a continuous-rotation
+        // `.symbolEffect` distinguishes "actively trying to connect" from
+        // "stationary update available."
+        case .connecting: "arrow.triangle.2.circlepath.circle.fill"
         case .current: "checkmark.circle.fill"
         case .unresponsive: "wifi.exclamationmark"
         // Triangle (vs the .waiting circle) signals "something went wrong"
@@ -98,6 +109,10 @@ struct SidebarAgentStatusButton: View {
         switch status {
         case .waiting: .secondary
         case .outdated: .orange
+        // Gray (not orange) — `.connecting` is informational, not an
+        // attention state. The rotation animation carries the "in
+        // progress" signal.
+        case .connecting: .secondary
         case .current: .green
         case .unresponsive: .orange
         case .expectedMissing: .orange
@@ -108,6 +123,7 @@ struct SidebarAgentStatusButton: View {
         switch status {
         case .waiting: "Guest agent not installed"
         case .outdated(let installed, let bundled): "Guest agent update available (\(installed) → \(bundled))"
+        case .connecting(let expected): "Connecting to guest agent (was \(expected))"
         case .current(let version): "Guest agent connected (\(version))"
         case .unresponsive(let version): "Guest agent unresponsive (\(version))"
         case .expectedMissing(let expected): "Guest agent didn't reconnect (was \(expected))"
@@ -171,7 +187,7 @@ struct AgentStatusPopoverContent: View {
         switch status {
         case .waiting: "Install Guest Agent…"
         case .outdated: "Update Guest Agent…"
-        case .current, .unresponsive: "Done"
+        case .current, .unresponsive, .connecting: "Done"
         case .expectedMissing: "Reinstall Guest Agent…"
         }
     }
@@ -224,6 +240,7 @@ enum AgentStatusPopoverMetrics {
         switch status {
         case .waiting: "Set up the Kernova guest agent"
         case .outdated: "Update available"
+        case .connecting: "Connecting to guest agent"
         case .current: "Guest agent connected"
         case .unresponsive: "Guest agent unresponsive"
         case .expectedMissing: "Guest agent didn't reconnect"
@@ -236,6 +253,8 @@ enum AgentStatusPopoverMetrics {
             return "The Kernova guest agent enables clipboard sync with \(vmName). Mounting the installer presents it as a disk inside the VM — open it in Finder and run install.command."
         case .outdated(let installed, let bundled):
             return "\(vmName) is running guest agent \(installed). Kernova bundles \(bundled). Mounting the installer presents it as a disk inside the VM — open it in Finder and run install.command."
+        case .connecting(let expected):
+            return "Waiting for guest agent \(expected) on \(vmName) to reconnect after boot. If it doesn't connect within a couple of minutes, you'll see a 'didn't reconnect' indicator with reinstall steps."
         case .current(let version):
             return "\(vmName) is connected with guest agent \(version)."
         case .unresponsive(let version):

--- a/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
@@ -10,15 +10,18 @@ import AppKit
 /// single notification surface for agent-driven features (clipboard sync today,
 /// drag/drop file copy and auto passthrough later).
 ///
-/// ## Why this uses NSPopover with an explicit contentSize
-/// SwiftUI's `.popover` modifier and `NSHostingController` with various
-/// `sizingOptions` both fail to size a multi-line-text popover correctly on
-/// macOS Tahoe — the body Text renders single-line and clips with an ellipsis.
-/// The fix is to bypass SwiftUI's sizing-up-to-host model entirely: measure
-/// the body text with `NSAttributedString.boundingRect`, set
-/// `popover.contentSize` to a known-good (width, computed-height), and let the
-/// SwiftUI view fill that bounded rectangle. Text wraps naturally to the
-/// bounded width with no `.frame(width:)` or `.fixedSize()` involved.
+/// ## Why this uses NSPopover with an explicit contentSize and AppKit text
+/// On macOS Tahoe, SwiftUI's `Text` does not reliably wrap inside an
+/// `NSHostingController` even with explicit `.frame(width:)` constraints —
+/// it renders single-line at its ideal width and overflows. The popover
+/// therefore:
+///   1. Pre-measures the body text with `NSAttributedString.boundingRect`
+///      and pins both `popover.contentSize` and the SwiftUI outer frame to
+///      that exact (width, height).
+///   2. Renders the wrapping body via `WrappingNSTextLabel`
+///      (`NSTextField(wrappingLabelWithString:)` bridged through
+///      `NSViewRepresentable`), which honors `preferredMaxLayoutWidth` and
+///      wraps reliably regardless of how SwiftUI propagates proposals.
 struct SidebarAgentStatusButton: View {
     let vmName: String
     let status: AgentStatus
@@ -103,39 +106,47 @@ struct SidebarAgentStatusButton: View {
 
 // MARK: - Popover content & metrics
 
-/// Body of the agent-status popover. Designed to **fill** its host (the
-/// popover's content area is sized externally by `AgentStatusPopoverMetrics`)
-/// rather than dictate its own size — `.frame(maxWidth: .infinity, …)` lets it
-/// expand into the bounded region, and Text wraps naturally to that width with
-/// no `.frame(width:)` or `.fixedSize()` modifiers needed.
+/// Body of the agent-status popover. The wrapping body text is rendered
+/// via `WrappingNSTextLabel` (an AppKit `NSTextField` wrapping label) because
+/// SwiftUI `Text` does not reliably wrap inside `NSHostingController` on
+/// macOS Tahoe even with explicit `.frame(width:)` and `.fixedSize(...)`.
 struct AgentStatusPopoverContent: View {
     let vmName: String
     let status: AgentStatus
     let onAction: () -> Void
 
     var body: some View {
+        let bodyWidth = AgentStatusPopoverMetrics.contentWidth
+            - AgentStatusPopoverMetrics.padding * 2
+        let size = AgentStatusPopoverMetrics.contentSize(forStatus: status, vmName: vmName)
+
         VStack(alignment: .leading, spacing: AgentStatusPopoverMetrics.verticalSpacing) {
             Text(AgentStatusPopoverMetrics.title(for: status))
                 .font(.headline)
+                .frame(width: bodyWidth, alignment: .leading)
 
-            Text(AgentStatusPopoverMetrics.bodyText(for: status, vmName: vmName))
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.leading)
+            WrappingNSTextLabel(
+                text: AgentStatusPopoverMetrics.bodyText(for: status, vmName: vmName),
+                font: .preferredFont(forTextStyle: .callout),
+                textColor: .secondaryLabelColor,
+                maxWidth: bodyWidth
+            )
+            .frame(width: bodyWidth, alignment: .leading)
 
             HStack {
                 Spacer()
                 Button(buttonTitle, action: onAction)
                     .keyboardShortcut(.defaultAction)
             }
+            .frame(width: bodyWidth)
         }
         .padding(AgentStatusPopoverMetrics.padding)
-        // Hard-pin width so the SwiftUI ideal width is exactly contentWidth.
-        // Without this the ideal width is the body Text's single-line width
-        // (huge), and NSHostingController publishes that as preferredContentSize,
-        // overriding popover.contentSize. The result was a wide popover with
-        // the body Text on one line clipped at the screen edge.
-        .frame(width: AgentStatusPopoverMetrics.contentWidth, alignment: .topLeading)
+        // Pin both width and height to the pre-measured contentSize so the
+        // SwiftUI view exactly fills the popover. Without an explicit height,
+        // SwiftUI's ideal height could fall below the popover's contentSize
+        // and NSHostingController would float the content inside the
+        // popover, clipping the title at the top edge.
+        .frame(width: size.width, height: size.height, alignment: .topLeading)
     }
 
     private var buttonTitle: String {
@@ -311,6 +322,41 @@ private struct NSPopoverAnchor<Content: View>: NSViewRepresentable {
             if isPresented.wrappedValue {
                 isPresented.wrappedValue = false
             }
+        }
+    }
+}
+
+// MARK: - Wrapping text label
+
+/// AppKit-backed multi-line wrapping label. SwiftUI's `Text` doesn't
+/// reliably wrap inside an `NSHostingController` on macOS Tahoe (it renders
+/// single-line at its ideal width and overflows), so the popover renders
+/// the wrapping body string through `NSTextField(wrappingLabelWithString:)`
+/// instead. AppKit's `preferredMaxLayoutWidth` property does what
+/// SwiftUI's `.frame(width:)` should: caps the line width and produces a
+/// correct intrinsic content size for the wrapped layout.
+struct WrappingNSTextLabel: NSViewRepresentable {
+    let text: String
+    let font: NSFont
+    let textColor: NSColor
+    let maxWidth: CGFloat
+
+    func makeNSView(context: Context) -> NSTextField {
+        let field = NSTextField(wrappingLabelWithString: text)
+        field.font = font
+        field.textColor = textColor
+        field.preferredMaxLayoutWidth = maxWidth
+        field.setContentHuggingPriority(.required, for: .vertical)
+        field.setContentCompressionResistancePriority(.required, for: .vertical)
+        return field
+    }
+
+    func updateNSView(_ nsView: NSTextField, context: Context) {
+        if nsView.stringValue != text { nsView.stringValue = text }
+        if nsView.font != font { nsView.font = font }
+        if nsView.textColor != textColor { nsView.textColor = textColor }
+        if nsView.preferredMaxLayoutWidth != maxWidth {
+            nsView.preferredMaxLayoutWidth = maxWidth
         }
     }
 }

--- a/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
@@ -26,6 +26,11 @@ struct SidebarAgentStatusButton: View {
     let vmName: String
     let status: AgentStatus
     let onMount: () -> Void
+    /// Optional opt-out callback. Wired only for `.waiting` — the other
+    /// states (`.outdated`, `.unresponsive`, `.expectedMissing`) are not
+    /// dismissable because they imply something more urgent than "you could
+    /// install this."
+    let onDismiss: (() -> Void)?
 
     @State private var isPopoverPresented = false
 
@@ -62,6 +67,12 @@ struct SidebarAgentStatusButton: View {
                             onMount()
                         }
                         isPopoverPresented = false
+                    },
+                    onDismiss: onDismiss.map { dismiss in
+                        {
+                            dismiss()
+                            isPopoverPresented = false
+                        }
                     }
                 )
             }
@@ -114,6 +125,9 @@ struct AgentStatusPopoverContent: View {
     let vmName: String
     let status: AgentStatus
     let onAction: () -> Void
+    /// When non-nil, a "Don't show again" button is rendered at the
+    /// bottom-leading edge of the action row.
+    let onDismiss: (() -> Void)?
 
     var body: some View {
         let bodyWidth = AgentStatusPopoverMetrics.contentWidth
@@ -134,6 +148,10 @@ struct AgentStatusPopoverContent: View {
             .frame(width: bodyWidth, alignment: .leading)
 
             HStack {
+                if let onDismiss {
+                    Button("Don't show again", action: onDismiss)
+                        .buttonStyle(.link)
+                }
                 Spacer()
                 Button(buttonTitle, action: onAction)
                     .keyboardShortcut(.defaultAction)
@@ -368,7 +386,8 @@ struct WrappingNSTextLabel: NSViewRepresentable {
     SidebarAgentStatusButton(
         vmName: "Sequoia Dev",
         status: .waiting,
-        onMount: {}
+        onMount: {},
+        onDismiss: {}
     )
     .padding(40)
 }
@@ -377,7 +396,8 @@ struct WrappingNSTextLabel: NSViewRepresentable {
     SidebarAgentStatusButton(
         vmName: "Sequoia Dev",
         status: .outdated(installed: "0.9.1", bundled: "0.9.2"),
-        onMount: {}
+        onMount: {},
+        onDismiss: nil
     )
     .padding(40)
 }
@@ -386,7 +406,8 @@ struct WrappingNSTextLabel: NSViewRepresentable {
     SidebarAgentStatusButton(
         vmName: "Sequoia Dev",
         status: .current(version: "0.9.2"),
-        onMount: {}
+        onMount: {},
+        onDismiss: nil
     )
     .padding(40)
 }
@@ -395,7 +416,8 @@ struct WrappingNSTextLabel: NSViewRepresentable {
     SidebarAgentStatusButton(
         vmName: "Sequoia Dev",
         status: .unresponsive(version: "0.9.2"),
-        onMount: {}
+        onMount: {},
+        onDismiss: nil
     )
     .padding(40)
 }
@@ -404,7 +426,8 @@ struct WrappingNSTextLabel: NSViewRepresentable {
     SidebarAgentStatusButton(
         vmName: "Sequoia Dev",
         status: .expectedMissing(expected: "0.9.2"),
-        onMount: {}
+        onMount: {},
+        onDismiss: nil
     )
     .padding(40)
 }
@@ -415,7 +438,8 @@ struct WrappingNSTextLabel: NSViewRepresentable {
     AgentStatusPopoverContent(
         vmName: "Sequoia Dev",
         status: .waiting,
-        onAction: {}
+        onAction: {},
+        onDismiss: {}
     )
     .frame(
         width: AgentStatusPopoverMetrics.contentSize(forStatus: .waiting, vmName: "Sequoia Dev").width,
@@ -427,7 +451,8 @@ struct WrappingNSTextLabel: NSViewRepresentable {
     AgentStatusPopoverContent(
         vmName: "Sequoia Dev",
         status: .outdated(installed: "0.9.1", bundled: "0.9.2"),
-        onAction: {}
+        onAction: {},
+        onDismiss: nil
     )
     .frame(
         width: AgentStatusPopoverMetrics.contentSize(forStatus: .outdated(installed: "0.9.1", bundled: "0.9.2"), vmName: "Sequoia Dev").width,
@@ -439,7 +464,8 @@ struct WrappingNSTextLabel: NSViewRepresentable {
     AgentStatusPopoverContent(
         vmName: "Sequoia Dev",
         status: .current(version: "0.9.2"),
-        onAction: {}
+        onAction: {},
+        onDismiss: nil
     )
     .frame(
         width: AgentStatusPopoverMetrics.contentSize(forStatus: .current(version: "0.9.2"), vmName: "Sequoia Dev").width,
@@ -451,7 +477,8 @@ struct WrappingNSTextLabel: NSViewRepresentable {
     AgentStatusPopoverContent(
         vmName: "Sequoia Dev",
         status: .expectedMissing(expected: "0.9.2"),
-        onAction: {}
+        onAction: {},
+        onDismiss: nil
     )
     .frame(
         width: AgentStatusPopoverMetrics.contentSize(forStatus: .expectedMissing(expected: "0.9.2"), vmName: "Sequoia Dev").width,
@@ -463,7 +490,8 @@ struct WrappingNSTextLabel: NSViewRepresentable {
     AgentStatusPopoverContent(
         vmName: "My Very Long macOS Sequoia Development VM Name",
         status: .outdated(installed: "0.9.1", bundled: "0.9.2"),
-        onAction: {}
+        onAction: {},
+        onDismiss: nil
     )
     .frame(
         width: AgentStatusPopoverMetrics.contentSize(forStatus: .outdated(installed: "0.9.1", bundled: "0.9.2"), vmName: "My Very Long macOS Sequoia Development VM Name").width,

--- a/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
@@ -411,6 +411,12 @@ struct WrappingNSTextLabel: NSViewRepresentable {
         if nsView.preferredMaxLayoutWidth != maxWidth {
             nsView.preferredMaxLayoutWidth = maxWidth
         }
+        // Notify the layout system that the intrinsic size may have
+        // changed (text/font/maxWidth all affect it). The current popover
+        // pins its outer frame to a pre-measured size and ignores the
+        // intrinsic value, so this is effectively a no-op there — but it
+        // keeps the component correct if reused in a flexible container.
+        nsView.invalidateIntrinsicContentSize()
     }
 }
 

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -20,6 +20,9 @@ struct SidebarView: View {
                         },
                         onMountAgentInstaller: {
                             viewModel.mountGuestAgentInstaller(on: instance)
+                        },
+                        onDismissAgentInstallNudge: {
+                            viewModel.dismissAgentInstallNudge(for: instance)
                         }
                     )
                     .tag(instance.id)

--- a/Kernova/Views/Sidebar/VMRowView.swift
+++ b/Kernova/Views/Sidebar/VMRowView.swift
@@ -7,6 +7,7 @@ struct VMRowView: View {
     var onCommitRename: (String) -> Void = { _ in }
     var onCancelRename: () -> Void = {}
     var onMountAgentInstaller: () -> Void = {}
+    var onDismissAgentInstallNudge: () -> Void = {}
 
     @State private var editingName: String = ""
     @FocusState private var isTextFieldFocused: Bool
@@ -46,7 +47,8 @@ struct VMRowView: View {
                 SidebarAgentStatusButton(
                     vmName: instance.name,
                     status: agentStatus,
-                    onMount: onMountAgentInstaller
+                    onMount: onMountAgentInstaller,
+                    onDismiss: agentStatus == .waiting ? onDismissAgentInstallNudge : nil
                 )
             }
 
@@ -87,14 +89,23 @@ struct VMRowView: View {
     ///   seen the agent on this VM (`lastSeenAgentVersion != nil`). In that
     ///   case the `.waiting` badge would just nag — the version is safely
     ///   persisted and the live state will resurface on next start.
+    /// - Status is `.waiting` and the user has explicitly dismissed the
+    ///   install nudge for this VM
+    ///   (`configuration.agentInstallNudgeDismissed`).
     ///
     /// `.waiting`, `.outdated`, `.unresponsive`, and `.expectedMissing` are
-    /// surfaced when applicable so the user has something to act on.
+    /// surfaced when applicable so the user has something to act on. Only
+    /// `.waiting` is suppressible — the others imply something more urgent
+    /// than "you could install this."
     private var visibleAgentStatus: AgentStatus? {
         guard instance.configuration.guestOS == .macOS else { return nil }
         guard instance.installState == nil else { return nil }
         let status = instance.agentStatus
         if case .current = status { return nil }
+        if case .waiting = status,
+           instance.configuration.agentInstallNudgeDismissed {
+            return nil
+        }
         // For stopped / cold-paused VMs we'd otherwise show `.waiting`. If
         // the agent has previously connected, suppress that nudge — we only
         // want to surface live-session signals (`.outdated` / `.unresponsive`

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -675,6 +675,50 @@ struct VMConfigurationTests {
         #expect(config.lastSeenAgentVersion == nil)
     }
 
+    // MARK: - agentInstallNudgeDismissed Tests
+
+    @Test("Default agentInstallNudgeDismissed is false")
+    func defaultAgentInstallNudgeDismissed() {
+        let config = VMConfiguration(
+            name: "Test VM",
+            guestOS: .macOS,
+            bootMode: .macOS
+        )
+        #expect(config.agentInstallNudgeDismissed == false)
+    }
+
+    @Test("Configuration round-trips agentInstallNudgeDismissed")
+    func agentInstallNudgeDismissedRoundTrip() throws {
+        let config = VMConfiguration(
+            name: "Dismissed VM",
+            guestOS: .macOS,
+            bootMode: .macOS,
+            agentInstallNudgeDismissed: true
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(config)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: data)
+
+        #expect(decoded.agentInstallNudgeDismissed == true)
+    }
+
+    @Test("Missing agentInstallNudgeDismissed decodes as false (existing-VM migration)")
+    func missingAgentInstallNudgeDismissedDecodesFalse() throws {
+        // Older configs predate the field — they must still decode, with the
+        // flag defaulting to off so the install nudge keeps surfacing for
+        // VMs the user has never actively dismissed.
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let config = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
+
+        #expect(config.agentInstallNudgeDismissed == false)
+    }
+
     // MARK: - microphoneEnabled Tests
 
     @Test("Default microphoneEnabled is false")

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -568,12 +568,13 @@ struct VMInstanceTests {
         #expect(instance.vsockClipboardListenerHost == nil)
     }
 
-    @Test("VMConfiguration.hotToggleFields covers both runtime-editable booleans")
+    @Test("VMConfiguration.hotToggleFields covers all runtime-editable booleans")
     func hotToggleFieldsCovered() {
         let fields = VMConfiguration.hotToggleFields
-        #expect(fields.count == 2)
+        #expect(fields.count == 3)
         #expect(fields.contains(\.agentLogForwardingEnabled))
         #expect(fields.contains(\.clipboardSharingEnabled))
+        #expect(fields.contains(\.agentInstallNudgeDismissed))
     }
 
     // MARK: - Agent Post-Start Watchdog
@@ -709,6 +710,44 @@ struct VMInstanceTests {
 
         try await Task.sleep(for: Self.testWatchdogGrace * 3)
         #expect(instance.agentExpectedButMissing == false)
+    }
+
+    @Test("Watchdog firing also clears a previously-dismissed install nudge and persists the change")
+    func watchdogClearsAgentInstallNudgeDismissed() async throws {
+        // Scenario: user previously installed the agent (lastSeenAgentVersion
+        // set) and earlier dismissed the install nudge for this VM. The
+        // agent now fails to reconnect after boot; the watchdog fires
+        // .expectedMissing AND resets the dismissed flag so any future
+        // .waiting (e.g. they wipe + reinstall the VM) is not silently
+        // suppressed by their old preference.
+        let instance = makeMacOSInstanceWithAgentInstalled()
+        instance.configuration.agentInstallNudgeDismissed = true
+
+        var persistCallCount = 0
+        instance.onConfigurationDidChange = { _ in persistCallCount += 1 }
+
+        instance.startAgentPostStartWatchdog(grace: Self.testWatchdogGrace)
+
+        try await waitUntil {
+            instance.agentExpectedButMissing
+        }
+        #expect(instance.configuration.agentInstallNudgeDismissed == false)
+        #expect(persistCallCount == 1)
+    }
+
+    @Test("Watchdog firing leaves an undismissed nudge alone (no spurious persist)")
+    func watchdogDoesNotPersistWhenDismissalAlreadyClear() async throws {
+        let instance = makeMacOSInstanceWithAgentInstalled()
+        // Default: agentInstallNudgeDismissed == false
+        var persistCallCount = 0
+        instance.onConfigurationDidChange = { _ in persistCallCount += 1 }
+
+        instance.startAgentPostStartWatchdog(grace: Self.testWatchdogGrace)
+
+        try await waitUntil {
+            instance.agentExpectedButMissing
+        }
+        #expect(persistCallCount == 0)
     }
 
     @Test("tearDownSession clears agentExpectedButMissing and cancels the watchdog")


### PR DESCRIPTION
## Summary
A focused pass on the sidebar guest-agent indicators — fixing a popover layout regression and reshaping the install/connect nudges so they stop misfiring at users with a previously-installed agent.

Closes #190

## Changes

**Popover layout fix** (\`adfaecb\`)
- Body text in \`SidebarAgentStatusButton\`'s \`NSPopover\` rendered single-line and clipped on macOS Tahoe even with explicit \`.frame(width:)\`. SwiftUI \`Text\` does not reliably wrap inside \`NSHostingController\` on Tahoe.
- Replaced the body \`Text\` with \`WrappingNSTextLabel\` (\`NSTextField(wrappingLabelWithString:)\` bridged through \`NSViewRepresentable\`); pinned the outer SwiftUI frame to both the measured width and height.

**Per-VM install-nudge dismiss** (\`9011c2c\`)
- New \`VMConfiguration.agentInstallNudgeDismissed: Bool\` (persisted, back-compat decode).
- \"Don't show again\" link button on the \`.waiting\` popover only — \`.outdated\`, \`.unresponsive\`, and \`.expectedMissing\` remain non-dismissable.
- \`VMRowView.visibleAgentStatus\` suppresses the icon when the flag is set.

**Reset paths for the dismissal** (\`8e23e23\`)
- \"Show install reminder\" toggle in VM Settings → Guest Agent.
- Auto-reset of the dismissal when the post-start watchdog fires \`.expectedMissing\` (a previously-installed agent disappearing is a louder signal than the gentle nudge).
- Added \`agentInstallNudgeDismissed\` to \`VMConfiguration.hotToggleFields\` so the toggle works while the VM is running.

**Rotating \"connecting\" indicator** (\`b2286e9\`)
- New synthesized \`AgentStatus.connecting(expected:)\` case for live sessions where \`lastSeenAgentVersion != nil\` and no Hello has arrived yet.
- Sidebar shows the existing \`arrow.triangle.2.circlepath.circle.fill\` symbol with \`.symbolEffect(.rotate, options: .repeat(.continuous))\` — gray (informational), not orange.
- Resolves to \`.current\` (icon hidden) on Hello, or \`.expectedMissing\` (orange triangle) if the watchdog fires.
- Replaces the prior immediate-\`.waiting\`-during-boot misfire that this branch was opened to address.

## Test plan
- [x] All \`KernovaTests\` pass on macOS 26 (incl. 5 new tests covering the persisted field, watchdog auto-reset, and \`hotToggleFields\` coverage)
- [x] Manual: popover body wraps correctly with title fully visible
- [x] Manual: \"Don't show again\" hides icon for that VM and survives relaunch
- [x] Manual: Settings toggle re-enables the icon mid-session
- [x] Manual: Starting a VM with prior agent shows rotating refresh icon during boot; resolves correctly to connected/missing