### PR TITLE
fix: Periphery workflow install + arg fixes

### DIFF
--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -63,8 +63,15 @@ jobs:
         id: scan
         run: |
           set +e
+          # Periphery 3.x takes xcodebuild args positionally after the options.
           periphery scan \
-            --xcargs "-skipPackagePluginValidation -derivedDataPath DerivedData CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES COMPILER_INDEX_STORE_ENABLE=YES" \
+            -- \
+            -skipPackagePluginValidation \
+            -derivedDataPath DerivedData \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=YES \
+            COMPILER_INDEX_STORE_ENABLE=YES \
             > scan-output.txt 2> scan-stderr.txt
           PERIPHERY_EXIT=$?
           set -e

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -35,7 +35,11 @@ jobs:
         id: cache-periphery
         uses: actions/cache@v5
         with:
-          path: /usr/local/bin/periphery
+          # The periphery binary uses @rpath/libIndexStore.dylib, so the dylib
+          # must live alongside it in /usr/local/bin/. Cache both files together.
+          path: |
+            /usr/local/bin/periphery
+            /usr/local/bin/libIndexStore.dylib
           key: periphery-${{ env.PERIPHERY_VERSION }}-${{ runner.os }}
 
       - name: Install Periphery
@@ -45,6 +49,7 @@ jobs:
           curl -fsSL "https://github.com/peripheryapp/periphery/releases/download/${PERIPHERY_VERSION}/periphery-${PERIPHERY_VERSION}.zip" -o /tmp/periphery.zip
           unzip -o /tmp/periphery.zip -d /tmp/periphery-extract
           sudo mv /tmp/periphery-extract/periphery /usr/local/bin/periphery
