### PR TITLE
refactor: Remove implicitly-unwrapped optionals from AppKit controllers

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -13,7 +13,7 @@
         "AllPublicDeclarationsHaveDocumentation": true,
         "AlwaysUseLiteralForEmptyCollectionInit": true,
         "NeverUseForceTry": true,
-        "NeverUseImplicitlyUnwrappedOptionals": false,
+        "NeverUseImplicitlyUnwrappedOptionals": true,
         "NeverForceUnwrap": true,
         "UseEarlyExits": true,
         "OmitExplicitReturns": true,

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -6,8 +6,7 @@ import SwiftUI
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenuDelegate {
     private var mainWindowController: MainWindowController?
-    private var viewModel: VMLibraryViewModel!
-    private var pendingOpenURLs: [URL] = []
+    private let viewModel: VMLibraryViewModel
     private var serialConsoleWindows: [UUID: SerialConsoleWindowController] = [:]
     private var serialConsoleObservers: [UUID: Any] = [:]
     private var clipboardWindows: [UUID: ClipboardWindowController] = [:]
@@ -15,8 +14,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private var displayWindows: [UUID: VMDisplayWindowController] = [:]
     private var displayWindowObservers: [UUID: Any] = [:]
     private var terminationObservation: ObservationLoop?
-    private var serialConsoleMenuItem: NSMenuItem!
-    private var clipboardMenuItem: NSMenuItem!
+    private let serialConsoleMenuItem: NSMenuItem
+    private let clipboardMenuItem: NSMenuItem
     /// Set in `applicationWillBecomeActive` and read in `applicationShouldHandleReopen`
     /// to distinguish a dock click that activates the app from one on an already-active app.
     ///
@@ -82,24 +81,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         app.run()
     }
 
