### PR TITLE
refactor: Remove Linux virtio device path hint from Storage Disks

### DIFF
--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -404,8 +404,6 @@ struct VMSettingsView: View {
                 )
             }
         ) {
-            let disks = storageDiskBinding.wrappedValue
-
             Group {
                 ForEach(storageDiskBinding) { $disk in
                     storageDiskRow(disk: $disk)
@@ -430,23 +428,6 @@ struct VMSettingsView: View {
                 }
             }
             .disabled(isReadOnly)
-
-            if instance.configuration.guestOS == .linux {
-                let virtioDisks = disks.filter { $0.kind == .virtio }
-                if !virtioDisks.isEmpty {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Find in guest:")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        ForEach(virtioDisks) { disk in
-                            Text("/dev/disk/by-id/virtio-\(disk.blockDeviceIdentifier)")
-                                .font(.system(.caption, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                                .textSelection(.enabled)
-                        }
-                    }
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove the "Find in guest: /dev/disk/by-id/virtio-..." hint shown below the Storage Disks section for Linux VMs

## Changes
- Delete the Linux-only virtio path display block in `VMSettingsView` storage section
- Drop the now-unused `disks` local binding

## Test plan
- [x] Built successfully on macOS 26 with Xcode 26
- [ ] Verified Linux VM Settings no longer displays the virtio device path hint in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)