### PR TITLE
refactor: Reformat doc comments to satisfy BeginDocumentationCommentWithOneLineSummary

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -18,7 +18,7 @@
         "UseEarlyExits": true,
         "OmitExplicitReturns": true,
         "AlwaysUseLowerCamelCase": true,
-        "BeginDocumentationCommentWithOneLineSummary": false,
+        "BeginDocumentationCommentWithOneLineSummary": true,
         "DontRepeatTypeInStaticProperties": true,
         "FileScopedDeclarationPrivacy": true,
         "NoAccessLevelOnExtensionDeclaration": true,

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -30,11 +30,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private var terminationIsTCCRevocation = false
 
     /// Set in `applicationShouldTerminate` when TCC revocation is detected AND
-    /// running VMs require an async save (`.terminateLater`). Checked in
+    /// running VMs require an async save (`.terminateLater`).
+    ///
+    /// Checked in
     /// `applicationWillTerminate` to launch the relaunch helper at the last moment.
     private var relaunchAfterTermination = false
 
     /// Bundle identifiers that indicate a TCC-initiated quit.
+    ///
     /// Stable since macOS 13 (Ventura) when System Preferences was replaced by
     /// System Settings with per-pane extensions. May differ on earlier versions.
     private static let tccSenderBundleIDs: Set<String> = [
@@ -238,6 +241,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     }
 
     /// Handles the `kAEQuitApplication` Apple Event by inspecting the sender.
+    ///
     /// If the sender is System Settings or the TCC daemon, sets `terminationIsTCCRevocation`
     /// so that `applicationShouldTerminate` knows to launch the relaunch helper.
     @objc private func handleQuitAppleEvent(
@@ -273,7 +277,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     }
 
     /// Launches the relaunch helper, which monitors this process and re-opens
-    /// the app after it terminates. Used for TCC permission revocations where
+    /// the app after it terminates.
+    ///
+    /// Used for TCC permission revocations where
     /// the built-in relaunch mechanism times out during VM save.
     private func launchRelaunchHelper() {
         guard
@@ -646,7 +652,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         controller.showWindow(nil)
     }
 
-    /// Returns the best screen for entering fullscreen, using a fallback chain:
+    /// Returns the best screen for entering fullscreen, using a fallback chain.
+    ///
     /// 1. The display the VM was last fullscreen on (persisted in configuration)
     /// 2. The library window's current display
     /// 3. The primary display
@@ -671,6 +678,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     // MARK: - Idle Termination
 
     /// Whether the main library window has been dismissed (closed by the user).
