### PR TITLE
feat: Resumable macOS install with Initial Boot state

### DIFF
--- a/Kernova/App/VMToolbarManager.swift
+++ b/Kernova/App/VMToolbarManager.swift
@@ -58,6 +58,8 @@ final class VMToolbarManager: NSObject {
 
     private static let startToolTip = "Start the virtual machine"
     private static let resumeToolTip = "Resume the virtual machine"
+    private static let installToolTip = "Download macOS and start the installation"
+    private static let resumeInstallToolTip = "Resume the interrupted download and install macOS"
     private static let pauseToolTip = "Pause the virtual machine"
     private static let stopToolTip = "Stop the virtual machine"
     private static let saveStateToolTip = "Suspend the virtual machine"
@@ -202,13 +204,37 @@ final class VMToolbarManager: NSObject {
         }
 
         let canResume = instance.status.canResume
-        let playLabel = canResume ? "Resume" : "Start"
+        // Trigger on installContext (not status) so .error retries — which
+        // happen when a previous install attempt failed — also get the
+        // install-flavored labels and reflect what Start will actually do.
+        let hasInstallIntent: Bool
+        let hasResumableDownload: Bool
+        #if arch(arm64)
+        hasInstallIntent = instance.configuration.installContext != nil
+        hasResumableDownload = hasInstallIntent && instance.hasResumableInstallDownload
+        #else
+        hasInstallIntent = false
+        hasResumableDownload = false
+        #endif
+
+        let playLabel: String
+        let playToolTip: String
+        if hasInstallIntent {
+            playLabel = hasResumableDownload ? "Resume Install" : "Install"
+            playToolTip = hasResumableDownload ? Self.resumeInstallToolTip : Self.installToolTip
+        } else if canResume {
+            playLabel = "Resume"
+            playToolTip = Self.resumeToolTip
+        } else {
+            playLabel = "Start"
+            playToolTip = Self.startToolTip
+        }
 
         let play = group.subitems[LifecycleSegment.play.rawValue]
         if play.label != playLabel {
             play.label = playLabel
             play.image = .systemSymbol("play.fill", accessibilityDescription: playLabel)
-            play.toolTip = canResume ? Self.resumeToolTip : Self.startToolTip
+            play.toolTip = playToolTip
         }
 
         play.isEnabled = instance.status.canStart || canResume

--- a/Kernova/Models/MacOSInstallContext.swift
+++ b/Kernova/Models/MacOSInstallContext.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Persisted intent to install macOS into a VM that has not yet completed
+/// its initial boot. Stored on `VMConfiguration` and consulted by
+/// `VMLifecycleCoordinator.installMacOS(on:context:)` on every Start while
+/// non-nil. Cleared exactly once, after a successful install.
+///
+/// The wizard's `IPSWSource` enum is a runtime-only type; this mirrored
+/// `Codable` representation keeps the model layer free of wizard knowledge
+/// while surviving bundle persistence.
+struct MacOSInstallContext: Codable, Sendable, Equatable {
+    enum Source: String, Codable, Sendable, Equatable {
+        case downloadLatest
+        case localFile
+    }
+
+    var source: Source
+
+    /// Where to write the downloaded IPSW (for `.downloadLatest`). The
+    /// `<path>.resumedata` sidecar at this location enables download resume
+    /// across app restarts. Ignored when `source == .localFile`.
+    var downloadDestinationPath: String?
+
+    /// Path to an existing IPSW file on disk (for `.localFile`). Ignored
+    /// when `source == .downloadLatest`.
+    var localIPSWPath: String?
+
+    var downloadDestinationURL: URL? {
+        downloadDestinationPath.map { URL(fileURLWithPath: $0) }
+    }
+
+    var localIPSWURL: URL? {
+        localIPSWPath.map { URL(fileURLWithPath: $0) }
+    }
+}

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -142,6 +142,16 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
 
     var sharedDirectories: [SharedDirectory]?
 
+    // MARK: - Install Intent
+
+    /// Pending macOS install plan from the creation wizard. Non-nil ⇔ this VM
+    /// has never completed its initial boot. Cleared exactly once, after
+    /// `MacOSInstallService.install(...)` returns successfully. The presence
+    /// of this field is what drives `start(_:)` to route through the install
+    /// pipeline (and the `.initialBoot` status assignment in reconcile).
+    /// Always `nil` for Linux guests.
+    var installContext: MacOSInstallContext?
+
     // MARK: - Metadata
 
     var createdAt: Date
@@ -177,6 +187,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         storageDisks: [StorageDisk]? = nil,
         removableMedia: [RemovableMediaItem]? = nil,
         sharedDirectories: [SharedDirectory]? = nil,
+        installContext: MacOSInstallContext? = nil,
         createdAt: Date = Date()
     ) {
         self.id = id
@@ -207,6 +218,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         self.storageDisks = storageDisks
         self.removableMedia = removableMedia
         self.sharedDirectories = sharedDirectories
+        self.installContext = installContext
         self.createdAt = createdAt
     }
 
@@ -246,6 +258,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         self.storageDisks = try c.decodeIfPresent([StorageDisk].self, forKey: .storageDisks)
         self.removableMedia = try c.decodeIfPresent([RemovableMediaItem].self, forKey: .removableMedia)
         self.sharedDirectories = try c.decodeIfPresent([SharedDirectory].self, forKey: .sharedDirectories)
+        self.installContext = try c.decodeIfPresent(MacOSInstallContext.self, forKey: .installContext)
         self.createdAt = try c.decode(Date.self, forKey: .createdAt)
     }
 
@@ -296,6 +309,12 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
         clone.sharedDirectories = sharedDirectories?.map { dir in
             SharedDirectory(id: UUID(), path: dir.path, readOnly: dir.readOnly)
         }
