### PR TITLE
docs: Disambiguate the two USB paths in storage doc-comments

### DIFF
--- a/Kernova/Models/StorageDisk.swift
+++ b/Kernova/Models/StorageDisk.swift
@@ -55,9 +55,17 @@ struct StorageDisk: Codable, Sendable, Equatable, Identifiable {
 
     /// Picks the bus class implied by the file extension.
     ///
-    /// `.iso` and `.dmg` default to USB mass storage so they appear as
-    /// removable drives in the guest; everything else defaults to virtio
-    /// block (the conventional permanent-disk bus).
+    /// `.iso` and `.dmg` default to `.usbMassStorage` — still attached on
+    /// `vzConfig.storageDevices` (and therefore bootable by EFI), but as
+    /// `VZUSBMassStorageDeviceConfiguration` rather than virtio. The
+    /// payoff is `/dev/vda` stability: inserting an installer ahead of
+    /// the main disk in the boot order doesn't shift the main disk's
+    /// Linux device letter. Everything else defaults to `.virtio`
+    /// (the conventional permanent-disk bus).
+    ///
+    /// This is the in-`storageDevices` USB path — distinct from
+    /// `RemovableMediaItem`, which lives on the XHCI controller's
+    /// `usbDevices` list and is not in the EFI boot path.
     static func defaultKind(forPath path: String) -> StorageDiskKind {
         let ext = (path as NSString).pathExtension.lowercased()
         return (ext == "iso" || ext == "dmg") ? .usbMassStorage : .virtio
@@ -80,9 +88,13 @@ struct StorageDisk: Codable, Sendable, Equatable, Identifiable {
 
 /// A USB mass storage device on the XHCI controller's `usbDevices` list.
 ///
-/// Hot-pluggable while the VM is running. Each item's `id` becomes the
-/// `VZUSBMassStorageDeviceConfiguration.uuid` so save-state restore can
-/// match the configured item against the saved-state device list.
+/// Hot-pluggable while the VM is running. **Not in the EFI boot path:**
+/// `VZEFIBootLoader` only walks `vzConfig.storageDevices`, so XHCI
+/// `usbDevices` are invisible to firmware boot selection. Use a
+/// `StorageDisk` with `kind == .usbMassStorage` for bootable removable
+/// media. Each item's `id` becomes the `VZUSBMassStorageDeviceConfiguration.uuid`
+/// so save-state restore can match the configured item against the
+/// saved-state device list.
 struct RemovableMediaItem: Codable, Sendable, Equatable, Identifiable {
     var id: UUID
     var path: String

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -354,7 +354,7 @@ struct VMSettingsView: View {
             }
 
             Text(
-                "Position 1 boots first on EFI guests. On macOS and Linux Kernel boot, position affects guest device enumeration. Installer images (.iso, .dmg) appear as USB drives in the guest; permanent disks appear as virtio block devices, so reordering an installer doesn't change your main disk's /dev/vda letter."
+                "Position 1 boots first on EFI guests. On macOS and Linux Kernel boot, position affects guest device enumeration. Installer images (.iso, .dmg) attach as USB Mass Storage entries on this list (still bootable, separate from hot-pluggable Removable Media); permanent disks attach as virtio block devices, so reordering an installer doesn't change your main disk's /dev/vda letter."
             )
             .font(.caption)
             .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- Make explicit, in code, that `StorageDisk` with `kind == .usbMassStorage` and `RemovableMediaItem` are **two distinct USB paths** — only the former is in the EFI boot path. PR #220 repurposed the "removable media" vocabulary without tightening the doc-comments that mention "USB", and reading the codebase piecemeal blurs the two paths today.
- Three small wording fixes; no behavior change.

## Changes
- `StorageDisk.defaultKind` doc-comment now spells out that `.iso`/`.dmg` default to `.usbMassStorage` on `vzConfig.storageDevices` (still bootable, EFI-visible), and explicitly contrasts that with `RemovableMediaItem` on XHCI `usbDevices` (not bootable).
- `RemovableMediaItem`'s doc-comment leads with "Not in the EFI boot path" and points readers at `StorageDisk` for bootable removable media — so the negative is *stated*, not derived from "lives on XHCI".
- The Storage Disks section footer in `VMSettingsView` swaps the ambiguous "appear as USB drives in the guest" for "attach as USB Mass Storage entries on this list (still bootable, separate from hot-pluggable Removable Media)".

## Test plan
- [x] `make build` succeeds
- [x] Doc-comments + one user-facing caption string only — no runtime behavior change, full test suite skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)