+          sudo mv /tmp/periphery-extract/libIndexStore.dylib /usr/local/bin/libIndexStore.dylib
           sudo chmod +x /usr/local/bin/periphery
           periphery version
 

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -1,0 +1,149 @@
+name: Dead Code Scan
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'  # Mondays 14:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    runs-on: macos-26
+    timeout-minutes: 30
+    env:
+      PERIPHERY_VERSION: 3.7.4
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          xcodebuild -version
+          echo "XCODE_BUILD=$(xcodebuild -version | awk '/Build version/ {print $3}')" >> "$GITHUB_ENV"
+
+      - name: Cache Periphery binary
+        id: cache-periphery
+        uses: actions/cache@v5
+        with:
+          path: /usr/local/bin/periphery
+          key: periphery-${{ env.PERIPHERY_VERSION }}-${{ runner.os }}
+
+      - name: Install Periphery
+        if: steps.cache-periphery.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/peripheryapp/periphery/releases/download/${PERIPHERY_VERSION}/periphery-${PERIPHERY_VERSION}.zip" -o /tmp/periphery.zip
+          unzip -o /tmp/periphery.zip -d /tmp/periphery-extract
+          sudo mv /tmp/periphery-extract/periphery /usr/local/bin/periphery
+          sudo chmod +x /usr/local/bin/periphery
+          periphery version
+
+      - name: Cache SwiftPM checkouts
+        uses: actions/cache@v5
+        with:
+          path: DerivedData/SourcePackages
+          key: ${{ runner.os }}-spm-${{ env.XCODE_BUILD }}-${{ hashFiles('Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+
+      - name: Run Periphery scan
+        id: scan
+        run: |
+          set +e
+          periphery scan \
+            --xcargs "-skipPackagePluginValidation -derivedDataPath DerivedData CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES COMPILER_INDEX_STORE_ENABLE=YES" \
+            > scan-output.txt 2> scan-stderr.txt
+          PERIPHERY_EXIT=$?
+          set -e
+
+          if [ "$PERIPHERY_EXIT" -ne 0 ]; then
+            echo "::error::Periphery exited with code $PERIPHERY_EXIT"
+            echo "--- stderr ---"
+            cat scan-stderr.txt
+            echo "--- stdout (first 200 lines) ---"
+            head -200 scan-output.txt
+            exit "$PERIPHERY_EXIT"
+          fi
+
+          findings=$(grep -cE ":[0-9]+:[0-9]+: warning:" scan-output.txt || true)
+          echo "findings=$findings" >> "$GITHUB_OUTPUT"
+          echo "Periphery surfaced $findings finding(s)"
+
+          if [ "$findings" -gt 0 ]; then
+            echo "--- Findings ---"
+            cat scan-output.txt
+          fi
+
+      - name: Upload scan output
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: periphery-scan
+          path: |
+            scan-output.txt
+            scan-stderr.txt
+          retention-days: 14
+
+      - name: Manage tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FINDINGS: ${{ steps.scan.outputs.findings }}
+        run: |
+          set -euo pipefail
+
+          ISSUE_NUMBER=$(gh issue list \
+            --label "review-debt/dead-code" \
+            --state all \
+            --limit 1 \
+            --json number,title \
+            --jq 'map(select(.title | startswith("Dead-code scan"))) | .[0].number // empty')
+
+          if [ "$FINDINGS" -eq 0 ]; then
+            if [ -n "$ISSUE_NUMBER" ]; then
+              STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state')
+              if [ "$STATE" = "OPEN" ]; then
+                gh issue comment "$ISSUE_NUMBER" \
+                  --body "Scan ran clean on $(date -u +%Y-%m-%dT%H:%MZ) — closing. Reopened automatically when new findings appear."
+                gh issue close "$ISSUE_NUMBER"
+              fi
+            fi
+            exit 0
+          fi
+
+          BODY_FILE=$(mktemp)
+          {
+            echo "Last scan: $(date -u +%Y-%m-%dT%H:%MZ) — **$FINDINGS finding(s)**"
+            echo
+            echo "Auto-managed by [\`.github/workflows/dead-code.yml\`](.github/workflows/dead-code.yml). Runs weekly (Mondays 14:00 UTC) and on \`workflow_dispatch\`. Closes automatically on the next clean run."
+            echo
+            echo "<details><summary>Periphery output</summary>"
+            echo
+            echo '```'
+            cat scan-output.txt
+            echo '```'
+            echo
+            echo "</details>"
+          } > "$BODY_FILE"
+
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue edit "$ISSUE_NUMBER" \
+              --title "Dead-code scan: $FINDINGS finding(s)" \
+              --body-file "$BODY_FILE"
+            STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state')
+            if [ "$STATE" = "CLOSED" ]; then
+              gh issue reopen "$ISSUE_NUMBER"
+            fi
+          else
+            gh issue create \
+              --title "Dead-code scan: $FINDINGS finding(s)" \
+              --label "review-debt/dead-code" \
+              --body-file "$BODY_FILE"
+          fi

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -53,25 +53,16 @@ jobs:
           sudo chmod +x /usr/local/bin/periphery
           periphery version
 
-      - name: Cache SwiftPM checkouts
-        uses: actions/cache@v5
-        with:
-          path: DerivedData/SourcePackages
-          key: ${{ runner.os }}-spm-${{ env.XCODE_BUILD }}-${{ hashFiles('Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-
       - name: Run Periphery scan
         id: scan
         run: |
           set +e
-          # Periphery 3.x takes xcodebuild args positionally after the options.
-          periphery scan \
-            -- \
-            -skipPackagePluginValidation \
-            -derivedDataPath DerivedData \
-            CODE_SIGN_IDENTITY=- \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=YES \
-            COMPILER_INDEX_STORE_ENABLE=YES \
+          # Periphery 3.x already passes its own `-derivedDataPath`, `-quiet`,
+          # `build-for-testing`, `CODE_SIGNING_ALLOWED=NO`, and
+          # `COMPILER_INDEX_STORE_ENABLE=YES` to xcodebuild. We only need to
+          # append `-skipPackagePluginValidation` because the project consumes
+          # SwiftPM packages.
+          periphery scan -- -skipPackagePluginValidation \
             > scan-output.txt 2> scan-stderr.txt
           PERIPHERY_EXIT=$?
           set -e

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,0 +1,31 @@
+# Periphery dead-code scan configuration.
+# https://github.com/peripheryapp/periphery
+#
+# Run via the weekly `.github/workflows/dead-code.yml` job. Local invocation
+# is intentionally not supported in this repo — Periphery is not installed
+# via brew or otherwise. To trigger an ad-hoc run:
+#
+#     gh workflow run dead-code.yml
+
+project: Kernova.xcodeproj
+schemes:
+  - Kernova
+
+# Conservative retain rules for v1 — dial down once we know the false-positive
+# shape on this codebase.
+
+# `KernovaProtocol` exposes a public API surface across module boundaries; the
+# Kernova app target itself has few public symbols, so this stays conservative.
+retain_public: true
+
+# Keeps AppKit selectors, NSMenuItemValidation conformance, target/action
+# wiring, and KVO observers from being flagged.
+retain_objc_accessible: true
+
+# Properties that are only assigned (never read) often back IBOutlets or
+# observation tokens whose lifetime IS the value — flagging them is noisy.
+retain_assign_only_properties: true
+
+report_exclude:
+  - "**/.build/**"
+  - "DerivedData/**"


### PR DESCRIPTION
## Summary
- The first dispatch of \`dead-code.yml\` on \`main\` failed in two places; this PR fixes both. Validated end-to-end on the fix branch — the workflow run completed cleanly and surfaced 30 findings (auto-tracked in #206).

## Changes
**Commit 1 — `fix: Bundle libIndexStore.dylib next to Periphery binary`**
- The Periphery release zip ships `periphery` plus `libIndexStore.dylib`; the binary uses an `@rpath/libIndexStore.dylib` reference, so the dylib must live alongside the executable
- Move both files into `/usr/local/bin/` and include both in the cache `path`

**Commit 2 — `fix: Pass xcodebuild args positionally to Periphery 3.x`**
- Periphery 3.x dropped `--xcargs` in favor of positional build arguments after `--`
- Reformat the `periphery scan` invocation accordingly

**Commit 3 — `fix: Drop duplicate xcodebuild args; remove unused SwiftPM cache`**
- Periphery 3.x already passes `-derivedDataPath`, `-quiet`, `build-for-testing`, `CODE_SIGNING_ALLOWED=NO`, `COMPILER_INDEX_STORE_ENABLE=YES`, `INDEX_ENABLE_DATA_STORE=YES` to xcodebuild itself — our duplicates triggered `option '-derivedDataPath' may only be provided once`
- Reduce positional args to just `-skipPackagePluginValidation`
- Drop the SwiftPM cache step — it cached `DerivedData/SourcePackages` (relative to repo) but Periphery uses `~/Library/Caches/com.github.peripheryapp/...`, so the cache was inert. A proper Periphery-DerivedData cache can be a follow-up

## Test plan
- [x] Workflow dispatched on the fix branch ([run](https://github.com/nicholas-lonsinger/kernova/actions/runs/25586127062)) completed all steps green in ~4 minutes
- [x] Tracking issue auto-opened with the periphery output (#206 — 30 findings)
- [ ] After merge, the next dispatch on `main` finds issue #206 by label and updates in place rather than duplicating

🤖 Generated with [Claude Code](https://claude.com/claude-code)