### PR TITLE
fix: Run KernovaProtocol package tests in make test and CI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,16 +10,20 @@ This is an Xcode project (not Swift Package Manager). Inside Xcode, use ⌘B / �
 
 ```bash
 make build               # Build for macOS
-make test                # Run the full test suite
-make test-suite SUITE=KernovaTests/VMConfigurationTests   # Run a single suite (Target/Suite form)
+make test                # Run the full test suite (project + KernovaProtocol package)
+make test-suite SUITE=KernovaTests/VMConfigurationTests   # Run a single project suite
+make test-package        # Run only the KernovaProtocol SwiftPM package tests
 make clean               # Remove DerivedData/
 ```
 
-The Makefile wraps the canonical `xcodebuild` invocation:
+`make test` runs the canonical `xcodebuild` invocation and then `swift test --package-path KernovaProtocol`:
 
 ```bash
 xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=macOS' -derivedDataPath DerivedData <build|test>
+swift test --package-path KernovaProtocol  # only as part of `make test`
 ```
+
+The package's own test target has to be invoked via `swift test` because Xcode's project-level test plan picker does not enumerate SwiftPM package test targets — `xcodebuild test -scheme Kernova` would otherwise silently skip `KernovaProtocolTests`. The two runners are sequential in `make test` (project tests first, then package tests).
 
 The `-derivedDataPath DerivedData` flag ensures build output goes to a deterministic local `DerivedData/` directory (already gitignored) instead of the per-path-hashed `~/Library/Developer/Xcode/DerivedData/` location. This avoids glob ambiguity when worktrees or parallel builds create multiple DerivedData folders. Xcode itself still uses the per-user default — they don't need to share.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,14 +16,14 @@ make test-package        # Run only the KernovaProtocol SwiftPM package tests
 make clean               # Remove DerivedData/
 ```
 
-`make test` runs the canonical `xcodebuild` invocation and then `swift test --package-path KernovaProtocol`:
+`make test` runs the canonical `xcodebuild` invocation and then `xcrun swift test --package-path KernovaProtocol`:
 
 ```bash
 xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=macOS' -derivedDataPath DerivedData <build|test>
