### PR TITLE
Tailor VM Settings info popovers per guest OS

### DIFF
--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -409,14 +409,22 @@ struct VMSettingsView: View {
     private var storageDiskSection: some View {
         Section(
             header: sectionHeader("Storage Disks", lockable: true) {
-                if instance.configuration.guestOS == .linux {
-                    Text(
-                        "Position 1 boots first on EFI guests; on Linux Kernel boot, position affects device enumeration but not boot priority. Permanent disks attach as virtio block devices (`/dev/vda`, `/dev/vdb`, …). Installer images (.iso, .dmg) attach as USB Mass Storage entries on this list — still bootable, separate from hot-pluggable Removable Media — so reordering an installer doesn't change your main disk's `/dev/vda` letter."
-                    )
-                } else {
-                    Text(
-                        "Position 1 is the main system disk; subsequent positions follow in order. Permanent disks attach as virtio block devices. Installer images (.iso, .dmg) attach as USB Mass Storage entries on this list — still bootable, separate from hot-pluggable Removable Media."
-                    )
+                VStack(alignment: .leading, spacing: 10) {
+                    if instance.configuration.guestOS == .linux {
+                        Text(
+                            "Position 1 boots first on EFI guests; on Linux Kernel boot, position affects device enumeration but not boot priority."
+                        )
+                        Text("Permanent disks attach as virtio block devices (`/dev/vda`, `/dev/vdb`, …).")
+                        Text(
+                            "Installer images (.iso, .dmg) attach as USB Mass Storage entries on this list — still bootable, separate from hot-pluggable Removable Media — so reordering an installer doesn't change your main disk's `/dev/vda` letter."
+                        )
+                    } else {
+                        Text("Position 1 is the main system disk; subsequent positions follow in order.")
+                        Text("Permanent disks attach as virtio block devices.")
+                        Text(
+                            "Installer images (.iso, .dmg) attach as USB Mass Storage entries on this list — still bootable, separate from hot-pluggable Removable Media."
+                        )
+                    }
                 }
             }
         ) {

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -286,9 +286,18 @@ struct VMSettingsView: View {
     private var removableMediaSection: some View {
         Section(
             header: sectionHeader("Removable Media") {
-                Text(
-                    "Appears as a USB drive in the guest. Hot-pluggable — changes take effect immediately while the VM is running. For boot media, use Storage Disks instead."
-                )
+                VStack(alignment: .leading, spacing: 10) {
+                    if instance.configuration.guestOS == .linux {
+                        Text(
+                            "Appears as a USB Mass Storage device (typically `/dev/sda` or similar). Most desktop distros auto-mount; headless installs need an explicit `mount`."
+                        )
+                    } else {
+                        Text("Appears as a removable USB drive in Finder; auto-mounts.")
+                    }
+                    Text(
+                        "Hot-pluggable — changes take effect immediately while the VM is running. For boot media, use Storage Disks instead."
+                    )
+                }
             }
         ) {
             let items = removableMediaBinding.wrappedValue
@@ -564,7 +573,13 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var resourcesSection: some View {
-        Section(header: sectionHeader("Resources", lockable: true)) {
+        Section(
+            header: sectionHeader("Resources", lockable: true) {
+                Text(
+                    "Memory is committed to the VM up-front at start time — keep enough free on the host to avoid swap pressure. CPU cores are scheduled by the host; over-committing is fine but reduces per-core performance under load."
+                )
+            }
+        ) {
             let os = instance.configuration.guestOS
 
             Group {
@@ -589,7 +604,20 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var networkSection: some View {
-        Section(header: sectionHeader("Network", lockable: true)) {
+        Section(
+            header: sectionHeader("Network", lockable: true) {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(
+                        "NAT-mode networking. The host assigns the guest a DHCP address on a private subnet. Outbound connections work; there is no port forwarding from host to guest — incoming connections require knowing the guest's IP."
+                    )
+                    if instance.configuration.guestOS == .linux {
+                        Text(
+                            "The interface usually appears as `enp0s1`. If networking doesn't come up, make sure your distro's DHCP client or NetworkManager is running."
+                        )
+                    }
+                }
+            }
+        ) {
             Group {
                 Toggle("Networking Enabled", isOn: configBinding(\.networkEnabled))
                 if let mac = instance.configuration.macAddress {
@@ -604,7 +632,14 @@ struct VMSettingsView: View {
     private var audioSection: some View {
         Section(
             header: sectionHeader("Audio", lockable: true) {
-                Text("Allows the guest to access the host microphone. Speaker output is always enabled.")
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(
+                        "Exposes a VirtioSound device. Speaker output is always enabled; toggle the microphone to grant the guest access to your host mic."
+                    )
+                    if instance.configuration.guestOS == .linux {
+                        Text("Requires Linux kernel 5.14 or newer to detect the VirtioSound device.")
+                    }
+                }
             }
         ) {
             Group {

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -400,9 +400,15 @@ struct VMSettingsView: View {
     private var storageDiskSection: some View {
         Section(
             header: sectionHeader("Storage Disks", lockable: true) {
-                Text(
-                    "Position 1 boots first on EFI guests. On macOS and Linux Kernel boot, position affects guest device enumeration. Installer images (.iso, .dmg) attach as USB Mass Storage entries on this list (still bootable, separate from hot-pluggable Removable Media); permanent disks attach as virtio block devices, so reordering an installer doesn't change your main disk's /dev/vda letter."
-                )
+                if instance.configuration.guestOS == .linux {
+                    Text(
+                        "Position 1 boots first on EFI guests; on Linux Kernel boot, position affects device enumeration but not boot priority. Permanent disks attach as virtio block devices (`/dev/vda`, `/dev/vdb`, …). Installer images (.iso, .dmg) attach as USB Mass Storage entries on this list — still bootable, separate from hot-pluggable Removable Media — so reordering an installer doesn't change your main disk's `/dev/vda` letter."
+                    )
+                } else {
+                    Text(
+                        "Position 1 is the main system disk; subsequent positions follow in order. Permanent disks attach as virtio block devices. Installer images (.iso, .dmg) attach as USB Mass Storage entries on this list — still bootable, separate from hot-pluggable Removable Media."
+                    )
+                }
             }
         ) {
             Group {
@@ -706,9 +712,15 @@ struct VMSettingsView: View {
     private var clipboardSection: some View {
         Section(
             header: sectionHeader("Clipboard") {
-                Text(
-                    "Exchanges clipboard text between host and guest. macOS guests use the bundled Kernova guest agent — Kernova will offer to install or update it from the clipboard window. Linux guests need spice-vdagent installed via the guest's package manager."
-                )
+                if instance.configuration.guestOS == .linux {
+                    Text(
+                        "Exchanges clipboard text between host and guest. Requires `spice-vdagent` installed in the guest via its package manager."
+                    )
+                } else {
+                    Text(
+                        "Exchanges clipboard text between host and guest. Uses the bundled Kernova guest agent — Kernova will offer to install or update it from the clipboard window."
+                    )
+                }
             }
         ) {
             Toggle("Clipboard Sharing", isOn: configBinding(\.clipboardSharingEnabled))
@@ -773,20 +785,6 @@ struct VMSettingsView: View {
                 }
             }
             .disabled(isReadOnly)
-
-            if instance.configuration.guestOS == .linux, !directories.isEmpty {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Mount in guest:")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    ForEach(Array(directories.enumerated()), id: \.element.id) { index, directory in
-                        Text("mount -t virtiofs share\(index) /mnt/\(directory.displayName)")
-                            .font(.system(.caption, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                            .textSelection(.enabled)
-                    }
-                }
-            }
         }
     }
 
@@ -795,14 +793,18 @@ struct VMSettingsView: View {
         VStack(alignment: .leading, spacing: 10) {
             if instance.configuration.guestOS == .linux {
                 Text(
-                    "Shared directories are available as virtiofs mounts in the guest. Mount them with `mount -t virtiofs <tag> <mountpoint>`."
+                    "Exposed as virtiofs mounts. Each share gets a numbered tag (`share0`, `share1`, …) in list order. Mount with:"
                 )
+                Text("mount -t virtiofs share0 /mnt/myshare")
+                    .font(.system(.callout, design: .monospaced))
+                    .textSelection(.enabled)
             } else {
-                Text("Shared directories auto-mount at /Volumes/My Shared Files/ in the guest.")
+                Text("Auto-mounts at `/Volumes/My Shared Files/` in the guest.")
             }
             Text(
-                "Note: File sharing uses VirtioFS which has known framework limitations — files may intermittently appear missing, and permission mapping between host and guest can differ."
+                "VirtioFS has known framework limitations — files may intermittently appear missing, and host/guest permission mapping can differ."
             )
+            .foregroundStyle(.secondary)
         }
     }
 


### PR DESCRIPTION
## Summary
- Split every section-level info popover that had divergent guest behavior so each VM sees only the relevant paragraph (Storage Disks, Removable Media, Shared Directories, Network, Audio, Clipboard).
- Fill in the two VM Settings sections that had no info button before — Network and Resources — so help coverage is consistent across the form.
- Replace the duplicate Linux "Mount in guest:" bottom block in Shared Directories with a richer popover that names the `share0`, `share1`, … tag convention and shows a copyable `mount -t virtiofs` example.

## Changes by section

| Section | Before | After |
| --- | --- | --- |
| Storage Disks | Single paragraph mixing macOS and Linux specifics (`/dev/vda`, EFI vs Kernel boot) | macOS drops Linux-only terminology; Linux keeps `/dev/vda` + EFI-vs-Kernel boot distinction |
| Removable Media | One OS-agnostic paragraph | Linux calls out USB Mass Storage + headless `mount`; macOS calls out Finder auto-mount |
| Shared Directories | Linux had a duplicate "Mount in guest:" block at the bottom of the section | Bottom block removed; popover now embeds the concrete mount example and tag-naming convention |
| Network | No info button | NAT-mode + no-port-forwarding explanation, plus a Linux `enp0s1` / DHCP / NetworkManager hint |
| Audio | One sentence | Names the VirtioSound device class; Linux variant notes the kernel ≥5.14 requirement |
| Clipboard | Single paragraph mentioning both OSes | macOS = bundled Kernova agent flow; Linux = `spice-vdagent` requirement |
| Resources | No info button | Explains up-front memory commit + CPU over-commit behavior (OS-agnostic) |

Removable Media, Audio, and Guest Agent toggles are otherwise unchanged where their behavior didn't actually diverge.

## Test plan
- [ ] Built successfully on macOS 26
- [ ] Opened each popover on a macOS guest VM and confirmed only macOS-relevant paragraphs render
- [ ] Opened each popover on a Linux guest VM and confirmed Linux-specific paragraphs (interface name, mount example, kernel note) render
- [ ] Confirmed Shared Directories no longer shows the "Mount in guest:" bottom block on Linux
- [ ] Verified Network and Resources sections now have info buttons in the header
- [ ] Verified popovers remain interactive in the read-only banner state

🤖 Generated with [Claude Code](https://claude.com/claude-code)