### PR TITLE
feat: Add Boot Order reorder sheet for storage disks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,6 +65,8 @@ Kernova/
 │   │   ├── MainDetailView.swift        # Detail pane wrapper — selection switch, creation sheet, error alert
 │   │   ├── VMDetailView.swift          # VM detail — console/settings switch (honors detailPaneMode), confirmation alerts
 │   │   ├── VMSettingsView.swift        # VM configuration editor; mostly read-only when the VM is running, but live-editable fields (clipboard, guest agent, removable media) stay interactive
+│   │   ├── StorageDiskReorderSheet.swift # Modal sheet presenting a native List for reordering storage disks (used because `.onMove` only works in `List`, not in `Form`)
+│   │   ├── StorageDiskSubtitle.swift   # Shared `diskSubtitle(for:in:)` free function used by both VMSettingsView and StorageDiskReorderSheet
 │   │   └── MacOSInstallProgressView.swift # Two-phase install progress (download + install)
 │   ├── Console/
 │   │   ├── VMConsoleView.swift         # Placeholder for non-inline display states (popped out, fullscreen, suspended, no display)

--- a/Kernova/Views/Detail/StorageDiskReorderSheet.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheet.swift
@@ -57,13 +57,10 @@ struct StorageDiskReorderSheet: View {
         HStack(spacing: 12) {
             Image(systemName: "line.3.horizontal")
                 .foregroundStyle(.secondary)
-                .accessibilityLabel("Drag to reorder")
+                .accessibilityHidden(true)
 
-            Image(
-                systemName: disk.kind == .usbMassStorage
-                    ? "opticaldisc" : (disk.isInternal ? "internaldrive" : "externaldrive")
-            )
-            .foregroundStyle(.secondary)
+            Image(systemName: diskIconSystemName(for: disk))
+                .foregroundStyle(.secondary)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(disk.label)

--- a/Kernova/Views/Detail/StorageDiskReorderSheet.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheet.swift
@@ -17,9 +17,14 @@ struct StorageDiskReorderSheet: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack {
+            HStack(spacing: 6) {
                 Text("Boot Order")
                     .font(.headline)
+                InfoButton(label: "Boot Order") {
+                    Text(
+                        "Drag rows to set the order in which the guest sees its storage. Position 1 boots first on EFI guests; on macOS and Linux Kernel boot, the order also determines guest device enumeration (for example, /dev/vda, /dev/vdb)."
+                    )
+                }
                 Spacer()
             }
             .padding()

--- a/Kernova/Views/Detail/StorageDiskReorderSheet.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheet.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Modal sheet for reordering a VM's storage disks.
+///
+/// Uses a real `List` with `.onMove` — the same pattern as `SidebarView` —
+/// so SwiftUI provides native drop affordances (insertion indicator between
+/// rows, drop-to-end). Writes flow through the supplied `disks` binding,
+/// which the parent wires to `VMSettingsView.storageDiskBinding`; every
+/// reorder therefore goes through `viewModel.updateConfiguration` and is
+/// persisted immediately.
+@MainActor
+struct StorageDiskReorderSheet: View {
+    @Binding var disks: [StorageDisk]
+    let instance: VMInstance
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Boot Order")
+                    .font(.headline)
+                Spacer()
+            }
+            .padding()
+
+            Divider()
+
+            List {
+                ForEach($disks) { $disk in
+                    row(for: disk)
+                }
+                .onMove { source, destination in
+                    disks.move(fromOffsets: source, toOffset: destination)
+                }
+            }
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+            .padding()
+        }
+        .frame(minWidth: 480, minHeight: 320)
+    }
+
+    @ViewBuilder
+    private func row(for disk: StorageDisk) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "line.3.horizontal")
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Drag to reorder")
+
+            Image(
+                systemName: disk.kind == .usbMassStorage
+                    ? "opticaldisc" : (disk.isInternal ? "internaldrive" : "externaldrive")
+            )
+            .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(disk.label)
+                Text(diskSubtitle(for: disk, in: instance))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer()
+        }
+    }
+}

--- a/Kernova/Views/Detail/StorageDiskReorderSheet.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheet.swift
@@ -73,5 +73,6 @@ struct StorageDiskReorderSheet: View {
 
             Spacer()
         }