-swift test --package-path KernovaProtocol  # only as part of `make test`
+xcrun swift test --package-path KernovaProtocol
 ```
 
-The package's own test target has to be invoked via `swift test` because Xcode's project-level test plan picker does not enumerate SwiftPM package test targets — `xcodebuild test -scheme Kernova` would otherwise silently skip `KernovaProtocolTests`. The two runners are sequential in `make test` (project tests first, then package tests).
+The package's own test target has to be invoked via `xcrun swift test` because Xcode's project-level test plan picker does not enumerate SwiftPM package test targets — `xcodebuild test -scheme Kernova` would otherwise silently skip `KernovaProtocolTests`. `xcrun` pins the toolchain to the one selected via `xcode-select`, matching `xcodebuild` and the existing `xcrun swift-format` invocation in the `Makefile`. In `make test` the two runners are sequential (project tests first, then package tests).
 
 The `-derivedDataPath DerivedData` flag ensures build output goes to a deterministic local `DerivedData/` directory (already gitignored) instead of the per-path-hashed `~/Library/Developer/Xcode/DerivedData/` location. This avoids glob ambiguity when worktrees or parallel builds create multiple DerivedData folders. Xcode itself still uses the per-user default — they don't need to share.
 

--- a/.github/workflows/xcodebuild-test.yml
+++ b/.github/workflows/xcodebuild-test.yml
@@ -68,7 +68,7 @@ jobs:
       # KernovaProtocolTests is gated by CI alongside the project suites.
       # See issue #215.
       - name: Test KernovaProtocol package
-        run: swift test --package-path KernovaProtocol
+        run: xcrun swift test --package-path KernovaProtocol
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/xcodebuild-test.yml
+++ b/.github/workflows/xcodebuild-test.yml
@@ -63,6 +63,13 @@ jobs:
             COMPILER_INDEX_STORE_ENABLE=NO \
             2>&1 | if command -v xcbeautify &>/dev/null; then xcbeautify --renderer github-actions; else cat; fi
 
+      # The Kernova scheme's xcodebuild test pass does not exercise the
+      # KernovaProtocol SwiftPM package's own test target. Run it directly so
+      # KernovaProtocolTests is gated by CI alongside the project suites.
+      # See issue #215.
+      - name: Test KernovaProtocol package
+        run: swift test --package-path KernovaProtocol
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v6

--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,15 @@ build:
 
 # `xcodebuild test -scheme Kernova` does not auto-discover SwiftPM package
 # test targets; KernovaProtocolTests lives inside the local package and has
-# to be run via `swift test`. See issue #215.
+# to be run via `swift test`. Use `xcrun` so the toolchain matches the one
+# selected via `xcode-select` (same rationale as `xcrun swift-format`
+# above). See issue #215.
 test:
 	xcodebuild $(XCODEBUILD_FLAGS) test
-	swift test --package-path KernovaProtocol
+	xcrun swift test --package-path KernovaProtocol
 
 test-package:
-	swift test --package-path KernovaProtocol
+	xcrun swift test --package-path KernovaProtocol
 
 test-suite:
 	@if [ -z "$(SUITE)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,15 @@ SWIFT_FORMAT      := xcrun swift-format
 SWIFT_SOURCE_DIRS := Kernova KernovaTests KernovaGuestAgent KernovaGuestAgentTests KernovaProtocol KernovaRelaunchHelper
 
 .DEFAULT_GOAL := help
-.PHONY: help build test test-suite clean format lint
+.PHONY: help build test test-suite test-package clean format lint
 
 help:
 	@printf 'Kernova build targets:\n\n'
 	@printf '  make build               Build the app for macOS\n'
-	@printf '  make test                Run the full test suite\n'
-	@printf '  make test-suite SUITE=X  Run a single test suite (Target/Suite form)\n'
+	@printf '  make test                Run the full test suite (project + KernovaProtocol package)\n'
+	@printf '  make test-suite SUITE=X  Run a single project test suite (Target/Suite form)\n'
 	@printf '                           (e.g. SUITE=KernovaTests/VMConfigurationTests)\n'
+	@printf '  make test-package        Run only the KernovaProtocol SwiftPM package tests\n'
 	@printf '  make format              Rewrite Swift sources in place via swift-format\n'
 	@printf '  make lint                Check Swift sources with swift-format (--strict)\n'
 	@printf '  make clean               Remove the DerivedData directory\n'
@@ -35,8 +36,15 @@ help:
 build:
 	xcodebuild $(XCODEBUILD_FLAGS) build
 
+# `xcodebuild test -scheme Kernova` does not auto-discover SwiftPM package
+# test targets; KernovaProtocolTests lives inside the local package and has
+# to be run via `swift test`. See issue #215.
 test:
 	xcodebuild $(XCODEBUILD_FLAGS) test
+	swift test --package-path KernovaProtocol
+
+test-package:
+	swift test --package-path KernovaProtocol
 
 test-suite:
 	@if [ -z "$(SUITE)" ]; then \


### PR DESCRIPTION
## Summary
- Close a test-coverage gap where `xcodebuild test -scheme Kernova` and the GitHub Actions test workflow both silently skipped the `KernovaProtocolTests` SwiftPM package test target.
- This is what allowed PR #214 to delete public symbols (`VsockFrameDecoder.isEmpty` / `bufferedByteCount`) that were still referenced by `VsockFrameTests` — `make test` passed locally because the package's tests were never run.

## Changes
- `Makefile`: append `swift test --package-path KernovaProtocol` to the `test` target; add a `test-package` shortcut for the package-only run.
- `.github/workflows/xcodebuild-test.yml`: add a `Test KernovaProtocol package` step after `Test without building`.
- `.claude/CLAUDE.md`: document the dual-runner behavior of `make test` and the reason the package tests can't be gated by `xcodebuild` alone.

## Why not integrate into `Kernova.xcscheme`?
The issue's "more integrated" option would have added `KernovaProtocolTests` as a `<TestableReference>` in `Kernova.xcscheme`'s test plan, letting `xcodebuild test -scheme Kernova` run it directly and letting Periphery index it. In practice this isn't reachable in Xcode 26: the project-level **Choose Test Targets** picker only enumerates Xcode-project test targets, not SwiftPM-package test targets. The canonical Apple pattern for that is to convert the project to an `.xcworkspace` containing both `Kernova.xcodeproj` and `KernovaProtocol/`. That's a meaningful refactor and out of scope for this fix.

Periphery's project-mode scan therefore still doesn't index `KernovaProtocolTests`, so the `// periphery:ignore` annotations added in #214 remain accurate and stay in place.

Closes #215

## Test plan
- [x] `make test` runs both runners locally — 66 project tests + 28 package tests pass
- [x] `make test-package` runs the package suite in isolation — 28 tests pass
- [ ] CI on this PR exercises both the `Test without building` and new `Test KernovaProtocol package` steps