### PR TITLE
refactor: Enable AllPublicDeclarationsHaveDocumentation rule

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -10,7 +10,7 @@
     "spacesBeforeEndOfLineComments": 2,
     "tabWidth": 4,
     "rules": {
-        "AllPublicDeclarationsHaveDocumentation": false,
+        "AllPublicDeclarationsHaveDocumentation": true,
         "AlwaysUseLiteralForEmptyCollectionInit": true,
         "NeverUseForceTry": true,
         "NeverUseImplicitlyUnwrappedOptionals": false,

--- a/KernovaGuestAgent/KernovaLogMessage.swift
+++ b/KernovaGuestAgent/KernovaLogMessage.swift
@@ -10,19 +10,19 @@ import os
 /// that reject manual construction from outside the `os` module —
 /// so we redact privately-marked values ourselves instead of relying on
 /// the OS's runtime privacy machinery.
-public struct LogPrivacy: Sendable {
-    @usableFromInline enum Kind: Sendable {
+struct LogPrivacy: Sendable {
+    enum Kind: Sendable {
         case `public`
         case `private`
         case sensitive
         case auto
     }
-    @usableFromInline let kind: Kind
+    let kind: Kind
 
-    public static let `public` = LogPrivacy(kind: .public)
-    public static let `private` = LogPrivacy(kind: .private)
-    public static let sensitive = LogPrivacy(kind: .sensitive)
-    public static let auto = LogPrivacy(kind: .auto)
+    static let `public` = LogPrivacy(kind: .public)
+    static let `private` = LogPrivacy(kind: .private)
+    static let sensitive = LogPrivacy(kind: .sensitive)
+    static let auto = LogPrivacy(kind: .auto)
 }
 
 /// Captures a log message in two parallel rendered forms — one suitable
@@ -46,26 +46,26 @@ public struct LogPrivacy: Sendable {
 /// another target, relocate this file (and `KernovaLogger.swift`) into
 /// the `KernovaProtocol` Swift Package and update the consuming targets'
 /// dependencies.
-public struct KernovaLogMessage: ExpressibleByStringInterpolation, ExpressibleByStringLiteral, Sendable {
-    public struct StringInterpolation: StringInterpolationProtocol {
-        @usableFromInline var localRendered: String
-        @usableFromInline var wireRendered: String
+struct KernovaLogMessage: ExpressibleByStringInterpolation, ExpressibleByStringLiteral, Sendable {
+    struct StringInterpolation: StringInterpolationProtocol {
+        var localRendered: String
+        var wireRendered: String
 
-        public init(literalCapacity: Int, interpolationCount: Int) {
+        init(literalCapacity: Int, interpolationCount: Int) {
             localRendered = ""
             wireRendered = ""
             localRendered.reserveCapacity(literalCapacity * 2)
             wireRendered.reserveCapacity(literalCapacity * 2)
         }
 
-        public mutating func appendLiteral(_ literal: String) {
+        mutating func appendLiteral(_ literal: String) {
             localRendered += literal
             wireRendered += literal
         }
 
         // Default-privacy = `.private` matches `os.Logger`'s string default.
 
-        public mutating func appendInterpolation(
+        mutating func appendInterpolation(
             _ value: String,
             privacy: LogPrivacy = .private
         ) {
@@ -76,7 +76,7 @@ public struct KernovaLogMessage: ExpressibleByStringInterpolation, ExpressibleBy
         // Generic fallback for non-`String` types — numbers, booleans,
         // arrays, anything `CustomStringConvertible`. Rendered via
         // `String(describing:)`.
-        public mutating func appendInterpolation<T>(
+        mutating func appendInterpolation<T>(
             _ value: T,
             privacy: LogPrivacy = .private
         ) {
@@ -85,7 +85,6 @@ public struct KernovaLogMessage: ExpressibleByStringInterpolation, ExpressibleBy
             localRendered += redacted(s, privacy: privacy)
         }
 
-        @usableFromInline
         func redacted(_ value: String, privacy: LogPrivacy) -> String {
             switch privacy.kind {
             case .public, .auto:
@@ -101,20 +100,20 @@ public struct KernovaLogMessage: ExpressibleByStringInterpolation, ExpressibleBy
     /// Values marked
     /// `.private` or `.sensitive` have already been replaced with the
     /// `<private>` placeholder.
-    public let localRendered: String
+    let localRendered: String
 
     /// String suitable for forwarding over vsock.
     ///
     /// Every interpolated
     /// value is rendered in cleartext.
-    public let wireRendered: String
+    let wireRendered: String
 
-    public init(stringInterpolation: StringInterpolation) {
+    init(stringInterpolation: StringInterpolation) {
         localRendered = stringInterpolation.localRendered
         wireRendered = stringInterpolation.wireRendered
     }
 
-    public init(stringLiteral value: String) {
+    init(stringLiteral value: String) {
         localRendered = value
         wireRendered = value
     }

--- a/KernovaGuestAgent/KernovaLogger.swift
+++ b/KernovaGuestAgent/KernovaLogger.swift
@@ -27,12 +27,12 @@ import os
 /// case needs the same wrapper on the host or in another target, relocate
 /// this file (and `KernovaLogMessage.swift`) into the `KernovaProtocol`
 /// Swift Package.
-public struct KernovaLogger: Sendable {
-    public let subsystem: String
-    public let category: String
+struct KernovaLogger: Sendable {
+    let subsystem: String
+    let category: String
     private let osLogger: Logger
 
-    public init(subsystem: String, category: String) {
+    init(subsystem: String, category: String) {
         self.subsystem = subsystem
         self.category = category
         self.osLogger = Logger(subsystem: subsystem, category: category)
@@ -40,32 +40,32 @@ public struct KernovaLogger: Sendable {
 
     // MARK: - Levels
 
-    public func debug(_ message: KernovaLogMessage) {
+    func debug(_ message: KernovaLogMessage) {
         osLogger.debug("\(message.localRendered, privacy: .public)")
         forward(level: .debug, message: message.wireRendered)
     }
 
-    public func info(_ message: KernovaLogMessage) {
+    func info(_ message: KernovaLogMessage) {
         osLogger.info("\(message.localRendered, privacy: .public)")
         forward(level: .info, message: message.wireRendered)
     }
 
-    public func notice(_ message: KernovaLogMessage) {
+    func notice(_ message: KernovaLogMessage) {
         osLogger.notice("\(message.localRendered, privacy: .public)")
         forward(level: .notice, message: message.wireRendered)
     }
 
-    public func warning(_ message: KernovaLogMessage) {
+    func warning(_ message: KernovaLogMessage) {
         osLogger.warning("\(message.localRendered, privacy: .public)")
         forward(level: .warning, message: message.wireRendered)
     }
 
-    public func error(_ message: KernovaLogMessage) {
+    func error(_ message: KernovaLogMessage) {
         osLogger.error("\(message.localRendered, privacy: .public)")
         forward(level: .error, message: message.wireRendered)
     }
 
-    public func fault(_ message: KernovaLogMessage) {
+    func fault(_ message: KernovaLogMessage) {
         osLogger.fault("\(message.localRendered, privacy: .public)")
         forward(level: .fault, message: message.wireRendered)
     }

--- a/KernovaProtocol/Sources/KernovaProtocol/VsockChannel.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/VsockChannel.swift
@@ -199,6 +199,11 @@ public enum VsockChannelError: Error, Sendable {
 }
 
 extension VsockChannelError: Equatable {
+    /// Compares two errors by case only.
+    ///
+    /// `.write` cases are equal regardless of the wrapped underlying error;
+    /// callers needing the exact cause should switch and inspect the
+    /// associated value directly.
     public static func == (lhs: VsockChannelError, rhs: VsockChannelError) -> Bool {
         switch (lhs, rhs) {
         case (.closed, .closed): return true

--- a/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
@@ -68,6 +68,7 @@ public struct VsockFrameDecoder: Sendable {
     private var buffer: Data = Data()
     private var readOffset: Int = 0
 
+    /// Creates an empty decoder ready to accept bytes via `feed(_:)`.
     public init() {}
 
     /// Appends raw bytes to the internal buffer (does not parse).


### PR DESCRIPTION
## Summary
- Enable swift-format's `AllPublicDeclarationsHaveDocumentation` rule, deferred from #199.
- For the 20 findings inside `KernovaGuestAgent` (a single binary target with no external consumers), downgrade the unnecessarily-`public` declarations to `internal` rather than papering over them with boilerplate doc comments. Tests share the module via the Xcode file-system-synchronized membership exception, so `internal` is sufficient.
- For the 2 findings on the genuinely-public `KernovaProtocol` surface (`VsockChannelError.==` and `VsockFrameDecoder.init()`), add concise `///` doc comments.

Closes #201.

## Changes
- `.swift-format` — flip `AllPublicDeclarationsHaveDocumentation` to `true`.
- `KernovaGuestAgent/KernovaLogMessage.swift` — drop `public` from `LogPrivacy`, its four static factories, `KernovaLogMessage`, the nested `StringInterpolation`, the `init`s, the `appendLiteral(_:)` / `appendInterpolation(_:privacy:)` methods, and the `localRendered` / `wireRendered` properties. Remove the now-redundant `@usableFromInline` markers (the type was never `@inlinable`-consumed and the markers required `internal`-or-stricter access anyway).
- `KernovaGuestAgent/KernovaLogger.swift` — drop `public` from `KernovaLogger`, its stored properties, init, and the six log-level methods.
- `KernovaProtocol/.../VsockChannel.swift` — add doc comment to `VsockChannelError.==(lhs:rhs:)` describing case-only equality.
- `KernovaProtocol/.../VsockFrame.swift` — add doc comment to `VsockFrameDecoder.init()`.

## Test plan
- [x] `make lint` is clean (rule enabled, zero findings)
- [x] `make test` passes the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)