### PR TITLE
feat: Reorganize VM Settings section headers with lock + info icons

### DIFF
--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -111,26 +111,22 @@ struct VMSettingsView: View {
             }
             ScrollView {
                 Form {
-                    // RATIONALE: `.disabled(isReadOnly)` is applied per section (or
-                    // per-control inside the section body) rather than at the Form
-                    // level so that informational popover triggers — the header info
-                    // buttons on Storage Disks / Shared Directories, and the in-body
-                    // mic-permission popover in `audioSection` — remain interactive in
-                    // read-only mode; SwiftUI's disabled state propagates irreversibly
-                    // to descendants. `resourcesSection` and `audioSection` disable
-                    // per-control. `storageDiskSection` and `sharedDirectoriesSection`
-                    // wrap their body content in a `Group { ... }.disabled(...)` so
-                    // their header's info button stays interactive. `guestAgentSection`,
-                    // `clipboardSection`, and `removableMediaSection` carry live-editable
-                    // fields that remain interactive while the VM is running. Storage
+                    // RATIONALE: Each section that locks while the VM is running wraps
+                    // its locked controls in `Group { ... }.disabled(isReadOnly)` *inside*
+                    // the section body. SwiftUI's `.disabled` propagates irreversibly to
+                    // descendants, so this scoping keeps the section's header (lock + info
+                    // button) and any always-on body content (info popovers, conditional
+                    // warnings, listings) outside the disabled subtree and therefore
+                    // interactive. Sections that are fully hot-toggleable (Removable
+                    // Media, Guest Agent, Clipboard) carry no disable wrapper. Storage
                     // Disks is `storageDevices`-backed and therefore restart-only;
                     // Removable Media is XHCI-backed and hot-pluggable.
-                    generalSection.disabled(isReadOnly)
+                    generalSection
                     resourcesSection
                     storageDiskSection
                     removableMediaSection
                     sharedDirectoriesSection
-                    networkSection.disabled(isReadOnly)
+                    networkSection
                     audioSection
                     if instance.configuration.guestOS == .macOS {
                         guestAgentSection
@@ -220,7 +216,7 @@ struct VMSettingsView: View {
                 lockIcon
             }
             Text(title)
-            SectionInfoButton(content: info)
+            InfoButton(label: title, content: info)
         }
     }
 
@@ -237,30 +233,33 @@ struct VMSettingsView: View {
     @ViewBuilder
     private var generalSection: some View {
         Section(header: sectionHeader("General", lockable: true)) {
-            if isRenaming {
-                TextField("Name", text: $editingName)
-                    .focused($isNameFieldFocused)
-                    .onSubmit {
-                        viewModel.commitRename(for: instance, newName: editingName)
+            Group {
+                if isRenaming {
+                    TextField("Name", text: $editingName)
+                        .focused($isNameFieldFocused)
+                        .onSubmit {
+                            viewModel.commitRename(for: instance, newName: editingName)
+                        }
+                        .onExitCommand {
+                            viewModel.cancelRename()
+                        }
+                } else {
+                    Button {
+                        viewModel.renameVM(instance)
+                    } label: {
+                        LabeledContent("Name") {
+                            Text(instance.name)
+                        }
                     }
-                    .onExitCommand {
-                        viewModel.cancelRename()
-                    }
-            } else {
-                Button {
-                    viewModel.renameVM(instance)
-                } label: {
-                    LabeledContent("Name") {
-                        Text(instance.name)
-                    }
+                    .buttonStyle(.plain)
+                    .disabled(!instance.status.canRename)
                 }
-                .buttonStyle(.plain)
-                .disabled(!instance.status.canRename)
+                LabeledContent("Type", value: instance.configuration.guestOS.displayName)
+                LabeledContent("Boot Mode", value: instance.configuration.bootMode.displayName)
+                LabeledContent(
+                    "Created", value: instance.configuration.createdAt.formatted(date: .abbreviated, time: .shortened))
             }
-            LabeledContent("Type", value: instance.configuration.guestOS.displayName)
-            LabeledContent("Boot Mode", value: instance.configuration.bootMode.displayName)
-            LabeledContent(
-                "Created", value: instance.configuration.createdAt.formatted(date: .abbreviated, time: .shortened))
+            .disabled(isReadOnly)
         }
         .onChange(of: isRenaming) { _, renaming in
             if renaming {
@@ -400,10 +399,6 @@ struct VMSettingsView: View {
         ) {
             let disks = storageDiskBinding.wrappedValue
 
-            // RATIONALE: disable wraps the body in a Group so the info
-            // button in the section header stays interactive in
-            // read-only mode (SwiftUI's `.disabled` would otherwise
-            // propagate to the header).
             Group {
                 ForEach(storageDiskBinding) { $disk in
                     storageDiskRow(disk: $disk)
@@ -592,18 +587,19 @@ struct VMSettingsView: View {
         Section(header: sectionHeader("Resources", lockable: true)) {
             let os = instance.configuration.guestOS
 
-            Stepper(
-                "CPU Cores: \(instance.configuration.cpuCount)",
-                value: configBinding(\.cpuCount),
-                in: os.minCPUCount...os.maxCPUCount
-            )
-            .disabled(isReadOnly)
+            Group {
+                Stepper(
+                    "CPU Cores: \(instance.configuration.cpuCount)",
+                    value: configBinding(\.cpuCount),
+                    in: os.minCPUCount...os.maxCPUCount
+                )
 
-            Stepper(
-                "Memory: \(instance.configuration.memorySizeInGB) GB",
-                value: configBinding(\.memorySizeInGB),
-                in: os.minMemoryInGB...os.maxMemoryInGB
-            )
+                Stepper(
+                    "Memory: \(instance.configuration.memorySizeInGB) GB",
+                    value: configBinding(\.memorySizeInGB),
+                    in: os.minMemoryInGB...os.maxMemoryInGB
+                )
+            }
             .disabled(isReadOnly)
         }
         .task(id: instance.id) {
@@ -614,10 +610,13 @@ struct VMSettingsView: View {
     @ViewBuilder
     private var networkSection: some View {
         Section(header: sectionHeader("Network", lockable: true)) {
-            Toggle("Networking Enabled", isOn: configBinding(\.networkEnabled))
-            if let mac = instance.configuration.macAddress {
-                LabeledContent("MAC Address", value: mac)
+            Group {
+                Toggle("Networking Enabled", isOn: configBinding(\.networkEnabled))
+                if let mac = instance.configuration.macAddress {
+                    LabeledContent("MAC Address", value: mac)
+                }
             }
+            .disabled(isReadOnly)
         }
     }
 
@@ -628,12 +627,14 @@ struct VMSettingsView: View {
                 Text("Allows the guest to access the host microphone. Speaker output is always enabled.")
             }
         ) {
-            Toggle("Microphone", isOn: configBinding(\.microphoneEnabled))
-                .disabled(isReadOnly)
+            Group {
+                Toggle("Microphone", isOn: configBinding(\.microphoneEnabled))
+            }
+            .disabled(isReadOnly)
 
-            // Permission warning + info-popover button are left un-disabled so the
-            // explanation of how to re-enable the mic in System Settings remains
-            // reachable in read-only mode.
+            // Permission warning + info-popover button are left outside the
+            // disabled Group so the explanation of how to re-enable the mic
+            // in System Settings remains reachable in read-only mode.
             if instance.configuration.microphoneEnabled {
                 if micPermission == .notDetermined {
                     Text("macOS will ask for microphone permission the first time a VM uses it.")
@@ -684,25 +685,16 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var guestAgentSection: some View {
-        Section(
-            header: sectionHeader("Guest Agent") {
-                VStack(alignment: .leading, spacing: 10) {
+        Section(header: sectionHeader("Guest Agent")) {
+            Toggle(isOn: configBinding(\.agentLogForwardingEnabled)) {
+                toggleLabel("Forward guest logs") {
                     Text(
-                        "**Forward guest logs** streams `os.Logger` records from the macOS guest agent to the host so they appear in Console.app under `com.kernova.guest`. Off by default; can be toggled while the VM is running."
-                    )
-                    Text(
-                        "**Show install reminder** surfaces the install icon in the sidebar when the guest agent has not yet connected. Turn off to suppress the nudge for this VM. The more urgent indicators (update available, didn't reconnect, unresponsive) are not affected."
+                        "Streams `os.Logger` records from the macOS guest agent to the host so they appear in Console.app under `com.kernova.guest`. Off by default; can be toggled while the VM is running."
                     )
                 }
             }
-        ) {
-            Toggle(
-                "Forward guest logs",
-                isOn: configBinding(\.agentLogForwardingEnabled)
-            )
 
             Toggle(
-                "Show install reminder",
                 isOn: Binding(
                     get: { !instance.configuration.agentInstallNudgeDismissed },
                     set: { newValue in
@@ -711,7 +703,27 @@ struct VMSettingsView: View {
                         }
                     }
                 )
-            )
+            ) {
+                toggleLabel("Show install reminder") {
+                    Text(
+                        "Surfaces the install icon in the sidebar when the guest agent has not yet connected. Turn off to suppress the nudge for this VM. The more urgent indicators (update available, didn't reconnect, unresponsive) are not affected."
+                    )
+                }
+            }
+        }
+    }
+
+    /// Toggle label that pairs a title with a trailing info button. Used
+    /// when the explanation is specific to that one control rather than to
+    /// the whole section.
+    @ViewBuilder
+    private func toggleLabel<Info: View>(
+        _ title: LocalizedStringKey,
+        @ViewBuilder info: @escaping () -> Info
+    ) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+            InfoButton(label: title, content: info)
         }
     }
 
@@ -742,9 +754,6 @@ struct VMSettingsView: View {
         ) {
             let directories = sharedDirectoriesBinding.wrappedValue
 
-            // RATIONALE: see storageDiskSection — wrap body controls in
-            // a Group so the header's info button stays interactive in
-            // read-only mode.
             Group {
                 if directories.isEmpty {
                     Text("No shared directories")
@@ -874,14 +883,19 @@ struct VMSettingsView: View {
     }
 }
 
-/// Trailing accessory used in section headers to reveal per-section help
-/// text in a popover.
+/// Trailing accessory that reveals per-section or per-control help text in
+/// a popover.
 ///
-/// Encapsulates the `@State isPresented` flag so each header gets its own
-/// independent popover anchor without leaking state into the surrounding
-/// view.
-private struct SectionInfoButton<Content: View>: View {
-    @ViewBuilder let content: () -> Content
+/// Used both next to section titles (when the explanation applies to the
+/// whole section) and next to individual controls (when the explanation is
+/// specific to that control). Owns its own `@State` so each call site gets
+/// an independent popover anchor.
+private struct InfoButton<Content: View>: View {
+    /// Title of the section or control this button explains. Used for the
+    /// hover tooltip and the VoiceOver label ("About Storage Disks",
+    /// "About Forward guest logs", etc.).
+    let label: LocalizedStringKey
+    let content: () -> Content
     @State private var isPresented = false
 
     var body: some View {
@@ -893,7 +907,8 @@ private struct SectionInfoButton<Content: View>: View {
                 .imageScale(.small)
         }
         .buttonStyle(.plain)
-        .help("About this section")
+        .help("About \(Text(label))")
+        .accessibilityLabel("About \(Text(label))")
         .popover(isPresented: $isPresented, arrowEdge: .bottom) {
             content()
                 .font(.callout)

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -195,9 +195,10 @@ struct VMSettingsView: View {
     /// initializer behavior so passing a literal participates in the same
     /// localization lookup as the rest of the app's titles would.
     ///
-    /// `.accessibilityElement(children: .combine)` collapses the
-    /// lock / title / info-button trio into a single VoiceOver element so
-    /// the section reads as one item rather than three sequential stops.
+    /// The HStack's children are intentionally **not** combined for
+    /// accessibility — `InfoButton` is interactive and must remain
+    /// independently focusable in VoiceOver, and `lockIcon` carries its
+    /// own accessibility label so the locked state is announced.
     @ViewBuilder
     private func sectionHeader(_ title: LocalizedStringKey, lockable: Bool = false) -> some View {
         HStack(spacing: 6) {
@@ -206,7 +207,6 @@ struct VMSettingsView: View {
             }
             Text(title)
         }
-        .accessibilityElement(children: .combine)
     }
 
     /// Section header variant that also surfaces an info button at the end,
@@ -224,7 +224,6 @@ struct VMSettingsView: View {
             Text(title)
             InfoButton(label: title, content: info)
         }
-        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder
@@ -233,6 +232,7 @@ struct VMSettingsView: View {
             .foregroundStyle(.orange)
             .imageScale(.small)
             .help("Locked while the VM is running")
+            .accessibilityLabel("Locked while the VM is running")
     }
 
     // MARK: - Sections

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -184,15 +184,20 @@ struct VMSettingsView: View {
         }
     }
 
-    /// Section header that prepends a lock SF Symbol when `lockable` is `true`
-    /// and the VM is running, signaling that the section's controls are
-    /// locked. Hot-toggleable sections (Guest Agent, Clipboard, Removable
-    /// Media) pass `lockable: false` so the absence of the lock is itself
-    /// the signal that those sections remain editable.
+    /// Section header that prepends a lock SF Symbol when the section is
+    /// lockable and the VM is running.
+    ///
+    /// Hot-toggleable sections (Guest Agent, Clipboard, Removable Media)
+    /// pass `lockable: false` so the absence of the lock is itself the
+    /// signal that those sections remain editable.
     ///
     /// `LocalizedStringKey` matches SwiftUI's built-in `Section("...")`
     /// initializer behavior so passing a literal participates in the same
     /// localization lookup as the rest of the app's titles would.
+    ///
+    /// `.accessibilityElement(children: .combine)` collapses the
+    /// lock / title / info-button trio into a single VoiceOver element so
+    /// the section reads as one item rather than three sequential stops.
     @ViewBuilder
     private func sectionHeader(_ title: LocalizedStringKey, lockable: Bool = false) -> some View {
         HStack(spacing: 6) {
@@ -201,6 +206,7 @@ struct VMSettingsView: View {
             }
             Text(title)
         }
+        .accessibilityElement(children: .combine)
     }
 
     /// Section header variant that also surfaces an info button at the end,
@@ -218,6 +224,7 @@ struct VMSettingsView: View {
             Text(title)
             InfoButton(label: title, content: info)
         }
+        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder
@@ -713,9 +720,10 @@ struct VMSettingsView: View {
         }
     }
 
-    /// Toggle label that pairs a title with a trailing info button. Used
-    /// when the explanation is specific to that one control rather than to
-    /// the whole section.
+    /// Toggle label that pairs a title with a trailing info button.
+    ///
+    /// Used when the explanation is specific to that one control rather
+    /// than to the whole section.
     @ViewBuilder
     private func toggleLabel<Info: View>(
         _ title: LocalizedStringKey,
@@ -891,9 +899,10 @@ struct VMSettingsView: View {
 /// specific to that control). Owns its own `@State` so each call site gets
 /// an independent popover anchor.
 private struct InfoButton<Content: View>: View {
-    /// Title of the section or control this button explains. Used for the
-    /// hover tooltip and the VoiceOver label ("About Storage Disks",
-    /// "About Forward guest logs", etc.).
+    /// Title of the section or control this button explains.
+    ///
+    /// Used for the hover tooltip and the VoiceOver label ("About Storage
+    /// Disks", "About Forward guest logs", etc.).
     let label: LocalizedStringKey
     let content: () -> Content
     @State private var isPresented = false

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -111,21 +111,25 @@ struct VMSettingsView: View {
             }
             ScrollView {
                 Form {
-                    // RATIONALE: `.disabled(isReadOnly)` is applied per section rather
-                    // than at the Form level so that informational popover triggers in
-                    // `resourcesSection` and `audioSection` (which handle their own
-                    // disabling per-control) remain interactive in read-only mode —
-                    // SwiftUI's disabled state propagates irreversibly to descendants.
-                    // `guestAgentSection`, `clipboardSection`, and
-                    // `removableMediaSection` carry live-editable fields that
-                    // remain interactive while the VM is running. Storage Disks
-                    // is `storageDevices`-backed and therefore restart-only;
+                    // RATIONALE: `.disabled(isReadOnly)` is applied per section (or
+                    // per-control inside the section body) rather than at the Form
+                    // level so that informational popover triggers — the header info
+                    // buttons on Storage Disks / Shared Directories, and the in-body
+                    // mic-permission popover in `audioSection` — remain interactive in
+                    // read-only mode; SwiftUI's disabled state propagates irreversibly
+                    // to descendants. `resourcesSection` and `audioSection` disable
+                    // per-control. `storageDiskSection` and `sharedDirectoriesSection`
+                    // wrap their body content in a `Group { ... }.disabled(...)` so
+                    // their header's info button stays interactive. `guestAgentSection`,
+                    // `clipboardSection`, and `removableMediaSection` carry live-editable
+                    // fields that remain interactive while the VM is running. Storage
+                    // Disks is `storageDevices`-backed and therefore restart-only;
                     // Removable Media is XHCI-backed and hot-pluggable.
                     generalSection.disabled(isReadOnly)
                     resourcesSection
-                    storageDiskSection.disabled(isReadOnly)
+                    storageDiskSection
                     removableMediaSection
-                    sharedDirectoriesSection.disabled(isReadOnly)
+                    sharedDirectoriesSection
                     networkSection.disabled(isReadOnly)
                     audioSection
                     if instance.configuration.guestOS == .macOS {
@@ -184,35 +188,55 @@ struct VMSettingsView: View {
         }
     }
 
-    /// Section header that appends a lock SF Symbol when `isReadOnly` is
-    /// `true`, signaling that the section's controls are locked while the
-    /// VM is running.
-    ///
-    /// Hot-toggleable sections (Guest Agent, Clipboard) keep
-    /// their plain headers so the absence of the lock is itself the signal
-    /// that those sections remain editable.
+    /// Section header that prepends a lock SF Symbol when `lockable` is `true`
+    /// and the VM is running, signaling that the section's controls are
+    /// locked. Hot-toggleable sections (Guest Agent, Clipboard, Removable
+    /// Media) pass `lockable: false` so the absence of the lock is itself
+    /// the signal that those sections remain editable.
     ///
     /// `LocalizedStringKey` matches SwiftUI's built-in `Section("...")`
     /// initializer behavior so passing a literal participates in the same
     /// localization lookup as the rest of the app's titles would.
     @ViewBuilder
-    private func lockableHeader(_ title: LocalizedStringKey) -> some View {
+    private func sectionHeader(_ title: LocalizedStringKey, lockable: Bool = false) -> some View {
         HStack(spacing: 6) {
-            Text(title)
-            if isReadOnly {
-                Image(systemName: "lock.fill")
-                    .foregroundStyle(.orange)
-                    .imageScale(.small)
-                    .help("Locked while the VM is running")
+            if lockable && isReadOnly {
+                lockIcon
             }
+            Text(title)
         }
+    }
+
+    /// Section header variant that also surfaces an info button at the end,
+    /// revealing the per-section help text in a popover.
+    @ViewBuilder
+    private func sectionHeader<Info: View>(
+        _ title: LocalizedStringKey,
+        lockable: Bool = false,
+        @ViewBuilder info: @escaping () -> Info
+    ) -> some View {
+        HStack(spacing: 6) {
+            if lockable && isReadOnly {
+                lockIcon
+            }
+            Text(title)
+            SectionInfoButton(content: info)
+        }
+    }
+
+    @ViewBuilder
+    private var lockIcon: some View {
+        Image(systemName: "lock.fill")
+            .foregroundStyle(.orange)
+            .imageScale(.small)
+            .help("Locked while the VM is running")
     }
 
     // MARK: - Sections
 
     @ViewBuilder
     private var generalSection: some View {
-        Section(header: lockableHeader("General")) {
+        Section(header: sectionHeader("General", lockable: true)) {
             if isRenaming {
                 TextField("Name", text: $editingName)
                     .focused($isNameFieldFocused)
@@ -253,7 +277,13 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var removableMediaSection: some View {
-        Section("Removable Media") {
+        Section(
+            header: sectionHeader("Removable Media") {
+                Text(
+                    "Appears as a USB drive in the guest. Hot-pluggable — changes take effect immediately while the VM is running. For boot media, use Storage Disks instead."
+                )
+            }
+        ) {
             let items = removableMediaBinding.wrappedValue
 
             if items.isEmpty {
@@ -306,12 +336,6 @@ struct VMSettingsView: View {
                     createRemovableMediaPopover
                 }
             }
-
-            Text(
-                "Appears as a USB drive in the guest. Hot-pluggable — changes take effect immediately while the VM is running. For boot media, use Storage Disks instead."
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
         }
     }
 
@@ -367,36 +391,43 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var storageDiskSection: some View {
-        Section(header: lockableHeader("Storage Disks")) {
+        Section(
+            header: sectionHeader("Storage Disks", lockable: true) {
+                Text(
+                    "Position 1 boots first on EFI guests. On macOS and Linux Kernel boot, position affects guest device enumeration. Installer images (.iso, .dmg) attach as USB Mass Storage entries on this list (still bootable, separate from hot-pluggable Removable Media); permanent disks attach as virtio block devices, so reordering an installer doesn't change your main disk's /dev/vda letter."
+                )
+            }
+        ) {
             let disks = storageDiskBinding.wrappedValue
 
-            ForEach(storageDiskBinding) { $disk in
-                storageDiskRow(disk: $disk)
-            }
-            .onMove { source, destination in
-                var current = storageDiskBinding.wrappedValue
-                current.move(fromOffsets: source, toOffset: destination)
-                storageDiskBinding.wrappedValue = current
-            }
-
-            HStack {
-                Button("Attach External Disk...") {
-                    addExternalDisk()
+            // RATIONALE: disable wraps the body in a Group so the info
+            // button in the section header stays interactive in
+            // read-only mode (SwiftUI's `.disabled` would otherwise
+            // propagate to the header).
+            Group {
+                ForEach(storageDiskBinding) { $disk in
+                    storageDiskRow(disk: $disk)
+                }
+                .onMove { source, destination in
+                    var current = storageDiskBinding.wrappedValue
+                    current.move(fromOffsets: source, toOffset: destination)
+                    storageDiskBinding.wrappedValue = current
                 }
 
-                Button("Create New Disk...") {
-                    showingCreateDisk = true
-                }
-                .popover(isPresented: $showingCreateDisk, arrowEdge: .bottom) {
-                    createDiskPopover
+                HStack {
+                    Button("Attach External Disk...") {
+                        addExternalDisk()
+                    }
+
+                    Button("Create New Disk...") {
+                        showingCreateDisk = true
+                    }
+                    .popover(isPresented: $showingCreateDisk, arrowEdge: .bottom) {
+                        createDiskPopover
+                    }
                 }
             }
-
-            Text(
-                "Position 1 boots first on EFI guests. On macOS and Linux Kernel boot, position affects guest device enumeration. Installer images (.iso, .dmg) attach as USB Mass Storage entries on this list (still bootable, separate from hot-pluggable Removable Media); permanent disks attach as virtio block devices, so reordering an installer doesn't change your main disk's /dev/vda letter."
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
+            .disabled(isReadOnly)
 
             if instance.configuration.guestOS == .linux {
                 let virtioDisks = disks.filter { $0.kind == .virtio }
@@ -558,7 +589,7 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var resourcesSection: some View {
-        Section(header: lockableHeader("Resources")) {
+        Section(header: sectionHeader("Resources", lockable: true)) {
             let os = instance.configuration.guestOS
 
             Stepper(
@@ -582,7 +613,7 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var networkSection: some View {
-        Section(header: lockableHeader("Network")) {
+        Section(header: sectionHeader("Network", lockable: true)) {
             Toggle("Networking Enabled", isOn: configBinding(\.networkEnabled))
             if let mac = instance.configuration.macAddress {
                 LabeledContent("MAC Address", value: mac)
@@ -592,12 +623,13 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var audioSection: some View {
-        Section(header: lockableHeader("Audio")) {
+        Section(
+            header: sectionHeader("Audio", lockable: true) {
+                Text("Allows the guest to access the host microphone. Speaker output is always enabled.")
+            }
+        ) {
             Toggle("Microphone", isOn: configBinding(\.microphoneEnabled))
                 .disabled(isReadOnly)
-            Text("Allows the guest to access the host microphone. Speaker output is always enabled.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
 
             // Permission warning + info-popover button are left un-disabled so the
             // explanation of how to re-enable the mic in System Settings remains
@@ -652,16 +684,22 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var guestAgentSection: some View {
-        Section("Guest Agent") {
+        Section(
+            header: sectionHeader("Guest Agent") {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(
+                        "**Forward guest logs** streams `os.Logger` records from the macOS guest agent to the host so they appear in Console.app under `com.kernova.guest`. Off by default; can be toggled while the VM is running."
+                    )
+                    Text(
+                        "**Show install reminder** surfaces the install icon in the sidebar when the guest agent has not yet connected. Turn off to suppress the nudge for this VM. The more urgent indicators (update available, didn't reconnect, unresponsive) are not affected."
+                    )
+                }
+            }
+        ) {
             Toggle(
                 "Forward guest logs",
                 isOn: configBinding(\.agentLogForwardingEnabled)
             )
-            Text(
-                "Streams `os.Logger` records from the macOS guest agent to the host so they appear in Console.app under `com.kernova.guest`. Off by default; can be toggled while the VM is running."
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
 
             Toggle(
                 "Show install reminder",
@@ -674,23 +712,19 @@ struct VMSettingsView: View {
                     }
                 )
             )
-            Text(
-                "Surfaces the install icon in the sidebar when the guest agent has not yet connected. Turn off to suppress the nudge for this VM. The more urgent indicators (update available, didn't reconnect, unresponsive) are not affected."
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
         }
     }
 
     @ViewBuilder
     private var clipboardSection: some View {
-        Section("Clipboard") {
+        Section(
+            header: sectionHeader("Clipboard") {
+                Text(
+                    "Exchanges clipboard text between host and guest. macOS guests use the bundled Kernova guest agent — Kernova will offer to install or update it from the clipboard window. Linux guests need spice-vdagent installed via the guest's package manager."
+                )
+            }
+        ) {
             Toggle("Clipboard Sharing", isOn: configBinding(\.clipboardSharingEnabled))
-            Text(
-                "Exchanges clipboard text between host and guest. macOS guests use the bundled Kernova guest agent — Kernova will offer to install or update it from the clipboard window. Linux guests need spice-vdagent installed via the guest's package manager."
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
             if isReadOnly && instance.configuration.guestOS == .linux {
                 Text("Takes effect on next start — Linux guests configure SPICE at VM start time.")
                     .font(.caption)
@@ -701,83 +735,90 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var sharedDirectoriesSection: some View {
-        Section(header: lockableHeader("Shared Directories")) {
+        Section(
+            header: sectionHeader("Shared Directories", lockable: true) {
+                sharedDirectoriesInfo
+            }
+        ) {
             let directories = sharedDirectoriesBinding.wrappedValue
 
-            if directories.isEmpty {
-                Text("No shared directories")
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(sharedDirectoriesBinding) { $directory in
-                    HStack {
-                        Image(systemName: "folder")
-                            .foregroundStyle(.secondary)
+            // RATIONALE: see storageDiskSection — wrap body controls in
+            // a Group so the header's info button stays interactive in
+            // read-only mode.
+            Group {
+                if directories.isEmpty {
+                    Text("No shared directories")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(sharedDirectoriesBinding) { $directory in
+                        HStack {
+                            Image(systemName: "folder")
+                                .foregroundStyle(.secondary)
 
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(directory.displayName)
-                            Text(directory.path)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(directory.displayName)
+                                Text(directory.path)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+
+                            Spacer()
+
+                            Toggle("Read Only", isOn: $directory.readOnly)
+                                .toggleStyle(.switch)
+                                .labelsHidden()
+                            Text("Read Only")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
+
+                            Button(role: .destructive) {
+                                sharedDirectoriesBinding.wrappedValue.removeAll { $0.id == directory.id }
+                            } label: {
+                                Image(systemName: "minus.circle.fill")
+                                    .foregroundStyle(.red)
+                            }
+                            .buttonStyle(.plain)
                         }
+                    }
+                }
 
-                        Spacer()
+                Button("Add Shared Directory...") {
+                    addSharedDirectory()
+                }
+            }
+            .disabled(isReadOnly)
 
-                        Toggle("Read Only", isOn: $directory.readOnly)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                        Text("Read Only")
-                            .font(.caption)
+            if instance.configuration.guestOS == .linux, !directories.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Mount in guest:")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    ForEach(Array(directories.enumerated()), id: \.element.id) { index, directory in
+                        Text("mount -t virtiofs share\(index) /mnt/\(directory.displayName)")
+                            .font(.system(.caption, design: .monospaced))
                             .foregroundStyle(.secondary)
-
-                        Button(role: .destructive) {
-                            sharedDirectoriesBinding.wrappedValue.removeAll { $0.id == directory.id }
-                        } label: {
-                            Image(systemName: "minus.circle.fill")
-                                .foregroundStyle(.red)
-                        }
-                        .buttonStyle(.plain)
+                            .textSelection(.enabled)
                     }
                 }
             }
+        }
+    }
 
-            Button("Add Shared Directory...") {
-                addSharedDirectory()
-            }
-
+    @ViewBuilder
+    private var sharedDirectoriesInfo: some View {
+        VStack(alignment: .leading, spacing: 10) {
             if instance.configuration.guestOS == .linux {
                 Text(
                     "Shared directories are available as virtiofs mounts in the guest. Mount them with `mount -t virtiofs <tag> <mountpoint>`."
                 )
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                if !directories.isEmpty {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Mount in guest:")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        ForEach(Array(directories.enumerated()), id: \.element.id) { index, directory in
-                            Text("mount -t virtiofs share\(index) /mnt/\(directory.displayName)")
-                                .font(.system(.caption, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                                .textSelection(.enabled)
-                        }
-                    }
-                }
             } else {
                 Text("Shared directories auto-mount at /Volumes/My Shared Files/ in the guest.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
-
-            if !directories.isEmpty {
-                Text(
-                    "Note: File sharing uses VirtioFS which has known framework limitations — files may intermittently appear missing, and permission mapping between host and guest can differ."
-                )
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
+            Text(
+                "Note: File sharing uses VirtioFS which has known framework limitations — files may intermittently appear missing, and permission mapping between host and guest can differ."
+            )
         }
     }
 
@@ -830,5 +871,34 @@ struct VMSettingsView: View {
         }
         .padding()
         .frame(width: 340)
+    }
+}
+
+/// Trailing accessory used in section headers to reveal per-section help
+/// text in a popover.
+///
+/// Encapsulates the `@State isPresented` flag so each header gets its own
+/// independent popover anchor without leaking state into the surrounding
+/// view.
+private struct SectionInfoButton<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+    @State private var isPresented = false
+
+    var body: some View {
+        Button {
+            isPresented.toggle()
+        } label: {
+            Image(systemName: "info.circle")
+                .foregroundStyle(.secondary)
+                .imageScale(.small)
+        }
+        .buttonStyle(.plain)
+        .help("About this section")
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            content()
+                .font(.callout)
+                .padding()
+                .frame(width: 340)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Move the lock indicator from the trailing edge of each section title to the leading edge so the trailing slot can host a new \`info.circle\` button
- Move the descriptive prose that used to trail each section into a popover behind that info button, cleaning up the Settings form without losing the guidance
- Place Guest Agent's per-toggle descriptions next to their respective toggles (since the explanations are control-specific, not section-wide)
- Unify the read-only disable pattern: every locked section now wraps its controls in \`Group { ... }.disabled(isReadOnly)\` inside the section body, so headers escape the disabled state and the orange lock icon renders at full strength

## Changes
### \`Kernova/Views/Detail/VMSettingsView.swift\`
- Replace \`lockableHeader(_:)\` with \`sectionHeader(_:lockable:)\` plus an overload that takes an \`@ViewBuilder\` info block; extract a shared \`lockIcon\` helper that renders before the title
- Add a private \`InfoButton\` view that owns its own popover \`@State\` and renders a 340-pt callout popover anchored below the icon; tooltip + VoiceOver label read \"About <title>\"
- Hoist the trailing captions from Storage Disks, Removable Media, Audio, Clipboard, and Shared Directories into header info popovers; keep operational listings (\`/dev/disk/by-id/virtio-…\`, \`mount -t virtiofs …\`) inline
- Branch Shared Directories info content on \`guestOS == .linux\` for the virtiofs guidance vs. the macOS auto-mount text
- Convert General, Resources, Network, Audio from section-level / per-control \`.disabled(isReadOnly)\` to the body-wrapped \`Group { ... }.disabled(...)\` pattern; rewrite the form-root \`RATIONALE:\` comment to describe the unified rule
- Replace Guest Agent's section-level info popover with two per-toggle info buttons via a new \`toggleLabel(_:info:)\` helper

## Test plan
- [x] \`make build\` succeeds on macOS 26
- [x] \`make test\` — full suite passes
- [ ] Open a VM, switch the detail pane to Settings, and confirm every section header shows the info button on the right
- [ ] Start a VM and confirm the lock icon appears on the *left* of each lockable title at full orange (no disabled fade)
- [ ] In read-only Settings, confirm the info buttons on Storage Disks and Shared Directories still open their popovers
- [ ] Open each Guest Agent toggle's info button and confirm it pops the description without flipping the switch