+
+        // Clones copy the source bundle's post-install artifacts (HardwareModel,
+        // MachineIdentifier, Disk.asif contents) so they're already installed.
+        // Preserving installContext would falsely mark the clone as awaiting
+        // an initial boot.
+        clone.installContext = nil
 
         return clone
     }

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -178,7 +178,10 @@ final class VMInstance: Identifiable {
     /// If `onUpdateConfiguration` is wired, the mutation flows through the
     /// view model's centralized dispatcher (persist + applyLivePolicy).
     /// Otherwise, falls back to a direct in-memory write — the test-only path.
-    private func performConfigurationMutation(_ mutate: (inout VMConfiguration) -> Void) {
+    ///
+    /// Internal so `VMLifecycleCoordinator` can clear `installContext` through
+    /// the persistence pipeline after a successful install.
+    func performConfigurationMutation(_ mutate: (inout VMConfiguration) -> Void) {
         if let onUpdateConfiguration {
             onUpdateConfiguration(mutate)
         } else {

--- a/Kernova/Models/VMStatus.swift
+++ b/Kernova/Models/VMStatus.swift
@@ -10,6 +10,10 @@ enum VMStatus: String, Codable, Sendable {
     case saving
     case restoring
     case installing
+    /// VM exists in the library but has never completed its initial boot
+    /// (macOS install pipeline hasn't run). Clicking Start kicks off the
+    /// install (which may resume an interrupted download), then auto-boots.
+    case initialBoot
     case error
 
     var displayName: String {
@@ -21,6 +25,7 @@ enum VMStatus: String, Codable, Sendable {
         case .saving: "Suspending"
         case .restoring: "Restoring"
         case .installing: "Installing"
+        case .initialBoot: "Initial Boot"
         case .error: "Error"
         }
     }
@@ -28,7 +33,7 @@ enum VMStatus: String, Codable, Sendable {
     var statusColor: Color {
         switch self {
         case .stopped: .secondary
-        case .starting, .saving, .restoring, .installing: .orange
+        case .starting, .saving, .restoring, .installing, .initialBoot: .orange
         case .running: .green
         case .paused: .yellow
         case .error: .red
@@ -52,7 +57,7 @@ enum VMStatus: String, Codable, Sendable {
         }
     }
 
-    var canStart: Bool { self == .stopped || self == .error }
+    var canStart: Bool { self == .stopped || self == .error || self == .initialBoot }
     /// Status-level stop eligibility.
     ///
     /// Does not account for cold-paused state;
@@ -65,7 +70,7 @@ enum VMStatus: String, Codable, Sendable {
     /// Does not account for cold-paused state;
     /// prefer `VMInstance.canSave` for runtime checks.
     var canSave: Bool { self == .running || self == .paused }
-    var canEditSettings: Bool { self == .stopped || self == .error }
+    var canEditSettings: Bool { self == .stopped || self == .error || self == .initialBoot }
     var canRename: Bool { !isTransitioning }
 
     /// Whether the VM has a live display session that a backing view should present.
@@ -91,7 +96,7 @@ enum VMStatus: String, Codable, Sendable {
         switch self {
         case .running, .starting, .saving, .restoring, .installing:
             true
-        case .paused, .stopped, .error:
+        case .paused, .stopped, .error, .initialBoot:
             false
         }
     }

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -21,7 +21,11 @@ struct IPSWService: Sendable {
     /// If a `<destinationURL>.resumedata` sidecar exists from a prior interrupted attempt,
     /// the download resumes from where it left off. On non-cancel failures (network drop,
     /// sleep timeout) the sidecar is written so a future attempt at the same path can resume.
-    /// User-initiated cancellation drops any resume data and surfaces as `CancellationError`.
+    /// User-initiated cancellation also preserves resume data via
+    /// `cancel(byProducingResumeData:)`, then surfaces as `CancellationError` so the
+    /// non-destructive cancel UX can stay on the same path and resume on the next Start.
+    /// If the destination already contains a completed IPSW (and no sidecar is present),
+    /// the download is skipped entirely.
     func downloadRestoreImage(
         from remoteURL: URL,
         to destinationURL: URL,
@@ -43,6 +47,15 @@ struct IPSWService: Sendable {
             Self.logger.notice(
                 "IPSW already present at '\(destinationURL.lastPathComponent, privacy: .public)' — skipping download"
             )
+            // Emit a final progress callback so the download UI shows 100% before
+            // the lifecycle transitions to the install phase.
+            let fileSize = (try? destinationURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+            let completed = DownloadProgress(
+                bytesWritten: Int64(fileSize),
+                totalBytes: Int64(fileSize),
+                bytesPerSecond: 0
+            )
+            await MainActor.run { progressHandler(completed) }
             return
         }
 

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -17,6 +17,11 @@ struct IPSWService: Sendable {
     }
 
     /// Downloads a macOS restore image from a remote URL to the specified destination.
+    ///
+    /// If a `<destinationURL>.resumedata` sidecar exists from a prior interrupted attempt,
+    /// the download resumes from where it left off. On non-cancel failures (network drop,
+    /// sleep timeout) the sidecar is written so a future attempt at the same path can resume.
+    /// User-initiated cancellation drops any resume data and surfaces as `CancellationError`.
     func downloadRestoreImage(
         from remoteURL: URL,
         to destinationURL: URL,
@@ -24,13 +29,12 @@ struct IPSWService: Sendable {
     ) async throws {
         Self.logger.info("Downloading restore image from \(remoteURL, privacy: .public)")
 
-        // RATIONALE: removeItem (not trashItem) is used here because these are incomplete/partial
-        // IPSW files from a prior failed download — not user data worth preserving. Trashing
-        // multi-gigabyte partial files would waste disk space and may fail on volumes without Trash.
-        do {
-            try FileManager.default.removeItem(at: destinationURL)
-        } catch CocoaError.fileNoSuchFile {
-            // No existing file to clean up — expected on first download.
+        let sidecarURL = Self.resumeDataSidecarURL(for: destinationURL)
+        let priorResumeData = try? Data(contentsOf: sidecarURL)
+        if priorResumeData != nil {
+            Self.logger.notice(
+                "Resuming prior IPSW download from sidecar at '\(sidecarURL.lastPathComponent, privacy: .public)'"
+            )
         }
 
         // nonisolated(unsafe) is needed because URLSessionDownloadTask is not Sendable,
@@ -42,6 +46,7 @@ struct IPSWService: Sendable {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
                 let delegate = IPSWDownloadDelegate(
                     destinationURL: destinationURL,
+                    sidecarURL: sidecarURL,
                     progressHandler: progressHandler,
                     continuation: continuation
                 )
@@ -50,7 +55,12 @@ struct IPSWService: Sendable {
                     delegate: delegate,
                     delegateQueue: nil
                 )
-                let task = session.downloadTask(with: remoteURL)
+                let task: URLSessionDownloadTask
+                if let priorResumeData {
+                    task = session.downloadTask(withResumeData: priorResumeData)
+                } else {
+                    task = session.downloadTask(with: remoteURL)
+                }
                 downloadTask = task
 
                 // Close the race where the Task was cancelled before downloadTask
@@ -68,6 +78,30 @@ struct IPSWService: Sendable {
         }
 
         Self.logger.info("Restore image downloaded to \(destinationURL.lastPathComponent, privacy: .public)")
+    }
+
+    /// Deletes any persisted resume-data sidecar for the given destination path.
+    /// Safe to call when no sidecar exists.
+    func discardResumeData(at destinationURL: URL) {
+        let sidecarURL = Self.resumeDataSidecarURL(for: destinationURL)
+        do {
+            try FileManager.default.removeItem(at: sidecarURL)
+            Self.logger.info(
+                "Discarded resume-data sidecar at '\(sidecarURL.lastPathComponent, privacy: .public)'"
+            )
+        } catch CocoaError.fileNoSuchFile {
+            // Nothing to discard — common case.
+        } catch {
+            Self.logger.warning(
+                "Failed to discard resume-data sidecar at '\(sidecarURL.path(percentEncoded: false), privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    /// Returns the on-disk location where URLSession resume data is persisted for a given
+    /// download destination. Lives next to the final file so cleanup tracks the user's chosen path.
+    static func resumeDataSidecarURL(for destinationURL: URL) -> URL {
+        destinationURL.appendingPathExtension("resumedata")
     }
     #endif
 }
@@ -88,6 +122,7 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
     private static let progressInterval: TimeInterval = 0.1  // 100 ms
 
     private let destinationURL: URL
+    private let sidecarURL: URL
     private let progressHandler: @MainActor @Sendable (DownloadProgress) -> Void
     // RATIONALE: URLSession guarantees exactly one didCompleteWithError call per task,
     // so this continuation is always resumed exactly once.
@@ -101,10 +136,12 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
 
     init(
         destinationURL: URL,
+        sidecarURL: URL,
         progressHandler: @MainActor @Sendable @escaping (DownloadProgress) -> Void,
         continuation: CheckedContinuation<Void, any Error>
     ) {
         self.destinationURL = destinationURL
+        self.sidecarURL = sidecarURL
         self.progressHandler = progressHandler
         self.continuation = continuation
     }
@@ -183,27 +220,48 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
         session.finishTasksAndInvalidate()
 
         if let error = error ?? moveError {
-            do {
-                try FileManager.default.removeItem(at: destinationURL)
-            } catch {
-                Self.logger.warning(
-                    "Failed to clean up partial download at '\(self.destinationURL.path(percentEncoded: false), privacy: .public)': \(error.localizedDescription, privacy: .public)"
-                )
-            }
-
             // Propagate cancellation as CancellationError so callers can distinguish
             // user-initiated cancellation from genuine download failures.
             if let nsError = error as NSError?,
                 nsError.domain == NSURLErrorDomain,
                 nsError.code == NSURLErrorCancelled
             {
+                // User/parent-task cancellation — drop any resume data so the next
+                // attempt starts fresh. IPSWService.discardResumeData also runs on
+                // the cancel path; this is belt-and-suspenders for the URLSession
+                // side of the cancel race.
+                removeSidecar(reason: "cancellation")
                 Self.logger.info("Restore image download cancelled")
                 continuation.resume(throwing: CancellationError())
             } else {
+                // Network failure / sleep timeout / etc. — persist resume data so a
+                // future attempt at the same destination can pick up where we left off.
+                if let resumeData = (error as NSError?)?
+                    .userInfo[NSURLSessionDownloadTaskResumeData] as? Data
+                {
+                    do {
+                        try resumeData.write(to: sidecarURL, options: .atomic)
+                        Self.logger.notice(
+                            "Persisted IPSW resume data (\(resumeData.count, privacy: .public) bytes) to '\(self.sidecarURL.lastPathComponent, privacy: .public)'"
+                        )
+                    } catch {
+                        Self.logger.warning(
+                            "Failed to persist IPSW resume data at '\(self.sidecarURL.path(percentEncoded: false), privacy: .public)': \(error.localizedDescription, privacy: .public)"
+                        )
+                    }
+                } else {
+                    // Server returned a non-resumable error (404, 4xx, validator
+                    // mismatch). Drop any stale sidecar so the next attempt is fresh.
+                    removeSidecar(reason: "non-resumable error")
+                }
+
                 Self.logger.error("Restore image download failed: \(error.localizedDescription, privacy: .public)")
                 continuation.resume(throwing: IPSWError.downloadFailed(error))
             }
         } else {
+            // Successful completion — sidecar has served its purpose.
+            removeSidecar(reason: "successful completion")
+
             let handler = self.progressHandler
             let progress = DownloadProgress(
                 bytesWritten: max(0, task.countOfBytesReceived),
@@ -212,6 +270,18 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
             )
             Task { @MainActor in handler(progress) }
             continuation.resume()
+        }
+    }
+
+    private func removeSidecar(reason: String) {
+        do {
+            try FileManager.default.removeItem(at: sidecarURL)
+        } catch CocoaError.fileNoSuchFile {
+            // Common case — nothing to clean up.
+        } catch {
+            Self.logger.warning(
+                "Failed to remove resume-data sidecar at '\(self.sidecarURL.path(percentEncoded: false), privacy: .public)' after \(reason, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
         }
     }
 }

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -31,6 +31,21 @@ struct IPSWService: Sendable {
 
         let sidecarURL = Self.resumeDataSidecarURL(for: destinationURL)
         let priorResumeData = try? Data(contentsOf: sidecarURL)
+
+        // Skip-existing fast path: a completed IPSW at the destination with no
+        // in-progress resume sidecar means a prior attempt already downloaded
+        // the file. This happens when the user cancelled or hit an error during
+        // the install phase (post-download). Skipping saves a multi-GB redownload
+        // and avoids a "File exists" failure when moveItem hits a populated path.
+        if priorResumeData == nil,
+            FileManager.default.fileExists(atPath: destinationURL.path(percentEncoded: false))
+        {
+            Self.logger.notice(
+                "IPSW already present at '\(destinationURL.lastPathComponent, privacy: .public)' — skipping download"
+            )
+            return
+        }
+
         if priorResumeData != nil {
             Self.logger.notice(
                 "Resuming prior IPSW download from sidecar at '\(sidecarURL.lastPathComponent, privacy: .public)'"
@@ -208,6 +223,13 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
         // URLSession deletes the temporary file after this method returns,
         // so the move must happen synchronously here.
         do {
+            // Replace any existing file at the destination to defend against
+            // the moveItem "File exists" failure on retry paths where the
+            // skip-existing fast path didn't apply (e.g. a stale partial file
+            // from a torn-down prior attempt).
+            if FileManager.default.fileExists(atPath: destinationURL.path(percentEncoded: false)) {
+                try FileManager.default.removeItem(at: destinationURL)
+            }
             try FileManager.default.moveItem(at: location, to: destinationURL)
         } catch {
             Self.logger.error(

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -74,7 +74,15 @@ struct IPSWService: Sendable {
                 task.resume()
             }
         } onCancel: {
-            downloadTask?.cancel()
+            // cancel(byProducingResumeData:) preserves the partial download
+            // as resume data we can write to the sidecar, so a future Start
+            // on the same VM resumes instead of restarting. Plain cancel()
+            // would discard the bytes.
+            downloadTask?.cancel { resumeData in
+                if let resumeData {
+                    try? resumeData.write(to: sidecarURL, options: .atomic)
+                }
+            }
         }
 
         Self.logger.info("Restore image downloaded to \(destinationURL.lastPathComponent, privacy: .public)")
@@ -226,11 +234,11 @@ private final class IPSWDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
                 nsError.domain == NSURLErrorDomain,
                 nsError.code == NSURLErrorCancelled
             {
-                // User/parent-task cancellation — drop any resume data so the next
-                // attempt starts fresh. IPSWService.discardResumeData also runs on
-                // the cancel path; this is belt-and-suspenders for the URLSession
-                // side of the cancel race.
-                removeSidecar(reason: "cancellation")
+                // User/parent-task cancellation — preserve any resume data the
+                // cancel handler may have written so the next Start can resume.
+                // The onCancel handler in downloadRestoreImage (which uses
+                // cancel(byProducingResumeData:)) is what populates the sidecar
+                // for user-initiated cancels.
                 Self.logger.info("Restore image download cancelled")
                 continuation.resume(throwing: CancellationError())
             } else {

--- a/Kernova/Services/MacOSInstallService.swift
+++ b/Kernova/Services/MacOSInstallService.swift
@@ -115,21 +115,29 @@ final class MacOSInstallService {
     // MARK: - Platform Setup
 
     /// Creates the auxiliary storage, hardware model, and machine identifier files.
+    /// Idempotent across install retries: hardware model and machine identifier
+    /// files are written only when absent so the VM keeps a stable on-disk identity
+    /// across attempts (the guest install sees the same machine regardless of how
+    /// many tries it took). Auxiliary storage is always re-created — it carries
+    /// firmware/NVRAM state that must match a fresh install run.
     private func setupPlatformFiles(
         for instance: VMInstance,
         hardwareModel: VZMacHardwareModel
     ) throws {
-        // Write hardware model
-        try hardwareModel.dataRepresentation.write(to: instance.hardwareModelURL)
+        let fm = FileManager.default
 
-        // Create machine identifier
-        let machineIdentifier = VZMacMachineIdentifier()
-        try machineIdentifier.dataRepresentation.write(to: instance.machineIdentifierURL)
+        if !fm.fileExists(atPath: instance.hardwareModelURL.path(percentEncoded: false)) {
+            try hardwareModel.dataRepresentation.write(to: instance.hardwareModelURL)
+        }
 
-        // Create auxiliary storage. `.allowOverwrite` lets us re-create the file
-        // when a prior install attempt got past setup but didn't finish — without
-        // it, the second Start throws "File exists" before the installer even runs.
-        // The other two platform files use Data.write which overwrites by default.
+        if !fm.fileExists(atPath: instance.machineIdentifierURL.path(percentEncoded: false)) {
+            let machineIdentifier = VZMacMachineIdentifier()
+            try machineIdentifier.dataRepresentation.write(to: instance.machineIdentifierURL)
+        }
+
+        // `.allowOverwrite` lets us re-create the file when a prior install attempt
+        // got past setup but didn't finish — without it, the second Start throws
+        // "File exists" before the installer even runs.
         _ = try VZMacAuxiliaryStorage(
             creatingStorageAt: instance.auxiliaryStorageURL,
             hardwareModel: hardwareModel,

--- a/Kernova/Services/MacOSInstallService.swift
+++ b/Kernova/Services/MacOSInstallService.swift
@@ -126,11 +126,14 @@ final class MacOSInstallService {
         let machineIdentifier = VZMacMachineIdentifier()
         try machineIdentifier.dataRepresentation.write(to: instance.machineIdentifierURL)
 
-        // Create auxiliary storage
+        // Create auxiliary storage. `.allowOverwrite` lets us re-create the file
+        // when a prior install attempt got past setup but didn't finish — without
+        // it, the second Start throws "File exists" before the installer even runs.
+        // The other two platform files use Data.write which overwrites by default.
         _ = try VZMacAuxiliaryStorage(
             creatingStorageAt: instance.auxiliaryStorageURL,
             hardwareModel: hardwareModel,
-            options: []
+            options: [.allowOverwrite]
         )
 
         Self.logger.info("Created platform files for '\(instance.name, privacy: .public)'")

--- a/Kernova/Services/Protocols/IPSWProviding.swift
+++ b/Kernova/Services/Protocols/IPSWProviding.swift
@@ -9,5 +9,10 @@ protocol IPSWProviding: Sendable {
         to destinationURL: URL,
         progressHandler: @MainActor @Sendable @escaping (DownloadProgress) -> Void
     ) async throws
+
+    /// Deletes any persisted resume-data sidecar for the given destination path.
+    /// Called when an in-progress download is explicitly cancelled so the next
+    /// attempt starts from scratch rather than resuming. Safe when no sidecar exists.
+    func discardResumeData(at destinationURL: URL)
     #endif
 }

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -190,6 +190,21 @@ final class VMCreationViewModel {
             && confirmedOverwritePath != ipswDownloadPath
     }
 
+    // MARK: - Resume Detection
+
+    /// `true` when the chosen download destination has an associated `.resumedata`
+    /// sidecar from a prior interrupted download, *and* no completed IPSW already
+    /// exists at the path. A completed file takes priority — the overwrite warning
+    /// flow handles that case instead.
+    var hasResumableDownload: Bool {
+        guard ipswSource == .downloadLatest,
+            let path = ipswDownloadPath,
+            !ipswDownloadPathFileExists
+        else { return false }
+        let sidecarPath = path + ".resumedata"
+        return FileManager.default.fileExists(atPath: sidecarPath)
+    }
+
     func confirmOverwrite() {
         confirmedOverwritePath = ipswDownloadPath
     }

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -190,6 +190,30 @@ final class VMCreationViewModel {
             && confirmedOverwritePath != ipswDownloadPath
     }
 
+    // MARK: - Install Context
+
+    #if arch(arm64)
+    /// Snapshots the wizard's macOS install choice into a persistable
+    /// `MacOSInstallContext`. Called by `VMLibraryViewModel.createVM` so the
+    /// VM's bundle records the install plan; the install pipeline then reads
+    /// from the bundle (not the wizard) on every Start until the install
+    /// completes and the context is cleared.
+    func buildInstallContext() -> MacOSInstallContext {
+        switch ipswSource {
+        case .downloadLatest:
+            return MacOSInstallContext(
+                source: .downloadLatest,
+                downloadDestinationPath: ipswDownloadPath
+            )
+        case .localFile:
+            return MacOSInstallContext(
+                source: .localFile,
+                localIPSWPath: ipswPath
+            )
+        }
+    }
+    #endif
+
     // MARK: - Resume Detection
 
     /// `true` when the chosen download destination has an associated `.resumedata`

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -122,6 +122,19 @@ final class VMLibraryViewModel {
         startSleepWatcher()
     }
 
+    // MARK: - Initial Status
+
+    /// Status to assign to a VM when it's first loaded from disk or imported.
+    /// `.initialBoot` takes priority over `.paused`/`.stopped` whenever an
+    /// install context is still on file — that's the canonical signal that the
+    /// VM has never completed its initial boot.
+    static func initialStatus(for config: VMConfiguration, layout: VMBundleLayout) -> VMStatus {
+        if config.installContext != nil {
+            return .initialBoot
+        }
+        return layout.hasSaveFile ? .paused : .stopped
+    }
+
     // MARK: - Load
 
     func loadVMs() {
@@ -133,7 +146,7 @@ final class VMLibraryViewModel {
                 do {
                     let config = try storageService.loadConfiguration(from: bundleURL)
                     let layout = VMBundleLayout(bundleURL: bundleURL)
-                    let initialStatus: VMStatus = layout.hasSaveFile ? .paused : .stopped
+                    let initialStatus = Self.initialStatus(for: config, layout: layout)
                     let instance = VMInstance(configuration: config, bundleURL: bundleURL, status: initialStatus)
                     wirePersistence(for: instance)
                     return instance
@@ -183,9 +196,20 @@ final class VMLibraryViewModel {
 
     func createVM(from wizard: VMCreationViewModel) async {
         do {
-            let config = wizard.buildConfiguration()
+            var config = wizard.buildConfiguration()
+
+            // For macOS guests, persist the install intent so the next Start
+            // can drive the install pipeline (and download resume) without
+            // the wizard. Linux guests have no Kernova-managed install step.
+            #if arch(arm64)
+            if config.guestOS == .macOS {
+                config.installContext = wizard.buildInstallContext()
+            }
+            #endif
+
             let bundleURL = try storageService.createVMBundle(for: config)
-            let instance = VMInstance(configuration: config, bundleURL: bundleURL)
+            let initialStatus: VMStatus = config.installContext != nil ? .initialBoot : .stopped
+            let instance = VMInstance(configuration: config, bundleURL: bundleURL, status: initialStatus)
             wirePersistence(for: instance)
 
             // Create disk image
@@ -198,40 +222,9 @@ final class VMLibraryViewModel {
             persistOrder()
             selectedID = instance.id
 
-            // For macOS guests, start installation (store task handle for cancellation support)
-            #if arch(arm64)
-            if config.guestOS == .macOS {
-                let context: MacOSInstallContext
-                switch wizard.ipswSource {
-                case .downloadLatest:
-                    context = MacOSInstallContext(
-                        source: .downloadLatest,
-                        downloadDestinationPath: wizard.ipswDownloadPath
-                    )
-                case .localFile:
-                    context = MacOSInstallContext(
-                        source: .localFile,
-                        localIPSWPath: wizard.ipswPath
-                    )
-                }
-                instance.installTask = Task {
-                    do {
-                        try await lifecycle.installMacOS(on: instance, context: context)
-                    } catch is CancellationError {
-                        // Expected when the user cancels — no presentation.
-                    } catch {
-                        if !Task.isCancelled {
-                            Self.logger.error(
-                                "Failed to install macOS on '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)"
-                            )
-                            presentError(error)
-                        }
-                    }
-                }
-            }
-            #endif
-
-            Self.logger.notice("Created VM '\(config.name, privacy: .public)'")
+            Self.logger.notice(
+                "Created VM '\(config.name, privacy: .public)' (status: \(initialStatus.displayName, privacy: .public))"
+            )
         } catch {
             Self.logger.error("Failed to create VM: \(error.localizedDescription, privacy: .public)")
             presentError(error)
@@ -241,41 +234,70 @@ final class VMLibraryViewModel {
     // MARK: - macOS Installation
 
     #if arch(arm64)
-    /// Cancels an in-progress macOS installation, cleans up the VM bundle, and removes it from the library.
+    /// Drives the install pipeline for an `.initialBoot` (or `.error` with
+    /// `installContext`) VM and, on success, chains an auto-boot. Non-cancel
+    /// errors leave the VM in `.error` so the user sees the message; cancel
+    /// returns it to `.initialBoot` for a future retry that will resume the
+    /// download from the `.resumedata` sidecar if present.
+    private func installAndAutoBoot(_ instance: VMInstance) {
+        guard let context = instance.configuration.installContext else {
+            assertionFailure("installAndAutoBoot called without installContext")
+            return
+        }
+        if instance.installTask != nil { return }  // guard against rapid double-click
+        instance.installTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.lifecycle.installMacOS(on: instance, context: context)
+                // installMacOS cleared installContext on success; start(_:) now
+                // sees no installContext and goes down the normal boot path.
+                await self.start(instance)
+            } catch is CancellationError {
+                instance.installState = nil
+                instance.status = .initialBoot
+                Self.logger.notice(
+                    "Install cancelled for '\(instance.name, privacy: .public)' — VM remains in .initialBoot"
+                )
+            } catch {
+                instance.installState = nil
+                if !Task.isCancelled {
+                    Self.logger.error(
+                        "Install failed for '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+                    )
+                    self.presentError(error)
+                }
+            }
+            instance.installTask = nil
+        }
+    }
+
+    /// Cancels an in-progress macOS install. The VM returns to `.initialBoot`
+    /// so a subsequent Start can resume (downloads pick up from the
+    /// `.resumedata` sidecar at the chosen path). Bundle is preserved. For
+    /// destructive removal, use the existing delete flow ("Move to Trash").
     func cancelInstallation(_ instance: VMInstance) {
         Self.logger.info("Cancelling installation for '\(instance.name, privacy: .public)'")
-
-        // 1. Cancel the in-flight task (triggers cooperative cancellation in download/install)
         instance.installTask?.cancel()
-        instance.installTask = nil
-
-        // 2. Release VZ resources (tearDownSession clears VM, pipes, delegate adapter)
-        instance.tearDownSession()
-        instance.installState = nil
-
-        // 3. Remove bundle from disk (moves to Trash)
-        do {
-            try storageService.deleteVMBundle(at: instance.bundleURL)
-        } catch {
-            Self.logger.error(
-                "Failed to trash VM bundle during cancellation: \(error.localizedDescription, privacy: .public)")
-            presentError(error)
-        }
-
-        // 4. Remove from library and update selection
-        instances.removeAll { $0.id == instance.id }
-        persistOrder()
-        if selectedID == instance.id {
-            selectedID = instances.first?.id
-        }
-
-        Self.logger.notice("Installation cancelled and VM '\(instance.name, privacy: .public)' moved to Trash")
+        // installAndAutoBoot's CancellationError catch handles the status
+        // transition to .initialBoot and installState cleanup. Don't duplicate
+        // that work here, and don't trash the bundle — non-destructive cancel.
     }
     #endif
 
     // MARK: - Lifecycle
 
     func start(_ instance: VMInstance) async {
+        #if arch(arm64)
+        // VMs awaiting initial boot route through the install pipeline. The
+        // pipeline clears installContext on success and chains an auto-boot;
+        // failure leaves .error / .initialBoot, ready for the user to retry.
+        // Check by installContext (not status) so .error retries also dispatch.
+        if instance.configuration.installContext != nil {
+            installAndAutoBoot(instance)
+            return
+        }
+        #endif
+
         if instance.configuration.displayPreference != .inline {
             onOpenDisplayWindow?(instance)
         }
@@ -472,7 +494,7 @@ final class VMLibraryViewModel {
 
             // Check save file from source bundle (destination doesn't exist yet)
             let sourceLayout = VMBundleLayout(bundleURL: sourceURL)
-            let initialStatus: VMStatus = sourceLayout.hasSaveFile ? .paused : .stopped
+            let initialStatus = Self.initialStatus(for: config, layout: sourceLayout)
 
             // Determine destination, avoiding filename collisions
             let destinationURL: URL = {
@@ -1353,7 +1375,7 @@ final class VMLibraryViewModel {
             var didChange = false
             for (config, bundleURL) in diskConfigs where !memoryIDs.contains(config.id) {
                 let layout = VMBundleLayout(bundleURL: bundleURL)
-                let initialStatus: VMStatus = layout.hasSaveFile ? .paused : .stopped
+                let initialStatus = Self.initialStatus(for: config, layout: layout)
                 let instance = VMInstance(
                     configuration: config,
                     bundleURL: bundleURL,
@@ -1366,11 +1388,13 @@ final class VMLibraryViewModel {
             }
 
             // Removals: instances in memory whose bundles no longer exist on disk
-            // Only remove stopped or errored VMs — never touch running/paused/preparing ones
+            // Only remove resting-state VMs — never touch running/paused/preparing ones
             let instancesToRemove = instances.filter { instance in
                 !diskIDs.contains(instance.id)
                     && !instance.isPreparing
-                    && (instance.status == .stopped || instance.status == .error)
+                    && (instance.status == .stopped
+                        || instance.status == .error
+                        || instance.status == .initialBoot)
             }
             for instance in instancesToRemove {
                 instances.removeAll { $0.id == instance.id }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -201,12 +201,24 @@ final class VMLibraryViewModel {
             // For macOS guests, start installation (store task handle for cancellation support)
             #if arch(arm64)
             if config.guestOS == .macOS {
+                let context: MacOSInstallContext
+                switch wizard.ipswSource {
+                case .downloadLatest:
+                    context = MacOSInstallContext(
+                        source: .downloadLatest,
+                        downloadDestinationPath: wizard.ipswDownloadPath
+                    )
+                case .localFile:
+                    context = MacOSInstallContext(
+                        source: .localFile,
+                        localIPSWPath: wizard.ipswPath
+                    )
+                }
                 instance.installTask = Task {
                     do {
-                        try await lifecycle.installMacOS(
-                            on: instance,
-                            wizard: wizard
-                        )
+                        try await lifecycle.installMacOS(on: instance, context: context)
+                    } catch is CancellationError {
+                        // Expected when the user cancels — no presentation.
                     } catch {
                         if !Task.isCancelled {
                             Self.logger.error(

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -208,7 +208,8 @@ final class VMLibraryViewModel {
             #endif
 
             let bundleURL = try storageService.createVMBundle(for: config)
-            let initialStatus: VMStatus = config.installContext != nil ? .initialBoot : .stopped
+            let layout = VMBundleLayout(bundleURL: bundleURL)
+            let initialStatus = Self.initialStatus(for: config, layout: layout)
             let instance = VMInstance(configuration: config, bundleURL: bundleURL, status: initialStatus)
             wirePersistence(for: instance)
 
@@ -247,6 +248,9 @@ final class VMLibraryViewModel {
         if instance.installTask != nil { return }  // guard against rapid double-click
         instance.installTask = Task { [weak self] in
             guard let self else { return }
+            // Caller owns installTask cleanup; defer nils it out on every exit
+            // path (success, cancel, error) so the coordinator doesn't have to.
+            defer { instance.installTask = nil }
             do {
                 try await self.lifecycle.installMacOS(on: instance, context: context)
                 // installMacOS cleared installContext on success; start(_:) now
@@ -267,7 +271,6 @@ final class VMLibraryViewModel {
                     self.presentError(error)
                 }
             }
-            instance.installTask = nil
         }
     }
 

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -1400,6 +1400,10 @@ final class VMLibraryViewModel {
                         || instance.status == .initialBoot)
             }
             for instance in instancesToRemove {
+                // Cancel any in-flight install task before evicting — otherwise
+                // the task keeps mutating an orphan instance the view model no
+                // longer knows about, wasting work and potentially racing.
+                instance.installTask?.cancel()
                 instances.removeAll { $0.id == instance.id }
                 if selectedID == instance.id {
                     selectedID = instances.first?.id

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -219,14 +219,11 @@ final class VMLifecycleCoordinator {
                 }
             } catch is CancellationError {
                 Self.logger.info("macOS installation cancelled for '\(instance.name, privacy: .public)'")
-                if let downloadDestination {
-                    ipswService.discardResumeData(at: downloadDestination)
-                }
+                // Resume data is preserved — IPSWService.downloadRestoreImage's
+                // onCancel handler writes the sidecar via cancel(byProducingResumeData:)
+                // so a future Start can resume the download from where it stopped.
             } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
                 Self.logger.info("IPSW download cancelled for '\(instance.name, privacy: .public)'")
-                if let downloadDestination {
-                    ipswService.discardResumeData(at: downloadDestination)
-                }
             } catch {
                 instance.status = .error
                 instance.errorMessage = error.localizedDescription

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -159,15 +159,21 @@ final class VMLifecycleCoordinator {
             Self.logger.debug(
                 "installMacOS: entering for '\(instance.name, privacy: .public)', source=\(String(describing: wizard.ipswSource), privacy: .public)"
             )
+            // Hoisted so the cancellation catch blocks can clear the resume-data sidecar
+            // at the chosen path. Nil when the user picked a local IPSW (no download step).
+            let downloadDestination: URL? =
+                wizard.ipswSource == .downloadLatest
+                ? wizard.ipswDownloadPath.map { URL(fileURLWithPath: $0) }
+                : nil
+
             do {
                 let ipswURL: URL
 
                 switch wizard.ipswSource {
                 case .downloadLatest:
-                    guard let downloadPath = wizard.ipswDownloadPath else {
+                    guard let downloadDestination else {
                         throw IPSWError.noDownloadURL
                     }
-                    let downloadDestination = URL(fileURLWithPath: downloadPath)
 
                     // Set up two-step install state before changing status
                     instance.installState = MacOSInstallState(
@@ -213,8 +219,14 @@ final class VMLifecycleCoordinator {
                 }
             } catch is CancellationError {
                 Self.logger.info("macOS installation cancelled for '\(instance.name, privacy: .public)'")
+                if let downloadDestination {
+                    ipswService.discardResumeData(at: downloadDestination)
+                }
             } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
                 Self.logger.info("IPSW download cancelled for '\(instance.name, privacy: .public)'")
+                if let downloadDestination {
+                    ipswService.discardResumeData(at: downloadDestination)
+                }
             } catch {
                 instance.status = .error
                 instance.errorMessage = error.localizedDescription

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -153,25 +153,19 @@ final class VMLifecycleCoordinator {
     #if arch(arm64)
     func installMacOS(
         on instance: VMInstance,
-        wizard: VMCreationViewModel
+        context: MacOSInstallContext
     ) async throws {
         try await serialized(instance, action: "installMacOS") {
             Self.logger.debug(
-                "installMacOS: entering for '\(instance.name, privacy: .public)', source=\(String(describing: wizard.ipswSource), privacy: .public)"
+                "installMacOS: entering for '\(instance.name, privacy: .public)', source=\(context.source.rawValue, privacy: .public)"
             )
-            // Hoisted so the cancellation catch blocks can clear the resume-data sidecar
-            // at the chosen path. Nil when the user picked a local IPSW (no download step).
-            let downloadDestination: URL? =
-                wizard.ipswSource == .downloadLatest
-                ? wizard.ipswDownloadPath.map { URL(fileURLWithPath: $0) }
-                : nil
 
             do {
                 let ipswURL: URL
 
-                switch wizard.ipswSource {
+                switch context.source {
                 case .downloadLatest:
-                    guard let downloadDestination else {
+                    guard let downloadDestination = context.downloadDestinationURL else {
                         throw IPSWError.noDownloadURL
                     }
 
@@ -197,10 +191,10 @@ final class VMLifecycleCoordinator {
                     ipswURL = downloadDestination
 
                 case .localFile:
-                    guard let path = wizard.ipswPath else {
+                    guard let localURL = context.localIPSWURL else {
                         throw IPSWError.noDownloadURL
                     }
-                    ipswURL = URL(fileURLWithPath: path)
+                    ipswURL = localURL
 
                     // Local file: single-step install (no download)
                     instance.installState = MacOSInstallState(
@@ -217,16 +211,29 @@ final class VMLifecycleCoordinator {
                 ) { @MainActor progress in
                     instance.installState?.currentPhase = .installing(progress: progress)
                 }
+
+                // Success: clear the persisted install intent through the
+                // configuration dispatcher so config.json is written. Subsequent
+                // Starts will see installContext == nil and go down the normal
+                // boot path. Also clear installState so the install progress UI
+                // tears down before the caller chains an auto-boot.
+                instance.performConfigurationMutation { $0.installContext = nil }
+                instance.installState = nil
             } catch is CancellationError {
                 Self.logger.info("macOS installation cancelled for '\(instance.name, privacy: .public)'")
-                // Resume data is preserved — IPSWService.downloadRestoreImage's
-                // onCancel handler writes the sidecar via cancel(byProducingResumeData:)
-                // so a future Start can resume the download from where it stopped.
+                // Re-throw so the caller knows to flip the VM back to
+                // .initialBoot rather than auto-booting on a non-success.
+                instance.installTask = nil
+                throw CancellationError()
             } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
                 Self.logger.info("IPSW download cancelled for '\(instance.name, privacy: .public)'")
+                // Normalize to CancellationError for consistent caller-side handling.
+                instance.installTask = nil
+                throw CancellationError()
             } catch {
                 instance.status = .error
                 instance.errorMessage = error.localizedDescription
+                instance.installTask = nil
                 throw error
             }
 

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -223,21 +223,18 @@ final class VMLifecycleCoordinator {
                 Self.logger.info("macOS installation cancelled for '\(instance.name, privacy: .public)'")
                 // Re-throw so the caller knows to flip the VM back to
                 // .initialBoot rather than auto-booting on a non-success.
-                instance.installTask = nil
                 throw CancellationError()
             } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
                 Self.logger.info("IPSW download cancelled for '\(instance.name, privacy: .public)'")
                 // Normalize to CancellationError for consistent caller-side handling.
-                instance.installTask = nil
                 throw CancellationError()
             } catch {
                 instance.status = .error
                 instance.errorMessage = error.localizedDescription
-                instance.installTask = nil
                 throw error
             }
-
-            instance.installTask = nil
+            // installTask lifecycle is owned by the caller (installAndAutoBoot);
+            // the coordinator just runs the install pipeline.
         }
     }
     #endif

--- a/Kernova/Views/Creation/IPSWSelectionStep.swift
+++ b/Kernova/Views/Creation/IPSWSelectionStep.swift
@@ -46,6 +46,8 @@ struct IPSWSelectionStep: View {
 
                 if creationVM.shouldShowOverwriteWarning {
                     overwriteWarningBanner
+                } else if creationVM.hasResumableDownload {
+                    resumeAvailableBanner
                 }
             }
 
@@ -101,6 +103,24 @@ struct IPSWSelectionStep: View {
             RoundedRectangle(cornerRadius: 8)
                 .fill(Color.yellow.opacity(0.1))
                 .strokeBorder(Color.yellow.opacity(0.3), lineWidth: 1)
+        }
+    }
+
+    private var resumeAvailableBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.clockwise.circle.fill")
+                .foregroundStyle(.blue)
+
+            Text("A previous download was interrupted at this location. It will resume when the install starts.")
+                .font(.callout)
+
+            Spacer()
+        }
+        .padding(10)
+        .background {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.blue.opacity(0.1))
+                .strokeBorder(Color.blue.opacity(0.3), lineWidth: 1)
         }
     }
 

--- a/Kernova/Views/Detail/MacOSInstallProgressView.swift
+++ b/Kernova/Views/Detail/MacOSInstallProgressView.swift
@@ -43,7 +43,10 @@ struct MacOSInstallProgressView: View {
         .frame(maxWidth: 400)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .alert(cancelAlertTitle, isPresented: $showCancelConfirmation) {
-            Button(cancelAlertConfirmLabel, role: .cancel) {
+            // No role on the affirmative button: SwiftUI treats it as the default
+            // action so Return triggers it. The dismiss button gets .cancel so
+            // Esc closes the alert without acting.
+            Button(cancelAlertConfirmLabel) {
                 onCancel?()
             }
             Button(cancelAlertDismissLabel, role: .cancel) {}

--- a/Kernova/Views/Detail/MacOSInstallProgressView.swift
+++ b/Kernova/Views/Detail/MacOSInstallProgressView.swift
@@ -43,12 +43,12 @@ struct MacOSInstallProgressView: View {
         .frame(maxWidth: 400)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .alert("Cancel Installation?", isPresented: $showCancelConfirmation) {
-            Button("Cancel Installation", role: .destructive) {
+            Button("Cancel Installation", role: .cancel) {
                 onCancel?()
             }
-            Button("Continue", role: .cancel) {}
+            Button("Keep Installing", role: .cancel) {}
         } message: {
-            Text("The virtual machine and all downloaded files will be moved to the Trash.")
+            Text("Progress will be saved. You can resume the installation by starting the virtual machine again.")
         }
     }
 

--- a/Kernova/Views/Detail/MacOSInstallProgressView.swift
+++ b/Kernova/Views/Detail/MacOSInstallProgressView.swift
@@ -42,14 +42,45 @@ struct MacOSInstallProgressView: View {
         }
         .frame(maxWidth: 400)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .alert("Cancel Installation?", isPresented: $showCancelConfirmation) {
-            Button("Cancel Installation", role: .cancel) {
+        .alert(cancelAlertTitle, isPresented: $showCancelConfirmation) {
+            Button(cancelAlertConfirmLabel, role: .cancel) {
                 onCancel?()
             }
-            Button("Keep Installing", role: .cancel) {}
+            Button(cancelAlertDismissLabel, role: .cancel) {}
         } message: {
-            Text("Progress will be saved. You can resume the installation by starting the virtual machine again.")
+            Text(cancelAlertMessage)
         }
+    }
+
+    // MARK: - Cancel Alert Strings
+
+    private var isDownloadPhase: Bool {
+        if case .downloading = installState.currentPhase { return true }
+        return false
+    }
+
+    private var cancelAlertTitle: String {
+        isDownloadPhase ? "Cancel Download?" : "Cancel Installation?"
+    }
+
+    private var cancelAlertConfirmLabel: String {
+        isDownloadPhase ? "Cancel Download" : "Cancel Installation"
+    }
+
+    private var cancelAlertDismissLabel: String {
+        isDownloadPhase ? "Keep Downloading" : "Keep Installing"
+    }
+
+    private var cancelAlertMessage: String {
+        // Download phase: the URLSession resume sidecar genuinely lets the
+        // next Start pick up where the bytes left off.
+        // Install phase: VZMacOSInstaller is one-shot, so the install itself
+        // restarts. The downloaded IPSW is already cached so the user doesn't
+        // pay the download cost again.
+        if isDownloadPhase {
+            return "The download progress will be saved and resumed the next time you start the virtual machine."
+        }
+        return "The installation will restart from the beginning the next time you start the virtual machine. The downloaded macOS image is cached, so you won't need to download it again."
     }
 
     // MARK: - Two-Step Indicator

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -26,6 +26,12 @@ struct VMDetailView: View {
             case .stopped, .error:
                 VMSettingsView(instance: instance, viewModel: viewModel, isReadOnly: false)
 
+            case .initialBoot:
+                VStack(spacing: 0) {
+                    InitialBootBanner(instance: instance)
+                    VMSettingsView(instance: instance, viewModel: viewModel, isReadOnly: false)
+                }
+
             case .installing:
                 if let installState = instance.installState {
                     MacOSInstallProgressView(installState: installState) {
@@ -57,6 +63,53 @@ struct VMDetailView: View {
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Banner shown above the settings panel for VMs whose initial boot hasn't
+/// happened yet. Adapts its subtitle to the persisted install context so the
+/// user knows what Start will do (download + install vs. install from local
+/// IPSW vs. resume an interrupted download).
+private struct InitialBootBanner: View {
+    let instance: VMInstance
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "sparkles")
+                .foregroundStyle(.orange)
+                .font(.title2)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Initial Boot")
+                    .font(.headline)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(Color.orange.opacity(0.1))
+        .overlay(Rectangle().frame(height: 1).foregroundStyle(.separator), alignment: .bottom)
+    }
+
+    private var subtitle: String {
+        #if arch(arm64)
+        guard let context = instance.configuration.installContext else {
+            return "Click Start to install macOS."
+        }
+        switch context.source {
+        case .downloadLatest:
+            if instance.hasResumableInstallDownload {
+                return "An interrupted download will resume when you click Start."
+            }
+            return "Click Start to download the latest macOS and install."
+        case .localFile:
+            let name = context.localIPSWURL?.lastPathComponent ?? "the selected IPSW"
+            return "Click Start to install from \(name)."
+        }
+        #else
+        return "Click Start to install macOS."
+        #endif
     }
 }
 

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -67,6 +67,17 @@ struct SidebarView: View {
         }
     }
 
+    /// Label for the Start context-menu item. Mirrors the toolbar play button
+    /// so the user knows whether clicking will install vs. boot.
+    private func startButtonLabel(for instance: VMInstance) -> String {
+        #if arch(arm64)
+        guard instance.configuration.installContext != nil else { return "Start" }
+        return instance.hasResumableInstallDownload ? "Resume Install" : "Install"
+        #else
+        return "Start"
+        #endif
+    }
+
     @ViewBuilder
     private func contextMenu(for instance: VMInstance) -> some View {
         if let preparing = instance.preparingState {
@@ -79,7 +90,7 @@ struct SidebarView: View {
         } else {
             // Lifecycle
             if instance.status.canStart {
-                Button("Start") {
+                Button(startButtonLabel(for: instance)) {
                     Task { await viewModel.start(instance) }
                 }
             }

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -17,9 +17,26 @@ extension VMInstance {
     /// Tooltip explaining the VM state variant, or `nil` for standard states.
     var statusToolTip: String? {
         if let state = preparingState { return state.operation.displayLabel }
+        if status == .initialBoot { return "Click Start to install macOS" }
         guard status == .paused else { return nil }
         return isColdPaused
             ? "VM state is saved to disk"
             : "VM is paused in memory"
+    }
+
+    /// `true` when this VM has a `.downloadLatest` install context, a
+    /// `.resumedata` sidecar at the chosen path, and no completed IPSW yet
+    /// at the same path. Drives the "Resume Install" label variant.
+    var hasResumableInstallDownload: Bool {
+        #if arch(arm64)
+        guard let context = configuration.installContext,
+            context.source == .downloadLatest,
+            let path = context.downloadDestinationPath
+        else { return false }
+        let fm = FileManager.default
+        return fm.fileExists(atPath: path + ".resumedata") && !fm.fileExists(atPath: path)
+        #else
+        return false
+        #endif
     }
 }

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -31,10 +31,12 @@ extension VMInstance {
         #if arch(arm64)
         guard let context = configuration.installContext,
             context.source == .downloadLatest,
-            let path = context.downloadDestinationPath
+            let destinationURL = context.downloadDestinationURL
         else { return false }
         let fm = FileManager.default
-        return fm.fileExists(atPath: path + ".resumedata") && !fm.fileExists(atPath: path)
+        let sidecarURL = IPSWService.resumeDataSidecarURL(for: destinationURL)
+        return fm.fileExists(atPath: sidecarURL.path(percentEncoded: false))
+            && !fm.fileExists(atPath: destinationURL.path(percentEncoded: false))
         #else
         return false
         #endif

--- a/KernovaTests/Mocks/MockIPSWService.swift
+++ b/KernovaTests/Mocks/MockIPSWService.swift
@@ -5,6 +5,8 @@ import Foundation
 final class MockIPSWService: IPSWProviding, @unchecked Sendable {
     var fetchCallCount = 0
     var downloadCallCount = 0
+    var discardResumeDataCallCount = 0
+    var lastDiscardResumeDataURL: URL?
 
     #if arch(arm64)
     private static let mockRestoreImageURL: URL = {
@@ -31,6 +33,11 @@ final class MockIPSWService: IPSWProviding, @unchecked Sendable {
     ) async throws {
         downloadCallCount += 1
         if let error = downloadError { throw error }
+    }
+
+    func discardResumeData(at destinationURL: URL) {
+        discardResumeDataCallCount += 1
+        lastDiscardResumeDataURL = destinationURL
     }
     #endif
 }

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -402,6 +402,101 @@ struct VMConfigurationTests {
         #expect(clone.storageDisks?[0].label == originalDisk.label)
     }
 
+    // MARK: - installContext Tests
+
+    @Test("installContext round-trips through JSON (downloadLatest)")
+    func installContextDownloadLatestRoundTrip() throws {
+        let context = MacOSInstallContext(
+            source: .downloadLatest,
+            downloadDestinationPath: "/Users/me/Downloads/RestoreImage.ipsw"
+        )
+        let config = VMConfiguration(
+            name: "Pending macOS VM",
+            guestOS: .macOS,
+            bootMode: .macOS,
+            installContext: context
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(config)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: data)
+
+        #expect(decoded.installContext == context)
+        #expect(decoded.installContext?.source == .downloadLatest)
+        #expect(decoded.installContext?.downloadDestinationPath == "/Users/me/Downloads/RestoreImage.ipsw")
+    }
+
+    @Test("installContext round-trips through JSON (localFile)")
+    func installContextLocalFileRoundTrip() throws {
+        let context = MacOSInstallContext(
+            source: .localFile,
+            localIPSWPath: "/tmp/macOS-26.ipsw"
+        )
+        let config = VMConfiguration(
+            name: "Local IPSW VM",
+            guestOS: .macOS,
+            bootMode: .macOS,
+            installContext: context
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(config)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: data)
+
+        #expect(decoded.installContext == context)
+        #expect(decoded.installContext?.source == .localFile)
+        #expect(decoded.installContext?.localIPSWPath == "/tmp/macOS-26.ipsw")
+    }
+
+    @Test("Legacy config.json without installContext key decodes as nil")
+    func legacyConfigWithoutInstallContextDecodesAsNil() throws {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let config = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
+
+        #expect(config.installContext == nil)
+    }
+
+    @Test("VMConfiguration with nil installContext omits field from JSON")
+    func nilInstallContextOmittedFromJSON() throws {
+        let config = VMConfiguration(
+            name: "Plain VM",
+            guestOS: .linux,
+            bootMode: .efi
+        )
+
+        let data = try JSONEncoder().encode(config)
+        let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        #expect(jsonObject["installContext"] == nil)
+    }
+
+    @Test("Clone clears installContext even when source has one set")
+    func cloneClearsInstallContext() {
+        let context = MacOSInstallContext(
+            source: .downloadLatest,
+            downloadDestinationPath: "/tmp/RestoreImage.ipsw"
+        )
+        let config = VMConfiguration(
+            name: "Pending macOS VM",
+            guestOS: .macOS,
+            bootMode: .macOS,
+            installContext: context
+        )
+
+        let clone = config.clonedForNewInstance(existingNames: [])
+
+        #expect(clone.installContext == nil)
+    }
+
     // MARK: - displayPreference Tests
 
     @Test("Default displayPreference is inline")

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -606,4 +606,34 @@ struct VMCreationViewModelTests {
         vm.vmName = "   "
         #expect(vm.validationMessage == "Enter a name for your virtual machine.")
     }
+
+    // MARK: - buildInstallContext
+
+    #if arch(arm64)
+    @Test("buildInstallContext snapshots downloadLatest with chosen path")
+    func buildInstallContextDownloadLatest() {
+        let vm = VMCreationViewModel()
+        vm.ipswSource = .downloadLatest
+        vm.ipswDownloadPath = "/Users/me/Downloads/RestoreImage.ipsw"
+
+        let context = vm.buildInstallContext()
+
+        #expect(context.source == .downloadLatest)
+        #expect(context.downloadDestinationPath == "/Users/me/Downloads/RestoreImage.ipsw")
+        #expect(context.localIPSWPath == nil)
+    }
+
+    @Test("buildInstallContext snapshots localFile with chosen path")
+    func buildInstallContextLocalFile() {
+        let vm = VMCreationViewModel()
+        vm.ipswSource = .localFile
+        vm.ipswPath = "/tmp/macOS-26.ipsw"
+
+        let context = vm.buildInstallContext()
+
+        #expect(context.source == .localFile)
+        #expect(context.localIPSWPath == "/tmp/macOS-26.ipsw")
+        #expect(context.downloadDestinationPath == nil)
+    }
+    #endif
 }

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -858,57 +858,127 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.errorMessage?.contains("recoverable") == true)
     }
 
+    // MARK: - Initial Boot status assignment
+
+    #if arch(arm64)
+    @Test("loadVMs assigns .initialBoot when config has installContext")
+    func loadVMsAssignsInitialBoot() {
+        let storage = MockVMStorageService()
+        var config = VMConfiguration(name: "Pending VM", guestOS: .macOS, bootMode: .macOS)
+        config.installContext = MacOSInstallContext(
+            source: .downloadLatest,
+            downloadDestinationPath: "/tmp/restore.ipsw"
+        )
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+        storage.bundles[url] = config
+
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+        viewModel.loadVMs()
+
+        #expect(viewModel.instances.count == 1)
+        #expect(viewModel.instances[0].status == .initialBoot)
+    }
+
+    @Test("loadVMs assigns .stopped when no installContext (back-compat)")
+    func loadVMsAssignsStoppedWithoutInstallContext() {
+        let storage = MockVMStorageService()
+        let config = VMConfiguration(name: "Installed VM", guestOS: .linux, bootMode: .efi)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+        storage.bundles[url] = config
+
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+        viewModel.loadVMs()
+
+        #expect(viewModel.instances.count == 1)
+        #expect(viewModel.instances[0].status == .stopped)
+    }
+
+    @Test("reconcileWithDisk removes .initialBoot VMs whose bundles vanish")
+    func reconcileRemovesInitialBootVMs() {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        var config = VMConfiguration(name: "Pending VM", guestOS: .macOS, bootMode: .macOS)
+        config.installContext = MacOSInstallContext(
+            source: .localFile, localIPSWPath: "/tmp/foo.ipsw"
+        )
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+        let instance = VMInstance(configuration: config, bundleURL: bundleURL, status: .initialBoot)
+        viewModel.instances.append(instance)
+        // Bundle is NOT in storage.bundles — simulating an on-disk deletion.
+
+        viewModel.reconcileWithDisk()
+
+        #expect(viewModel.instances.isEmpty)
+        // Note: deleteVMBundle is NOT called — reconcile only evicts the in-memory entry.
+        #expect(storage.deleteVMBundleCallCount == 0)
+    }
+    #endif
+
     // MARK: - Cancel Installation
 
     #if arch(arm64)
-    @Test("cancelInstallation removes instance and deletes bundle")
-    func cancelInstallationRemovesInstance() {
+    @Test("cancelInstallation preserves bundle and instance (non-destructive)")
+    func cancelInstallationPreservesBundle() async {
         let (viewModel, storage, _, _, _) = makeViewModel()
         let instance = makeInstance(name: "Installing VM")
+        instance.configuration.installContext = MacOSInstallContext(
+            source: .localFile, localIPSWPath: "/tmp/foo.ipsw"
+        )
         instance.status = .installing
         viewModel.instances.append(instance)
         storage.bundles[instance.bundleURL] = instance.configuration
 
-        viewModel.cancelInstallation(instance)
+        // Spawn a fake long-running install task we can observe being cancelled.
+        let cancelStream = AsyncStream<Void>.makeStream()
+        instance.installTask = Task {
+            await withTaskCancellationHandler {
+                try? await Task.sleep(for: .seconds(60))
+            } onCancel: {
+                cancelStream.continuation.yield(())
+                cancelStream.continuation.finish()
+            }
+        }
 
-        #expect(viewModel.instances.isEmpty)
-        #expect(storage.deleteVMBundleCallCount == 1)
+        viewModel.cancelInstallation(instance)
+        for await _ in cancelStream.stream { break }
+
+        // Bundle is preserved, instance stays in library, installContext intact.
+        #expect(viewModel.instances.count == 1)
+        #expect(storage.deleteVMBundleCallCount == 0)
+        #expect(instance.configuration.installContext != nil)
     }
 
-    @Test("cancelInstallation updates selection to first remaining instance")
-    func cancelInstallationUpdatesSelection() {
+    @Test("cancelInstallation does not change selection")
+    func cancelInstallationKeepsSelection() async {
         let (viewModel, storage, _, _, _) = makeViewModel()
         let first = makeInstance(name: "First")
         let installing = makeInstance(name: "Installing")
+        installing.configuration.installContext = MacOSInstallContext(
+            source: .localFile, localIPSWPath: "/tmp/foo.ipsw"
+        )
         installing.status = .installing
         viewModel.instances = [first, installing]
         viewModel.selectedID = installing.id
         storage.bundles[installing.bundleURL] = installing.configuration
 
+        let cancelStream = AsyncStream<Void>.makeStream()
+        installing.installTask = Task {
+            await withTaskCancellationHandler {
+                try? await Task.sleep(for: .seconds(60))
+            } onCancel: {
+                cancelStream.continuation.yield(())
+                cancelStream.continuation.finish()
+            }
+        }
+
         viewModel.cancelInstallation(installing)
+        for await _ in cancelStream.stream { break }
 
-        #expect(viewModel.instances.count == 1)
-        #expect(viewModel.selectedID == first.id)
-    }
-
-    @Test("cancelInstallation surfaces error when trash fails")
-    func cancelInstallationSurfacesTrashError() {
-        let storage = MockVMStorageService()
-        storage.deleteVMBundleError = VMStorageError.bundleNotFound(
-            FileManager.default.temporaryDirectory
-        )
-        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
-        let instance = makeInstance(name: "Installing VM")
-        instance.status = .installing
-        viewModel.instances.append(instance)
-
-        viewModel.cancelInstallation(instance)
-
-        // Error surfaced to user
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
-        // Instance still removed from library despite trash failure
-        #expect(viewModel.instances.isEmpty)
+        // Both instances remain; selection unchanged.
+        #expect(viewModel.instances.count == 2)
+        #expect(viewModel.selectedID == installing.id)
     }
     #endif
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -914,6 +914,36 @@ struct VMLibraryViewModelTests {
         // Note: deleteVMBundle is NOT called — reconcile only evicts the in-memory entry.
         #expect(storage.deleteVMBundleCallCount == 0)
     }
+
+    @Test("reconcileWithDisk cancels installTask before evicting an orphaned VM")
+    func reconcileCancelsInstallTaskBeforeEviction() async {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        var config = VMConfiguration(name: "Pending VM", guestOS: .macOS, bootMode: .macOS)
+        config.installContext = MacOSInstallContext(
+            source: .localFile, localIPSWPath: "/tmp/foo.ipsw"
+        )
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+        let instance = VMInstance(configuration: config, bundleURL: bundleURL, status: .initialBoot)
+
+        // Spawn a long-running install task we can observe getting cancelled.
+        let cancelStream = AsyncStream<Void>.makeStream()
+        instance.installTask = Task {
+            await withTaskCancellationHandler {
+                try? await Task.sleep(for: .seconds(60))
+            } onCancel: {
+                cancelStream.continuation.yield(())
+                cancelStream.continuation.finish()
+            }
+        }
+        viewModel.instances.append(instance)
+        // Bundle absent from storage → eligible for eviction.
+
+        viewModel.reconcileWithDisk()
+        for await _ in cancelStream.stream { break }  // cancel propagated
+
+        #expect(viewModel.instances.isEmpty)
+    }
     #endif
 
     // MARK: - Cancel Installation

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -405,8 +405,8 @@ struct VMLifecycleCoordinatorTests {
         }
     }
 
-    @Test("installMacOS discards IPSW resume data when download is cancelled")
-    func installMacOSCancelDiscardsResumeData() async throws {
+    @Test("installMacOS preserves IPSW resume data when download is cancelled")
+    func installMacOSCancelPreservesResumeData() async throws {
         let (coordinator, _, _, ipswService, _) = makeCoordinator()
         ipswService.downloadError = CancellationError()
         let instance = makeInstance()
@@ -419,12 +419,13 @@ struct VMLifecycleCoordinatorTests {
 
         try await coordinator.installMacOS(on: instance, wizard: wizard)
 
-        #expect(ipswService.discardResumeDataCallCount == 1)
-        #expect(ipswService.lastDiscardResumeDataURL == URL(fileURLWithPath: downloadPath))
+        // User cancel must preserve resume data so a future Start can resume
+        // the download from where it stopped (non-destructive cancel UX).
+        #expect(ipswService.discardResumeDataCallCount == 0)
     }
 
-    @Test("installMacOS discards IPSW resume data on NSURLErrorCancelled")
-    func installMacOSURLCancelDiscardsResumeData() async throws {
+    @Test("installMacOS preserves IPSW resume data on NSURLErrorCancelled")
+    func installMacOSURLCancelPreservesResumeData() async throws {
         let (coordinator, _, _, ipswService, _) = makeCoordinator()
         ipswService.downloadError = NSError(
             domain: NSURLErrorDomain,
@@ -441,8 +442,7 @@ struct VMLifecycleCoordinatorTests {
 
         try await coordinator.installMacOS(on: instance, wizard: wizard)
 
-        #expect(ipswService.discardResumeDataCallCount == 1)
-        #expect(ipswService.lastDiscardResumeDataURL == URL(fileURLWithPath: downloadPath))
+        #expect(ipswService.discardResumeDataCallCount == 0)
     }
 
     @Test("installMacOS preserves IPSW resume data on non-cancel download failure")

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -355,31 +355,28 @@ struct VMLifecycleCoordinatorTests {
     // MARK: - macOS Installation
 
     #if arch(arm64)
-    @Test("installMacOS with localFile sets hasDownloadStep to false")
+    @Test("installMacOS with localFile context sets hasDownloadStep to false")
     func installMacOSLocalFile() async throws {
         let (coordinator, _, installService, _, _) = makeCoordinator()
         let instance = makeInstance()
-        let wizard = VMCreationViewModel()
-        wizard.selectedOS = .macOS
-        wizard.ipswSource = .localFile
-        wizard.ipswPath = "/tmp/restore.ipsw"
+        let context = MacOSInstallContext(source: .localFile, localIPSWPath: "/tmp/restore.ipsw")
 
-        try await coordinator.installMacOS(on: instance, wizard: wizard)
+        try await coordinator.installMacOS(on: instance, context: context)
 
         #expect(installService.installCallCount == 1)
     }
 
-    @Test("installMacOS with downloadLatest calls fetch and download")
+    @Test("installMacOS with downloadLatest context calls fetch and download")
     func installMacOSDownload() async throws {
         let (coordinator, _, installService, ipswService, _) = makeCoordinator()
         let instance = makeInstance()
-        let wizard = VMCreationViewModel()
-        wizard.selectedOS = .macOS
-        wizard.ipswSource = .downloadLatest
-        wizard.ipswDownloadPath = FileManager.default.temporaryDirectory
-            .appendingPathComponent("test-restore.ipsw").path(percentEncoded: false)
+        let context = MacOSInstallContext(
+            source: .downloadLatest,
+            downloadDestinationPath: FileManager.default.temporaryDirectory
+                .appendingPathComponent("test-restore.ipsw").path(percentEncoded: false)
+        )
 
-        try await coordinator.installMacOS(on: instance, wizard: wizard)
+        try await coordinator.installMacOS(on: instance, context: context)
 
         #expect(ipswService.fetchCallCount == 1)
         #expect(ipswService.downloadCallCount == 1)
@@ -391,13 +388,10 @@ struct VMLifecycleCoordinatorTests {
         let (coordinator, _, installService, _, _) = makeCoordinator()
         installService.installError = IPSWError.downloadFailed(URLError(.badServerResponse))
         let instance = makeInstance()
-        let wizard = VMCreationViewModel()
-        wizard.selectedOS = .macOS
-        wizard.ipswSource = .localFile
-        wizard.ipswPath = "/tmp/restore.ipsw"
+        let context = MacOSInstallContext(source: .localFile, localIPSWPath: "/tmp/restore.ipsw")
 
         do {
-            try await coordinator.installMacOS(on: instance, wizard: wizard)
+            try await coordinator.installMacOS(on: instance, context: context)
             Issue.record("Expected error to be thrown")
         } catch {
             #expect(instance.status == .error)
@@ -405,19 +399,57 @@ struct VMLifecycleCoordinatorTests {
         }
     }
 
-    @Test("installMacOS preserves IPSW resume data when download is cancelled")
-    func installMacOSCancelPreservesResumeData() async throws {
+    @Test("installMacOS clears installContext on successful completion")
+    func installMacOSClearsInstallContextOnSuccess() async throws {
+        let (coordinator, _, _, _, _) = makeCoordinator()
+        let instance = makeInstance()
+        instance.configuration.installContext = MacOSInstallContext(
+            source: .localFile, localIPSWPath: "/tmp/restore.ipsw"
+        )
+        // Wire the dispatcher so performConfigurationMutation actually mutates.
+        instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
+        let context = instance.configuration.installContext!
+
+        try await coordinator.installMacOS(on: instance, context: context)
+
+        #expect(instance.configuration.installContext == nil)
+        #expect(instance.installState == nil)
+    }
+
+    @Test("installMacOS throws CancellationError on cancel and preserves installContext")
+    func installMacOSCancelPreservesContext() async {
         let (coordinator, _, _, ipswService, _) = makeCoordinator()
         ipswService.downloadError = CancellationError()
         let instance = makeInstance()
-        let wizard = VMCreationViewModel()
-        wizard.selectedOS = .macOS
-        wizard.ipswSource = .downloadLatest
-        let downloadPath = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cancel-test-restore.ipsw").path(percentEncoded: false)
-        wizard.ipswDownloadPath = downloadPath
+        let originalContext = MacOSInstallContext(
+            source: .downloadLatest,
+            downloadDestinationPath: FileManager.default.temporaryDirectory
+                .appendingPathComponent("cancel-preserves-context.ipsw").path(percentEncoded: false)
+        )
+        instance.configuration.installContext = originalContext
+        instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
 
-        try await coordinator.installMacOS(on: instance, wizard: wizard)
+        await #expect(throws: CancellationError.self) {
+            try await coordinator.installMacOS(on: instance, context: originalContext)
+        }
+
+        #expect(instance.configuration.installContext == originalContext)
+    }
+
+    @Test("installMacOS preserves IPSW resume data when download is cancelled")
+    func installMacOSCancelPreservesResumeData() async {
+        let (coordinator, _, _, ipswService, _) = makeCoordinator()
+        ipswService.downloadError = CancellationError()
+        let instance = makeInstance()
+        let context = MacOSInstallContext(
+            source: .downloadLatest,
+            downloadDestinationPath: FileManager.default.temporaryDirectory
+                .appendingPathComponent("cancel-test-restore.ipsw").path(percentEncoded: false)
+        )
+
+        await #expect(throws: CancellationError.self) {
+            try await coordinator.installMacOS(on: instance, context: context)
+        }
 
         // User cancel must preserve resume data so a future Start can resume
         // the download from where it stopped (non-destructive cancel UX).
@@ -425,7 +457,7 @@ struct VMLifecycleCoordinatorTests {
     }
 
     @Test("installMacOS preserves IPSW resume data on NSURLErrorCancelled")
-    func installMacOSURLCancelPreservesResumeData() async throws {
+    func installMacOSURLCancelPreservesResumeData() async {
         let (coordinator, _, _, ipswService, _) = makeCoordinator()
         ipswService.downloadError = NSError(
             domain: NSURLErrorDomain,
@@ -433,14 +465,15 @@ struct VMLifecycleCoordinatorTests {
             userInfo: nil
         )
         let instance = makeInstance()
-        let wizard = VMCreationViewModel()
-        wizard.selectedOS = .macOS
-        wizard.ipswSource = .downloadLatest
-        let downloadPath = FileManager.default.temporaryDirectory
-            .appendingPathComponent("url-cancel-test-restore.ipsw").path(percentEncoded: false)
-        wizard.ipswDownloadPath = downloadPath
+        let context = MacOSInstallContext(
+            source: .downloadLatest,
+            downloadDestinationPath: FileManager.default.temporaryDirectory
+                .appendingPathComponent("url-cancel-test-restore.ipsw").path(percentEncoded: false)
+        )
 
-        try await coordinator.installMacOS(on: instance, wizard: wizard)
+        await #expect(throws: CancellationError.self) {
+            try await coordinator.installMacOS(on: instance, context: context)
+        }
 
         #expect(ipswService.discardResumeDataCallCount == 0)
     }
@@ -450,18 +483,22 @@ struct VMLifecycleCoordinatorTests {
         let (coordinator, _, _, ipswService, _) = makeCoordinator()
         ipswService.downloadError = IPSWError.downloadFailed(URLError(.notConnectedToInternet))
         let instance = makeInstance()
-        let wizard = VMCreationViewModel()
-        wizard.selectedOS = .macOS
-        wizard.ipswSource = .downloadLatest
-        wizard.ipswDownloadPath = FileManager.default.temporaryDirectory
-            .appendingPathComponent("network-fail-restore.ipsw").path(percentEncoded: false)
+        let originalContext = MacOSInstallContext(
+            source: .downloadLatest,
+            downloadDestinationPath: FileManager.default.temporaryDirectory
+                .appendingPathComponent("network-fail-restore.ipsw").path(percentEncoded: false)
+        )
+        instance.configuration.installContext = originalContext
+        instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
 
         do {
-            try await coordinator.installMacOS(on: instance, wizard: wizard)
+            try await coordinator.installMacOS(on: instance, context: originalContext)
             Issue.record("Expected error to be thrown")
         } catch {
             #expect(ipswService.discardResumeDataCallCount == 0)
             #expect(instance.status == .error)
+            // installContext stays so the user can retry via Start.
+            #expect(instance.configuration.installContext == originalContext)
         }
     }
     #endif

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -404,6 +404,66 @@ struct VMLifecycleCoordinatorTests {
             #expect(instance.errorMessage != nil)
         }
     }
+
+    @Test("installMacOS discards IPSW resume data when download is cancelled")
+    func installMacOSCancelDiscardsResumeData() async throws {
+        let (coordinator, _, _, ipswService, _) = makeCoordinator()
+        ipswService.downloadError = CancellationError()
+        let instance = makeInstance()
+        let wizard = VMCreationViewModel()
+        wizard.selectedOS = .macOS
+        wizard.ipswSource = .downloadLatest
+        let downloadPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cancel-test-restore.ipsw").path(percentEncoded: false)
+        wizard.ipswDownloadPath = downloadPath
+
+        try await coordinator.installMacOS(on: instance, wizard: wizard)
+
+        #expect(ipswService.discardResumeDataCallCount == 1)
+        #expect(ipswService.lastDiscardResumeDataURL == URL(fileURLWithPath: downloadPath))
+    }
+
+    @Test("installMacOS discards IPSW resume data on NSURLErrorCancelled")
+    func installMacOSURLCancelDiscardsResumeData() async throws {
+        let (coordinator, _, _, ipswService, _) = makeCoordinator()
+        ipswService.downloadError = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorCancelled,
+            userInfo: nil
+        )
+        let instance = makeInstance()
+        let wizard = VMCreationViewModel()
+        wizard.selectedOS = .macOS
+        wizard.ipswSource = .downloadLatest
+        let downloadPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("url-cancel-test-restore.ipsw").path(percentEncoded: false)
+        wizard.ipswDownloadPath = downloadPath
+
+        try await coordinator.installMacOS(on: instance, wizard: wizard)
+
+        #expect(ipswService.discardResumeDataCallCount == 1)
+        #expect(ipswService.lastDiscardResumeDataURL == URL(fileURLWithPath: downloadPath))
+    }
+
+    @Test("installMacOS preserves IPSW resume data on non-cancel download failure")
+    func installMacOSFailurePreservesResumeData() async {
+        let (coordinator, _, _, ipswService, _) = makeCoordinator()
+        ipswService.downloadError = IPSWError.downloadFailed(URLError(.notConnectedToInternet))
+        let instance = makeInstance()
+        let wizard = VMCreationViewModel()
+        wizard.selectedOS = .macOS
+        wizard.ipswSource = .downloadLatest
+        wizard.ipswDownloadPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("network-fail-restore.ipsw").path(percentEncoded: false)
+
+        do {
+            try await coordinator.installMacOS(on: instance, wizard: wizard)
+            Issue.record("Expected error to be thrown")
+        } catch {
+            #expect(ipswService.discardResumeDataCallCount == 0)
+            #expect(instance.status == .error)
+        }
+    }
     #endif
 
     // MARK: - USB Device Pass-Through

--- a/KernovaTests/VMStatusTests.swift
+++ b/KernovaTests/VMStatusTests.swift
@@ -6,10 +6,11 @@ import SwiftUI
 struct VMStatusTests {
     // MARK: - State Checks
 
-    @Test("canStart returns true for stopped and error states")
+    @Test("canStart returns true for stopped, error, and initialBoot states")
     func canStart() {
         #expect(VMStatus.stopped.canStart == true)
         #expect(VMStatus.error.canStart == true)
+        #expect(VMStatus.initialBoot.canStart == true)
         #expect(VMStatus.running.canStart == false)
         #expect(VMStatus.paused.canStart == false)
         #expect(VMStatus.starting.canStart == false)
@@ -27,6 +28,7 @@ struct VMStatusTests {
         #expect(VMStatus.saving.canStop == false)
         #expect(VMStatus.restoring.canStop == false)
         #expect(VMStatus.installing.canStop == false)
+        #expect(VMStatus.initialBoot.canStop == false)
         #expect(VMStatus.error.canStop == false)
     }
 
@@ -39,6 +41,7 @@ struct VMStatusTests {
         #expect(VMStatus.saving.canPause == false)
         #expect(VMStatus.restoring.canPause == false)
         #expect(VMStatus.installing.canPause == false)
+        #expect(VMStatus.initialBoot.canPause == false)
         #expect(VMStatus.error.canPause == false)
     }
 
@@ -51,6 +54,7 @@ struct VMStatusTests {
         #expect(VMStatus.saving.canResume == false)
         #expect(VMStatus.restoring.canResume == false)
         #expect(VMStatus.installing.canResume == false)
+        #expect(VMStatus.initialBoot.canResume == false)
         #expect(VMStatus.error.canResume == false)
     }
 
@@ -63,13 +67,15 @@ struct VMStatusTests {
         #expect(VMStatus.saving.canSave == false)
         #expect(VMStatus.restoring.canSave == false)
         #expect(VMStatus.installing.canSave == false)
+        #expect(VMStatus.initialBoot.canSave == false)
         #expect(VMStatus.error.canSave == false)
     }
 
-    @Test("canEditSettings returns true for stopped and error states")
+    @Test("canEditSettings returns true for stopped, error, and initialBoot states")
     func canEditSettings() {
         #expect(VMStatus.stopped.canEditSettings == true)
         #expect(VMStatus.error.canEditSettings == true)
+        #expect(VMStatus.initialBoot.canEditSettings == true)
         #expect(VMStatus.running.canEditSettings == false)
         #expect(VMStatus.paused.canEditSettings == false)
         #expect(VMStatus.starting.canEditSettings == false)
@@ -83,6 +89,7 @@ struct VMStatusTests {
         #expect(VMStatus.stopped.canRename == true)
         #expect(VMStatus.running.canRename == true)
         #expect(VMStatus.paused.canRename == true)
+        #expect(VMStatus.initialBoot.canRename == true)
         #expect(VMStatus.error.canRename == true)
         #expect(VMStatus.starting.canRename == false)
         #expect(VMStatus.saving.canRename == false)
@@ -99,6 +106,7 @@ struct VMStatusTests {
         #expect(VMStatus.restoring.canForceStop == true)
         #expect(VMStatus.stopped.canForceStop == false)
         #expect(VMStatus.installing.canForceStop == false)
+        #expect(VMStatus.initialBoot.canForceStop == false)
         #expect(VMStatus.error.canForceStop == false)
     }
 
@@ -113,6 +121,7 @@ struct VMStatusTests {
         #expect(VMStatus.installing.isActive == true)
         #expect(VMStatus.paused.isActive == false)
         #expect(VMStatus.stopped.isActive == false)
+        #expect(VMStatus.initialBoot.isActive == false)
         #expect(VMStatus.error.isActive == false)
     }
 
@@ -127,6 +136,7 @@ struct VMStatusTests {
         #expect(VMStatus.stopped.hasActiveDisplay == false)
         #expect(VMStatus.starting.hasActiveDisplay == false)
         #expect(VMStatus.installing.hasActiveDisplay == false)
+        #expect(VMStatus.initialBoot.hasActiveDisplay == false)
         #expect(VMStatus.error.hasActiveDisplay == false)
     }
 
@@ -141,6 +151,7 @@ struct VMStatusTests {
         #expect(VMStatus.stopped.isTransitioning == false)
         #expect(VMStatus.running.isTransitioning == false)
         #expect(VMStatus.paused.isTransitioning == false)
+        #expect(VMStatus.initialBoot.isTransitioning == false)
         #expect(VMStatus.error.isTransitioning == false)
     }
 
@@ -155,6 +166,7 @@ struct VMStatusTests {
         #expect(VMStatus.running.transitionLabel == nil)
         #expect(VMStatus.paused.transitionLabel == nil)
         #expect(VMStatus.installing.transitionLabel == nil)
+        #expect(VMStatus.initialBoot.transitionLabel == nil)
         #expect(VMStatus.error.transitionLabel == nil)
     }
 
@@ -169,6 +181,7 @@ struct VMStatusTests {
         #expect(VMStatus.saving.displayName == "Suspending")
         #expect(VMStatus.restoring.displayName == "Restoring")
         #expect(VMStatus.installing.displayName == "Installing")
+        #expect(VMStatus.initialBoot.displayName == "Initial Boot")
         #expect(VMStatus.error.displayName == "Error")
     }
 
@@ -183,6 +196,23 @@ struct VMStatusTests {
         #expect(VMStatus.saving.statusColor == .orange)
         #expect(VMStatus.restoring.statusColor == .orange)
         #expect(VMStatus.installing.statusColor == .orange)
+        #expect(VMStatus.initialBoot.statusColor == .orange)
         #expect(VMStatus.error.statusColor == .red)
+    }
+
+    // MARK: - Initial Boot
+
+    @Test("initialBoot has install-friendly properties")
+    func initialBootProperties() {
+        #expect(VMStatus.initialBoot.canStart == true)
+        #expect(VMStatus.initialBoot.canEditSettings == true)
+        #expect(VMStatus.initialBoot.canRename == true)
+        #expect(VMStatus.initialBoot.isActive == false)
+        #expect(VMStatus.initialBoot.isTransitioning == false)
+        #expect(VMStatus.initialBoot.hasActiveDisplay == false)
+        #expect(VMStatus.initialBoot.canStop == false)
+        #expect(VMStatus.initialBoot.canForceStop == false)
+        #expect(VMStatus.initialBoot.displayName == "Initial Boot")
+        #expect(VMStatus.initialBoot.statusColor == .orange)
     }
 }


### PR DESCRIPTION
## Summary
- Adds a new `.initialBoot` VM state for macOS guests that have not yet completed their initial boot. The creation wizard becomes a pure bootstrap (creates the bundle, persists the install plan as `VMConfiguration.installContext`, allocates the disk image) and parks the VM at "Initial Boot". The user's normal Start button drives the install pipeline on demand, then auto-boots once on success.
- Adds resume support for the macOS IPSW download via a URLSession `.resumedata` sidecar next to the chosen path. Interrupted downloads — from network drops, sleep, app quit, or user cancel — pick up where they left off on the next Start. Cancel is non-destructive: VM stays in the library at Initial Boot, partial download is preserved. Destructive removal stays on the existing "Move to Trash" flow.
- Adapts the Start button label across the toolbar and sidebar context menu to reflect what clicking will do (`Install` / `Resume Install` / `Start` / `Resume`), keyed on `installContext` so VMs that landed in `.error` from a failed install also surface the right label on retry.

## Changes
- New `Models/MacOSInstallContext.swift` (Codable struct mirroring the wizard's `IPSWSource` for bundle persistence).
- `VMStatus.initialBoot` case with all exhaustive enumerations updated; `canStart` and `canEditSettings` return true.
- `VMConfiguration.installContext` field with `decodeIfPresent` migration; `clonedForNewInstance` explicitly clears it.
- `VMLifecycleCoordinator.installMacOS(on:context:)` (renamed from `on:wizard:`); clears `installContext` on success via `performConfigurationMutation`, re-throws `CancellationError` on cancel.
- `VMLibraryViewModel.installAndAutoBoot(_:)` drives install + chains auto-boot. `start(_:)` forks on `installContext != nil`. `cancelInstallation` is now non-destructive (cancel task, leave bundle).
- IPSWService:
  - Reads `.resumedata` sidecar on start; `downloadTask(withResumeData:)` if present.
  - Skip-existing fast path: returns early when the destination already has a completed IPSW and no sidecar (saves a multi-GB redownload after the install phase failed and the user retries).
  - `onCancel` handler uses `cancel(byProducingResumeData:)` so user cancel preserves the sidecar.
  - `didFinishDownloadingTo` removes any stale file at the destination before `moveItem` to defend against the "File exists" failure mode.
- `MacOSInstallService.setupPlatformFiles` is now idempotent: HardwareModel and MachineIdentifier files are only written when absent (so the VM keeps a stable identity across install retries); AuxiliaryStorage uses `[.allowOverwrite]` so the retry doesn't trip on the prior attempt's file.
- `VMDetailView` adds a `.initialBoot` branch with an `InitialBootBanner` whose subtitle adapts to the install context (fresh download / resume / local file).
- `MacOSInstallProgressView` cancel alert is now phase-aware: download-phase says "the download will be saved and resumed"; install-phase honestly says "the installation will restart from the beginning" (since `VZMacOSInstaller` is one-shot — only the cached IPSW carries over).
- `VMToolbarManager.updateLifecycleGroup` and `SidebarView` context menu both compute the adaptive Start label from `installContext`.
- Reconcile / loadVMs / importVM use a shared `initialStatus(for:layout:)` helper that prefers `.initialBoot` when an install is pending.

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes (all new and existing tests green)
- [ ] Fresh install, download path: wizard dismisses with VM at "Initial Boot" → Start → download + install → auto-boot to Running
- [ ] Fresh install, local IPSW: Start → install runs immediately → auto-boot
- [ ] Cancel during download → "Cancel Download?" alert → VM returns to Initial Boot, toolbar reads "Resume Install", sidecar exists at chosen path → Start resumes from where it stopped
- [ ] Cancel during install phase → "Cancel Installation?" alert (honest about restart) → VM returns to Initial Boot, toolbar reads "Install" (no sidecar, IPSW cached) → Start re-runs installer against cached IPSW
- [ ] Quit during download → relaunch → "Resume Install" label, sidecar intact, Start resumes
- [ ] Quit during install → relaunch → "Install" label, IPSW cached, Start re-runs installer
- [ ] Failed install (e.g. unreachable mirror) → VM lands in `.error` → toolbar still reads "Resume Install" / "Install" because trigger is `installContext != nil` → Start re-enters install pipeline
- [ ] Settings edits while `.initialBoot`: change CPU/RAM/network → persists across reload; disk size remains locked (existing behavior)
- [ ] Clone a fully-installed VM → clone is `.stopped`, no `installContext`, boots normally
- [ ] Pre-existing VM (created on `main`) loads as `.stopped`/`.paused` with no `installContext`, behaves identically
- [ ] "Move to Trash" on a `.initialBoot` VM removes the bundle (distinct from Cancel)