### PR TITLE
fix: Standardize Create New Disk default to 100 GB and clean up per-VM @State leaks

### DIFF
--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -185,7 +185,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         self.bootMode = bootMode
         self.cpuCount = cpuCount ?? guestOS.defaultCPUCount
         self.memorySizeInGB = memorySizeInGB ?? guestOS.defaultMemoryInGB
-        self.diskSizeInGB = diskSizeInGB ?? guestOS.defaultDiskSizeInGB
+        self.diskSizeInGB = diskSizeInGB ?? VMGuestOS.defaultDiskSizeInGB
         self.displayWidth = displayWidth
         self.displayHeight = displayHeight
         self.displayPPI = displayPPI

--- a/Kernova/Models/VMGuestOS.swift
+++ b/Kernova/Models/VMGuestOS.swift
@@ -37,9 +37,10 @@ enum VMGuestOS: String, Codable, CaseIterable, Sendable {
         return min(preferred, maxMemoryInGB)
     }
 
-    /// Default size used when creating a new disk image. OS-independent —
-    /// fits comfortably above both guest OSes' `minDiskSizeInGB` and is
-    /// present in `allDiskSizes`.
+    /// Default size used when creating a new disk image.
+    ///
+    /// OS-independent — fits comfortably above both guest OSes'
+    /// `minDiskSizeInGB` and is present in `allDiskSizes`.
     static let defaultDiskSizeInGB = 100
 
     /// All offered disk sizes in GB, matching bundled ASIF templates.

--- a/Kernova/Models/VMGuestOS.swift
+++ b/Kernova/Models/VMGuestOS.swift
@@ -37,12 +37,10 @@ enum VMGuestOS: String, Codable, CaseIterable, Sendable {
         return min(preferred, maxMemoryInGB)
     }
 
