### PR TITLE
chore: Scan KernovaGuestAgent and KernovaRelaunchHelper with Periphery (#204)

### DIFF
--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   scan:
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       PERIPHERY_VERSION: 3.7.4
     steps:

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -10,6 +10,8 @@
 project: Kernova.xcodeproj
 schemes:
   - Kernova
+  - KernovaGuestAgent
+  - KernovaRelaunchHelper
 
 # Conservative retain rules for v1 — dial down once we know the false-positive
 # shape on this codebase.

--- a/Kernova.xcodeproj/xcshareddata/xcschemes/KernovaGuestAgent.xcscheme
+++ b/Kernova.xcodeproj/xcshareddata/xcschemes/KernovaGuestAgent.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1000303"
+               BuildableName = "KernovaGuestAgentTests.xctest"
+               BlueprintName = "KernovaGuestAgentTests"
+               ReferencedContainer = "container:Kernova.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Kernova.xcodeproj/xcshareddata/xcschemes/KernovaGuestAgent.xcscheme
+++ b/Kernova.xcodeproj/xcshareddata/xcschemes/KernovaGuestAgent.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.8">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1000204"
+               BuildableName = "KernovaGuestAgent"
+               BlueprintName = "KernovaGuestAgent"
+               ReferencedContainer = "container:Kernova.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         reuseLastBuildConfiguration = "YES"
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1000204"
+            BuildableName = "KernovaGuestAgent"
+            BlueprintName = "KernovaGuestAgent"
+            ReferencedContainer = "container:Kernova.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         reuseLastBuildConfiguration = "YES"
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1000204"
+            BuildableName = "KernovaGuestAgent"
+            BlueprintName = "KernovaGuestAgent"
+            ReferencedContainer = "container:Kernova.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Kernova.xcodeproj/xcshareddata/xcschemes/KernovaRelaunchHelper.xcscheme
+++ b/Kernova.xcodeproj/xcshareddata/xcschemes/KernovaRelaunchHelper.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.8">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1000102"
+               BuildableName = "KernovaRelaunchHelper"
+               BlueprintName = "KernovaRelaunchHelper"
+               ReferencedContainer = "container:Kernova.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         reuseLastBuildConfiguration = "YES"
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1000102"
+            BuildableName = "KernovaRelaunchHelper"
+            BlueprintName = "KernovaRelaunchHelper"
+            ReferencedContainer = "container:Kernova.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         reuseLastBuildConfiguration = "YES"
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1000102"
+            BuildableName = "KernovaRelaunchHelper"
+            BlueprintName = "KernovaRelaunchHelper"
+            ReferencedContainer = "container:Kernova.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary
- Extend the weekly Periphery scan to cover the two auxiliary executables shipped alongside the main app — `KernovaGuestAgent` (the in-guest agent bundled into the DMG) and `KernovaRelaunchHelper` (the TCC-revocation helper). Their source was previously not scanned for dead code because neither target is linked into the `Kernova` scheme.
- Bump the dead-code workflow timeout from 30 to 45 minutes to absorb the two extra index-store builds.

## Changes
- Add shared schemes for `KernovaGuestAgent` and `KernovaRelaunchHelper` in `Kernova.xcodeproj/xcshareddata/xcschemes/` so Periphery (which consumes shared schemes) can build them.
- `.periphery.yml`: add `KernovaGuestAgent` and `KernovaRelaunchHelper` to the `schemes:` list.
- `.github/workflows/dead-code.yml`: raise `timeout-minutes` from 30 to 45.

## Test plan
- [x] `xcodebuild -project Kernova.xcodeproj -list` shows all three schemes.
- [x] `xcodebuild ... -scheme KernovaGuestAgent build` succeeds.
- [x] `xcodebuild ... -scheme KernovaRelaunchHelper build` succeeds.
- [ ] Workflow dispatch (\`gh workflow run dead-code.yml\`) completes within the new timeout and surfaces findings from the additional schemes.

Closes #204