+        .accessibilityElement(children: .combine)
     }
 }

--- a/Kernova/Views/Detail/StorageDiskSubtitle.swift
+++ b/Kernova/Views/Detail/StorageDiskSubtitle.swift
@@ -6,6 +6,17 @@ import Foundation
 /// for other internal disks, and the absolute file path for external disks.
 /// Shared by `VMSettingsView` and `StorageDiskReorderSheet` so both surfaces
 /// render identical row subtitles.
+/// SF Symbol name for a storage disk row's leading icon.
+///
+/// Shared so the settings list and the reorder sheet stay in lockstep
+/// if the icon mapping ever changes.
+func diskIconSystemName(for disk: StorageDisk) -> String {
+    if disk.kind == .usbMassStorage {
+        return "opticaldisc"
+    }
+    return disk.isInternal ? "internaldrive" : "externaldrive"
+}
+
 @MainActor
 func diskSubtitle(for disk: StorageDisk, in instance: VMInstance) -> String {
     if disk.isInternal && disk.path == instance.bundleLayout.diskImageURL.lastPathComponent {

--- a/Kernova/Views/Detail/StorageDiskSubtitle.swift
+++ b/Kernova/Views/Detail/StorageDiskSubtitle.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Human-readable subtitle for a storage disk row.
+///
+/// Returns disk usage stats for the in-bundle main disk, "In-bundle disk image"
+/// for other internal disks, and the absolute file path for external disks.
+/// Shared by `VMSettingsView` and `StorageDiskReorderSheet` so both surfaces
+/// render identical row subtitles.
+@MainActor
+func diskSubtitle(for disk: StorageDisk, in instance: VMInstance) -> String {
+    if disk.isInternal && disk.path == instance.bundleLayout.diskImageURL.lastPathComponent {
+        if let usage = instance.cachedDiskUsageBytes {
+            return
+                "\(DataFormatters.formatBytes(usage)) (on disk) / \(DataFormatters.formatDiskSize(instance.configuration.diskSizeInGB)) (allocated)"
+        }
+        return "\(DataFormatters.formatDiskSize(instance.configuration.diskSizeInGB)) allocated"
+    }
+    if disk.isInternal {
+        return "In-bundle disk image"
+    }
+    return disk.path
+}

--- a/Kernova/Views/Detail/StorageDiskSubtitle.swift
+++ b/Kernova/Views/Detail/StorageDiskSubtitle.swift
@@ -1,11 +1,5 @@
 import Foundation
 
-/// Human-readable subtitle for a storage disk row.
-///
-/// Returns disk usage stats for the in-bundle main disk, "In-bundle disk image"
-/// for other internal disks, and the absolute file path for external disks.
-/// Shared by `VMSettingsView` and `StorageDiskReorderSheet` so both surfaces
-/// render identical row subtitles.
 /// SF Symbol name for a storage disk row's leading icon.
 ///
 /// Shared so the settings list and the reorder sheet stay in lockstep
@@ -17,6 +11,12 @@ func diskIconSystemName(for disk: StorageDisk) -> String {
     return disk.isInternal ? "internaldrive" : "externaldrive"
 }
 
+/// Human-readable subtitle for a storage disk row.
+///
+/// Returns disk usage stats for the in-bundle main disk, "In-bundle disk image"
+/// for other internal disks, and the absolute file path for external disks.
+/// Shared by `VMSettingsView` and `StorageDiskReorderSheet` so both surfaces
+/// render identical row subtitles.
 @MainActor
 func diskSubtitle(for disk: StorageDisk, in instance: VMInstance) -> String {
     if disk.isInternal && disk.path == instance.bundleLayout.diskImageURL.lastPathComponent {

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -17,6 +17,7 @@ struct VMSettingsView: View {
     @State private var showingMicPermissionInfo = false
     @State private var micPermission: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
     @State private var showingCreateDisk = false
+    @State private var showingReorderDisksSheet = false
     @State private var showingCreateRemovableMedia = false
     @State private var newDiskSizeInGB = VMGuestOS.defaultDiskSizeInGB
     @State private var diskToRemove: StorageDisk?
@@ -408,11 +409,6 @@ struct VMSettingsView: View {
                 ForEach(storageDiskBinding) { $disk in
                     storageDiskRow(disk: $disk)
                 }
-                .onMove { source, destination in
-                    var current = storageDiskBinding.wrappedValue
-                    current.move(fromOffsets: source, toOffset: destination)
-                    storageDiskBinding.wrappedValue = current
-                }
 
                 HStack {
                     Button("Attach External Disk...") {
@@ -425,9 +421,18 @@ struct VMSettingsView: View {
                     .popover(isPresented: $showingCreateDisk, arrowEdge: .bottom) {
                         createDiskPopover
                     }
+
+                    if storageDiskBinding.wrappedValue.count > 1 {
+                        Button("Edit Boot Order...") {
+                            showingReorderDisksSheet = true
+                        }
+                    }
                 }
             }
             .disabled(isReadOnly)
+            .sheet(isPresented: $showingReorderDisksSheet) {
+                StorageDiskReorderSheet(disks: storageDiskBinding, instance: instance)
+            }
         }
     }
 
@@ -442,7 +447,7 @@ struct VMSettingsView: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(disk.wrappedValue.label)
-                Text(diskSubtitle(for: disk.wrappedValue))
+                Text(diskSubtitle(for: disk.wrappedValue, in: instance))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -467,22 +472,6 @@ struct VMSettingsView: View {
             }
             .buttonStyle(.plain)
         }
-    }
-
-    /// Subtitle string: disk usage stats for the main bundle disk, path or
-    /// label for everything else.
-    private func diskSubtitle(for disk: StorageDisk) -> String {
-        if disk.isInternal && disk.path == instance.bundleLayout.diskImageURL.lastPathComponent {
-            if let usage = instance.cachedDiskUsageBytes {
-                return
-                    "\(DataFormatters.formatBytes(usage)) (on disk) / \(DataFormatters.formatDiskSize(instance.configuration.diskSizeInGB)) (allocated)"
-            }
-            return "\(DataFormatters.formatDiskSize(instance.configuration.diskSizeInGB)) allocated"
-        }
-        if disk.isInternal {
-            return "In-bundle disk image"
-        }
-        return disk.path
     }
 
     private func addExternalDisk() {

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -332,11 +332,11 @@ struct VMSettingsView: View {
             }
 
             HStack {
-                Button("Attach Disc Image...") {
+                Button("Attach Disc Image") {
                     browseRemovableMedia()
                 }
 
-                Button("Create New Disk...") {
+                Button("Create New Disk") {
                     showingCreateRemovableMedia = true
                 }
                 .popover(isPresented: $showingCreateRemovableMedia, arrowEdge: .bottom) {
@@ -411,11 +411,11 @@ struct VMSettingsView: View {
                 }
 
                 HStack {
-                    Button("Attach External Disk...") {
+                    Button("Attach External Disk") {
                         addExternalDisk()
                     }
 
-                    Button("Create New Disk...") {
+                    Button("Create New Disk") {
                         showingCreateDisk = true
                     }
                     .popover(isPresented: $showingCreateDisk, arrowEdge: .bottom) {
@@ -423,7 +423,7 @@ struct VMSettingsView: View {
                     }
 
                     if storageDiskBinding.wrappedValue.count > 1 {
-                        Button("Edit Boot Order...") {
+                        Button("Edit Boot Order") {
                             showingReorderDisksSheet = true
                         }
                     }
@@ -771,7 +771,7 @@ struct VMSettingsView: View {
                     }
                 }
 
-                Button("Add Shared Directory...") {
+                Button("Add Shared Directory") {
                     addSharedDirectory()
                 }
             }
@@ -868,7 +868,7 @@ struct VMSettingsView: View {
 /// whole section) and next to individual controls (when the explanation is
 /// specific to that control). Owns its own `@State` so each call site gets
 /// an independent popover anchor.
-private struct InfoButton<Content: View>: View {
+struct InfoButton<Content: View>: View {
     /// Title of the section or control this button explains.
     ///
     /// Used for the hover tooltip and the VoiceOver label ("About Storage

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -332,11 +332,11 @@ struct VMSettingsView: View {
             }
 
             HStack {
-                Button("Attach Disc Image") {
+                Button("Attach Disc Image...") {
                     browseRemovableMedia()
                 }
 
-                Button("Create New Disk") {
+                Button("Create New Disk...") {
                     showingCreateRemovableMedia = true
                 }
                 .popover(isPresented: $showingCreateRemovableMedia, arrowEdge: .bottom) {
@@ -411,11 +411,11 @@ struct VMSettingsView: View {
                 }
 
                 HStack {
-                    Button("Attach External Disk") {
+                    Button("Attach External Disk...") {
                         addExternalDisk()
                     }
 
-                    Button("Create New Disk") {
+                    Button("Create New Disk...") {
                         showingCreateDisk = true
                     }
                     .popover(isPresented: $showingCreateDisk, arrowEdge: .bottom) {
@@ -423,7 +423,7 @@ struct VMSettingsView: View {
                     }
 
                     if storageDiskBinding.wrappedValue.count > 1 {
-                        Button("Edit Boot Order") {
+                        Button("Edit Boot Order...") {
                             showingReorderDisksSheet = true
                         }
                     }
@@ -768,7 +768,7 @@ struct VMSettingsView: View {
                     }
                 }
 
-                Button("Add Shared Directory") {
+                Button("Add Shared Directory...") {
                     addSharedDirectory()
                 }
             }

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -439,11 +439,8 @@ struct VMSettingsView: View {
     @ViewBuilder
     private func storageDiskRow(disk: Binding<StorageDisk>) -> some View {
         HStack {
-            Image(
-                systemName: disk.wrappedValue.kind == .usbMassStorage
-                    ? "opticaldisc" : (disk.wrappedValue.isInternal ? "internaldrive" : "externaldrive")
-            )
-            .foregroundStyle(.secondary)
+            Image(systemName: diskIconSystemName(for: disk.wrappedValue))
+                .foregroundStyle(.secondary)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(disk.wrappedValue.label)


### PR DESCRIPTION
## Summary
- Add a modal sheet for reordering the VM's storage disks, accessible via a new **Edit Boot Order** button in the Storage Disks section. Position 1 boots first on EFI guests; on macOS and Linux Kernel boot, the order also determines guest device enumeration.
- Sheet hosts a real SwiftUI `List` with `.onMove` (matching `SidebarView`'s pattern) so drops get native insertion indicators and drop-to-end behavior — the previous inline `.draggable`/`.dropDestination` attempt was a no-op inside the `Form`.
- Drive-by cleanup: drop trailing `...` from every action button in VM Settings, move the Boot Order explanation into an `InfoButton` popover (matching the section-header style), and de-duplicate the disk-icon SF Symbol mapping between the inline list and the sheet.

## Changes
- New `Kernova/Views/Detail/StorageDiskReorderSheet.swift` — the modal sheet.
- New `Kernova/Views/Detail/StorageDiskSubtitle.swift` — shared `diskSubtitle(for:in:)` and `diskIconSystemName(for:)` helpers used by both surfaces.
- `Kernova/Views/Detail/VMSettingsView.swift` — wires the sheet, strips ellipses from six button labels, promotes `InfoButton` from `private` to internal so the sheet can reuse it, removes the dead inline `.onMove`/`.draggable` code, and routes the inline list's disk icon and subtitle through the shared helpers.
- `ARCHITECTURE.md` — lists the two new files under `Kernova/Views/Detail/`.

## Test plan
- [x] \`make build\` clean
- [x] \`make test\` passes
- [ ] Manual: stopped VM with ≥2 disks → click **Edit Boot Order** → drag rows including to the absolute bottom → click **Done** → reopen and confirm the new order persisted.
- [ ] Manual: VM with 1 disk → **Edit Boot Order** button is not shown.
- [ ] Manual: VM running → Storage Disks section is read-only and **Edit Boot Order** is disabled.
- [ ] Manual: click the ⓘ next to "Boot Order" in the sheet — popover renders the explanatory copy in the same style as section-header popovers.
- [ ] Manual: VoiceOver no longer announces the decorative grabber icon as "Drag to reorder".