### PR TITLE
fix: Stop sidebar agent rotation hanging the main thread

### DIFF
--- a/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
@@ -54,6 +54,7 @@ struct SidebarAgentStatusButton: View {
             if status.isConnecting && !reduceMotion {
                 ProgressView()
                     .controlSize(.mini)
+                    .tint(symbolColor)
             } else {
                 Image(systemName: symbolName)
                     .foregroundStyle(symbolColor)

--- a/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
@@ -39,23 +39,26 @@ struct SidebarAgentStatusButton: View {
         Button {
             isPopoverPresented.toggle()
         } label: {
-            Image(systemName: symbolName)
-                .foregroundStyle(symbolColor)
-                .font(.system(size: 12, weight: .semibold))
-                // Spin the refresh symbol while we're in the post-start
-                // grace window for a previously-installed agent. The
-                // rotation stops automatically once `.connecting` resolves
-                // to `.current` (icon hidden) or `.expectedMissing` (icon
-                // becomes the warning triangle). Gated on
-                // `accessibilityReduceMotion` so users who've disabled
-                // motion in System Settings see a static icon — the gray
-                // color (vs. orange `.outdated`) still differentiates the
-                // state, and the popover/help text carry the meaning.
-                .symbolEffect(
-                    .rotate,
-                    options: .repeat(.continuous),
-                    isActive: status.isConnecting && !reduceMotion
-                )
+            // RATIONALE: An earlier version used
+            // `.symbolEffect(.rotate, options: .repeat(.continuous))` on
+            // the SF Symbol while `.connecting`. On macOS Tahoe that
+            // modifier re-ran the SwiftUI view graph (and re-laid out
+            // the sidebar) every animation tick, generating enough CA
+            // commits to backlog the render server and freeze the main
+            // thread for the entire post-start grace window — often
+            // 10s+ after login. `ProgressView` uses
+            // `NSProgressIndicator` under the hood; it animates in
+            // Core Animation without invalidating SwiftUI. Reduce
+            // motion still falls through to the static icon, matching
+            // the prior behavior.
+            if status.isConnecting && !reduceMotion {
+                ProgressView()
+                    .controlSize(.mini)
+            } else {
+                Image(systemName: symbolName)
+                    .foregroundStyle(symbolColor)
+                    .font(.system(size: 12, weight: .semibold))
+            }
         }
         .buttonStyle(.plain)
         .help(helpText)


### PR DESCRIPTION
## Summary
- Multi-second post-login hangs were caused by the sidebar's rotating agent-status icon while the agent was `.connecting`. The `.symbolEffect(.rotate, options: .repeat(.continuous))` modifier re-ran the SwiftUI view graph every animation tick, generating CA commits faster than the render server could drain — main thread blocked in `[CAContext waitForCommitId:timeout:]` for the entire post-start grace window (often 10s+ after login).
- Replace with a conditional `ProgressView().controlSize(.mini)`, which bridges to `NSProgressIndicator` and animates in CA layers without invalidating the SwiftUI view graph.

## Investigation
Hang was localized via lldb during a live freeze. Three `bt all` samples showed:
- Two samples with the main thread parked in `[CAContext waitForCommitId:timeout:]` inside `stepIdle` (render-server backlog symptom).
- One sample with the main thread deep in `Image.Resolved.mustUpdate` → `ViewGraph.updateOutputs` → ~15 levels of recursive `[NSView _layoutSubtreeWithOldSize:]` under `NSHostingView.layout()` (the actual cause — SwiftUI view graph re-evaluation per animation tick).

Confirmation: enabling **System Settings → Accessibility → Reduce Motion** eliminated the hang because the existing `isActive: status.isConnecting && \!reduceMotion` guard already short-circuited the effect under reduce-motion.

## Changes
- `Kernova/Views/Sidebar/SidebarAgentStatusButton.swift` — replace the rotating `.symbolEffect` with a conditional `ProgressView().controlSize(.mini)` for `.connecting` + non-reduceMotion. Reduce-motion users still see the static refresh SF Symbol — same prior behavior.
- `RATIONALE:` comment captures the regression history so the symbol-effect pattern doesn't get reintroduced in a future PR.

## Test plan
- [x] Debug build succeeds
- [x] Full test suite passes
- [x] Manual: sidebar shows mini spinner during `.connecting`, desktop is responsive throughout the post-start window
- [x] Manual: reduce motion still shows the static refresh icon
- [x] Manual: `.connecting` → `.current` transition hides the indicator cleanly (no orphan spinner)

## Notes
- The full sidebar → AppKit migration is tracked separately as #195. This patch is the surgical mitigation; the larger refactor will replace the sidebar's SwiftUI hosting entirely so future trailing accessories can use animated `NSImageView`/`NSButton` directly without the `NSHostingView → SwiftUI → NSViewRepresentable → NSView` "double bridge" pattern.
- The `.symbolEffect(.rotate, options: .repeat(.continuous))` pattern is the textbook recommendation in every public tutorial. There is no Apple documentation, FB ticket, or release note connecting it to render-server backpressure inside `NSHostingView`. Adopting "default to `ProgressView` for indeterminate state" as a project habit is the durable lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)