+    ///
     /// Distinguishes closed from hidden (Cmd+H) and minimized (Cmd+M) via runtime inspection.
     /// Returns `false` if the window controller or its window is nil (no window to inspect).
     private var isMainWindowDismissed: Bool {

--- a/Kernova/App/DetailContainerViewController.swift
+++ b/Kernova/App/DetailContainerViewController.swift
@@ -2,8 +2,7 @@ import Cocoa
 import os
 import SwiftUI
 
-/// AppKit container that layers pure-AppKit VM displays on top of an always-present SwiftUI
-/// hosting controller.
+/// AppKit container that layers pure-AppKit VM displays on top of an always-present SwiftUI hosting controller.
 ///
 /// Each running VM that displays inline gets its own `VMDisplayBackingView`
 /// (and thus its own `VZVirtualMachineView`). Switching VMs swaps visibility rather than

--- a/Kernova/App/DetailContainerViewController.swift
+++ b/Kernova/App/DetailContainerViewController.swift
@@ -3,7 +3,9 @@ import os
 import SwiftUI
 
 /// AppKit container that layers pure-AppKit VM displays on top of an always-present SwiftUI
-/// hosting controller. Each running VM that displays inline gets its own `VMDisplayBackingView`
+/// hosting controller.
+///
+/// Each running VM that displays inline gets its own `VMDisplayBackingView`
 /// (and thus its own `VZVirtualMachineView`). Switching VMs swaps visibility rather than
 /// reassigning the `virtualMachine` property, which `VZVirtualMachineView` does not handle
 /// correctly.

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -3,7 +3,9 @@ import os
 import SwiftUI
 
 /// Manages the main library window using an `NSSplitViewController` for sidebar/detail layout
-/// and an `NSToolbar` with native toolbar items. SwiftUI views render content inside each pane.
+/// and an `NSToolbar` with native toolbar items.
+///
+/// SwiftUI views render content inside each pane.
 @MainActor
 final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindowDelegate {
     private let viewModel: VMLibraryViewModel

--- a/Kernova/App/VMToolbarManager.swift
+++ b/Kernova/App/VMToolbarManager.swift
@@ -1,7 +1,9 @@
 import Cocoa
 import os
 
-/// Shared toolbar logic for VM window controllers. Creates and manages the lifecycle,
+/// Shared toolbar logic for VM window controllers.
+///
+/// Creates and manages the lifecycle,
 /// suspend, and display toolbar item groups that appear in both the main window
 /// and per-VM display windows.
 ///
@@ -19,7 +21,9 @@ final class VMToolbarManager: NSObject {
         let removableMediaID: NSToolbarItem.Identifier?
         let displayID: NSToolbarItem.Identifier
         /// When non-nil, a gear-icon button that toggles the detail pane between the live
-        /// display and the (read-only) settings form. Only the main window sets this; the
+        /// display and the (read-only) settings form.
+        ///
+        /// Only the main window sets this; the
         /// pop-out window has no settings pane.
         let settingsToggleID: NSToolbarItem.Identifier?
 
@@ -94,7 +98,9 @@ final class VMToolbarManager: NSObject {
     // MARK: - Item Factory
 
     /// Creates the `NSToolbarItem` for the given identifier, or returns `nil` if it is not
-    /// a shared item managed by this manager. Called from the controller's
+    /// a shared item managed by this manager.
+    ///
+    /// Called from the controller's
     /// `toolbar(_:itemForItemIdentifier:willBeInsertedIntoToolbar:)`.
     func makeToolbarItem(for identifier: NSToolbarItem.Identifier) -> NSToolbarItem? {
         switch identifier {

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -53,7 +53,9 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     // MARK: - Audio
 
     /// When `true`, the host microphone is passed through to the guest as a
-    /// virtio sound input stream. Defaults to `false` so guests cannot silently
+    /// virtio sound input stream.
+    ///
+    /// Defaults to `false` so guests cannot silently
     /// listen to the host. Speaker output is always enabled regardless of this flag.
     var microphoneEnabled: Bool
 
@@ -61,7 +63,9 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
 
     /// When `true`, the macOS guest agent forwards `os.Logger` records to the
     /// host over vsock so they appear in Console.app under
-    /// `com.kernova.guest`. Defaults to `false` for new and existing VMs:
+    /// `com.kernova.guest`.
+    ///
+    /// Defaults to `false` for new and existing VMs:
     /// log forwarding is opt-in. Linux guests have no Kernova agent and ignore
     /// this flag.
     ///
@@ -86,7 +90,9 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     var lastSeenAgentVersion: String?
 
     /// When `true`, the user has explicitly dismissed the sidebar "install
-    /// guest agent" nudge for this VM. Suppresses only the gentle `.waiting`
+    /// guest agent" nudge for this VM.
+    ///
+    /// Suppresses only the gentle `.waiting`
     /// affordance — the `.outdated`, `.unresponsive`, and `.expectedMissing`
     /// states still surface because they imply something more urgent than
     /// "you could install this." Defaults to `false` for new and migrated
@@ -109,10 +115,13 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
     // MARK: - Removable Media
 
     /// Path to a disk image attached as a USB mass storage device at VM start time.
+    ///
     /// For runtime hot-plug, see `USBDeviceService`.
     var discImagePath: String?
 
-    /// When `true`, the disc image attachment is read-only. Defaults to `true`.
+    /// When `true`, the disc image attachment is read-only.
+    ///
+    /// Defaults to `true`.
     var discImageReadOnly: Bool
 
     /// When `true` and `bootMode == .efi`, the disc image device is placed before the main disk
@@ -303,7 +312,9 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
 
     // MARK: - Hot-Toggleable Fields
 
-    /// Fields the user may edit while the VM is running. Changes to these
+    /// Fields the user may edit while the VM is running.
+    ///
+    /// Changes to these
     /// bypass the `VMSettingsView` read-only settings lock so the user can
     /// flip them mid-session.
     ///

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -509,8 +509,7 @@ final class VMInstance: Identifiable {
         Self.logger.info("SPICE clipboard service started for '\(self.name, privacy: .public)'")
     }
 
-    /// Stops and releases the clipboard service and (for SPICE) closes pipe
-    /// file handles.
+    /// Stops and releases the clipboard service and (for SPICE) closes pipe file handles.
     ///
     /// Safe to call when no service is active.
     func stopClipboardService() {

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -13,6 +13,7 @@ enum VMDisplayMode: Sendable {
 }
 
 /// Which inline detail pane the user has chosen to view for a running VM.
+///
 /// Ignored when the VM is stopped (settings are always shown then).
 enum DetailPaneMode: Sendable {
     case display
@@ -67,7 +68,9 @@ final class VMInstance: Identifiable {
         }
     }
 
-    /// Tracks an in-flight clone or import operation. Non-nil when this instance is a
+    /// Tracks an in-flight clone or import operation.
+    ///
+    /// Non-nil when this instance is a
     /// "phantom row" awaiting a file copy to finish (see `VMLibraryViewModel`).
     struct PreparingState {
         let operation: PreparingOperation
@@ -87,17 +90,21 @@ final class VMInstance: Identifiable {
     var displayMode: VMDisplayMode = .inline
 
     /// Which inline detail pane is shown for this VM while it has an active display.
+    ///
     /// When the VM is stopped, the settings pane is always shown regardless of this value.
     var detailPaneMode: DetailPaneMode = .display
 
     // MARK: - Clipboard Sharing
 
     /// Bidirectional pipes for the SPICE clipboard console port (Linux guests).
+    ///
     /// Unused for macOS guests, which sync clipboard over vsock instead.
     var clipboardInputPipe: Pipe?
     var clipboardOutputPipe: Pipe?
 
-    /// Active clipboard service for this VM. The concrete type depends on the
+    /// Active clipboard service for this VM.
+    ///
+    /// The concrete type depends on the
     /// guest OS: `SpiceClipboardService` for Linux, `VsockClipboardService`
     /// for macOS. Held as the existential so consumers don't need to branch.
     /// May be nil on macOS until the guest agent connects.
@@ -109,7 +116,9 @@ final class VMInstance: Identifiable {
     /// while the VM has a live `VZVirtualMachine`.
     var vsockLogListenerHost: VsockListenerHost?
 
-    /// Service handling an active guest log connection. Populated when a
+    /// Service handling an active guest log connection.
+    ///
+    /// Populated when a
     /// guest agent has connected and forwarded its first frame; cleared on
     /// disconnect or VM teardown.
     var vsockLogService: VsockGuestLogService?
@@ -120,12 +129,16 @@ final class VMInstance: Identifiable {
     var vsockClipboardListenerHost: VsockListenerHost?
 
     /// Listener for the always-on guest control channel; populated for macOS
-    /// guests while the VM has a live `VZVirtualMachine`. Carries the agent
+    /// guests while the VM has a live `VZVirtualMachine`.
+    ///
+    /// Carries the agent
     /// version handshake and a bidirectional heartbeat independent of any
     /// optional feature toggle.
     var vsockControlListenerHost: VsockListenerHost?
 
-    /// Service handling an active guest control connection. Populated when
+    /// Service handling an active guest control connection.
+    ///
+    /// Populated when
     /// the guest agent's control channel connects; cleared on disconnect or
     /// VM teardown.
     var vsockControlService: VsockControlService?
@@ -133,19 +146,24 @@ final class VMInstance: Identifiable {
     /// `true` when this VM has reached `.running`, the host previously saw a
     /// guest agent connect (`configuration.lastSeenAgentVersion != nil`), and
     /// the post-start grace period has elapsed without a fresh `Hello`
-    /// arriving over the control channel. Drives the sidebar's louder
+    /// arriving over the control channel.
+    ///
+    /// Drives the sidebar's louder
     /// "didn't reconnect" badge — distinct from the gentler `.waiting` state
     /// shown on VMs that have never had an agent. Reset on `tearDownSession`
     /// and on the next successful Hello.
     var agentExpectedButMissing: Bool = false
 
-    /// Backing task for the post-start agent-arrival watchdog. One-shot per
+    /// Backing task for the post-start agent-arrival watchdog.
+    ///
+    /// One-shot per
     /// VM session. Set in `startAgentPostStartWatchdog`; cancelled in
     /// `tearDownSession` and on the first Hello of the session.
     private var agentPostStartTask: Task<Void, Never>?
 
     /// Notified whenever a host-side mutation to `configuration` should be
     /// persisted (e.g. the guest reported a new agent version via Hello).
+    ///
     /// Wired by `VMLibraryViewModel` to `saveConfiguration(for:)` so the
     /// JSON on disk stays in sync. Direct file writes from inside the
     /// instance would bypass the storage abstraction the rest of the app
@@ -182,7 +200,9 @@ final class VMInstance: Identifiable {
 
     // MARK: - Serial Console
 
-    /// Observable text buffer driven by serial port output. Capped at 1 MB in memory;
+    /// Observable text buffer driven by serial port output.
+    ///
+    /// Capped at 1 MB in memory;
     /// full history is preserved on disk in `serial.log`.
     var serialOutputText: String = ""
 
@@ -247,6 +267,7 @@ final class VMInstance: Identifiable {
     // MARK: - Runtime USB Devices
 
     /// USB mass storage devices currently attached via the XHCI controller.
+    ///
     /// Populated at runtime only; cleared on VM stop/teardown.
     var attachedUSBDevices: [USBDeviceInfo] = []
 
@@ -310,8 +331,9 @@ final class VMInstance: Identifiable {
 
     /// Tears down the live VM session: stops clipboard and serial I/O, releases
     /// pipes, clears attached USB devices, and nils the delegate adapter and
-    /// `VZVirtualMachine` reference. Does **not** change `status` — callers set
-    /// the appropriate status after calling this.
+    /// `VZVirtualMachine` reference.
+    ///
+    /// Does **not** change `status` — callers set the appropriate status after calling this.
     func tearDownSession() {
         stopVsockServices()
         stopClipboardService()
@@ -335,7 +357,9 @@ final class VMInstance: Identifiable {
         detailPaneMode = .display
     }
 
-    /// Creates a VZVirtualMachine, assigns it, and wires up the delegate. Returns the VM.
+    /// Creates a VZVirtualMachine, assigns it, and wires up the delegate.
+    ///
+    /// Returns the VM.
     @discardableResult
     func attachVirtualMachine(from vzConfig: VZVirtualMachineConfiguration) -> VZVirtualMachine {
         let vm = VZVirtualMachine(configuration: vzConfig)
@@ -362,7 +386,9 @@ final class VMInstance: Identifiable {
 
     // MARK: - Serial Console I/O
 
-    /// Begins reading from the serial output pipe. Output is appended to
+    /// Begins reading from the serial output pipe.
+    ///
+    /// Output is appended to
     /// `serialOutputText` (for the UI) and written to the on-disk log file.
     func startSerialReading() {
         guard let outputPipe = serialOutputPipe else { return }
@@ -484,7 +510,9 @@ final class VMInstance: Identifiable {
     }
 
     /// Stops and releases the clipboard service and (for SPICE) closes pipe
-    /// file handles. Safe to call when no service is active.
+    /// file handles.
+    ///
+    /// Safe to call when no service is active.
     func stopClipboardService() {
         clipboardService?.stop()
         clipboardService = nil
@@ -526,8 +554,9 @@ final class VMInstance: Identifiable {
 
     // MARK: - Vsock Service Lifecycle
 
-    /// Installs vsock listeners on the live VM's `VZVirtioSocketDevice`. Safe
-    /// to call when no socket device is present (Linux guests, or macOS guests
+    /// Installs vsock listeners on the live VM's `VZVirtioSocketDevice`.
+    ///
+    /// Safe to call when no socket device is present (Linux guests, or macOS guests
     /// whose configuration omitted it) — the call becomes a no-op.
     /// Idempotent: any previously installed listeners are torn down first.
     ///
@@ -610,8 +639,9 @@ final class VMInstance: Identifiable {
 
     // MARK: - Agent Post-Start Watchdog
 
-    /// Default grace period before the post-start watchdog fires. Forgiving
-    /// enough to cover slow first boots and post-OS-update boots inside the
+    /// Default grace period before the post-start watchdog fires.
+    ///
+    /// Forgiving enough to cover slow first boots and post-OS-update boots inside the
     /// guest. Tests override this with a millisecond-scale duration.
     static let defaultAgentPostStartGrace: Duration = .seconds(120)
 
@@ -667,7 +697,9 @@ final class VMInstance: Identifiable {
         }
     }
 
-    /// Cancels the post-start watchdog if armed. Used both when an agent
+    /// Cancels the post-start watchdog if armed.
+    ///
+    /// Used both when an agent
     /// Hello arrives during the grace window and from `tearDownSession`.
     /// Does not clear `agentExpectedButMissing` — callers do that explicitly
     /// where appropriate.
@@ -679,9 +711,11 @@ final class VMInstance: Identifiable {
     /// Reacts to a fresh, non-empty `agent_version` reported by the guest:
     /// cancel the post-start watchdog, clear the expected-missing flag, and
     /// persist the new value via `onConfigurationDidChange` if it differs
-    /// from what's on record. Wired by `startVsockServices()` into the
-    /// `VsockControlService` callback; exposed at this scope so tests can
-    /// drive the path without standing up a real control channel.
+    /// from what's on record.
+    ///
+    /// Wired by `startVsockServices()` into the `VsockControlService` callback;
+    /// exposed at this scope so tests can drive the path without standing up a
+    /// real control channel.
     ///
     /// Empty strings are filtered upstream by `VsockControlService` — they
     /// would represent an agent that didn't populate the field, and
@@ -704,6 +738,7 @@ final class VMInstance: Identifiable {
     }
 
     /// Tears down all vsock listeners and any active services running on them.
+    ///
     /// The clipboard service is only stopped here when it's the vsock variant —
     /// the SPICE service is owned by `stopClipboardService()` and would already
     /// be nil at this point under normal teardown order.
@@ -725,7 +760,9 @@ final class VMInstance: Identifiable {
 
     /// Reacts to a configuration change while the VM is running by installing
     /// or tearing down vsock listeners and pushing a fresh `PolicyUpdate` to
-    /// the guest agent. No-op when the VM isn't running, when no socket
+    /// the guest agent.
+    ///
+    /// No-op when the VM isn't running, when no socket
     /// device is attached, or when neither hot-toggleable field changed.
     ///
     /// Only `agentLogForwardingEnabled` and `clipboardSharingEnabled` are

--- a/Kernova/Models/VMStatus.swift
+++ b/Kernova/Models/VMStatus.swift
@@ -53,12 +53,16 @@ enum VMStatus: String, Codable, Sendable {
     }
 
     var canStart: Bool { self == .stopped || self == .error }
-    /// Status-level stop eligibility. Does not account for cold-paused state;
+    /// Status-level stop eligibility.
+    ///
+    /// Does not account for cold-paused state;
     /// prefer `VMInstance.canStop` for runtime checks.
     var canStop: Bool { self == .running || self == .paused }
     var canPause: Bool { self == .running }
     var canResume: Bool { self == .paused }
-    /// Status-level save eligibility. Does not account for cold-paused state;
+    /// Status-level save eligibility.
+    ///
+    /// Does not account for cold-paused state;
     /// prefer `VMInstance.canSave` for runtime checks.
     var canSave: Bool { self == .running || self == .paused }
     var canEditSettings: Bool { self == .stopped || self == .error }
@@ -80,6 +84,7 @@ enum VMStatus: String, Codable, Sendable {
     }
 
     /// Whether this status represents an active VM that should keep the app alive.
+    ///
     /// Note: live-paused VMs (`.paused` with a non-nil `VZVirtualMachine`) should
     /// be handled separately by the caller.
     var isActive: Bool {

--- a/Kernova/Services/AgentStatus.swift
+++ b/Kernova/Services/AgentStatus.swift
@@ -58,7 +58,9 @@ enum AgentStatus: Equatable, Sendable {
     case connecting(expected: String)
 
     /// True when this case carries the "actively trying to reconnect"
-    /// semantic. Convenience for UI code that wants to attach a continuous
+    /// semantic.
+    ///
+    /// Convenience for UI code that wants to attach a continuous
     /// rotation `.symbolEffect` to the icon.
     var isConnecting: Bool {
         if case .connecting = self { return true }
@@ -67,7 +69,9 @@ enum AgentStatus: Equatable, Sendable {
 
     /// Resolves an upstream `AgentStatus` (sourced from `VsockControlService`
     /// or a SPICE service) plus persisted host-side context into the final
-    /// `AgentStatus` the UI should render. Pure function — given the same
+    /// `AgentStatus` the UI should render.
+    ///
+    /// Pure function — given the same
     /// inputs, always produces the same output — so it can be unit-tested
     /// without standing up a `VZVirtualMachine`.
     ///

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -363,6 +363,7 @@ struct ConfigurationBuilder: Sendable {
     // MARK: - Serial Port
 
     /// Configures a bidirectional virtio console serial port using pipe-backed file handles.
+    ///
     /// Returns the (input, output) pipes for the host side.
     private func configureSerialPort(_ vzConfig: VZVirtualMachineConfiguration) -> (Pipe, Pipe) {
         let inputPipe = Pipe()  // host writes → guest reads
@@ -423,7 +424,9 @@ struct ConfigurationBuilder: Sendable {
 
     // MARK: - Vsock
 
-    /// Adds a single virtio-socket device to the configuration. Listeners are
+    /// Adds a single virtio-socket device to the configuration.
+    ///
+    /// Listeners are
     /// installed post-VM-create against the live `VZVirtioSocketDevice` rather
     /// than declared on the configuration.
     private func configureVsockDevice(_ vzConfig: VZVirtualMachineConfiguration) {

--- a/Kernova/Services/SpiceAgentProtocol.swift
+++ b/Kernova/Services/SpiceAgentProtocol.swift
@@ -10,6 +10,7 @@ enum SpiceConstants {
     static let agentProtocol: UInt32 = 1
 
     /// Destination port for host → guest messages (`VDP_SERVER_PORT`).
+    ///
     /// Host-side `SpiceClipboardService` writes everything with this port.
     /// (`VDP_CLIENT_PORT = 1` is part of the SPICE wire format but no longer
     /// referenced now that macOS guests have moved to vsock — the
@@ -245,10 +246,12 @@ struct SpiceAgentParser: Sendable {
     private static let maxChunkDataSize: UInt32 = 1_048_576  // 1 MB
 
     /// `true` when the buffer was reset due to overflow or corruption.
+    ///
     /// Consumers should check this after each `feed()` call to log appropriately.
     private(set) var didReset = false
 
     /// Feed raw bytes from the pipe into the parser.
+    ///
     /// Returns zero or more fully parsed messages.
     mutating func feed(_ data: Data) -> [SpiceAgentParsedMessage] {
         buffer.append(data)
@@ -271,6 +274,7 @@ struct SpiceAgentParser: Sendable {
     }
 
     /// Attempts to parse one complete message from the buffer.
+    ///
     /// Consumes the bytes on success, leaves the buffer unchanged when incomplete,
     /// or resets it entirely when corruption is detected.
     private mutating func tryParseNext() -> SpiceAgentParsedMessage? {

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -32,7 +32,9 @@ final class SpiceClipboardService: ClipboardServicing {
 
     /// SPICE agents (e.g. `spice-vdagent` on Linux) are user-installed and
     /// version-tracked by the guest's package manager — Kernova does not bundle
-    /// or update them. The UI distinguishes Linux guests from macOS guests
+    /// or update them.
+    ///
+    /// The UI distinguishes Linux guests from macOS guests
     /// before offering an install affordance, so reporting `.current` once
     /// connected is enough to suppress the host-side install/update flow.
     var agentStatus: AgentStatus {
@@ -52,6 +54,7 @@ final class SpiceClipboardService: ClipboardServicing {
     private var lastGrabbedText: String?
 
     /// Whether the guest advertised `VD_AGENT_CAP_CLIPBOARD_BY_DEMAND`.
+    ///
     /// When `false` (legacy mode), we send clipboard data immediately after GRAB
     /// instead of waiting for a REQUEST.
     private var guestSupportsByDemand = false

--- a/Kernova/Services/SystemSleepWatcher.swift
+++ b/Kernova/Services/SystemSleepWatcher.swift
@@ -10,7 +10,9 @@ final class SystemSleepWatcher {
     private static let logger = Logger(subsystem: "com.kernova.app", category: "SystemSleepWatcher")
 
     /// `nonisolated(unsafe)` because `NSObjectProtocol` observer tokens are not `Sendable`
-    /// and we need to remove them in `deinit` (which is nonisolated). Safe because they are
+    /// and we need to remove them in `deinit` (which is nonisolated).
+    ///
+    /// Safe because they are
     /// only written in `start()` and read in `deinit`.
     nonisolated(unsafe) private var sleepObserver: (any NSObjectProtocol)?
     nonisolated(unsafe) private var wakeObserver: (any NSObjectProtocol)?

--- a/Kernova/Services/VirtualizationService.swift
+++ b/Kernova/Services/VirtualizationService.swift
@@ -233,7 +233,9 @@ final class VirtualizationService {
     // MARK: - Error Classification
 
     /// Returns `true` when the error is a transient environmental condition (e.g. too many
-    /// concurrent VMs) rather than a problem with the VM itself. Transient errors leave the
+    /// concurrent VMs) rather than a problem with the VM itself.
+    ///
+    /// Transient errors leave the
     /// VM in `.stopped` so the indicator stays grey; permanent errors set `.error` (red).
     static func isTransientStartError(_ error: Error) -> Bool {
         if error is ConfigurationBuilderError { return false }
@@ -262,6 +264,7 @@ final class VirtualizationService {
     }
 
     /// Builds a `VZVirtualMachine`, restores from a save file, and resumes.
+    ///
     /// On restore failure, deletes the stale save file and falls back to a cold boot.
     private func restoreOrColdBoot(_ instance: VMInstance) async throws {
         let result = try await buildConfiguration(for: instance)

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -22,12 +22,16 @@ import os
 final class VsockClipboardService: ClipboardServicing {
     // MARK: - Observable state
 
-    /// Bidirectional clipboard buffer. Set by the user (via the clipboard
+    /// Bidirectional clipboard buffer.
+    ///
+    /// Set by the user (via the clipboard
     /// window) to seed an outbound offer; updated when the guest sends
     /// fresh data.
     var clipboardText: String = ""
 
-    /// `true` once `start()` has been called. The clipboard channel is
+    /// `true` once `start()` has been called.
+    ///
+    /// The clipboard channel is
     /// established by `VsockListenerHost` accepting a connection — by the time
     /// this service is constructed the socket is up, so connectivity is
     /// equivalent to "started and not yet stopped". A separate liveness signal
@@ -50,20 +54,27 @@ final class VsockClipboardService: ClipboardServicing {
 
     private var consumeTask: Task<Void, Never>?
 
-    /// Counter for outbound offer generations. Starts at 1 so 0 can serve as
+    /// Counter for outbound offer generations.
+    ///
+    /// Starts at 1 so 0 can serve as
     /// "no pending request" sentinel for the inbound side.
     private var nextLocalGeneration: UInt64 = 1
 
-    /// The most recent offer we sent the guest. Held until the guest requests
+    /// The most recent offer we sent the guest.
+    ///
+    /// Held until the guest requests
     /// (or supersedes) it so we can answer `ClipboardRequest`.
     private var pendingOutbound: (generation: UInt64, text: String)?
 
-    /// The most recent offer the guest sent us that we asked to receive. We
-    /// track it so a delayed `ClipboardData` for an older offer can be
+    /// The most recent offer the guest sent us that we asked to receive.
+    ///
+    /// We track it so a delayed `ClipboardData` for an older offer can be
     /// dropped.
     private var pendingInboundGeneration: UInt64?
 
-    /// Last text we successfully announced. Skips redundant offers when
+    /// Last text we successfully announced.
+    ///
+    /// Skips redundant offers when
     /// `grabIfChanged()` is called repeatedly with the same content.
     private var lastGrabbedText: String?
 

--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -3,7 +3,9 @@ import KernovaProtocol
 import os
 
 /// Snapshot of the toggle state delivered to the guest agent via
-/// `PolicyUpdate` on the control channel. Decouples `VsockControlService`
+/// `PolicyUpdate` on the control channel.
+///
+/// Decouples `VsockControlService`
 /// from `VMConfiguration` — the host supplies a closure that reads the
 /// fields each time policy is sent.
 struct AgentPolicySnapshot: Equatable, Sendable {
@@ -36,19 +38,27 @@ struct AgentPolicySnapshot: Equatable, Sendable {
 final class VsockControlService {
     // MARK: - Observable state
 
-    /// `true` once the guest agent has sent its `Hello`. Reset on `stop()`.
+    /// `true` once the guest agent has sent its `Hello`.
+    ///
+    /// Reset on `stop()`.
     private(set) var isConnected: Bool = false
 
-    /// The guest-reported `Hello.agent_info.agent_version`. `nil` until the
+    /// The guest-reported `Hello.agent_info.agent_version`.
+    ///
+    /// `nil` until the
     /// guest sends its `Hello`. Reset on `stop()`.
     private(set) var agentVersion: String?
 
     /// `true` when the inbound liveness watchdog has fired but the channel has
-    /// not yet been torn down. Surfaces as `.unresponsive` in `agentStatus`.
+    /// not yet been torn down.
+    ///
+    /// Surfaces as `.unresponsive` in `agentStatus`.
     private(set) var isUnresponsive: Bool = false
 
     /// Whether the guest agent is missing, current, outdated, or unresponsive
-    /// relative to the bundled binary. Drives sidebar / clipboard-window
+    /// relative to the bundled binary.
+    ///
+    /// Drives sidebar / clipboard-window
     /// install/update affordances and the unresponsive indicator.
     var agentStatus: AgentStatus {
         guard let installed = agentVersion else { return .waiting }
@@ -78,13 +88,17 @@ final class VsockControlService {
     private let terminateAfter: Duration
     private let livenessTickInterval: Duration
 
-    /// Reads the latest policy from the host configuration. Invoked once per
+    /// Reads the latest policy from the host configuration.
+    ///
+    /// Invoked once per
     /// guest `Hello` so the guest receives the current snapshot at every
     /// (re)connect. `nil` in tests that don't exercise policy delivery.
     private let policyProvider: (@MainActor () -> AgentPolicySnapshot)?
 
     /// Notified each time the guest reports a non-empty `agentVersion` in its
-    /// `Hello`. Fire-and-forget — this service does not care whether the host
+    /// `Hello`.
+    ///
+    /// Fire-and-forget — this service does not care whether the host
     /// persists the value. Wired by `VMInstance.startVsockServices()` to write
     /// the version into `VMConfiguration.lastSeenAgentVersion`. `nil` in tests
     /// and contexts where persistence is not exercised.
@@ -99,7 +113,9 @@ final class VsockControlService {
     /// inbound frame arrives.
     private var lastInboundFrame: ContinuousClock.Instant?
 
-    /// Outbound heartbeat sequence number. Echoed only for diagnostics — the
+    /// Outbound heartbeat sequence number.
+    ///
+    /// Echoed only for diagnostics — the
     /// peer does not respond to a specific nonce.
     private var nextHeartbeatNonce: UInt64 = 1
 
@@ -222,7 +238,9 @@ final class VsockControlService {
     }
 
     /// Sends a `PolicyUpdate` frame carrying the current toggle snapshot to
-    /// the guest. Called once on Hello receipt and again any time the user
+    /// the guest.
+    ///
+    /// Called once on Hello receipt and again any time the user
     /// flips a hot-toggleable setting while the VM is running.
     func sendPolicyUpdate(_ policy: AgentPolicySnapshot) {
         var frame = Frame()

--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -2,12 +2,10 @@ import Foundation
 import KernovaProtocol
 import os
 
-/// Snapshot of the toggle state delivered to the guest agent via
-/// `PolicyUpdate` on the control channel.
+/// Snapshot of the toggle state delivered to the guest agent via `PolicyUpdate` on the control channel.
 ///
-/// Decouples `VsockControlService`
-/// from `VMConfiguration` — the host supplies a closure that reads the
-/// fields each time policy is sent.
+/// Decouples `VsockControlService` from `VMConfiguration` — the host supplies a closure that reads
+/// the fields each time policy is sent.
 struct AgentPolicySnapshot: Equatable, Sendable {
     var logForwardingEnabled: Bool
     var clipboardSharingEnabled: Bool
@@ -45,21 +43,17 @@ final class VsockControlService {
 
     /// The guest-reported `Hello.agent_info.agent_version`.
     ///
-    /// `nil` until the
-    /// guest sends its `Hello`. Reset on `stop()`.
+    /// `nil` until the guest sends its `Hello`. Reset on `stop()`.
     private(set) var agentVersion: String?
 
-    /// `true` when the inbound liveness watchdog has fired but the channel has
-    /// not yet been torn down.
+    /// `true` when the inbound liveness watchdog has fired but the channel has not yet been torn down.
     ///
     /// Surfaces as `.unresponsive` in `agentStatus`.
     private(set) var isUnresponsive: Bool = false
 
-    /// Whether the guest agent is missing, current, outdated, or unresponsive
-    /// relative to the bundled binary.
+    /// Whether the guest agent is missing, current, outdated, or unresponsive relative to the bundled binary.
     ///
-    /// Drives sidebar / clipboard-window
-    /// install/update affordances and the unresponsive indicator.
+    /// Drives sidebar / clipboard-window install/update affordances and the unresponsive indicator.
     var agentStatus: AgentStatus {
         guard let installed = agentVersion else { return .waiting }
         if isUnresponsive { return .unresponsive(version: installed) }
@@ -90,18 +84,16 @@ final class VsockControlService {
 
     /// Reads the latest policy from the host configuration.
     ///
-    /// Invoked once per
-    /// guest `Hello` so the guest receives the current snapshot at every
-    /// (re)connect. `nil` in tests that don't exercise policy delivery.
+    /// Invoked once per guest `Hello` so the guest receives the current snapshot at every (re)connect.
+    /// `nil` in tests that don't exercise policy delivery.
     private let policyProvider: (@MainActor () -> AgentPolicySnapshot)?
 
-    /// Notified each time the guest reports a non-empty `agentVersion` in its
-    /// `Hello`.
+    /// Notified each time the guest reports a non-empty `agentVersion` in its `Hello`.
     ///
-    /// Fire-and-forget — this service does not care whether the host
-    /// persists the value. Wired by `VMInstance.startVsockServices()` to write
-    /// the version into `VMConfiguration.lastSeenAgentVersion`. `nil` in tests
-    /// and contexts where persistence is not exercised.
+    /// Fire-and-forget — this service does not care whether the host persists the value. Wired by
+    /// `VMInstance.startVsockServices()` to write the version into
+    /// `VMConfiguration.lastSeenAgentVersion`. `nil` in tests and contexts where persistence is not
+    /// exercised.
     private let onAgentVersionObserved: (@MainActor (String) -> Void)?
 
     private var consumeTask: Task<Void, Never>?
@@ -237,11 +229,10 @@ final class VsockControlService {
         }
     }
 
-    /// Sends a `PolicyUpdate` frame carrying the current toggle snapshot to
-    /// the guest.
+    /// Sends a `PolicyUpdate` frame carrying the current toggle snapshot to the guest.
     ///
-    /// Called once on Hello receipt and again any time the user
-    /// flips a hot-toggleable setting while the VM is running.
+    /// Called once on Hello receipt and again any time the user flips a hot-toggleable setting while
+    /// the VM is running.
     func sendPolicyUpdate(_ policy: AgentPolicySnapshot) {
         var frame = Frame()
         frame.protocolVersion = 1

--- a/Kernova/Services/VsockGuestLogService.swift
+++ b/Kernova/Services/VsockGuestLogService.swift
@@ -37,7 +37,9 @@ final class VsockGuestLogService {
         self.emitter = emitter ?? OSLogGuestLogEmitter(label: label)
     }
 
-    /// Begins consuming frames from the channel. Idempotent.
+    /// Begins consuming frames from the channel.
+    ///
+    /// Idempotent.
     func start() {
         guard consumeTask == nil else { return }
         let label = self.label
@@ -105,13 +107,16 @@ final class VsockGuestLogService {
 
 // MARK: - GuestLogEmitter
 
-/// Receives `LogRecord` payloads forwarded from a guest agent. Production
-/// code uses `OSLogGuestLogEmitter`; tests substitute a recording emitter.
+/// Receives `LogRecord` payloads forwarded from a guest agent.
+///
+/// Production code uses `OSLogGuestLogEmitter`; tests substitute a recording emitter.
 protocol GuestLogEmitter: Sendable {
     func emit(_ record: Kernova_V1_LogRecord)
 }
 
-/// Republishes guest log records via `os.Logger`. Each record is emitted at
+/// Republishes guest log records via `os.Logger`.
+///
+/// Each record is emitted at
 /// the closest matching host log level, with the guest's subsystem and
 /// category preserved in the message body.
 struct OSLogGuestLogEmitter: GuestLogEmitter {

--- a/Kernova/Services/VsockGuestLogService.swift
+++ b/Kernova/Services/VsockGuestLogService.swift
@@ -37,9 +37,7 @@ final class VsockGuestLogService {
         self.emitter = emitter ?? OSLogGuestLogEmitter(label: label)
     }
 
-    /// Begins consuming frames from the channel.
-    ///
-    /// Idempotent.
+    /// Begins consuming frames from the channel (idempotent).
     func start() {
         guard consumeTask == nil else { return }
         let label = self.label

--- a/Kernova/Services/VsockListenerHost.swift
+++ b/Kernova/Services/VsockListenerHost.swift
@@ -27,14 +27,18 @@ final class VsockListenerHost: NSObject, VZVirtioSocketListenerDelegate {
         self.listener.delegate = self
     }
 
-    /// Installs this listener on the supplied socket device. Connections to
+    /// Installs this listener on the supplied socket device.
+    ///
+    /// Connections to
     /// `port` from the guest will subsequently invoke `onConnect`.
     func attach(to socketDevice: VZVirtioSocketDevice) {
         socketDevice.setSocketListener(listener, forPort: port)
         Self.logger.info("Listening on vsock port \(self.port, privacy: .public)")
     }
 
-    /// Removes the listener from the socket device. Safe to call after the VM
+    /// Removes the listener from the socket device.
+    ///
+    /// Safe to call after the VM
     /// has stopped — the device may already have torn down its listener map.
     func detach(from socketDevice: VZVirtioSocketDevice) {
         socketDevice.removeSocketListener(forPort: port)

--- a/Kernova/Services/VsockPorts.swift
+++ b/Kernova/Services/VsockPorts.swift
@@ -6,7 +6,9 @@ import Foundation
 /// handles demultiplexing instead of in-band tagging in our wire protocol.
 /// Ports live in the IANA dynamic range (49152-65535).
 enum KernovaVsockPort {
-    /// Always-on control plane. Carries the agent version handshake and
+    /// Always-on control plane.
+    ///
+    /// Carries the agent version handshake and
     /// bidirectional heartbeats independent of any optional feature toggle,
     /// so the host can detect agent presence/liveness even when clipboard
     /// sharing or other features are disabled.

--- a/Kernova/Utilities/DataFormatters.swift
+++ b/Kernova/Utilities/DataFormatters.swift
@@ -14,6 +14,7 @@ enum DataFormatters {
     }
 
     /// Formats a byte count with fixed width for stable progress display (e.g., "861.900 MB").
+    ///
     /// Uses `%7.3f` padding so the numeric part is always 7 characters wide, preventing
     /// horizontal jitter as values change during downloads.
     static func formatBytesFixedWidth(_ bytes: UInt64) -> String {
@@ -37,6 +38,7 @@ enum DataFormatters {
     }
 
     /// Formats a download speed in bytes/second into a human-readable string (e.g., "42.5 MB/s").
+    ///
     /// Uses fixed-width formatting to prevent horizontal jitter during rapid updates.
     static func formatSpeed(_ bytesPerSecond: Double) -> String {
         let kb = bytesPerSecond / 1_000
@@ -56,6 +58,7 @@ enum DataFormatters {
     }
 
     /// Formats an ETA from remaining bytes and current speed into a human-readable string.
+    ///
     /// Returns `nil` if speed is negligible, the estimate exceeds 100 hours, or the result is non-finite.
     static func formatETA(remainingBytes: Int64, bytesPerSecond: Double) -> String? {
         guard bytesPerSecond > 1_000 else { return nil }

--- a/Kernova/Utilities/ObservationLoop.swift
+++ b/Kernova/Utilities/ObservationLoop.swift
@@ -18,7 +18,9 @@ final class ObservationLoop {
         register()
     }
 
-    /// Stops the observation loop. Idempotent; safe to call multiple times.
+    /// Stops the observation loop.
+    ///
+    /// Idempotent; safe to call multiple times.
     func cancel() {
         isCancelled = true
     }

--- a/Kernova/ViewModels/VMDirectoryWatcher.swift
+++ b/Kernova/ViewModels/VMDirectoryWatcher.swift
@@ -8,7 +8,9 @@ final class VMDirectoryWatcher {
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VMDirectoryWatcher")
 
     /// `nonisolated(unsafe)` because `DispatchSource` is not `Sendable` and we need
-    /// to cancel it in `deinit` (which is nonisolated). Safe because it is only
+    /// to cancel it in `deinit` (which is nonisolated).
+    ///
+    /// Safe because it is only
     /// written in `start()` and read in `deinit`.
     nonisolated(unsafe) private var directorySource: DispatchSourceFileSystemObject?
     private var debounceTask: Task<Void, Never>?

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -700,13 +700,11 @@ final class VMLibraryViewModel {
         }
     }
 
-    /// Marks this VM's `.waiting` install nudge as dismissed and persists
-    /// the choice.
+    /// Marks this VM's `.waiting` install nudge as dismissed and persists the choice.
     ///
-    /// The sidebar icon for `.waiting` will no longer surface;
-    /// `.outdated`, `.unresponsive`, and `.expectedMissing` continue to
-    /// surface (those imply something more urgent than "you could install
-    /// this").
+    /// The sidebar icon for `.waiting` will no longer surface; `.outdated`, `.unresponsive`, and
+    /// `.expectedMissing` continue to surface (those imply something more urgent than "you could
+    /// install this").
     func dismissAgentInstallNudge(for instance: VMInstance) {
         guard !instance.configuration.agentInstallNudgeDismissed else { return }
         Self.logger.notice("User dismissed install-agent nudge for '\(instance.name, privacy: .public)'")

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -374,16 +374,12 @@ final class VMLibraryViewModel {
         }
     }
 
-    /// Saves VM state.
-    ///
-    /// Throws on failure (used by suspend-on-quit in AppDelegate).
+    /// Saves VM state, throwing on failure (used by suspend-on-quit in AppDelegate).
     func trySave(_ instance: VMInstance) async throws {
         try await lifecycle.save(instance)
     }
 
-    /// Force-stops a VM.
-    ///
-    /// Throws on failure (used by suspend-on-quit fallback in AppDelegate).
+    /// Force-stops a VM, throwing on failure (used by suspend-on-quit fallback in AppDelegate).
     func tryForceStop(_ instance: VMInstance) async throws {
         try await lifecycle.forceStop(instance)
     }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -34,14 +34,18 @@ final class VMLibraryViewModel {
     var showError = false
     var errorMessage: String?
 
-    /// Drives the post-mount instructions alert. Set after a successful
+    /// Drives the post-mount instructions alert.
+    ///
+    /// Set after a successful
     /// `mountGuestAgentInstaller(on:)` so the user gets unified guidance no
     /// matter which entry point (sidebar popover, clipboard window button, or
     /// menubar item) triggered the mount.
     var showInstallerMountedAlert = false
     var installerMountedVMName: String?
 
-    /// VMs with an in-flight installer mount. Prevents rapid double-clicks
+    /// VMs with an in-flight installer mount.
+    ///
+    /// Prevents rapid double-clicks
     /// from spawning two parallel attaches — the second would race the first
     /// and likely surface as a spurious "operation in progress" error alert.
     private var mountingInstanceIDs: Set<UUID> = []
@@ -61,6 +65,7 @@ final class VMLibraryViewModel {
     private var customOrder: [UUID] = []
 
     /// Bundle names whose load failures have already been reported to the user.
+    ///
     /// Prevents repeated error dialogs for persistently corrupted bundles across successive
     /// `reconcileWithDisk()` calls. Populated by both `loadVMs()` and `reconcileWithDisk()`.
     /// Reset on full reload (`loadVMs`), when a previously-failed bundle loads successfully,
@@ -280,7 +285,9 @@ final class VMLibraryViewModel {
         }
     }
 
-    /// Resumes a paused VM then requests a graceful ACPI shutdown. Used by the
+    /// Resumes a paused VM then requests a graceful ACPI shutdown.
+    ///
+    /// Used by the
     /// stop-paused confirmation sheet's "Resume and Shut Down" action.
     ///
     /// Note: `lifecycle.resume` is serialized through the lifecycle coordinator,
@@ -367,12 +374,16 @@ final class VMLibraryViewModel {
         }
     }
 
-    /// Saves VM state. Throws on failure (used by suspend-on-quit in AppDelegate).
+    /// Saves VM state.
+    ///
+    /// Throws on failure (used by suspend-on-quit in AppDelegate).
     func trySave(_ instance: VMInstance) async throws {
         try await lifecycle.save(instance)
     }
 
-    /// Force-stops a VM. Throws on failure (used by suspend-on-quit fallback in AppDelegate).
+    /// Force-stops a VM.
+    ///
+    /// Throws on failure (used by suspend-on-quit fallback in AppDelegate).
     func tryForceStop(_ instance: VMInstance) async throws {
         try await lifecycle.forceStop(instance)
     }
@@ -569,7 +580,9 @@ final class VMLibraryViewModel {
 
     /// Wires `instance.onConfigurationDidChange` so host-driven mutations
     /// (e.g. the guest reporting a new agent version via `Hello`) flow back
-    /// through the storage abstraction. Called at every VMInstance
+    /// through the storage abstraction.
+    ///
+    /// Called at every VMInstance
     /// construction site in this view model.
     private func wirePersistence(for instance: VMInstance) {
         instance.onConfigurationDidChange = { [weak self] inst in
@@ -577,7 +590,9 @@ final class VMLibraryViewModel {
         }
     }
 
-    /// Pushes a configuration change to a running VM. Hot-toggleable fields
+    /// Pushes a configuration change to a running VM.
+    ///
+    /// Hot-toggleable fields
     /// (`agentLogForwardingEnabled`, `clipboardSharingEnabled`) take effect
     /// immediately via `VMInstance.applyLivePolicy`; everything else is
     /// persisted-only and waits for next start.
@@ -629,7 +644,9 @@ final class VMLibraryViewModel {
     // MARK: - Guest Agent Installer
 
     /// Mounts the bundled `KernovaGuestAgent.dmg` as a read-only USB device so
-    /// the user can run `install.command` inside the guest. Used by the
+    /// the user can run `install.command` inside the guest.
+    ///
+    /// Used by the
     /// clipboard window's "Install Guest Agent…" affordance, the sidebar's
     /// agent-status popover, and the menubar item.
     ///
@@ -688,7 +705,9 @@ final class VMLibraryViewModel {
     }
 
     /// Marks this VM's `.waiting` install nudge as dismissed and persists
-    /// the choice. The sidebar icon for `.waiting` will no longer surface;
+    /// the choice.
+    ///
+    /// The sidebar icon for `.waiting` will no longer surface;
     /// `.outdated`, `.unresponsive`, and `.expectedMissing` continue to
     /// surface (those imply something more urgent than "you could install
     /// this").
@@ -700,6 +719,7 @@ final class VMLibraryViewModel {
     }
 
     /// Detaches the bundled guest agent installer if currently mounted.
+    ///
     /// Identified by path equality with `KernovaGuestAgentInfo.installerDiskImageURL`.
     func unmountGuestAgentInstaller(from instance: VMInstance) {
         guard let url = KernovaGuestAgentInfo.installerDiskImageURL else { return }
@@ -949,7 +969,9 @@ final class VMLibraryViewModel {
 
     // MARK: - Sleep/Wake
 
-    /// Pauses all running VMs before system sleep. Tracks which VMs were auto-paused
+    /// Pauses all running VMs before system sleep.
+    ///
+    /// Tracks which VMs were auto-paused
     /// so only those are resumed on wake (preserving user-paused VMs).
     func pauseAllForSleep() async {
         let runningInstances = instances.filter { $0.status == .running }
@@ -1169,7 +1191,9 @@ final class VMLibraryViewModel {
 
     // MARK: - Reorder
 
-    /// Moves VMs in the sidebar list and persists the new order. Called by SwiftUI's onMove handler.
+    /// Moves VMs in the sidebar list and persists the new order.
+    ///
+    /// Called by SwiftUI's onMove handler.
     func moveVM(fromOffsets source: IndexSet, toOffset destination: Int) {
         instances.move(fromOffsets: source, toOffset: destination)
         persistOrder()

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -27,6 +27,7 @@ final class VMLifecycleCoordinator {
     let usbDeviceService: any USBDeviceProviding
 
     /// Maps VM ID → operation token for VMs that currently have a lifecycle operation in flight.
+    ///
     /// The token allows `defer` blocks to avoid clobbering entries inserted by a later operation.
     private var activeOperations: [UUID: UUID] = [:]
 
@@ -63,6 +64,7 @@ final class VMLifecycleCoordinator {
     }
 
     /// Removes any active-operation tracking for the given VM.
+    ///
     /// Call when a VM is deleted to avoid stale entries in the dictionary.
     func clearActiveOperation(for instanceID: UUID) {
         activeOperations.removeValue(forKey: instanceID)
@@ -106,7 +108,9 @@ final class VMLifecycleCoordinator {
         }
     }
 
-    /// Requests a graceful stop. Bypasses serialization so users can always
+    /// Requests a graceful stop.
+    ///
+    /// Bypasses serialization so users can always
     /// interrupt an in-progress operation (e.g. a hung start). Clears the
     /// active-operation token *before* calling the service, invalidating any
     /// in-flight operation's defer guard.
@@ -115,7 +119,9 @@ final class VMLifecycleCoordinator {
         try virtualizationService.stop(instance)
     }
 
-    /// Immediately terminates the VM. Bypasses serialization so users can
+    /// Immediately terminates the VM.
+    ///
+    /// Bypasses serialization so users can
     /// always force-kill, even during another in-flight operation. Clears the
     /// active-operation token *before* calling the service, invalidating any
     /// in-flight operation's defer guard.
@@ -224,6 +230,7 @@ final class VMLifecycleCoordinator {
     // MARK: - USB Device Management
 
     /// Attaches a USB mass storage device to a running VM.
+    ///
     /// Does not use the lifecycle operation token — USB operations are short
     /// and independent of start/stop/save lifecycle transitions.
     func attachUSBDevice(diskImagePath: String, readOnly: Bool, to instance: VMInstance) async throws -> USBDeviceInfo {

--- a/Kernova/Views/Console/RemovableMediaPopoverView.swift
+++ b/Kernova/Views/Console/RemovableMediaPopoverView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 /// Popover content for managing runtime USB mass storage devices on a running VM.
+///
 /// Shown from the "Removable Media" toolbar button.
 struct RemovableMediaPopoverView: View {
     @Bindable var instance: VMInstance

--- a/Kernova/Views/Console/VMConsoleView.swift
+++ b/Kernova/Views/Console/VMConsoleView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
 /// Console view that displays placeholder content when the VM display is unavailable: popped out,
-/// fullscreen, suspended (cold-paused), or no virtual machine assigned. When the display is
-/// inline and active, the AppKit `VMDisplayBackingView` layer covers this view, so the inline
-/// branch shows an inert black background.
+/// fullscreen, suspended (cold-paused), or no virtual machine assigned.
+///
+/// When the display is inline and active, the AppKit `VMDisplayBackingView` layer covers this
+/// view, so the inline branch shows an inert black background.
 struct VMConsoleView: View {
     @Bindable var instance: VMInstance
 

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -61,6 +61,7 @@ struct VMDetailView: View {
 }
 
 /// Lifecycle confirmation alerts (delete, cancel preparing, force stop, stop paused).
+///
 /// Extracted into a separate modifier to keep the parent `body` expression within
 /// the Swift type-checker's complexity budget.
 private struct LifecycleAlerts: ViewModifier {

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -6,7 +6,9 @@ import SwiftUI
 struct VMSettingsView: View {
     @Bindable var instance: VMInstance
     @Bindable var viewModel: VMLibraryViewModel
-    /// When `true`, all controls are disabled and a banner explains why. Used when the
+    /// When `true`, all controls are disabled and a banner explains why.
+    ///
+    /// Used when the
     /// user toggles the detail pane to settings while the VM is running.
     let isReadOnly: Bool
 
@@ -120,7 +122,9 @@ struct VMSettingsView: View {
 
     /// Section header that appends a lock SF Symbol when `isReadOnly` is
     /// `true`, signaling that the section's controls are locked while the
-    /// VM is running. Hot-toggleable sections (Guest Agent, Clipboard) keep
+    /// VM is running.
+    ///
+    /// Hot-toggleable sections (Guest Agent, Clipboard) keep
     /// their plain headers so the absence of the lock is itself the signal
     /// that those sections remain editable.
     ///

--- a/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
@@ -209,12 +209,10 @@ struct AgentStatusPopoverContent: View {
     }
 }
 
-/// Static helpers that compute the popover's `contentSize` and the per-status
-/// strings.
+/// Static helpers that compute the popover's `contentSize` and the per-status strings.
 ///
-/// Centralized here so `AgentStatusPopoverContent` and
-/// `SidebarAgentStatusButton` agree on the layout numbers used for the
-/// `NSPopover` content size and the SwiftUI padding/spacing.
+/// Centralized here so `AgentStatusPopoverContent` and `SidebarAgentStatusButton` agree on the
+/// layout numbers used for the `NSPopover` content size and the SwiftUI padding/spacing.
 enum AgentStatusPopoverMetrics {
     static let contentWidth: CGFloat = 360
     static let padding: CGFloat = 16
@@ -292,12 +290,10 @@ enum AgentStatusPopoverMetrics {
 
 // MARK: - NSPopover bridge
 
-/// Bridges a SwiftUI `Bool` binding to an `NSPopover` whose `contentSize` is
-/// supplied by the caller.
+/// Bridges a SwiftUI `Bool` binding to an `NSPopover` whose `contentSize` is supplied by the caller.
 ///
-/// The host SwiftUI view (typically placed via
-/// `.background(NSPopoverAnchor(...))`) provides the anchor `NSView`; flipping
-/// the binding shows or closes the popover.
+/// The host SwiftUI view (typically placed via `.background(NSPopoverAnchor(...))`) provides the
+/// anchor `NSView`; flipping the binding shows or closes the popover.
 private struct NSPopoverAnchor<Content: View>: NSViewRepresentable {
     @Binding var isPresented: Bool
     let contentSize: NSSize

--- a/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButton.swift
@@ -146,7 +146,9 @@ struct SidebarAgentStatusButton: View {
 
 // MARK: - Popover content & metrics
 
-/// Body of the agent-status popover. The wrapping body text is rendered
+/// Body of the agent-status popover.
+///
+/// The wrapping body text is rendered
 /// via `WrappingNSTextLabel` (an AppKit `NSTextField` wrapping label) because
 /// SwiftUI `Text` does not reliably wrap inside `NSHostingController` on
 /// macOS Tahoe even with explicit `.frame(width:)` and `.fixedSize(...)`.
@@ -208,7 +210,9 @@ struct AgentStatusPopoverContent: View {
 }
 
 /// Static helpers that compute the popover's `contentSize` and the per-status
-/// strings. Centralized here so `AgentStatusPopoverContent` and
+/// strings.
+///
+/// Centralized here so `AgentStatusPopoverContent` and
 /// `SidebarAgentStatusButton` agree on the layout numbers used for the
 /// `NSPopover` content size and the SwiftUI padding/spacing.
 enum AgentStatusPopoverMetrics {
@@ -216,8 +220,9 @@ enum AgentStatusPopoverMetrics {
     static let padding: CGFloat = 16
     static let verticalSpacing: CGFloat = 10
 
-    /// Line height of the `.headline` font as currently configured. Reading
-    /// from `NSFont.preferredFont` honors the user's Dynamic Type setting, so
+    /// Line height of the `.headline` font as currently configured.
+    ///
+    /// Reading from `NSFont.preferredFont` honors the user's Dynamic Type setting, so
     /// the popover height stays correct under accessibility text scaling.
     /// `descender` is negative on macOS, so subtracting it adds the descent
     /// portion to the total height.
@@ -288,7 +293,9 @@ enum AgentStatusPopoverMetrics {
 // MARK: - NSPopover bridge
 
 /// Bridges a SwiftUI `Bool` binding to an `NSPopover` whose `contentSize` is
-/// supplied by the caller. The host SwiftUI view (typically placed via
+/// supplied by the caller.
+///
+/// The host SwiftUI view (typically placed via
 /// `.background(NSPopoverAnchor(...))`) provides the anchor `NSView`; flipping
 /// the binding shows or closes the popover.
 private struct NSPopoverAnchor<Content: View>: NSViewRepresentable {
@@ -386,7 +393,9 @@ private struct NSPopoverAnchor<Content: View>: NSViewRepresentable {
 
 // MARK: - Wrapping text label
 
-/// AppKit-backed multi-line wrapping label. SwiftUI's `Text` doesn't
+/// AppKit-backed multi-line wrapping label.
+///
+/// SwiftUI's `Text` doesn't
 /// reliably wrap inside an `NSHostingController` on macOS Tahoe (it renders
 /// single-line at its ideal width and overflows), so the popover renders
 /// the wrapping body string through `NSTextField(wrappingLabelWithString:)`

--- a/KernovaGuestAgent/KernovaLogMessage.swift
+++ b/KernovaGuestAgent/KernovaLogMessage.swift
@@ -96,12 +96,16 @@ public struct KernovaLogMessage: ExpressibleByStringInterpolation, ExpressibleBy
         }
     }
 
-    /// String suitable for emission to local `os.Logger`. Values marked
+    /// String suitable for emission to local `os.Logger`.
+    ///
+    /// Values marked
     /// `.private` or `.sensitive` have already been replaced with the
     /// `<private>` placeholder.
     public let localRendered: String
 
-    /// String suitable for forwarding over vsock. Every interpolated
+    /// String suitable for forwarding over vsock.
+    ///
+    /// Every interpolated
     /// value is rendered in cleartext.
     public let wireRendered: String
 

--- a/KernovaGuestAgent/VsockGuestClient.swift
+++ b/KernovaGuestAgent/VsockGuestClient.swift
@@ -68,14 +68,18 @@ final class VsockGuestClient: @unchecked Sendable {
     private var stopped = false
 
     /// When `true`, the reconnect loop skips connect attempts and waits for
-    /// `resume()`. Distinct from `stopped` — pause is reversible, stop is
+    /// `resume()`.
+    ///
+    /// Distinct from `stopped` — pause is reversible, stop is
     /// terminal. Used by higher-level agents to honor host policy updates
     /// (e.g., log forwarding disabled → pause the client → no connects).
     private var paused = false
 
     // MARK: - Init
 
-    /// Creates a client for the given port. Pass a custom `socketProvider` and
+    /// Creates a client for the given port.
+    ///
+    /// Pass a custom `socketProvider` and
     /// `retryInterval` in tests; production callers can use the defaults.
     init(
         port: UInt32,
@@ -94,7 +98,9 @@ final class VsockGuestClient: @unchecked Sendable {
 
     // MARK: - Lifecycle
 
-    /// Begins the connect/serve/reconnect loop. Idempotent — repeated calls
+    /// Begins the connect/serve/reconnect loop.
+    ///
+    /// Idempotent — repeated calls
     /// after the first are no-ops. Once stopped (or permanently terminated by a
     /// permanent provider failure), the client cannot be restarted; create a
     /// new instance.
@@ -108,6 +114,7 @@ final class VsockGuestClient: @unchecked Sendable {
     }
 
     /// Pauses the reconnect loop and tears down any active channel.
+    ///
     /// Subsequent reconnect attempts are skipped until `resume()` is called.
     /// Idempotent. Distinct from `stop()` — pause is reversible.
     func pause() {
@@ -120,13 +127,17 @@ final class VsockGuestClient: @unchecked Sendable {
         ch?.close()
     }
 
-    /// Resumes the reconnect loop after `pause()`. The next reconnect attempt
+    /// Resumes the reconnect loop after `pause()`.
+    ///
+    /// The next reconnect attempt
     /// happens within `retryInterval`. Idempotent.
     func resume() {
         lock.withLock { paused = false }
     }
 
-    /// Stops the loop and tears down any active channel. Subsequent `start`
+    /// Stops the loop and tears down any active channel.
+    ///
+    /// Subsequent `start`
     /// calls are no-ops.
     func stop() {
         let (task, ch): (Task<Void, Never>?, VsockChannel?) = lock.withLock {
@@ -141,7 +152,9 @@ final class VsockGuestClient: @unchecked Sendable {
         ch?.close()
     }
 
-    /// Currently-attached channel, or nil. Useful for callers that need to
+    /// Currently-attached channel, or nil.
+    ///
+    /// Useful for callers that need to
     /// peek for synchronous best-effort sends (e.g. log forwarding) without
     /// owning the loop.
     var liveChannel: VsockChannel? {
@@ -324,7 +337,9 @@ final class VsockGuestClient: @unchecked Sendable {
     }
 
     /// Waits up to `connectTimeoutSeconds` for an in-flight non-blocking connect
-    /// to complete on `fd`. Returns true on success, false on timeout, poll
+    /// to complete on `fd`.
+    ///
+    /// Returns true on success, false on timeout, poll
     /// error, or a deferred connect error. Caller owns `fd` on both paths and
     /// must `close()` it on false return — this helper does not assume ownership.
     private static func awaitConnectCompletion(fd: Int32, label: String, port: UInt32) -> Bool {

--- a/KernovaGuestAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaGuestAgent/VsockGuestClipboardAgent.swift
@@ -51,7 +51,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
 
     // MARK: - Main-queue state
 
-    /// Live channel for the current connection, if any. Nil between
+    /// Live channel for the current connection, if any.
+    ///
+    /// Nil between
     /// connections; checked by the polling timer to short-circuit when
     /// the host isn't reachable.
     private var liveChannel: VsockChannel?
@@ -71,7 +73,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// commit logic itself.
     var pendingInboundGenerationForTesting: UInt64? { pendingInboundGeneration }
 
-    /// Counter for outbound offer generations. Starts at 1 so 0 can serve as
+    /// Counter for outbound offer generations.
+    ///
+    /// Starts at 1 so 0 can serve as
     /// "no pending request" sentinel for the inbound side.
     private var nextLocalGeneration: UInt64 = 1
 
@@ -79,24 +83,31 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// with a request (or supersedes it with a newer offer of our own).
     private var pendingOutbound: (generation: UInt64, text: String)?
 
-    /// Last inbound offer we requested data for. Used to drop a delayed
+    /// Last inbound offer we requested data for.
+    ///
+    /// Used to drop a delayed
     /// `ClipboardData` for an older offer.
     private var pendingInboundGeneration: UInt64?
 
-    /// Last `NSPasteboard.changeCount` we observed. Set after every
+    /// Last `NSPasteboard.changeCount` we observed.
+    ///
+    /// Set after every
     /// poll cycle and after every host write so we don't echo back our own
     /// content.
     private var lastPasteboardChangeCount: Int
 
-    /// The most recent text we sent or wrote. Suppresses re-offering after
+    /// The most recent text we sent or wrote.
+    ///
+    /// Suppresses re-offering after
     /// a host-driven write and avoids redundant offers when the user
     /// touches the clipboard without changing the contents.
     private var lastSeenText: String?
 
     private var pollingTimer: DispatchSourceTimer?
 
-    /// Whether clipboard sync is currently allowed by host policy. Default
-    /// `false` so the agent doesn't connect or poll until the host's first
+    /// Whether clipboard sync is currently allowed by host policy.
+    ///
+    /// Default `false` so the agent doesn't connect or poll until the host's first
     /// `PolicyUpdate(clipboardSharingEnabled: true)` arrives. Mutated only
     /// on the main queue.
     private var enabled: Bool = false
@@ -126,7 +137,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
 
     // MARK: - Lifecycle
 
-    /// Begins the connect/serve loop. The pasteboard poll is started when
+    /// Begins the connect/serve loop.
+    ///
+    /// The pasteboard poll is started when
     /// host policy enables clipboard sharing — see `setEnabled(_:)`.
     func start() {
         client.start { [weak self] channel in
@@ -148,7 +161,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         }
     }
 
-    /// Main-queue body of `setEnabled(_:)`. Caller must dispatch to main.
+    /// Main-queue body of `setEnabled(_:)`.
+    ///
+    /// Caller must dispatch to main.
     private func applyEnabledOnMain(_ enabled: Bool) {
         guard self.enabled != enabled else { return }
         self.enabled = enabled

--- a/KernovaGuestAgent/VsockGuestControlAgent.swift
+++ b/KernovaGuestAgent/VsockGuestControlAgent.swift
@@ -36,7 +36,9 @@ final class VsockGuestControlAgent: @unchecked Sendable {
     private let terminateAfter: Duration
     private let livenessTickInterval: Duration
 
-    /// Invoked on every inbound `PolicyUpdate`. The closure receives the raw
+    /// Invoked on every inbound `PolicyUpdate`.
+    ///
+    /// The closure receives the raw
     /// protobuf snapshot; main.swift wires it to `VsockHostConnection` and
     /// `VsockGuestClipboardAgent` so each capability honors host policy.
     private let onPolicy: (@Sendable (Kernova_V1_PolicyUpdate) -> Void)?
@@ -83,7 +85,9 @@ final class VsockGuestControlAgent: @unchecked Sendable {
 
     // MARK: - Lifecycle
 
-    /// Begins the connect/serve/reconnect loop. Idempotent.
+    /// Begins the connect/serve/reconnect loop.
+    ///
+    /// Idempotent.
     func start() {
         client.start { [weak self] channel in
             await self?.serve(channel: channel)

--- a/KernovaGuestAgent/VsockGuestControlAgent.swift
+++ b/KernovaGuestAgent/VsockGuestControlAgent.swift
@@ -85,9 +85,7 @@ final class VsockGuestControlAgent: @unchecked Sendable {
 
     // MARK: - Lifecycle
 
-    /// Begins the connect/serve/reconnect loop.
-    ///
-    /// Idempotent.
+    /// Begins the connect/serve/reconnect loop (idempotent).
     func start() {
         client.start { [weak self] channel in
             await self?.serve(channel: channel)

--- a/KernovaGuestAgent/VsockHostConnection.swift
+++ b/KernovaGuestAgent/VsockHostConnection.swift
@@ -3,7 +3,9 @@ import KernovaProtocol
 import os
 
 /// Forwards guest-emitted log records to the host on `KernovaVsockPort.log`
-/// (49153). Connection lifecycle is delegated to `VsockGuestClient`; this
+/// (49153).
+///
+/// Connection lifecycle is delegated to `VsockGuestClient`; this
 /// class layers log-specific buffering and inbound drain on top.
 ///
 /// The version handshake and agent liveness live on the always-on control
@@ -17,7 +19,9 @@ final class VsockHostConnection: @unchecked Sendable {
     private static let logger = Logger(subsystem: "com.kernova.agent", category: "VsockHostConnection")
 
     /// Maximum number of `LogRecord` frames buffered while the channel is
-    /// down. Older entries are dropped first.
+    /// down.
+    ///
+    /// Older entries are dropped first.
     ///
     /// Sized for the bursty pre-connect window: agent boot can take 30s+
     /// from VM-start to first vsock connect on macOS, and clipboard activity
@@ -31,8 +35,9 @@ final class VsockHostConnection: @unchecked Sendable {
     let lock = NSLock()
     var pendingLogs: [Frame] = []
 
-    /// Whether log forwarding is currently allowed by host policy. Default
-    /// `false` so the agent doesn't connect or buffer until the host's
+    /// Whether log forwarding is currently allowed by host policy.
+    ///
+    /// Default `false` so the agent doesn't connect or buffer until the host's
     /// initial `PolicyUpdate` says otherwise. Toggled by `setEnabled(_:)`.
     private var enabled: Bool = false
 
@@ -48,7 +53,9 @@ final class VsockHostConnection: @unchecked Sendable {
         self.client.pause()
     }
 
-    /// Begins the connect/serve/reconnect loop. Idempotent.
+    /// Begins the connect/serve/reconnect loop.
+    ///
+    /// Idempotent.
     func start() {
         client.start { [weak self] channel in
             await self?.serveLogChannel(channel)
@@ -87,7 +94,9 @@ final class VsockHostConnection: @unchecked Sendable {
         }
     }
 
-    /// Builds and best-effort sends a `LogRecord` frame to the host. When no
+    /// Builds and best-effort sends a `LogRecord` frame to the host.
+    ///
+    /// When no
     /// connection is currently active, the frame is buffered (up to
     /// `logBufferLimit` records, oldest dropped first) and flushed once the
     /// next connection comes up. Returns `true` when the frame was handed to a

--- a/KernovaGuestAgent/VsockHostConnection.swift
+++ b/KernovaGuestAgent/VsockHostConnection.swift
@@ -53,9 +53,7 @@ final class VsockHostConnection: @unchecked Sendable {
         self.client.pause()
     }
 
-    /// Begins the connect/serve/reconnect loop.
-    ///
-    /// Idempotent.
+    /// Begins the connect/serve/reconnect loop (idempotent).
     func start() {
         client.start { [weak self] channel in
             await self?.serveLogChannel(channel)

--- a/KernovaGuestAgent/VsockPorts.swift
+++ b/KernovaGuestAgent/VsockPorts.swift
@@ -7,7 +7,9 @@ import Foundation
 /// an older host). The port numbers are part of the wire contract — keep
 /// both sides in sync.
 enum KernovaVsockPort {
-    /// Always-on control plane. Carries the agent version handshake and
+    /// Always-on control plane.
+    ///
+    /// Carries the agent version handshake and
     /// bidirectional heartbeats independent of any optional feature toggle,
     /// so the host can detect agent presence/liveness even when clipboard
     /// sharing or other features are disabled.

--- a/KernovaGuestAgent/main.swift
+++ b/KernovaGuestAgent/main.swift
@@ -46,7 +46,9 @@ if CommandLine.arguments.contains("--version") {
 
 // MARK: - Vsock connections
 
-/// Long-lived vsock connection to the host for log forwarding. Created and
+/// Long-lived vsock connection to the host for log forwarding.
+///
+/// Created and
 /// registered with `VsockLogBridge` *before* the `logger.notice(...)`
 /// startup banner emission below, so that banner is buffered into the
 /// connection's pre-connect ring buffer rather than dropped.
@@ -62,7 +64,9 @@ VsockLogBridge.connection = vsockConnection
 
 logger.notice("Kernova Guest Agent v\(version, privacy: .public) (\(buildNumber, privacy: .public)) started")
 
-/// Clipboard sync agent. Maintains its own connection on
+/// Clipboard sync agent.
+///
+/// Maintains its own connection on
 /// `KernovaVsockPort.clipboard` independent of the log connection, so a
 /// disconnect on one channel doesn't take the other down.
 ///
@@ -70,7 +74,9 @@ logger.notice("Kernova Guest Agent v\(version, privacy: .public) (\(buildNumber,
 /// `PolicyUpdate(clipboardSharingEnabled: true)` arrives.
 let clipboardAgent = VsockGuestClipboardAgent()
 
-/// Control-plane agent. Always-on connection on `KernovaVsockPort.control`
+/// Control-plane agent.
+///
+/// Always-on connection on `KernovaVsockPort.control`
 /// carrying the version handshake, bidirectional heartbeats, and the
 /// `PolicyUpdate` push that drives `vsockConnection.setEnabled(_:)` and
 /// `clipboardAgent.setEnabled(_:)`. Independent of any feature toggle on the

--- a/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
@@ -6,7 +6,9 @@ import KernovaProtocol
 
 // MARK: - Fake Pasteboard
 
-/// In-memory `Pasteboard` substitute. Thread-safe via NSLock so tests running
+/// In-memory `Pasteboard` substitute.
+///
+/// Thread-safe via NSLock so tests running
 /// on DispatchQueue.main don't race the setup thread.
 final class FakePasteboard: Pasteboard, @unchecked Sendable {
     private let lock = NSLock()
@@ -23,7 +25,9 @@ final class FakePasteboard: Pasteboard, @unchecked Sendable {
     }
 
     /// Make the next `n` `setString` calls return `false` and skip storage
-    /// updates. Lets tests model OS-level pasteboard write failures.
+    /// updates.
+    ///
+    /// Lets tests model OS-level pasteboard write failures.
     func failNextSetString(times: Int = 1) {
         lock.withLock { storedSetStringFailureCount += times }
     }
@@ -61,8 +65,9 @@ struct VsockGuestClipboardAgentTests {
     // MARK: - Agent factory helpers
 
     /// Sets up an agent with the given pasteboard and a socket provider that
-    /// returns the given fd on first call, transient failure thereafter. The
-    /// short retry interval keeps the pause/resume wake-up snappy — the agent
+    /// returns the given fd on first call, transient failure thereafter.
+    ///
+    /// The short retry interval keeps the pause/resume wake-up snappy — the agent
     /// is now default-paused at construction, and `setEnabled(true)` only
     /// takes effect on the next loop iteration after the current sleep.
     private func makeAgent(pasteboard: FakePasteboard, agentFd: Int32) -> VsockGuestClipboardAgent {
@@ -79,7 +84,9 @@ struct VsockGuestClipboardAgentTests {
 
     /// Starts the agent, enables it (production agents are default-disabled
     /// until host policy says otherwise), and waits until `liveChannel` is
-    /// published on the main queue. After this returns, callers driving
+    /// published on the main queue.
+    ///
+    /// After this returns, callers driving
     /// `checkClipboardChange()` see a non-nil channel.
     private func startAgentAndWaitForLiveChannel(
         agent: VsockGuestClipboardAgent,

--- a/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
@@ -30,7 +30,9 @@ struct VsockGuestControlAgentTests {
         return frame
     }
 
-    /// Builds a single-fd-shot agent at small test cadences. The agent's
+    /// Builds a single-fd-shot agent at small test cadences.
+    ///
+    /// The agent's
     /// `client` provider hands `agentFd` on the first call, transient failure
     /// after — so reconnect tests must use a multi-fd provider explicitly.
     private func makeAgent(

--- a/KernovaGuestAgentTests/VsockHostConnectionTests.swift
+++ b/KernovaGuestAgentTests/VsockHostConnectionTests.swift
@@ -123,8 +123,9 @@ struct VsockHostConnectionTests {
     // MARK: - flushPendingLogs: partial failure re-enqueue (Critical #1)
 
     /// Verifies the interesting bug-prone path: some frames are successfully
-    /// sent, then send fails mid-flush. The unflushed remainder must be
-    /// re-enqueued in order at the front of the buffer.
+    /// sent, then send fails mid-flush.
+    ///
+    /// The unflushed remainder must be re-enqueued in order at the front of the buffer.
     ///
     /// Technique: set a tiny SO_SNDBUF on the sender fd so the kernel buffer
     /// fills after a few frames, causing the N-th write to fail. Then close

--- a/KernovaProtocol/Sources/KernovaProtocol/VsockChannel.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/VsockChannel.swift
@@ -94,9 +94,7 @@ public final class VsockChannel: @unchecked Sendable {
         close()
     }
 
-    /// Begins reading from the underlying descriptor.
-    ///
-    /// Idempotent.
+    /// Begins reading from the underlying descriptor (idempotent).
     public func start() {
         lock.lock()
         defer { lock.unlock() }

--- a/KernovaProtocol/Sources/KernovaProtocol/VsockChannel.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/VsockChannel.swift
@@ -30,7 +30,9 @@ public typealias Frame = Kernova_V1_Frame
 /// The lock-based design lets either side call `send` from any context and
 /// drain `incoming` from any task without isolation hops.
 public final class VsockChannel: @unchecked Sendable {
-    /// Inbound frames. The stream finishes on EOF and finishes-with-error on
+    /// Inbound frames.
+    ///
+    /// The stream finishes on EOF and finishes-with-error on
     /// any framing or decoding failure.
     public let incoming: AsyncThrowingStream<Frame, Error>
 
@@ -45,8 +47,9 @@ public final class VsockChannel: @unchecked Sendable {
 
     /// Set once on first `VsockChannel` construction: ignore `SIGPIPE`
     /// process-wide so a write to a peer whose read side has closed surfaces
-    /// as `EPIPE` from `write(2)` instead of killing the process. Belt-and-
-    /// suspenders alongside the per-fd `SO_NOSIGPIPE` set in `init` —
+    /// as `EPIPE` from `write(2)` instead of killing the process.
+    ///
+    /// Belt-and-suspenders alongside the per-fd `SO_NOSIGPIPE` set in `init` —
     /// `SO_NOSIGPIPE` doesn't appear to take effect on every code path
     /// across macOS versions / `FileHandle` write internals (CI on macOS-26.3
     /// VMs still delivers `SIGPIPE` despite the socket option being set), so
@@ -55,7 +58,9 @@ public final class VsockChannel: @unchecked Sendable {
         signal(SIGPIPE, SIG_IGN)
     }()
 
-    /// Wraps the given file descriptor. The descriptor must be a connected
+    /// Wraps the given file descriptor.
+    ///
+    /// The descriptor must be a connected
     /// SOCK_STREAM endpoint; the channel will close it on teardown.
     public init(fileDescriptor: Int32) {
         _ = Self.suppressSIGPIPEOnce
@@ -89,7 +94,9 @@ public final class VsockChannel: @unchecked Sendable {
         close()
     }
 
-    /// Begins reading from the underlying descriptor. Idempotent.
+    /// Begins reading from the underlying descriptor.
+    ///
+    /// Idempotent.
     public func start() {
         lock.lock()
         defer { lock.unlock() }
@@ -102,7 +109,9 @@ public final class VsockChannel: @unchecked Sendable {
         }
     }
 
-    /// Encodes and sends a frame. Multiple concurrent calls are safe — they
+    /// Encodes and sends a frame.
+    ///
+    /// Multiple concurrent calls are safe — they
     /// serialize on an internal lock.
     ///
     /// Errors thrown:
@@ -128,7 +137,9 @@ public final class VsockChannel: @unchecked Sendable {
         }
     }
 
-    /// Tears down the channel. Subsequent `send` calls throw `.closed` and
+    /// Tears down the channel.
+    ///
+    /// Subsequent `send` calls throw `.closed` and
     /// the `incoming` stream finishes (without error).
     public func close() {
         lock.lock()

--- a/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
@@ -70,9 +70,7 @@ public struct VsockFrameDecoder: Sendable {
 
     public init() {}
 
-    /// Appends raw bytes to the internal buffer.
-    ///
-    /// Does not parse.
+    /// Appends raw bytes to the internal buffer (does not parse).
     public mutating func feed(_ chunk: Data) {
         buffer.append(chunk)
     }

--- a/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
@@ -58,7 +58,9 @@ public enum VsockFrameError: Error, Sendable, Equatable {
 /// queue at a time.
 public struct VsockFrameDecoder: Sendable {
     /// Compact the consumed prefix once the read offset crosses this many
-    /// bytes. Sized to amortize the shift cost (each byte is copied at most
+    /// bytes.
+    ///
+    /// Sized to amortize the shift cost (each byte is copied at most
     /// once before being dropped) without keeping more than ~64 KiB of stale
     /// storage live per decoder.
     private static let compactionThreshold: Int = 64 * 1024
@@ -68,7 +70,9 @@ public struct VsockFrameDecoder: Sendable {
 
     public init() {}
 
-    /// Appends raw bytes to the internal buffer. Does not parse.
+    /// Appends raw bytes to the internal buffer.
+    ///
+    /// Does not parse.
     public mutating func feed(_ chunk: Data) {
         buffer.append(chunk)
     }

--- a/KernovaProtocol/Tests/KernovaProtocolTests/VsockChannelTests.swift
+++ b/KernovaProtocol/Tests/KernovaProtocolTests/VsockChannelTests.swift
@@ -8,6 +8,7 @@ struct VsockChannelTests {
     // MARK: - Helpers
 
     /// Creates two `VsockChannel`s connected by a `socketpair(AF_UNIX, SOCK_STREAM)`.
+    ///
     /// AF_UNIX behaves identically to AF_VSOCK at the SOCK_STREAM level for our purposes
     /// and is testable on the host.
     private func makePair() throws -> (a: VsockChannel, b: VsockChannel) {

--- a/KernovaTests/AgentStatusTests.swift
+++ b/KernovaTests/AgentStatusTests.swift
@@ -3,7 +3,9 @@ import Testing
 
 /// Unit tests for `AgentStatus.synthesize(...)` — the pure function that
 /// folds the upstream service value, persisted host context, and live-
-/// session flag into the final UI-facing `AgentStatus`. The function is
+/// session flag into the final UI-facing `AgentStatus`.
+///
+/// The function is
 /// extracted from `VMInstance.agentStatus` specifically to make this logic
 /// testable without standing up a `VZVirtualMachine`.
 @Suite("AgentStatus.synthesize")

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -7,7 +7,9 @@ import Virtualization
 struct ConfigurationBuilderTests {
     // MARK: - Helpers
 
-    /// Creates a temp directory with a dummy disk image. Caller must `defer` removal of the returned URL.
+    /// Creates a temp directory with a dummy disk image.
+    ///
+    /// Caller must `defer` removal of the returned URL.
     private func makeTempBundle(withDisk: Bool = false) throws -> URL {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)

--- a/KernovaTests/Mocks/MockVirtualizationService.swift
+++ b/KernovaTests/Mocks/MockVirtualizationService.swift
@@ -17,9 +17,7 @@ final class MockVirtualizationService: VirtualizationProviding {
     // MARK: - Error Injection & Recovery
 
     var startError: (any Error)?
-    /// Status to set on start failure.
-    ///
-    /// Defaults to `.error`; set to `.stopped` to simulate transient errors.
+    /// Status to set on start failure (defaults to `.error`; set to `.stopped` to simulate transient errors).
     var startErrorRecoveryStatus: VMStatus = .error
     var stopError: (any Error)?
     var forceStopError: (any Error)?

--- a/KernovaTests/Mocks/MockVirtualizationService.swift
+++ b/KernovaTests/Mocks/MockVirtualizationService.swift
@@ -17,7 +17,9 @@ final class MockVirtualizationService: VirtualizationProviding {
     // MARK: - Error Injection & Recovery
 
     var startError: (any Error)?
-    /// Status to set on start failure. Defaults to `.error`; set to `.stopped` to simulate transient errors.
+    /// Status to set on start failure.
+    ///
+    /// Defaults to `.error`; set to `.stopped` to simulate transient errors.
     var startErrorRecoveryStatus: VMStatus = .error
     var stopError: (any Error)?
     var forceStopError: (any Error)?

--- a/KernovaTests/Mocks/SuspendingMockUSBDeviceService.swift
+++ b/KernovaTests/Mocks/SuspendingMockUSBDeviceService.swift
@@ -2,6 +2,7 @@ import Foundation
 @testable import Kernova
 
 /// A mock USB device service whose `attach` method suspends until explicitly resumed.
+///
 /// Used to test the rapid-double-click mount mutex in `VMLibraryViewModel`.
 ///
 /// - Important: Only **one** operation can be suspended at a time. The mock stores a
@@ -9,7 +10,9 @@ import Foundation
 ///   operation is already suspended will trigger a precondition failure.
 @MainActor
 final class SuspendingMockUSBDeviceService: USBDeviceProviding {
-    /// When `true`, `attach` will suspend. Set to `false` to allow subsequent calls through immediately.
+    /// When `true`, `attach` will suspend.
+    ///
+    /// Set to `false` to allow subsequent calls through immediately.
     var shouldSuspendOnAttach = true
 
     var attachCallCount = 0

--- a/KernovaTests/Mocks/SuspendingMockVirtualizationService.swift
+++ b/KernovaTests/Mocks/SuspendingMockVirtualizationService.swift
@@ -2,17 +2,23 @@ import Foundation
 @testable import Kernova
 
 /// A mock virtualization service whose `start` and `pause` methods suspend until
-/// explicitly resumed. Used to test operation serialization in `VMLifecycleCoordinator`.
+/// explicitly resumed.
+///
+/// Used to test operation serialization in `VMLifecycleCoordinator`.
 ///
 /// - Important: Only **one** operation can be suspended at a time. The mock stores a
 ///   single `suspendedContinuation` slot; calling `suspendIfNeeded()` while another
 ///   operation is already suspended will trigger a precondition failure.
 @MainActor
 final class SuspendingMockVirtualizationService: VirtualizationProviding {
-    /// When `true`, `start` will suspend. Set to `false` to allow subsequent calls through immediately.
+    /// When `true`, `start` will suspend.
+    ///
+    /// Set to `false` to allow subsequent calls through immediately.
     var shouldSuspendOnStart = true
 
-    /// When `true`, `pause` will suspend. Set to `false` to allow subsequent calls through immediately.
+    /// When `true`, `pause` will suspend.
+    ///
+    /// Set to `false` to allow subsequent calls through immediately.
     var shouldSuspendOnPause = true
 
     // MARK: - Suspension Mechanism

--- a/KernovaTests/SpiceClipboardServiceTests.swift
+++ b/KernovaTests/SpiceClipboardServiceTests.swift
@@ -7,7 +7,9 @@ import Foundation
 struct SpiceClipboardServiceTests {
     // MARK: - Helpers
 
-    /// Creates a fresh service with connected pipes. The input pipe's read end
+    /// Creates a fresh service with connected pipes.
+    ///
+    /// The input pipe's read end
     /// is set to non-blocking so `drainPipe` returns immediately when empty.
     private func makeService() -> (service: SpiceClipboardService, inputPipe: Pipe, outputPipe: Pipe) {
         let inputPipe = Pipe()

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -5,6 +5,7 @@ import Foundation
 @Suite("VMConfiguration Tests")
 struct VMConfigurationTests {
     /// Builds a complete `VMConfiguration` JSON string with all required fields populated.
+    ///
     /// Pass extra comma-separated JSON fields via `extraFields` to add or override entries.
     private static func makeBaseJSON(
         name: String = "Old VM",
@@ -753,7 +754,9 @@ struct VMConfigurationTests {
     // MARK: - Full-field round-trip
 
     /// Populates every property with a non-default value, encodes to JSON,
-    /// decodes back, and asserts equality. Tripwire for the custom
+    /// decodes back, and asserts equality.
+    ///
+    /// Tripwire for the custom
     /// `init(from:)`: if a new field is added to `VMConfiguration` but the
     /// decoder is not updated, the missed field will silently default-
     /// initialize on decode and the round-trip equality will fail.

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -585,8 +585,9 @@ struct VMInstanceTests {
     //   - No Hello arrives during the grace window.
     // Tests inject a millisecond-scale grace so the suite stays fast.
 
-    /// Builds a macOS VMInstance with a known `lastSeenAgentVersion`. The
-    /// caller is responsible for explicitly clearing the watchdog if needed
+    /// Builds a macOS VMInstance with a known `lastSeenAgentVersion`.
+    ///
+    /// The caller is responsible for explicitly clearing the watchdog if needed
     /// across tests.
     private func makeMacOSInstanceWithAgentInstalled(
         lastSeen: String = "0.9.2",

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -22,6 +22,7 @@ struct VsockClipboardServiceTests {
     }
 
     /// MainActor-isolated buffer fed by a single iterator on the channel.
+    ///
     /// Tests that need both "expect frame" and "expect no frame" assertions
     /// against the same channel must not hand-roll iterators per call —
     /// `AsyncThrowingStream` is single-consumer and cancelling an iterator
@@ -61,6 +62,7 @@ struct VsockClipboardServiceTests {
     }
 
     /// Sleeps `duration` then asserts no frames arrived since `before`.
+    ///
     /// Used in suppression tests where we want to prove a `grabIfChanged()`
     /// call produced *no* wire traffic, not just "fewer than the next two".
     private func expectNoNewFrames(

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -14,7 +14,9 @@ struct VsockControlServiceTests {
         return (VsockChannel(fileDescriptor: a), VsockChannel(fileDescriptor: b))
     }
 
-    /// Builds a guest-side Hello frame with the given agent version. Tests use
+    /// Builds a guest-side Hello frame with the given agent version.
+    ///
+    /// Tests use
     /// this to drive the `agentStatus` numeric-comparison matrix.
     private func makeGuestHello(agentVersion: String) -> Frame {
         var frame = Frame()
@@ -38,13 +40,17 @@ struct VsockControlServiceTests {
         return frame
     }
 
-    /// Default test cadences. Small enough that liveness assertions don't
+    /// Default test cadences.
+    ///
+    /// Small enough that liveness assertions don't
     /// drag the suite, large enough to avoid scheduler-induced flakiness.
     private static let testHeartbeat: Duration = .milliseconds(40)
     private static let testUnresponsive: Duration = .milliseconds(160)
     private static let testTerminate: Duration = .milliseconds(400)
 
-    /// Builds a service with the test cadences applied. Caller decides
+    /// Builds a service with the test cadences applied.
+    ///
+    /// Caller decides
     /// `bundledAgentVersion`. The service is NOT started — caller invokes
     /// `start()` after wiring the recorder.
     private func makeService(
@@ -632,6 +638,7 @@ struct VsockControlServiceTests {
 }
 
 /// MainActor-isolated recorder for the `onAgentVersionObserved` closure.
+///
 /// Reference type so the observer's closure capture and the test's read site
 /// see the same buffer without `inout` shenanigans.
 @MainActor


### PR DESCRIPTION
## Summary
- Insert a blank `///` line between the one-line summary and detail body in 173 doc comments across 50 files, satisfying swift-format's [`BeginDocumentationCommentWithOneLineSummary`](https://github.com/swiftlang/swift-format/blob/main/Documentation/RuleDocumentation.md#begindocumentationcommentwithonelinesummary) rule.
- Enable the rule in `.swift-format` so future doc comments follow Apple/DocC convention.

Closes #200

## Changes
- Flip `BeginDocumentationCommentWithOneLineSummary` to `true` in `.swift-format`.
- For doc comments where the first sentence ended at end-of-line: insert `///` directly after the summary line.
- For doc comments where the first sentence ended mid-line: split the line at the period, move the remainder onto a new `///` line, and insert a blank `///` between summary and detail.
- Two cases (`AppDelegate.targetScreen`, `SpiceConstants.serverPort`) had the original "terminate this sentence with a period" finding — replaced the trailing `:` / `)` with `.` and applied the blank-line split.
- Cleaned up nine spots where the mechanical split orphaned a single short word ("Safe", "Forgiving", "Default", "The", "We", "Reading", "Production") on its own line by rejoining it with the following line.

## Test plan
- [x] `make lint` is clean with the new rule enabled
- [x] `make build` succeeds on macOS
- [x] `make test` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)