-    var defaultDiskSizeInGB: Int {
-        switch self {
-        case .macOS: 100
-        case .linux: 50
-        }
-    }
+    /// Default size used when creating a new disk image. OS-independent —
+    /// fits comfortably above both guest OSes' `minDiskSizeInGB` and is
+    /// present in `allDiskSizes`.
+    static let defaultDiskSizeInGB = 100
 
     /// All offered disk sizes in GB, matching bundled ASIF templates.
     static let allDiskSizes = [

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -174,7 +174,7 @@ final class VMCreationViewModel {
     func applyOSDefaults() {
         cpuCount = selectedOS.defaultCPUCount
         memoryInGB = selectedOS.defaultMemoryInGB
-        diskSizeInGB = selectedOS.defaultDiskSizeInGB
+        diskSizeInGB = VMGuestOS.defaultDiskSizeInGB
     }
 
     // MARK: - Overwrite Warning

--- a/Kernova/Views/Detail/MainDetailView.swift
+++ b/Kernova/Views/Detail/MainDetailView.swift
@@ -9,6 +9,12 @@ struct MainDetailView: View {
         Group {
             if let selected = viewModel.selectedInstance {
                 VMDetailView(instance: selected, viewModel: viewModel)
+                    // Tie SwiftUI view identity to the selected VM so all per-VM transient
+                    // @State in the detail subtree (settings popovers, alerts, rename fields,
+                    // focus, picker defaults) resets on a sidebar switch. The AppKit
+                    // VMDisplayBackingView layer in DetailContainerViewController is keyed
+                    // separately and is not affected by this rebuild.
+                    .id(selected.id)
             } else {
                 ContentUnavailableView {
                     Label("No Virtual Machine Selected", systemImage: "desktopcomputer")

--- a/Kernova/Views/Detail/MainDetailView.swift
+++ b/Kernova/Views/Detail/MainDetailView.swift
@@ -9,11 +9,12 @@ struct MainDetailView: View {
         Group {
             if let selected = viewModel.selectedInstance {
                 VMDetailView(instance: selected, viewModel: viewModel)
-                    // Tie SwiftUI view identity to the selected VM so all per-VM transient
-                    // @State in the detail subtree (settings popovers, alerts, rename fields,
-                    // focus, picker defaults) resets on a sidebar switch. The AppKit
-                    // VMDisplayBackingView layer in DetailContainerViewController is keyed
-                    // separately and is not affected by this rebuild.
+                    // RATIONALE: Tie SwiftUI view identity to the selected VM so all
+                    // per-VM transient @State in the detail subtree (settings popovers,
+                    // alerts, rename fields, focus, picker defaults) resets on a sidebar
+                    // switch. The AppKit VMDisplayBackingView layer in
+                    // DetailContainerViewController is keyed separately by `instance.id`
+                    // and is not affected by this rebuild.
                     .id(selected.id)
             } else {
                 ContentUnavailableView {

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -16,22 +16,10 @@ struct VMSettingsView: View {
     @State private var showingMicPermissionInfo = false
     @State private var micPermission: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
     @State private var showingCreateDisk = false
-    @State private var newDiskSizeInGB: Int
+    @State private var newDiskSizeInGB = VMGuestOS.defaultDiskSizeInGB
     @State private var diskToRemove: StorageDisk?
     @State private var showingRemoveDiskAlert = false
     @FocusState private var isNameFieldFocused: Bool
-
-    init(instance: VMInstance, viewModel: VMLibraryViewModel, isReadOnly: Bool) {
-        self.instance = instance
-        self.viewModel = viewModel
-        self.isReadOnly = isReadOnly
-        // Seed the picker selection from the disk-size default so the popover's
-        // MenuPickerStyle renders the checkmark on the same value its closed-state
-        // button displays. Mutating @State in the same tick as the popover toggle
-        // updates the button label but leaves the underlying NSPopupButton's
-        // selectedTag on the initial @State value.
-        _newDiskSizeInGB = State(initialValue: VMGuestOS.defaultDiskSizeInGB)
-    }
 
     private var currentMicPermission: AVAuthorizationStatus {
         AVCaptureDevice.authorizationStatus(for: .audio)

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -15,7 +15,7 @@ struct VMSettingsView: View {
     @State private var editingName = ""
     @State private var showingMicPermissionInfo = false
     @State private var micPermission: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
-    @State private var showingCreateDisk = false
+    @State private var createDiskRequest: CreateDiskRequest?
     @State private var newDiskSizeInGB = 50
     @State private var diskToRemove: StorageDisk?
     @State private var showingRemoveDiskAlert = false
@@ -346,9 +346,9 @@ struct VMSettingsView: View {
 
                 Button("Create New Disk...") {
                     newDiskSizeInGB = instance.configuration.guestOS == .macOS ? 100 : 50
-                    showingCreateDisk = true
+                    createDiskRequest = CreateDiskRequest()
                 }
-                .popover(isPresented: $showingCreateDisk, arrowEdge: .bottom) {
+                .popover(item: $createDiskRequest, arrowEdge: .bottom) { _ in
                     createDiskPopover
                 }
             }
@@ -469,11 +469,11 @@ struct VMSettingsView: View {
 
             HStack {
                 Button("Cancel") {
-                    showingCreateDisk = false
+                    createDiskRequest = nil
                 }
                 Spacer()
                 Button("Create") {
-                    showingCreateDisk = false
+                    createDiskRequest = nil
                     viewModel.createStorageDisk(for: instance, sizeInGB: newDiskSizeInGB)
                 }
                 .buttonStyle(.borderedProminent)
@@ -758,4 +758,13 @@ struct VMSettingsView: View {
         .padding()
         .frame(width: 340)
     }
+}
+
+// RATIONALE: Fresh identity per click so `.popover(item:)` rebuilds the
+// content (and its child Picker) from scratch. `.popover(isPresented:)`
+// reuses the cached content view, and Picker's MenuPickerStyle leaves the
+// menu's checkmark on the prior binding value when the selection is
+// mutated in the same tick as the presentation toggle.
+private struct CreateDiskRequest: Identifiable {
+    let id = UUID()
 }

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -25,12 +25,12 @@ struct VMSettingsView: View {
         self.instance = instance
         self.viewModel = viewModel
         self.isReadOnly = isReadOnly
-        // Seed the picker selection from the guest OS default so the popover's
+        // Seed the picker selection from the disk-size default so the popover's
         // MenuPickerStyle renders the checkmark on the same value its closed-state
         // button displays. Mutating @State in the same tick as the popover toggle
         // updates the button label but leaves the underlying NSPopupButton's
         // selectedTag on the initial @State value.
-        _newDiskSizeInGB = State(initialValue: instance.configuration.guestOS.defaultDiskSizeInGB)
+        _newDiskSizeInGB = State(initialValue: VMGuestOS.defaultDiskSizeInGB)
     }
 
     private var currentMicPermission: AVAuthorizationStatus {

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -172,13 +172,6 @@ struct VMSettingsView: View {
                 Text("This will delist the disk from the VM. The file at \(disk.path) is left alone.")
             }
         }
-        // VMSettingsView shares one identity across sibling VMs in the sidebar
-        // (same position in the hierarchy), so @State persists when the user
-        // switches VMs. Reset the picker default so the popover opens with the
-        // new VM's OS default, not the previous VM's.
-        .onChange(of: instance.id) {
-            newDiskSizeInGB = instance.configuration.guestOS.defaultDiskSizeInGB
-        }
     }
 
     @ViewBuilder

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -15,11 +15,23 @@ struct VMSettingsView: View {
     @State private var editingName = ""
     @State private var showingMicPermissionInfo = false
     @State private var micPermission: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
-    @State private var createDiskRequest: CreateDiskRequest?
-    @State private var newDiskSizeInGB = 50
+    @State private var showingCreateDisk = false
+    @State private var newDiskSizeInGB: Int
     @State private var diskToRemove: StorageDisk?
     @State private var showingRemoveDiskAlert = false
     @FocusState private var isNameFieldFocused: Bool
+
+    init(instance: VMInstance, viewModel: VMLibraryViewModel, isReadOnly: Bool) {
+        self.instance = instance
+        self.viewModel = viewModel
+        self.isReadOnly = isReadOnly
+        // Seed the picker selection from the guest OS default so the popover's
+        // MenuPickerStyle renders the checkmark on the same value its closed-state
+        // button displays. Mutating @State in the same tick as the popover toggle
+        // updates the button label but leaves the underlying NSPopupButton's
+        // selectedTag on the initial @State value.
+        _newDiskSizeInGB = State(initialValue: instance.configuration.guestOS.defaultDiskSizeInGB)
+    }
 
     private var currentMicPermission: AVAuthorizationStatus {
         AVCaptureDevice.authorizationStatus(for: .audio)
@@ -159,6 +171,13 @@ struct VMSettingsView: View {
             } else {
                 Text("This will delist the disk from the VM. The file at \(disk.path) is left alone.")
             }
+        }
+        // VMSettingsView shares one identity across sibling VMs in the sidebar
+        // (same position in the hierarchy), so @State persists when the user
+        // switches VMs. Reset the picker default so the popover opens with the
+        // new VM's OS default, not the previous VM's.
+        .onChange(of: instance.id) {
+            newDiskSizeInGB = instance.configuration.guestOS.defaultDiskSizeInGB
         }
     }
 
@@ -345,10 +364,9 @@ struct VMSettingsView: View {
                 }
 
                 Button("Create New Disk...") {
-                    newDiskSizeInGB = instance.configuration.guestOS == .macOS ? 100 : 50
-                    createDiskRequest = CreateDiskRequest()
+                    showingCreateDisk = true
                 }
-                .popover(item: $createDiskRequest, arrowEdge: .bottom) { _ in
+                .popover(isPresented: $showingCreateDisk, arrowEdge: .bottom) {
                     createDiskPopover
                 }
             }
@@ -469,11 +487,11 @@ struct VMSettingsView: View {
 
             HStack {
                 Button("Cancel") {
-                    createDiskRequest = nil
+                    showingCreateDisk = false
                 }
                 Spacer()
                 Button("Create") {
-                    createDiskRequest = nil
+                    showingCreateDisk = false
                     viewModel.createStorageDisk(for: instance, sizeInGB: newDiskSizeInGB)
                 }
                 .buttonStyle(.borderedProminent)
@@ -758,13 +776,4 @@ struct VMSettingsView: View {
         .padding()
         .frame(width: 340)
     }
-}
-
-// RATIONALE: Fresh identity per click so `.popover(item:)` rebuilds the
-// content (and its child Picker) from scratch. `.popover(isPresented:)`
-// reuses the cached content view, and Picker's MenuPickerStyle leaves the
-// menu's checkmark on the prior binding value when the selection is
-// mutated in the same tick as the presentation toggle.
-private struct CreateDiskRequest: Identifiable {
-    let id = UUID()
 }

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -46,7 +46,7 @@ struct VMConfigurationTests {
         #expect(config.bootMode == .macOS)
         #expect(config.cpuCount == VMGuestOS.macOS.defaultCPUCount)
         #expect(config.memorySizeInGB == VMGuestOS.macOS.defaultMemoryInGB)
-        #expect(config.diskSizeInGB == VMGuestOS.macOS.defaultDiskSizeInGB)
+        #expect(config.diskSizeInGB == VMGuestOS.defaultDiskSizeInGB)
         #expect(config.networkEnabled == true)
         #expect(config.displayWidth == 1920)
         #expect(config.displayHeight == 1200)
@@ -65,7 +65,7 @@ struct VMConfigurationTests {
         #expect(config.bootMode == .efi)
         #expect(config.cpuCount == VMGuestOS.linux.defaultCPUCount)
         #expect(config.memorySizeInGB == VMGuestOS.linux.defaultMemoryInGB)
-        #expect(config.diskSizeInGB == VMGuestOS.linux.defaultDiskSizeInGB)
+        #expect(config.diskSizeInGB == VMGuestOS.defaultDiskSizeInGB)
     }
 
     @Test("Configuration encodes and decodes via JSON")

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -229,7 +229,7 @@ struct VMCreationViewModelTests {
 
         #expect(vm.cpuCount == VMGuestOS.macOS.defaultCPUCount)
         #expect(vm.memoryInGB == VMGuestOS.macOS.defaultMemoryInGB)
-        #expect(vm.diskSizeInGB == VMGuestOS.macOS.defaultDiskSizeInGB)
+        #expect(vm.diskSizeInGB == VMGuestOS.defaultDiskSizeInGB)
     }
 
     @Test("applyOSDefaults sets correct values for Linux")
@@ -245,7 +245,7 @@ struct VMCreationViewModelTests {
 
         #expect(vm.cpuCount == VMGuestOS.linux.defaultCPUCount)
         #expect(vm.memoryInGB == VMGuestOS.linux.defaultMemoryInGB)
-        #expect(vm.diskSizeInGB == VMGuestOS.linux.defaultDiskSizeInGB)
+        #expect(vm.diskSizeInGB == VMGuestOS.defaultDiskSizeInGB)
     }
 
     // MARK: - buildConfiguration

--- a/KernovaTests/VMGuestOSTests.swift
+++ b/KernovaTests/VMGuestOSTests.swift
@@ -18,18 +18,21 @@ struct VMGuestOSTests {
 
     // MARK: - Default Resource Values
 
-    @Test("macOS defaults: 4 CPUs, 8 GB memory, 100 GB disk (clamped to hardware maximums)")
+    @Test("macOS defaults: 4 CPUs, 8 GB memory (clamped to hardware maximums)")
     func macOSDefaults() {
         #expect(VMGuestOS.macOS.defaultCPUCount == min(4, VMGuestOS.macOS.maxCPUCount))
         #expect(VMGuestOS.macOS.defaultMemoryInGB == min(8, VMGuestOS.macOS.maxMemoryInGB))
-        #expect(VMGuestOS.macOS.defaultDiskSizeInGB == 100)
     }
 
-    @Test("Linux defaults: 2 CPUs, 4 GB memory, 50 GB disk (clamped to hardware maximums)")
+    @Test("Linux defaults: 2 CPUs, 4 GB memory (clamped to hardware maximums)")
     func linuxDefaults() {
         #expect(VMGuestOS.linux.defaultCPUCount == min(2, VMGuestOS.linux.maxCPUCount))
         #expect(VMGuestOS.linux.defaultMemoryInGB == min(4, VMGuestOS.linux.maxMemoryInGB))
-        #expect(VMGuestOS.linux.defaultDiskSizeInGB == 50)
+    }
+
+    @Test("Default disk size is 100 GB, OS-independent")
+    func defaultDiskSize() {
+        #expect(VMGuestOS.defaultDiskSizeInGB == 100)
     }
 
     // MARK: - Min Resource Constraints
@@ -83,8 +86,8 @@ struct VMGuestOSTests {
         #expect(os.defaultCPUCount <= os.maxCPUCount)
         #expect(os.minMemoryInGB <= os.defaultMemoryInGB)
         #expect(os.defaultMemoryInGB <= os.maxMemoryInGB)
-        #expect(os.minDiskSizeInGB <= os.defaultDiskSizeInGB)
-        #expect(os.defaultDiskSizeInGB <= os.maxDiskSizeInGB)
+        #expect(os.minDiskSizeInGB <= VMGuestOS.defaultDiskSizeInGB)
+        #expect(VMGuestOS.defaultDiskSizeInGB <= os.maxDiskSizeInGB)
     }
 
     @Test("Linux constraints satisfy min <= default <= max")
@@ -94,8 +97,8 @@ struct VMGuestOSTests {
         #expect(os.defaultCPUCount <= os.maxCPUCount)
         #expect(os.minMemoryInGB <= os.defaultMemoryInGB)
         #expect(os.defaultMemoryInGB <= os.maxMemoryInGB)
-        #expect(os.minDiskSizeInGB <= os.defaultDiskSizeInGB)
-        #expect(os.defaultDiskSizeInGB <= os.maxDiskSizeInGB)
+        #expect(os.minDiskSizeInGB <= VMGuestOS.defaultDiskSizeInGB)
+        #expect(VMGuestOS.defaultDiskSizeInGB <= os.maxDiskSizeInGB)
     }
 
     // MARK: - Available Disk Sizes
@@ -120,7 +123,7 @@ struct VMGuestOSTests {
 
     @Test("Default disk size is contained in available disk sizes for both OS types")
     func defaultDiskSizeInAvailableSizes() {
-        #expect(VMGuestOS.macOS.availableDiskSizes.contains(VMGuestOS.macOS.defaultDiskSizeInGB))
-        #expect(VMGuestOS.linux.availableDiskSizes.contains(VMGuestOS.linux.defaultDiskSizeInGB))
+        #expect(VMGuestOS.macOS.availableDiskSizes.contains(VMGuestOS.defaultDiskSizeInGB))
+        #expect(VMGuestOS.linux.availableDiskSizes.contains(VMGuestOS.defaultDiskSizeInGB))
     }
 }


### PR DESCRIPTION
## Summary
- **User-visible:** the Create New Disk picker now consistently defaults to 100 GB for both macOS and Linux guests (was 100 GB for macOS / 50 GB for Linux), and its dropdown checkmark matches the displayed default.
- **Under the hood:** the picker bug was a SwiftUI MenuPicker quirk — mutating `@State` in the same render tick as toggling the popover updated the closed-state label but left `NSPopupButton.selectedTag` stuck on the initial `@State` value. Fixed by seeding the `@State` at declaration time from `VMGuestOS.defaultDiskSizeInGB` (now a static constant), eliminating the same-tick mutation entirely.
- **Per-VM @State hygiene:** `VMDetailView` now binds its identity to `selected.id` via `.id()` so the entire detail subtree's transient `@State` (settings popovers, alerts, rename fields, focus, picker defaults) resets on a sidebar VM switch — no more per-field enumeration.

## Behavior changes
1. **Linux VM creation default doubled** (50 GB → 100 GB). ASIF sparse images mean physical storage impact is minimal, but allocated size shown in the UI doubles for new Linux VMs.
2. **Detail-pane `@State` resets on every VM switch.** Mid-rename, partial form input, scroll position, expanded sections — all reset. Previously these silently persisted across sidebar switches.
3. **Within-VM picker persistence.** The user's last picked disk size now persists across popover close/reopen within a VM (previously reset on every Button click). Switching VMs still resets via `.id()`.

## Why `.id(selected.id)` is safe for the live VM display
`VZVirtualMachineView` is owned by the AppKit `VMDisplayBackingView` layer, which `DetailContainerViewController` keeps in a `[UUID: VMDisplayBackingView]` dictionary keyed independently of the SwiftUI hierarchy. Switching VMs swaps visibility on the AppKit layer rather than reassigning `virtualMachine` (which `VZVirtualMachineView` doesn't tolerate). The SwiftUI `.id()` rebuild only touches the inert `VMConsoleView` placeholder (`Color.black` under the AppKit overlay) and the settings form — no display flicker, no VM-display teardown.

## Changes
- `VMGuestOS.defaultDiskSizeInGB`: collapsed from a per-OS computed property (macOS:100, linux:50) to a `static let = 100`. All call sites updated.
- `VMSettingsView`: removed the Button's same-tick `newDiskSizeInGB = ...` reset (the race source) and seeded `@State` inline from the static constant. No custom init needed.
- `MainDetailView`: added `.id(selected.id)` on the `VMDetailView` call (with a `RATIONALE:` comment explaining why the AppKit display layer is unaffected).
- Tests: `VMGuestOSTests`, `VMConfigurationTests`, `VMCreationViewModelTests` updated to use the static constant. Per-OS default tests for disk size extracted into a single OS-independent test.

## Test plan
- [x] `make build`
- [x] `make test`
- [x] `make lint`
- [ ] Manual: macOS VM — open Settings → Create New Disk → dropdown shows 100 GB checked.
- [ ] Manual: Linux VM — same flow shows 100 GB checked (was 50 GB pre-change).
- [ ] Manual: switch macOS ↔ Linux mid-session → Create New Disk → 100 GB.
- [ ] Manual: switch between running VMs — no display flicker.
- [ ] Manual: start a rename on VM A, switch to VM B → rename field starts empty on VM B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)