### PR TITLE
chore: Add weekly Periphery dead-code scan

### DIFF
--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -1,0 +1,149 @@
+name: Dead Code Scan
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'  # Mondays 14:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    runs-on: macos-26
+    timeout-minutes: 30
+    env:
+      PERIPHERY_VERSION: 3.7.4
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          xcodebuild -version
+          echo "XCODE_BUILD=$(xcodebuild -version | awk '/Build version/ {print $3}')" >> "$GITHUB_ENV"
+
+      - name: Cache Periphery binary
+        id: cache-periphery
+        uses: actions/cache@v5
+        with:
+          path: /usr/local/bin/periphery
+          key: periphery-${{ env.PERIPHERY_VERSION }}-${{ runner.os }}
+
+      - name: Install Periphery
+        if: steps.cache-periphery.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/peripheryapp/periphery/releases/download/${PERIPHERY_VERSION}/periphery-${PERIPHERY_VERSION}.zip" -o /tmp/periphery.zip
+          unzip -o /tmp/periphery.zip -d /tmp/periphery-extract
+          sudo mv /tmp/periphery-extract/periphery /usr/local/bin/periphery
+          sudo chmod +x /usr/local/bin/periphery
+          periphery version
+
+      - name: Cache SwiftPM checkouts
+        uses: actions/cache@v5
+        with:
+          path: DerivedData/SourcePackages
+          key: ${{ runner.os }}-spm-${{ env.XCODE_BUILD }}-${{ hashFiles('Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+
+      - name: Run Periphery scan
+        id: scan
+        run: |
+          set +e
+          periphery scan \
+            --xcargs "-skipPackagePluginValidation -derivedDataPath DerivedData CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES COMPILER_INDEX_STORE_ENABLE=YES" \
+            > scan-output.txt 2> scan-stderr.txt
+          PERIPHERY_EXIT=$?
+          set -e
+
+          if [ "$PERIPHERY_EXIT" -ne 0 ]; then
+            echo "::error::Periphery exited with code $PERIPHERY_EXIT"
+            echo "--- stderr ---"
+            cat scan-stderr.txt
+            echo "--- stdout (first 200 lines) ---"
+            head -200 scan-output.txt
+            exit "$PERIPHERY_EXIT"
+          fi
+
+          findings=$(grep -cE ":[0-9]+:[0-9]+: warning:" scan-output.txt || true)
+          echo "findings=$findings" >> "$GITHUB_OUTPUT"
+          echo "Periphery surfaced $findings finding(s)"
+
+          if [ "$findings" -gt 0 ]; then
+            echo "--- Findings ---"
+            cat scan-output.txt
+          fi
+
+      - name: Upload scan output
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: periphery-scan
+          path: |
+            scan-output.txt
+            scan-stderr.txt
+          retention-days: 14
+
+      - name: Manage tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FINDINGS: ${{ steps.scan.outputs.findings }}
+        run: |
+          set -euo pipefail
+
+          ISSUE_NUMBER=$(gh issue list \
+            --label "review-debt/dead-code" \
+            --state all \
+            --limit 1 \
+            --json number,title \
+            --jq 'map(select(.title | startswith("Dead-code scan"))) | .[0].number // empty')
+
+          if [ "$FINDINGS" -eq 0 ]; then
+            if [ -n "$ISSUE_NUMBER" ]; then
+              STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state')
+              if [ "$STATE" = "OPEN" ]; then
+                gh issue comment "$ISSUE_NUMBER" \
+                  --body "Scan ran clean on $(date -u +%Y-%m-%dT%H:%MZ) — closing. Reopened automatically when new findings appear."
+                gh issue close "$ISSUE_NUMBER"
+              fi
+            fi
+            exit 0
+          fi
+
+          BODY_FILE=$(mktemp)
+          {
+            echo "Last scan: $(date -u +%Y-%m-%dT%H:%MZ) — **$FINDINGS finding(s)**"
+            echo
+            echo "Auto-managed by [\`.github/workflows/dead-code.yml\`](.github/workflows/dead-code.yml). Runs weekly (Mondays 14:00 UTC) and on \`workflow_dispatch\`. Closes automatically on the next clean run."
+            echo
+            echo "<details><summary>Periphery output</summary>"
+            echo
+            echo '```'
+            cat scan-output.txt
+            echo '```'
+            echo
+            echo "</details>"
+          } > "$BODY_FILE"
+
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue edit "$ISSUE_NUMBER" \
+              --title "Dead-code scan: $FINDINGS finding(s)" \
+              --body-file "$BODY_FILE"
+            STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state')
+            if [ "$STATE" = "CLOSED" ]; then
+              gh issue reopen "$ISSUE_NUMBER"
+            fi
+          else
+            gh issue create \
+              --title "Dead-code scan: $FINDINGS finding(s)" \
+              --label "review-debt/dead-code" \
+              --body-file "$BODY_FILE"
+          fi

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,0 +1,31 @@
+# Periphery dead-code scan configuration.
+# https://github.com/peripheryapp/periphery
+#
+# Run via the weekly `.github/workflows/dead-code.yml` job. Local invocation
+# is intentionally not supported in this repo — Periphery is not installed
+# via brew or otherwise. To trigger an ad-hoc run:
+#
+#     gh workflow run dead-code.yml
+
+project: Kernova.xcodeproj
+schemes:
+  - Kernova
+
+# Conservative retain rules for v1 — dial down once we know the false-positive
+# shape on this codebase.
+
+# `KernovaProtocol` exposes a public API surface across module boundaries; the
+# Kernova app target itself has few public symbols, so this stays conservative.
+retain_public: true
+
+# Keeps AppKit selectors, NSMenuItemValidation conformance, target/action
+# wiring, and KVO observers from being flagged.
+retain_objc_accessible: true
+
+# Properties that are only assigned (never read) often back IBOutlets or
+# observation tokens whose lifetime IS the value — flagging them is noisy.
+retain_assign_only_properties: true
+
+report_exclude:
+  - "**/.build/**"
+  - "DerivedData/**"


### PR DESCRIPTION
## Summary
- Automated weekly Periphery scan that maintains a single tracking issue for dead-code findings
- No local install required — the workflow is the only entry point; ad-hoc runs via `gh workflow run dead-code.yml`

## Changes
**`.periphery.yml`** — conservative retain rules for v1:
- `retain_public: true` (preserves `KernovaProtocol`'s public API)
- `retain_objc_accessible: true` (AppKit selectors, NSMenuItemValidation, KVO)
- `retain_assign_only_properties: true` (IBOutlet-style storage)
- excludes `**/.build/**` and `DerivedData/**`

**`.github/workflows/dead-code.yml`** — Mondays 14:00 UTC + `workflow_dispatch`:
- Pins Periphery `3.7.4`, downloads from GitHub releases, caches the binary by version
- Builds with `COMPILER_INDEX_STORE_ENABLE=YES` (required by Periphery — the build/test workflow disables it for speed, so this needs its own build pass)
- Caches SwiftPM checkouts the same way the build/test job does
- Uploads `scan-output.txt` + `scan-stderr.txt` as a 14-day artifact for debugging
- Manages a single tracking issue labeled `review-debt/dead-code`:
  - First findings → creates issue
  - Subsequent runs with findings → edits title (`Dead-code scan: N finding(s)`) and body in place
  - Closed issue with new findings → reopens
  - Clean run with open issue → comments and closes
  - Clean run with no issue → no-op

**Label** — `review-debt/dead-code` created on the repo (matches the existing `review-debt/*` convention).

## Test plan
- [ ] CI workflows on this PR remain green (the scan workflow itself does not trigger on `pull_request`)
- [ ] After merge: `gh workflow run dead-code.yml` to validate end-to-end (cron + dispatch only resolve files on the default branch)
- [ ] First scan completes within the 30-minute timeout
- [ ] If findings exist: a single new issue opens with the label and Periphery output in a `<details>` block

## Notes
- v1 errs conservative on retain rules. Once the first real scan lands, we can dial down based on the false-positive shape (e.g. drop `retain_public` for the app target if Periphery supports per-target retention).
- The 30-minute timeout is generous; a full xcodebuild + index-store-enabled build + scan typically runs 10–20 minutes on `macos-26` runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)