### PR TITLE
chore: Drop periphery:ignore directives the peer-package layout obsoleted

### DIFF
--- a/KernovaGuestAgent/KernovaLogMessage.swift
+++ b/KernovaGuestAgent/KernovaLogMessage.swift
@@ -10,9 +10,6 @@ import os
 /// that reject manual construction from outside the `os` module —
 /// so we redact privately-marked values ourselves instead of relying on
 /// the OS's runtime privacy machinery.
-// periphery:ignore - Resolved through type inference on the `privacy:`
-// label of `appendInterpolation(_:privacy:)`; Periphery's symbol graph
-// doesn't trace argument-type inference back to the type declaration.
 struct LogPrivacy: Sendable {
     enum Kind: Sendable {
         case `public`

--- a/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift
@@ -110,13 +110,9 @@ struct VsockFrameDecoder: Sendable {
     }
 
     /// `true` when no buffered bytes remain.
-    // periphery:ignore - Used by `VsockFrameTests` via `@testable import`,
-    // which Periphery's scheme-based scan doesn't currently index for the
-    // SwiftPM package test target.
     var isEmpty: Bool { buffer.count == readOffset }
 
     /// Number of buffered bytes not yet consumed.
-    // periphery:ignore - Same rationale as `isEmpty` above.
     var bufferedByteCount: Int { buffer.count - readOffset }
 
     private func readLengthPrefix() -> UInt32 {


### PR DESCRIPTION
## Summary
- Remove six `// periphery:ignore` directives that the latest Periphery scan flagged as superfluous. These were workarounds for symbols Periphery had previously failed to see as referenced; the peer-package layout introduced in #218 made those references visible.

## Background
PR #218 promoted `KernovaProtocol` from `XCLocalSwiftPackageReference` to a peer file reference. As a side effect, `KernovaProtocolTests` is now built and indexed as part of Periphery's scheme-based scan, and indexing of the project's test targets appears to have been broadened too. The follow-up `dead-code.yml` run against the merge commit (`cbe0061`) confirmed this — Periphery surfaced exactly these six "Superfluous ignore comment" warnings and no others.

## Changes
- `KernovaProtocol/Sources/KernovaProtocol/VsockFrame.swift`: drop the ignores on `VsockFrameDecoder.isEmpty` and `bufferedByteCount` (originally added in #214). Both are referenced from `VsockFrameTests`, which is now built via `KernovaProtocolTests`.
- `KernovaGuestAgent/KernovaLogMessage.swift`: drop the struct-level ignore on `LogPrivacy`. The directive cascaded to its four static-let members (`public`, `private`, `sensitive`, `auto`), which Periphery now sees as referenced through `KernovaGuestAgentTests` indexing.

## Test plan
- [x] `make test` passes (699 passed, 0 failed) — comment removal cannot affect runtime, but confirms the build still parses cleanly.
- [ ] Next `dead-code.yml` run on this branch reports zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)