### PR TITLE
chore: Drop Periphery retain_public (#205)

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -11,12 +11,14 @@ project: Kernova.xcodeproj
 schemes:
   - Kernova
 
-# Conservative retain rules for v1 — dial down once we know the false-positive
-# shape on this codebase.
-
-# `KernovaProtocol` exposes a public API surface across module boundaries; the
-# Kernova app target itself has few public symbols, so this stays conservative.
-retain_public: true
+# `KernovaProtocol` is a closed monorepo package — every consumer (the
+# `Kernova` app and `KernovaGuestAgent`) lives in this same project, so
+# Periphery's cross-target index can resolve real usage of public symbols.
+# We let it surface unused public declarations rather than retaining them
+# wholesale. If a specific public symbol is exported intentionally but
+# unused in-repo, prefer a per-symbol `// periphery:ignore` over flipping
+# this back to `true`.
+retain_public: false
 
 # Keeps AppKit selectors, NSMenuItemValidation conformance, target/action
 # wiring, and KVO observers from being flagged.


### PR DESCRIPTION
## Summary
- Flip \`retain_public\` to \`false\` in \`.periphery.yml\` so Periphery surfaces unused \`public\` declarations (primarily in the local \`KernovaProtocol\` SPM package) instead of retaining them wholesale.
- Kernova is a closed monorepo: every consumer of \`KernovaProtocol\` (\`Kernova\` app, \`KernovaGuestAgent\`) lives in this same project, so Periphery's cross-target index can resolve real usage of public symbols. The conservative \`true\` setting was a v1 hedge against false positives; with the dead-code scan workflow now stable, the bigger risk is silent retention of genuinely-unused public API.
- Replace the v1-hedge comment with guidance steering future exceptions to per-symbol \`// periphery:ignore\` annotations rather than flipping the flag back.

## Changes
- \`.periphery.yml\`: \`retain_public: true\` → \`false\`; rewrite the surrounding comment.

## Sequencing
Best landed **after** #211 (scan all schemes) and #212 (clear existing 30 findings) so this PR's effect is visible against a clean baseline. The next workflow run after merge will surface the new findings shape — triage by either fixing or annotating per-symbol.

## Test plan
- [ ] Land after #211 and #212
- [ ] \`gh workflow run dead-code.yml\` after merge to surface new findings
- [ ] Triage and fix / per-symbol \`// periphery:ignore\` as a follow-up

Closes #205