### PR TITLE
Add Makefile + fix Xcode IDE build version

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,6 +23,10 @@ xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=mac
 
 The `-derivedDataPath DerivedData` flag ensures build output goes to a deterministic local `DerivedData/` directory (already gitignored) instead of the per-path-hashed `~/Library/Developer/Xcode/DerivedData/` location. This avoids glob ambiguity when worktrees or parallel builds create multiple DerivedData folders. Xcode itself still uses the per-user default — they don't need to share.
 
+### Build version
+
+`CFBundleVersion` is `git rev-list --count HEAD` (the total commit count), substituted into the source `Info.plist` via `INFOPLIST_PREPROCESS`. The `Set Build Number from Git` build phase generates `KernovaBuildNumber.h` with `#define KERNOVA_BUILD_NUMBER N`, and `Kernova/App/Info.plist` references the symbol directly (`<string>KERNOVA_BUILD_NUMBER</string>`). Substitution happens inside `ProcessInfoPlistFile` so build-graph reordering can't clobber it. The `KernovaGuestAgent` target uses the same pattern with its own `AGENT_BUILD_NUMBER` (scoped to `git rev-list --count HEAD -- KernovaGuestAgent/`). When adding a new top-level target that needs a dynamic build number, replicate this pattern instead of patching the built `Info.plist` after the fact.
+
 Requires **macOS 26 (Tahoe)**, **Xcode 26**, **Swift 6**, and **Apple Silicon** (for macOS guest support). The app uses the `com.apple.security.virtualization` entitlement.
 
 ## Architecture

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,20 +6,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build & Test
 
-This is an Xcode project (not Swift Package Manager). Build and test via `xcodebuild`:
+This is an Xcode project (not Swift Package Manager). Inside Xcode, use ⌘B / ⌘U as normal. From the terminal, prefer the `Makefile` wrapper:
 
 ```bash
-# Build
-xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=macOS' -derivedDataPath DerivedData build
-
-# Run tests
-xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=macOS' -derivedDataPath DerivedData test
-
-# Run a single test suite
-xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=macOS' -derivedDataPath DerivedData test -only-testing:KernovaTests/VMConfigurationTests
+make build               # Build for macOS
+make test                # Run the full test suite
+make test-suite SUITE=VMConfigurationTests   # Run a single suite
+make clean               # Remove DerivedData/
 ```
 
-The `-derivedDataPath DerivedData` flag ensures build output goes to a deterministic local `DerivedData/` directory (already gitignored) instead of the per-path-hashed `~/Library/Developer/Xcode/DerivedData/` location. This avoids glob ambiguity when worktrees or parallel builds create multiple DerivedData folders.
+The Makefile wraps the canonical `xcodebuild` invocation:
+
+```bash
+xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=macOS' -derivedDataPath DerivedData <build|test>
+```
+
+The `-derivedDataPath DerivedData` flag ensures build output goes to a deterministic local `DerivedData/` directory (already gitignored) instead of the per-path-hashed `~/Library/Developer/Xcode/DerivedData/` location. This avoids glob ambiguity when worktrees or parallel builds create multiple DerivedData folders. Xcode itself still uses the per-user default — they don't need to share.
 
 Requires **macOS 26 (Tahoe)**, **Xcode 26**, **Swift 6**, and **Apple Silicon** (for macOS guest support). The app uses the `com.apple.security.virtualization` entitlement.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@ This is an Xcode project (not Swift Package Manager). Inside Xcode, use âŒ˜B / â
 ```bash
 make build               # Build for macOS
 make test                # Run the full test suite
-make test-suite SUITE=VMConfigurationTests   # Run a single suite
+make test-suite SUITE=KernovaTests/VMConfigurationTests   # Run a single suite (Target/Suite form)
 make clean               # Remove DerivedData/
 ```
 

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -197,10 +197,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A1000030 /* Build configuration list for PBXNativeTarget "Kernova" */;
 			buildPhases = (
+				A10000D0 /* Set Build Number from Git */,
 				A1000040 /* Sources */,
 				A1000010 /* Frameworks */,
 				A1000050 /* Resources */,
-				A10000D0 /* Set Build Number from Git */,
 				A100010A /* Embed Helpers */,
 				A100020A /* Package Guest Agent DMG */,
 			);