-    // MARK: - NSApplicationDelegate
+    override init() {
+        self.viewModel = VMLibraryViewModel()
 
-    func applicationDidFinishLaunching(_ notification: Notification) {
-        viewModel = VMLibraryViewModel()
+        let serialItem = NSMenuItem(
+            title: "Serial Console",
+            action: #selector(showSerialConsole(_:)),
+            keyEquivalent: "t"
+        )
+        serialItem.keyEquivalentModifierMask = [.command, .shift]
+        self.serialConsoleMenuItem = serialItem
+
+        let clipboardItem = NSMenuItem(
+            title: "Clipboard",
+            action: #selector(showClipboard(_:)),
+            keyEquivalent: "v"
+        )
+        clipboardItem.keyEquivalentModifierMask = [.command, .shift]
+        self.clipboardMenuItem = clipboardItem
+
+        super.init()
+
         viewModel.onOpenDisplayWindow = { [weak self] instance in
             self?.openDisplayWindow(for: instance)
         }
+    }
+
+    // MARK: - NSApplicationDelegate
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
         setupMainMenu()
 
         let windowController = MainWindowController(viewModel: viewModel)
         windowController.showWindow(nil)
         mainWindowController = windowController
-
-        // Process any URLs received before the view model was ready
-        for url in pendingOpenURLs {
-            viewModel.importVM(from: url)
-        }
-        pendingOpenURLs.removeAll()
 
         observeForTermination()
 
@@ -310,13 +325,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     func application(_ application: NSApplication, open urls: [URL]) {
         let vmURLs = urls.filter { $0.pathExtension == VMStorageService.bundleExtension }
-
-        guard let viewModel else {
-            // Called before applicationDidFinishLaunching — queue for later
-            pendingOpenURLs.append(contentsOf: vmURLs)
-            return
-        }
-
         for url in vmURLs {
             viewModel.importVM(from: url)
         }
@@ -915,22 +923,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         )
         windowMenu.addItem(showLibraryItem)
         windowMenu.addItem(.separator())
-        let serialItem = NSMenuItem(
-            title: "Serial Console",
-            action: #selector(showSerialConsole(_:)),
-            keyEquivalent: "t"
-        )
-        serialItem.keyEquivalentModifierMask = [.command, .shift]
-        self.serialConsoleMenuItem = serialItem
-        windowMenu.addItem(serialItem)
-        let clipboardItem = NSMenuItem(
-            title: "Clipboard",
-            action: #selector(showClipboard(_:)),
-            keyEquivalent: "v"
-        )
-        clipboardItem.keyEquivalentModifierMask = [.command, .shift]
-        self.clipboardMenuItem = clipboardItem
-        windowMenu.addItem(clipboardItem)
+        windowMenu.addItem(serialConsoleMenuItem)
+        windowMenu.addItem(clipboardMenuItem)
         let removableMediaItem = NSMenuItem(
             title: "Removable Media",
             action: #selector(showRemovableMedia(_:)),

--- a/Kernova/App/ClipboardContentViewController.swift
+++ b/Kernova/App/ClipboardContentViewController.swift
@@ -14,10 +14,11 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
 
     private let instance: VMInstance
     private weak var viewModel: VMLibraryViewModel?
-    private var textView: NSTextView!
-    private var statusCircle: NSView!
-    private var statusLabel: NSTextField!
-    private var actionButton: NSButton!
+    private let textView: NSTextView
+    private let scrollView: NSScrollView
+    private let statusCircle: NSView
+    private let statusLabel: NSTextField
+    private let actionButton: NSButton
     private var isUpdatingFromService = false
     private var serviceObservation: ObservationLoop?
 
@@ -29,7 +30,60 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
     init(instance: VMInstance, viewModel: VMLibraryViewModel) {
         self.instance = instance
         self.viewModel = viewModel
+
+        let textView = NSTextView()
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.allowsUndo = true
+        textView.usesFindPanel = true
+        textView.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+        textView.textContainerInset = NSSize(width: 4, height: 8)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(
+            width: 0,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        self.textView = textView
+
+        let scrollView = NSScrollView()
+        scrollView.documentView = textView
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = false
+        self.scrollView = scrollView
+
+        let circle = NSView()
+        circle.wantsLayer = true
+        circle.layer?.cornerRadius = 4
+        circle.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            circle.widthAnchor.constraint(equalToConstant: 8),
+            circle.heightAnchor.constraint(equalToConstant: 8),
+        ])
+        self.statusCircle = circle
+
+        let label = NSTextField(labelWithString: "")
+        label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        label.textColor = .secondaryLabelColor
+        label.lineBreakMode = .byTruncatingTail
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        self.statusLabel = label
+
+        let button = NSButton(title: "", target: nil, action: nil)
+        button.bezelStyle = .accessoryBarAction
+        button.controlSize = .small
+        button.isHidden = true
+        self.actionButton = button
+
         super.init(nibName: nil, bundle: nil)
+
+        textView.delegate = self
+        button.target = self
+        button.action = #selector(actionButtonClicked(_:))
     }
 
     required init?(coder: NSCoder) {
@@ -41,18 +95,14 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
     override func loadView() {
         let container = NSView()
 
-        // Text editor
-        let scrollView = makeScrollableTextView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(scrollView)
 
-        // Divider
         let divider = NSBox()
         divider.boxType = .separator
         divider.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(divider)
 
-        // Status bar
         let statusBar = makeStatusBar()
         statusBar.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(statusBar)
@@ -191,59 +241,7 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
 
     // MARK: - View Construction
 
-    private func makeScrollableTextView() -> NSScrollView {
-        let textView = NSTextView()
-        textView.isEditable = true
-        textView.isSelectable = true
-        textView.isRichText = false
-        textView.allowsUndo = true
-        textView.usesFindPanel = true
-        textView.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
-        textView.textContainerInset = NSSize(width: 4, height: 8)
-        textView.isVerticallyResizable = true
-        textView.isHorizontallyResizable = false
-        textView.textContainer?.widthTracksTextView = true
-        textView.textContainer?.containerSize = NSSize(
-            width: 0,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-        textView.delegate = self
-        self.textView = textView
-
-        let scrollView = NSScrollView()
-        scrollView.documentView = textView
-        scrollView.hasVerticalScroller = true
-        scrollView.hasHorizontalScroller = false
-        scrollView.autohidesScrollers = true
-        scrollView.drawsBackground = false
-
-        return scrollView
-    }
-
     private func makeStatusBar() -> NSView {
-        let circle = NSView()
-        circle.wantsLayer = true
-        circle.layer?.cornerRadius = 4
-        circle.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            circle.widthAnchor.constraint(equalToConstant: 8),
-            circle.heightAnchor.constraint(equalToConstant: 8),
-        ])
-        self.statusCircle = circle
-
-        let label = NSTextField(labelWithString: "")
-        label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
-        label.textColor = .secondaryLabelColor
-        label.lineBreakMode = .byTruncatingTail
-        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        self.statusLabel = label
-
-        let button = NSButton(title: "", target: self, action: #selector(actionButtonClicked(_:)))
-        button.bezelStyle = .accessoryBarAction
-        button.controlSize = .small
-        button.isHidden = true
-        self.actionButton = button
-
         // Spacer needs an explicit low horizontal hugging priority to actually
         // expand inside the NSStackView. NSView's default hugging priority is
         // 250 — same as the label's — so without this, the stack view has no
@@ -252,7 +250,7 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
         let spacer = NSView()
         spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
-        let stack = NSStackView(views: [circle, label, spacer, button])
+        let stack = NSStackView(views: [statusCircle, statusLabel, spacer, actionButton])
         stack.orientation = .horizontal
         stack.spacing = 6
         stack.edgeInsets = NSEdgeInsets(top: 6, left: 12, bottom: 6, right: 12)

--- a/Kernova/App/SerialConsoleContentViewController.swift
+++ b/Kernova/App/SerialConsoleContentViewController.swift
@@ -9,16 +9,77 @@ import Cocoa
 @MainActor
 final class SerialConsoleContentViewController: NSViewController {
     private let instance: VMInstance
-    private var textView: SerialTextView!
-    private var scrollView: NSScrollView!
-    private var statusCircle: NSView!
-    private var statusLabel: NSTextField!
-    private var characterCountLabel: NSTextField!
+    private let textView: SerialTextView
+    private let scrollView: NSScrollView
+    private let statusCircle: NSView
+    private let statusLabel: NSTextField
+    private let characterCountLabel: NSTextField
     private var instanceObservation: ObservationLoop?
 
     init(instance: VMInstance) {
         self.instance = instance
+
+        let textView = SerialTextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.isFieldEditor = false
+        textView.allowsUndo = false
+        textView.usesFindPanel = true
+        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.textColor = .init(white: 0.9, alpha: 1.0)
+        textView.backgroundColor = .init(white: 0.1, alpha: 1.0)
+        textView.insertionPointColor = .init(white: 0.9, alpha: 1.0)
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.isGrammarCheckingEnabled = false
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(
+            width: 0,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        self.textView = textView
+
+        let scrollView = NSScrollView()
+        scrollView.documentView = textView
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = .init(white: 0.1, alpha: 1.0)
+        self.scrollView = scrollView
+
+        let circle = NSView()
+        circle.wantsLayer = true
+        circle.layer?.cornerRadius = 4
+        circle.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            circle.widthAnchor.constraint(equalToConstant: 8),
+            circle.heightAnchor.constraint(equalToConstant: 8),
+        ])
+        self.statusCircle = circle
+
+        let label = NSTextField(labelWithString: "")
+        label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        label.textColor = .secondaryLabelColor
+        self.statusLabel = label
+
+        let countLabel = NSTextField(labelWithString: "")
+        countLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        countLabel.textColor = .secondaryLabelColor
+        countLabel.alignment = .right
+        self.characterCountLabel = countLabel
+
         super.init(nibName: nil, bundle: nil)
+
+        textView.sendInput = { [weak self] string in
+            self?.instance.sendSerialInput(string)
+        }
     }
 
     required init?(coder: NSCoder) {
@@ -30,19 +91,14 @@ final class SerialConsoleContentViewController: NSViewController {
     override func loadView() {
         let container = NSView()
 
-        // Terminal
-        let scrollView = makeTerminalScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(scrollView)
-        self.scrollView = scrollView
 
-        // Divider
         let divider = NSBox()
         divider.boxType = .separator
         divider.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(divider)
 
-        // Status bar
         let statusBar = makeStatusBar()
         statusBar.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(statusBar)
@@ -119,74 +175,12 @@ final class SerialConsoleContentViewController: NSViewController {
 
     // MARK: - View Construction
 
-    private func makeTerminalScrollView() -> NSScrollView {
-        let textView = SerialTextView()
-        textView.sendInput = { [weak self] string in
-            self?.instance.sendSerialInput(string)
-        }
-        textView.isEditable = false
-        textView.isSelectable = true
-        textView.isRichText = false
-        textView.isFieldEditor = false
-        textView.allowsUndo = false
-        textView.usesFindPanel = true
-        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
-        textView.textColor = .init(white: 0.9, alpha: 1.0)
-        textView.backgroundColor = .init(white: 0.1, alpha: 1.0)
-        textView.insertionPointColor = .init(white: 0.9, alpha: 1.0)
-        textView.isAutomaticQuoteSubstitutionEnabled = false
-        textView.isAutomaticDashSubstitutionEnabled = false
-        textView.isAutomaticTextReplacementEnabled = false
-        textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.isContinuousSpellCheckingEnabled = false
-        textView.isGrammarCheckingEnabled = false
-        textView.isVerticallyResizable = true
-        textView.isHorizontallyResizable = false
-        textView.textContainer?.widthTracksTextView = true
-        textView.textContainer?.containerSize = NSSize(
-            width: 0,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-        self.textView = textView
-
-        let scrollView = NSScrollView()
-        scrollView.documentView = textView
-        scrollView.hasVerticalScroller = true
-        scrollView.hasHorizontalScroller = false
-        scrollView.autohidesScrollers = true
-        scrollView.drawsBackground = true
-        scrollView.backgroundColor = .init(white: 0.1, alpha: 1.0)
-
-        return scrollView
-    }
-
     private func makeStatusBar() -> NSView {
-        let circle = NSView()
-        circle.wantsLayer = true
-        circle.layer?.cornerRadius = 4
-        circle.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            circle.widthAnchor.constraint(equalToConstant: 8),
-            circle.heightAnchor.constraint(equalToConstant: 8),
-        ])
-        self.statusCircle = circle
-
-        let label = NSTextField(labelWithString: "")
-        label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
-        label.textColor = .secondaryLabelColor
-        self.statusLabel = label
-
-        let countLabel = NSTextField(labelWithString: "")
-        countLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
-        countLabel.textColor = .secondaryLabelColor
-        countLabel.alignment = .right
-        self.characterCountLabel = countLabel
-
-        let leftStack = NSStackView(views: [circle, label])
+        let leftStack = NSStackView(views: [statusCircle, statusLabel])
         leftStack.orientation = .horizontal
         leftStack.spacing = 6
 
-        let stack = NSStackView(views: [leftStack, countLabel])
+        let stack = NSStackView(views: [leftStack, characterCountLabel])
         stack.orientation = .horizontal
         stack.distribution = .fill
         stack.edgeInsets = NSEdgeInsets(top: 5, left: 10, bottom: 5, right: 10)


### PR DESCRIPTION
## Summary
- Eliminate the 12 IUO declarations across `SerialConsoleContentViewController`, `ClipboardContentViewController`, and `AppDelegate` so swift-format's `NeverUseImplicitlyUnwrappedOptionals` rule can be enabled.
- Keep AppKit conventions: `loadView()` still owns view-hierarchy assembly; subviews are now constructed in `init` as `let` properties.

Closes #202

## Changes
- **`SerialConsoleContentViewController` / `ClipboardContentViewController`** — construct subviews (`textView`, `scrollView`, `statusCircle`, `statusLabel`, `characterCountLabel` / `actionButton`) as `let` properties in `init`. `loadView` now only assembles the hierarchy and applies layout constraints. `sendInput` closure and `textView.delegate`/`actionButton.target` are wired up after `super.init`.
- **`AppDelegate`** — initialize `viewModel`, `serialConsoleMenuItem`, and `clipboardMenuItem` in `init` as `let` properties. `setupMainMenu` consumes the pre-built menu items rather than constructing them locally. The `viewModel.onOpenDisplayWindow` callback now wires up in `init` after `super.init`.
- **`AppDelegate`** — drop the now-dead `pendingOpenURLs` deferral. With `viewModel` available before any delegate callback can fire (init runs before AppKit dispatches `application(_:open:)` or `applicationDidFinishLaunching`), the queueing branch is unreachable.
- **`.swift-format`** — flip `NeverUseImplicitlyUnwrappedOptionals` to `true`.

## Notes
- Behavioral change worth flagging: `VMLibraryViewModel` now constructs in `AppDelegate.init()` (called from `static main()`) instead of `applicationDidFinishLaunching`. `loadVMs()` and watcher registration happen marginally earlier, but DispatchSource and `NSWorkspace` notification callbacks still can't fire until `app.run()` starts the main run loop, so this should be invisible.
- A manual smoke test (launch + Finder drag of a `.kernova` bundle) is worth doing before merge — the AppDelegate init-order change is the riskiest surface and isn't covered by the unit tests.

## Test plan
- [x] `make lint` (--strict) exits 0
- [x] `make build` succeeds on macOS 26
- [x] `make test` — full suite passes
- [ ] Manual smoke: launch app, open library, open serial console, open clipboard window
- [ ] Manual smoke: Finder drag of a `.kernova` bundle imports correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)