@@ -407,10 +407,11 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/KernovaBuildNumber.h",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "BUILD_NUMBER=$(git rev-list --count HEAD)\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $BUILD_NUMBER\" \"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"\n";
+			shellScript = "set -euo pipefail\nBUILD_NUMBER=$(git -C \"${SRCROOT}\" rev-list --count HEAD)\nif [ -z \"${BUILD_NUMBER}\" ]; then\n    echo \"error: Could not determine app build number from git history\" >&2\n    exit 1\nfi\nmkdir -p \"${DERIVED_FILE_DIR}\"\necho \"#define KERNOVA_BUILD_NUMBER ${BUILD_NUMBER}\" > \"${DERIVED_FILE_DIR}/KernovaBuildNumber.h\"\n";
 		};
 		A100020A /* Package Guest Agent DMG */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -454,7 +455,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\nBUILD_NUMBER=$(git rev-list --count HEAD -- KernovaGuestAgent/)\nif [ -z \"${BUILD_NUMBER}\" ]; then\n    echo \"error: Could not determine agent build number from git history\" >&2\n    exit 1\nfi\nmkdir -p \"${DERIVED_FILE_DIR}\"\necho \"#define AGENT_BUILD_NUMBER ${BUILD_NUMBER}\" > \"${DERIVED_FILE_DIR}/AgentBuildNumber.h\"\n";
+			shellScript = "set -euo pipefail\nBUILD_NUMBER=$(git -C \"${SRCROOT}\" rev-list --count HEAD -- KernovaGuestAgent/)\nif [ -z \"${BUILD_NUMBER}\" ]; then\n    echo \"error: Could not determine agent build number from git history\" >&2\n    exit 1\nfi\nmkdir -p \"${DERIVED_FILE_DIR}\"\necho \"#define AGENT_BUILD_NUMBER ${BUILD_NUMBER}\" > \"${DERIVED_FILE_DIR}/AgentBuildNumber.h\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -657,6 +658,8 @@
 				INFOPLIST_FILE = Kernova/App/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright 2025 Kernova. All rights reserved.";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
+				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/KernovaBuildNumber.h";
+				INFOPLIST_PREPROCESS = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -682,6 +685,8 @@
 				INFOPLIST_FILE = Kernova/App/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright 2025 Kernova. All rights reserved.";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
+				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/KernovaBuildNumber.h";
+				INFOPLIST_PREPROCESS = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/Kernova/App/Info.plist
+++ b/Kernova/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>KERNOVA_BUILD_NUMBER</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSPrincipalClass</key>

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ help:
 	@printf 'Kernova build targets:\n\n'
 	@printf '  make build               Build the app for macOS\n'
 	@printf '  make test                Run the full test suite\n'
-	@printf '  make test-suite SUITE=X  Run a single test suite\n'
-	@printf '                           (e.g. SUITE=VMConfigurationTests)\n'
+	@printf '  make test-suite SUITE=X  Run a single test suite (Target/Suite form)\n'
+	@printf '                           (e.g. SUITE=KernovaTests/VMConfigurationTests)\n'
 	@printf '  make clean               Remove the DerivedData directory\n'
 
 build:
@@ -33,10 +33,11 @@ test:
 
 test-suite:
 	@if [ -z "$(SUITE)" ]; then \
-		echo 'Usage: make test-suite SUITE=<TestSuiteName>' >&2; \
+		echo 'Usage: make test-suite SUITE=<Target/Suite>' >&2; \
+		echo 'Example: make test-suite SUITE=KernovaTests/VMConfigurationTests' >&2; \
 		exit 2; \
 	fi
-	xcodebuild $(XCODEBUILD_FLAGS) test -only-testing:KernovaTests/$(SUITE)
+	xcodebuild $(XCODEBUILD_FLAGS) test -only-testing:$(SUITE)
 
 clean:
 	rm -rf $(DERIVED_DATA)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# Kernova build & test invocations.
+#
+# These targets wrap the canonical `xcodebuild` calls documented in
+# .claude/CLAUDE.md. Inside Xcode, just use the IDE (CMD-B / CMD-U); this
+# Makefile is for terminal, CI, and tooling use.
+
+PROJECT      := Kernova.xcodeproj
+SCHEME       := Kernova
+DESTINATION  := platform=macOS
+DERIVED_DATA := DerivedData
+
+XCODEBUILD_FLAGS := -project $(PROJECT) \
+                    -scheme $(SCHEME) \
+                    -destination '$(DESTINATION)' \
+                    -derivedDataPath $(DERIVED_DATA)
+
+.DEFAULT_GOAL := help
+.PHONY: help build test test-suite clean
+
+help:
+	@printf 'Kernova build targets:\n\n'
+	@printf '  make build               Build the app for macOS\n'
+	@printf '  make test                Run the full test suite\n'
+	@printf '  make test-suite SUITE=X  Run a single test suite\n'
+	@printf '                           (e.g. SUITE=VMConfigurationTests)\n'
+	@printf '  make clean               Remove the DerivedData directory\n'
+
+build:
+	xcodebuild $(XCODEBUILD_FLAGS) build
+
+test:
+	xcodebuild $(XCODEBUILD_FLAGS) test
+
+test-suite:
+	@if [ -z "$(SUITE)" ]; then \
+		echo 'Usage: make test-suite SUITE=<TestSuiteName>' >&2; \
+		exit 2; \
+	fi
+	xcodebuild $(XCODEBUILD_FLAGS) test -only-testing:KernovaTests/$(SUITE)
+
+clean:
+	rm -rf $(DERIVED_DATA)


### PR DESCRIPTION
## Summary

Two related changes for build tooling:

1. **`chore: Add Makefile for terminal build & test entry`** — wraps the canonical `xcodebuild` invocation behind `make build` / `make test` / `make test-suite SUITE=…` / `make clean`. Inside Xcode, ⌘B / ⌘U continue to work unchanged; this is for terminal/CI use only.

2. **`fix: Stamp CFBundleVersion via INFOPLIST_PREPROCESS so Xcode IDE builds match CLI`** — when building from Xcode (⌘B / ⌘R), the About panel showed `Version 0.9.0 (1 | Debug)` instead of the git commit count. CLI builds (`xcodebuild`) were correct. Root cause: in incremental builds, Xcode deferred the final `builtin-infoPlistUtility` merge until after `actool` produced `assetcatalog_generated_info.plist`. That merge ran *after* our post-Resources `PlistBuddy` patch and re-substituted `$(CURRENT_PROJECT_VERSION) → 1`, clobbering our value. Switched to the same `INFOPLIST_PREPROCESS` + generated header pattern the `KernovaGuestAgent` target already uses, so substitution happens *inside* `ProcessInfoPlistFile` and can't be reordered around.

## Test plan

- [x] `make help` lists targets, `make build` succeeds, `make test` passes
- [x] Clean Xcode IDE build → About panel shows `Version 0.9.0 (<git commit count> | Debug)`
- [x] Incremental Xcode IDE build (Run button) → CFBundleVersion stays at git commit count
- [x] CLI `xcodebuild build` still produces correct CFBundleVersion (no regression)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)