### PR TITLE
feat: Confirm removable disc removal and trash external storage discs

### DIFF
--- a/Kernova/Models/MacOSInstallContext.swift
+++ b/Kernova/Models/MacOSInstallContext.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 /// Persisted intent to install macOS into a VM that has not yet completed
-/// its initial boot. Stored on `VMConfiguration` and consulted by
+/// its initial boot.
+///
+/// Stored on `VMConfiguration` and consulted by
 /// `VMLifecycleCoordinator.installMacOS(on:context:)` on every Start while
 /// non-nil. Cleared exactly once, after a successful install.
 ///
@@ -16,13 +18,15 @@ struct MacOSInstallContext: Codable, Sendable, Equatable {
 
     var source: Source
 
-    /// Where to write the downloaded IPSW (for `.downloadLatest`). The
-    /// `<path>.resumedata` sidecar at this location enables download resume
-    /// across app restarts. Ignored when `source == .localFile`.
+    /// Where to write the downloaded IPSW (for `.downloadLatest`).
+    ///
+    /// The `<path>.resumedata` sidecar at this location enables download
+    /// resume across app restarts. Ignored when `source == .localFile`.
     var downloadDestinationPath: String?
 
-    /// Path to an existing IPSW file on disk (for `.localFile`). Ignored
-    /// when `source == .downloadLatest`.
+    /// Path to an existing IPSW file on disk (for `.localFile`).
+    ///
+    /// Ignored when `source == .downloadLatest`.
     var localIPSWPath: String?
 
     var downloadDestinationURL: URL? {

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -144,11 +144,12 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
 
     // MARK: - Install Intent
 
-    /// Pending macOS install plan from the creation wizard. Non-nil ⇔ this VM
-    /// has never completed its initial boot. Cleared exactly once, after
-    /// `MacOSInstallService.install(...)` returns successfully. The presence
-    /// of this field is what drives `start(_:)` to route through the install
-    /// pipeline (and the `.initialBoot` status assignment in reconcile).
+    /// Pending macOS install plan from the creation wizard.
+    ///
+    /// Non-nil ⇔ this VM has never completed its initial boot. Cleared exactly
+    /// once, after `MacOSInstallService.install(...)` returns successfully. The
+    /// presence of this field is what drives `start(_:)` to route through the
+    /// install pipeline (and the `.initialBoot` status assignment in reconcile).
     /// Always `nil` for Linux guests.
     var installContext: MacOSInstallContext?
 

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -692,23 +692,23 @@ struct ConfigurationBuilder: Sendable {
         } catch {
             switch error {
             case .notFound:
-                logger.error("\(context, privacy: .public) not found at '\(path, privacy: .public)'")
+                logger.error("\(context, privacy: .public) not found at '\(path, privacy: .private)'")
                 throw notFound
             case .unexpectedType:
-                logger.error("\(context, privacy: .public) path is a directory: '\(path, privacy: .public)'")
+                logger.error("\(context, privacy: .public) path is a directory: '\(path, privacy: .private)'")
                 throw isDirectory
             case .notWritable:
-                logger.error("\(context, privacy: .public) is not writable: '\(path, privacy: .public)'")
+                logger.error("\(context, privacy: .public) is not writable: '\(path, privacy: .private)'")
                 guard let notWritableError = notWritable else {
                     logger.fault(
-                        "resolveFile called with requireWritable but no notWritable error for '\(path, privacy: .public)'"
+                        "resolveFile called with requireWritable but no notWritable error for '\(path, privacy: .private)'"
                     )
                     assertionFailure("'notWritable' error must be provided when 'requireWritable' is true")
                     throw notFound
                 }
                 throw notWritableError
             case .notReadable:
-                logger.fault("Unexpected .notReadable from resolveFile for '\(path, privacy: .public)'")
+                logger.fault("Unexpected .notReadable from resolveFile for '\(path, privacy: .private)'")
                 assertionFailure("resolveFile should never throw .notReadable")
                 throw notFound
             }
@@ -734,26 +734,26 @@ struct ConfigurationBuilder: Sendable {
         } catch {
             switch error {
             case .notFound:
-                logger.error("\(context, privacy: .public) not found at '\(path, privacy: .public)'")
+                logger.error("\(context, privacy: .public) not found at '\(path, privacy: .private)'")
                 throw notFound
             case .unexpectedType:
-                logger.error("\(context, privacy: .public) path is not a directory: '\(path, privacy: .public)'")
+                logger.error("\(context, privacy: .public) path is not a directory: '\(path, privacy: .private)'")
                 throw notADirectory
             case .notReadable:
-                logger.error("\(context, privacy: .public) is not readable: '\(path, privacy: .public)'")
+                logger.error("\(context, privacy: .public) is not readable: '\(path, privacy: .private)'")
                 guard let notReadableError = notReadable else {
                     logger.fault(
-                        "resolveDirectory called with requireReadable but no notReadable error for '\(path, privacy: .public)'"
+                        "resolveDirectory called with requireReadable but no notReadable error for '\(path, privacy: .private)'"
                     )
                     assertionFailure("'notReadable' error must be provided when 'requireReadable' is true")
                     throw notFound
                 }
                 throw notReadableError
             case .notWritable:
-                logger.error("\(context, privacy: .public) is not writable: '\(path, privacy: .public)'")
+                logger.error("\(context, privacy: .public) is not writable: '\(path, privacy: .private)'")
                 guard let notWritableError = notWritable else {
                     logger.fault(
-                        "resolveDirectory called with requireWritable but no notWritable error for '\(path, privacy: .public)'"
+                        "resolveDirectory called with requireWritable but no notWritable error for '\(path, privacy: .private)'"
                     )
                     assertionFailure("'notWritable' error must be provided when 'requireWritable' is true")
                     throw notFound

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -117,6 +117,7 @@ struct IPSWService: Sendable {
     }
 
     /// Deletes any persisted resume-data sidecar for the given destination path.
+    ///
     /// Safe to call when no sidecar exists.
     func discardResumeData(at destinationURL: URL) {
         let sidecarURL = Self.resumeDataSidecarURL(for: destinationURL)
@@ -135,7 +136,9 @@ struct IPSWService: Sendable {
     }
 
     /// Returns the on-disk location where URLSession resume data is persisted for a given
-    /// download destination. Lives next to the final file so cleanup tracks the user's chosen path.
+    /// download destination.
+    ///
+    /// Lives next to the final file so cleanup tracks the user's chosen path.
     static func resumeDataSidecarURL(for destinationURL: URL) -> URL {
         destinationURL.appendingPathExtension("resumedata")
     }

--- a/Kernova/Services/MacOSInstallService.swift
+++ b/Kernova/Services/MacOSInstallService.swift
@@ -115,11 +115,14 @@ final class MacOSInstallService {
     // MARK: - Platform Setup
 
     /// Creates the auxiliary storage, hardware model, and machine identifier files.
+    ///
     /// Idempotent across install retries: hardware model and machine identifier
     /// files are written only when absent so the VM keeps a stable on-disk identity
     /// across attempts (the guest install sees the same machine regardless of how
-    /// many tries it took). Auxiliary storage is always re-created — it carries
-    /// firmware/NVRAM state that must match a fresh install run.
+    /// many tries it took).
+    ///
+    /// Auxiliary storage is always re-created — it carries firmware/NVRAM state
+    /// that must match a fresh install run.
     private func setupPlatformFiles(
         for instance: VMInstance,
         hardwareModel: VZMacHardwareModel

--- a/Kernova/Services/USBDeviceService.swift
+++ b/Kernova/Services/USBDeviceService.swift
@@ -27,18 +27,19 @@ final class USBDeviceService: USBDeviceProviding {
             resolved = try PathValidation.resolveFile(at: diskImagePath, requireWritable: !readOnly)
             resolved.logResolution(logger: Self.logger, context: "USB disk image")
         } catch {
+            let basename = URL(fileURLWithPath: diskImagePath).lastPathComponent
             switch error {
             case .notFound:
-                Self.logger.error("USB disk image not found at '\(diskImagePath, privacy: .public)'")
+                Self.logger.error("USB disk image not found: '\(basename, privacy: .public)'")
                 throw USBDeviceError.diskImageNotFound(diskImagePath)
             case .unexpectedType:
-                Self.logger.error("USB disk image path is a directory: '\(diskImagePath, privacy: .public)'")
+                Self.logger.error("USB disk image path is a directory: '\(basename, privacy: .public)'")
                 throw USBDeviceError.diskImageIsDirectory(diskImagePath)
             case .notWritable:
-                Self.logger.error("USB disk image is not writable: '\(diskImagePath, privacy: .public)'")
+                Self.logger.error("USB disk image is not writable: '\(basename, privacy: .public)'")
                 throw USBDeviceError.diskImageNotWritable(diskImagePath)
             case .notReadable:
-                Self.logger.fault("Unexpected .notReadable from resolveFile for '\(diskImagePath, privacy: .public)'")
+                Self.logger.fault("Unexpected .notReadable from resolveFile for '\(basename, privacy: .public)'")
                 assertionFailure("resolveFile should never throw .notReadable")
                 throw USBDeviceError.diskImageNotFound(diskImagePath)
             }
@@ -49,7 +50,7 @@ final class USBDeviceService: USBDeviceProviding {
             attachment = try VZDiskImageStorageDeviceAttachment(url: resolved.url, readOnly: readOnly)
         } catch {
             Self.logger.error(
-                "Failed to create disk attachment for '\(diskImagePath, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+                "Failed to create disk attachment for '\(resolved.url.lastPathComponent, privacy: .public)': \(error.localizedDescription, privacy: .public)"
             )
             throw error
         }

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -194,10 +194,12 @@ final class VMCreationViewModel {
 
     #if arch(arm64)
     /// Snapshots the wizard's macOS install choice into a persistable
-    /// `MacOSInstallContext`. Called by `VMLibraryViewModel.createVM` so the
-    /// VM's bundle records the install plan; the install pipeline then reads
-    /// from the bundle (not the wizard) on every Start until the install
-    /// completes and the context is cleared.
+    /// `MacOSInstallContext`.
+    ///
+    /// Called by `VMLibraryViewModel.createVM` so the VM's bundle records the
+    /// install plan; the install pipeline then reads from the bundle (not the
+    /// wizard) on every Start until the install completes and the context is
+    /// cleared.
     func buildInstallContext() -> MacOSInstallContext {
         switch ipswSource {
         case .downloadLatest:
@@ -218,8 +220,10 @@ final class VMCreationViewModel {
 
     /// `true` when the chosen download destination has an associated `.resumedata`
     /// sidecar from a prior interrupted download, *and* no completed IPSW already
-    /// exists at the path. A completed file takes priority — the overwrite warning
-    /// flow handles that case instead.
+    /// exists at the path.
+    ///
+    /// A completed file takes priority — the overwrite warning flow handles that
+    /// case instead.
     var hasResumableDownload: Bool {
         guard ipswSource == .downloadLatest,
             let path = ipswDownloadPath,

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -966,7 +966,8 @@ final class VMLibraryViewModel {
         }
 
         guard trashFile else { return nil }
-        let diskURL: URL = disk.isInternal
+        let diskURL: URL =
+            disk.isInternal
             ? instance.bundleURL.appendingPathComponent(disk.path)
             : URL(fileURLWithPath: disk.path)
         let label = disk.label

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -987,7 +987,7 @@ final class VMLibraryViewModel {
                 Self.logger.warning(
                     "Failed to trash disk '\(label, privacy: .public)' (\(diskURL.lastPathComponent, privacy: .public)): \(message, privacy: .public)"
                 )
-                await MainActor.run {
+                await MainActor.run { [weak self] in
                     guard let self else { return }
                     self.errorMessage = message
                     self.showError = true
@@ -1044,7 +1044,7 @@ final class VMLibraryViewModel {
                 Self.logger.warning(
                     "Failed to trash removable media '\(label, privacy: .public)' (\(url.lastPathComponent, privacy: .public)): \(message, privacy: .public)"
                 )
-                await MainActor.run {
+                await MainActor.run { [weak self] in
                     guard let self else { return }
                     self.errorMessage = message
                     self.showError = true

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -6,7 +6,7 @@ import os
 @MainActor
 @Observable
 final class VMLibraryViewModel {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMLibraryViewModel")
+    nonisolated private static let logger = Logger(subsystem: "com.kernova.app", category: "VMLibraryViewModel")
     static let lastSelectedVMIDKey = "lastSelectedVMID"
     static let vmOrderKey = "vmOrder"
 
@@ -949,31 +949,49 @@ final class VMLibraryViewModel {
     /// external disks resolve against their absolute path. If the file is
     /// already gone, the missing-file error is logged and swallowed so the
     /// user doesn't see an alert for a no-op cleanup.
-    func removeStorageDisk(_ disk: StorageDisk, from instance: VMInstance, trashFile: Bool) {
+    ///
+    /// `FileManager.trashItem` is a synchronous call that can block for
+    /// seconds on slow or unresponsive volumes (network shares, sleeping
+    /// external drives), so the trash runs in `Task.detached` to keep the
+    /// MainActor responsive. The returned Task lets tests await completion;
+    /// production callers use `@discardableResult` and ignore it.
+    @discardableResult
+    func removeStorageDisk(
+        _ disk: StorageDisk, from instance: VMInstance, trashFile: Bool
+    ) -> Task<Void, Never>? {
         updateConfiguration(of: instance) { config in
             var disks = config.storageDisks ?? Self.defaultStorageDisks(for: instance)
             disks.removeAll { $0.id == disk.id }
             config.storageDisks = disks.isEmpty ? nil : disks
         }
 
-        guard trashFile else { return }
+        guard trashFile else { return nil }
         let diskURL: URL = disk.isInternal
             ? instance.bundleURL.appendingPathComponent(disk.path)
             : URL(fileURLWithPath: disk.path)
-        do {
-            try FileManager.default.trashItem(at: diskURL, resultingItemURL: nil)
-            Self.logger.notice(
-                "Trashed disk '\(disk.label, privacy: .public)' for VM '\(instance.name, privacy: .public)'"
-            )
-        } catch let error as CocoaError where error.code == .fileNoSuchFile || error.code == .fileReadNoSuchFile {
-            Self.logger.notice(
-                "Disk file already gone for '\(disk.label, privacy: .public)' (\(diskURL.lastPathComponent, privacy: .public)); skipping trash"
-            )
-        } catch {
-            Self.logger.warning(
-                "Failed to trash disk '\(disk.label, privacy: .public)' (\(diskURL.lastPathComponent, privacy: .public)): \(error.localizedDescription, privacy: .public)"
-            )
-            presentError(error)
+        let label = disk.label
+        let vmName = instance.name
+        return Task.detached(priority: .userInitiated) { [weak self] in
+            do {
+                try FileManager.default.trashItem(at: diskURL, resultingItemURL: nil)
+                Self.logger.notice(
+                    "Trashed disk '\(label, privacy: .public)' for VM '\(vmName, privacy: .public)'"
+                )
+            } catch let error as CocoaError where error.code == .fileNoSuchFile || error.code == .fileReadNoSuchFile {
+                Self.logger.notice(
+                    "Disk file already gone for '\(label, privacy: .public)' (\(diskURL.lastPathComponent, privacy: .public)); skipping trash"
+                )
+            } catch {
+                let message = error.localizedDescription
+                Self.logger.warning(
+                    "Failed to trash disk '\(label, privacy: .public)' (\(diskURL.lastPathComponent, privacy: .public)): \(message, privacy: .public)"
+                )
+                await MainActor.run {
+                    guard let self else { return }
+                    self.errorMessage = message
+                    self.showError = true
+                }
+            }
         }
     }
 
@@ -985,36 +1003,52 @@ final class VMLibraryViewModel {
     /// disambiguate. Missing files are swallowed (`.notice` log, no error
     /// alert) because removable media are often transient — a user may
     /// have already deleted or unmounted the source. Other failures are
-    /// surfaced via `presentError`.
+    /// surfaced via the error alert.
     ///
     /// Mutating `config.removableMedia` through `updateConfiguration`
     /// triggers `applyLivePolicy` → `applyLiveRemovableMediaChange`, so
     /// the hot-detach reconciliation runs automatically when the VM is
     /// running. `trashItem` succeeds even while the VM still holds the
     /// file open, so we don't need to wait for the detach to complete.
-    func removeRemovableMedia(_ item: RemovableMediaItem, from instance: VMInstance, trashFile: Bool) {
+    ///
+    /// The trash runs in `Task.detached` (see `removeStorageDisk` for the
+    /// reasoning). The returned Task lets tests await completion; the
+    /// SwiftUI caller uses `@discardableResult` and ignores it.
+    @discardableResult
+    func removeRemovableMedia(
+        _ item: RemovableMediaItem, from instance: VMInstance, trashFile: Bool
+    ) -> Task<Void, Never>? {
         updateConfiguration(of: instance) { config in
             var items = config.removableMedia ?? []
             items.removeAll { $0.id == item.id }
             config.removableMedia = items.isEmpty ? nil : items
         }
 
-        guard trashFile else { return }
+        guard trashFile else { return nil }
         let url = URL(fileURLWithPath: item.path)
-        do {
-            try FileManager.default.trashItem(at: url, resultingItemURL: nil)
-            Self.logger.notice(
-                "Trashed removable media '\(item.label, privacy: .public)' for VM '\(instance.name, privacy: .public)'"
-            )
-        } catch let error as CocoaError where error.code == .fileNoSuchFile || error.code == .fileReadNoSuchFile {
-            Self.logger.notice(
-                "Removable media file already gone for '\(item.label, privacy: .public)' (\(url.lastPathComponent, privacy: .public)) on VM '\(instance.name, privacy: .public)'; skipping trash"
-            )
-        } catch {
-            Self.logger.warning(
-                "Failed to trash removable media '\(item.label, privacy: .public)' (\(url.lastPathComponent, privacy: .public)): \(error.localizedDescription, privacy: .public)"
-            )
-            presentError(error)
+        let label = item.label
+        let vmName = instance.name
+        return Task.detached(priority: .userInitiated) { [weak self] in
+            do {
+                try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+                Self.logger.notice(
+                    "Trashed removable media '\(label, privacy: .public)' for VM '\(vmName, privacy: .public)'"
+                )
+            } catch let error as CocoaError where error.code == .fileNoSuchFile || error.code == .fileReadNoSuchFile {
+                Self.logger.notice(
+                    "Removable media file already gone for '\(label, privacy: .public)' (\(url.lastPathComponent, privacy: .public)) on VM '\(vmName, privacy: .public)'; skipping trash"
+                )
+            } catch {
+                let message = error.localizedDescription
+                Self.logger.warning(
+                    "Failed to trash removable media '\(label, privacy: .public)' (\(url.lastPathComponent, privacy: .public)): \(message, privacy: .public)"
+                )
+                await MainActor.run {
+                    guard let self else { return }
+                    self.errorMessage = message
+                    self.showError = true
+                }
+            }
         }
     }
 

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -944,9 +944,11 @@ final class VMLibraryViewModel {
 
     /// Removes a storage disk entry from the configuration.
     ///
-    /// When `trashFile` is `true` and the disk is internal (bundle-owned),
-    /// the underlying file is moved to Trash. External disks ignore the
-    /// flag — they belong to the user, not the bundle.
+    /// When `trashFile` is `true`, the underlying file is moved to Trash —
+    /// internal (bundle-owned) disks resolve against `instance.bundleURL`,
+    /// external disks resolve against their absolute path. If the file is
+    /// already gone, the missing-file error is logged and swallowed so the
+    /// user doesn't see an alert for a no-op cleanup.
     func removeStorageDisk(_ disk: StorageDisk, from instance: VMInstance, trashFile: Bool) {
         updateConfiguration(of: instance) { config in
             var disks = config.storageDisks ?? Self.defaultStorageDisks(for: instance)
@@ -954,16 +956,63 @@ final class VMLibraryViewModel {
             config.storageDisks = disks.isEmpty ? nil : disks
         }
 
-        guard disk.isInternal && trashFile else { return }
-        let diskURL = instance.bundleURL.appendingPathComponent(disk.path)
+        guard trashFile else { return }
+        let diskURL: URL = disk.isInternal
+            ? instance.bundleURL.appendingPathComponent(disk.path)
+            : URL(fileURLWithPath: disk.path)
         do {
             try FileManager.default.trashItem(at: diskURL, resultingItemURL: nil)
             Self.logger.notice(
-                "Trashed internal disk '\(disk.label, privacy: .public)' for VM '\(instance.name, privacy: .public)'"
+                "Trashed disk '\(disk.label, privacy: .public)' for VM '\(instance.name, privacy: .public)'"
+            )
+        } catch let error as CocoaError where error.code == .fileNoSuchFile || error.code == .fileReadNoSuchFile {
+            Self.logger.notice(
+                "Disk file already gone for '\(disk.label, privacy: .public)' at '\(diskURL.path, privacy: .public)'; skipping trash"
             )
         } catch {
             Self.logger.warning(
-                "Failed to trash internal disk '\(disk.label, privacy: .public)' at '\(diskURL.lastPathComponent, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+                "Failed to trash disk '\(disk.label, privacy: .public)' at '\(diskURL.lastPathComponent, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+            presentError(error)
+        }
+    }
+
+    /// Removes a removable media entry from the configuration.
+    ///
+    /// When `trashFile` is `true`, the underlying file at the item's
+    /// absolute path is moved to Trash. Every removable item is a
+    /// user-picked external file, so there's no bundle-relative case to
+    /// disambiguate. Missing files are swallowed (`.notice` log, no error
+    /// alert) because removable media are often transient — a user may
+    /// have already deleted or unmounted the source. Other failures are
+    /// surfaced via `presentError`.
+    ///
+    /// Mutating `config.removableMedia` through `updateConfiguration`
+    /// triggers `applyLivePolicy` → `applyLiveRemovableMediaChange`, so
+    /// the hot-detach reconciliation runs automatically when the VM is
+    /// running. `trashItem` succeeds even while the VM still holds the
+    /// file open, so we don't need to wait for the detach to complete.
+    func removeRemovableMedia(_ item: RemovableMediaItem, from instance: VMInstance, trashFile: Bool) {
+        updateConfiguration(of: instance) { config in
+            var items = config.removableMedia ?? []
+            items.removeAll { $0.id == item.id }
+            config.removableMedia = items.isEmpty ? nil : items
+        }
+
+        guard trashFile else { return }
+        let url = URL(fileURLWithPath: item.path)
+        do {
+            try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+            Self.logger.notice(
+                "Trashed removable media '\(item.label, privacy: .public)' for VM '\(instance.name, privacy: .public)'"
+            )
+        } catch let error as CocoaError where error.code == .fileNoSuchFile || error.code == .fileReadNoSuchFile {
+            Self.logger.notice(
+                "Removable media file already gone at '\(item.path, privacy: .public)' for VM '\(instance.name, privacy: .public)'; skipping trash"
+            )
+        } catch {
+            Self.logger.warning(
+                "Failed to trash removable media '\(item.label, privacy: .public)' at '\(item.path, privacy: .public)': \(error.localizedDescription, privacy: .public)"
             )
             presentError(error)
         }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -967,11 +967,11 @@ final class VMLibraryViewModel {
             )
         } catch let error as CocoaError where error.code == .fileNoSuchFile || error.code == .fileReadNoSuchFile {
             Self.logger.notice(
-                "Disk file already gone for '\(disk.label, privacy: .public)' at '\(diskURL.path, privacy: .public)'; skipping trash"
+                "Disk file already gone for '\(disk.label, privacy: .public)' (\(diskURL.lastPathComponent, privacy: .public)); skipping trash"
             )
         } catch {
             Self.logger.warning(
-                "Failed to trash disk '\(disk.label, privacy: .public)' at '\(diskURL.lastPathComponent, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+                "Failed to trash disk '\(disk.label, privacy: .public)' (\(diskURL.lastPathComponent, privacy: .public)): \(error.localizedDescription, privacy: .public)"
             )
             presentError(error)
         }
@@ -1008,11 +1008,11 @@ final class VMLibraryViewModel {
             )
         } catch let error as CocoaError where error.code == .fileNoSuchFile || error.code == .fileReadNoSuchFile {
             Self.logger.notice(
-                "Removable media file already gone at '\(item.path, privacy: .public)' for VM '\(instance.name, privacy: .public)'; skipping trash"
+                "Removable media file already gone for '\(item.label, privacy: .public)' (\(url.lastPathComponent, privacy: .public)) on VM '\(instance.name, privacy: .public)'; skipping trash"
             )
         } catch {
             Self.logger.warning(
-                "Failed to trash removable media '\(item.label, privacy: .public)' at '\(item.path, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+                "Failed to trash removable media '\(item.label, privacy: .public)' (\(url.lastPathComponent, privacy: .public)): \(error.localizedDescription, privacy: .public)"
             )
             presentError(error)
         }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -236,10 +236,11 @@ final class VMLibraryViewModel {
 
     #if arch(arm64)
     /// Drives the install pipeline for an `.initialBoot` (or `.error` with
-    /// `installContext`) VM and, on success, chains an auto-boot. Non-cancel
-    /// errors leave the VM in `.error` so the user sees the message; cancel
-    /// returns it to `.initialBoot` for a future retry that will resume the
-    /// download from the `.resumedata` sidecar if present.
+    /// `installContext`) VM and, on success, chains an auto-boot.
+    ///
+    /// Non-cancel errors leave the VM in `.error` so the user sees the message;
+    /// cancel returns it to `.initialBoot` for a future retry that will resume
+    /// the download from the `.resumedata` sidecar if present.
     private func installAndAutoBoot(_ instance: VMInstance) {
         guard let context = instance.configuration.installContext else {
             assertionFailure("installAndAutoBoot called without installContext")
@@ -274,10 +275,12 @@ final class VMLibraryViewModel {
         }
     }
 
-    /// Cancels an in-progress macOS install. The VM returns to `.initialBoot`
-    /// so a subsequent Start can resume (downloads pick up from the
-    /// `.resumedata` sidecar at the chosen path). Bundle is preserved. For
-    /// destructive removal, use the existing delete flow ("Move to Trash").
+    /// Cancels an in-progress macOS install.
+    ///
+    /// The VM returns to `.initialBoot` so a subsequent Start can resume
+    /// (downloads pick up from the `.resumedata` sidecar at the chosen path).
+    /// Bundle is preserved. For destructive removal, use the existing delete
+    /// flow ("Move to Trash").
     func cancelInstallation(_ instance: VMInstance) {
         Self.logger.info("Cancelling installation for '\(instance.name, privacy: .public)'")
         instance.installTask?.cancel()

--- a/Kernova/Views/Detail/MacOSInstallProgressView.swift
+++ b/Kernova/Views/Detail/MacOSInstallProgressView.swift
@@ -83,7 +83,8 @@ struct MacOSInstallProgressView: View {
         if isDownloadPhase {
             return "The download progress will be saved and resumed the next time you start the virtual machine."
         }
-        return "The installation will restart from the beginning the next time you start the virtual machine. The downloaded macOS image is cached, so you won't need to download it again."
+        return
+            "The installation will restart from the beginning the next time you start the virtual machine. The downloaded macOS image is cached, so you won't need to download it again."
     }
 
     // MARK: - Two-Step Indicator

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -67,9 +67,11 @@ struct VMDetailView: View {
 }
 
 /// Banner shown above the settings panel for VMs whose initial boot hasn't
-/// happened yet. Adapts its subtitle to the persisted install context so the
-/// user knows what Start will do (download + install vs. install from local
-/// IPSW vs. resume an interrupted download).
+/// happened yet.
+///
+/// Adapts its subtitle to the persisted install context so the user knows what
+/// Start will do (download + install vs. install from local IPSW vs. resume an
+/// interrupted download).
 private struct InitialBootBanner: View {
     let instance: VMInstance
 

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -22,6 +22,8 @@ struct VMSettingsView: View {
     @State private var newDiskSizeInGB = VMGuestOS.defaultDiskSizeInGB
     @State private var diskToRemove: StorageDisk?
     @State private var showingRemoveDiskAlert = false
+    @State private var removableMediaToRemove: RemovableMediaItem?
+    @State private var showingRemoveRemovableMediaAlert = false
     @FocusState private var isNameFieldFocused: Bool
 
     private var currentMicPermission: AVAuthorizationStatus {
@@ -157,11 +159,34 @@ struct VMSettingsView: View {
         } message: { disk in
             if disk.isInternal {
                 Text(
-                    "The disk image is stored inside the VM bundle. Move to Trash to delete it, or Remove from VM to delist the entry while keeping the file."
+                    "Move to Trash will send the bundle-owned disk image to the Trash. Remove from VM will delist the entry while keeping the file."
                 )
             } else {
-                Text("This will delist the disk from the VM. The file at \(disk.path) is left alone.")
+                Text(
+                    "Move to Trash will send \(disk.path) to the Trash. Remove from VM will delist the disk and leave the file alone."
+                )
             }
+        }
+        .alert(
+            "Remove \(removableMediaToRemove?.label ?? "Disc")?",
+            isPresented: $showingRemoveRemovableMediaAlert,
+            presenting: removableMediaToRemove
+        ) { item in
+            Button("Move to Trash", role: .destructive) {
+                viewModel.removeRemovableMedia(item, from: instance, trashFile: true)
+                removableMediaToRemove = nil
+            }
+            Button("Remove from VM") {
+                viewModel.removeRemovableMedia(item, from: instance, trashFile: false)
+                removableMediaToRemove = nil
+            }
+            Button("Cancel", role: .cancel) {
+                removableMediaToRemove = nil
+            }
+        } message: { item in
+            Text(
+                "Move to Trash will send \(item.path) to the Trash. Remove from VM will detach the disc and leave the file alone."
+            )
         }
     }
 
@@ -330,7 +355,8 @@ struct VMSettingsView: View {
                             .foregroundStyle(.secondary)
 
                         Button(role: .destructive) {
-                            removableMediaBinding.wrappedValue.removeAll { $0.id == item.id }
+                            removableMediaToRemove = item
+                            showingRemoveRemovableMediaAlert = true
                         } label: {
                             Image(systemName: "minus.circle.fill")
                                 .foregroundStyle(.red)

--- a/Kernova/Views/Sidebar/SidebarView.swift
+++ b/Kernova/Views/Sidebar/SidebarView.swift
@@ -67,8 +67,10 @@ struct SidebarView: View {
         }
     }
 
-    /// Label for the Start context-menu item. Mirrors the toolbar play button
-    /// so the user knows whether clicking will install vs. boot.
+    /// Label for the Start context-menu item.
+    ///
+    /// Mirrors the toolbar play button so the user knows whether clicking will
+    /// install vs. boot.
     private func startButtonLabel(for instance: VMInstance) -> String {
         #if arch(arm64)
         guard instance.configuration.installContext != nil else { return "Start" }

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -26,7 +26,9 @@ extension VMInstance {
 
     /// `true` when this VM has a `.downloadLatest` install context, a
     /// `.resumedata` sidecar at the chosen path, and no completed IPSW yet
-    /// at the same path. Drives the "Resume Install" label variant.
+    /// at the same path.
+    ///
+    /// Drives the "Resume Install" label variant.
     var hasResumableInstallDownload: Bool {
         #if arch(arm64)
         guard let context = configuration.installContext,

--- a/KernovaRelaunchHelper/main.swift
+++ b/KernovaRelaunchHelper/main.swift
@@ -24,7 +24,7 @@ let appPath = CommandLine.arguments[2]
 let appURL = URL(fileURLWithPath: appPath)
 
 guard FileManager.default.fileExists(atPath: appPath) else {
-    logger.error("App bundle not found: \(appPath, privacy: .public)")
+    logger.error("App bundle not found: \(appPath, privacy: .private)")
     exit(1)
 }
 
@@ -79,7 +79,7 @@ func relaunchApp() async {
 
 // MARK: - PID monitoring
 
-logger.notice("Watching PID \(pid, privacy: .public) for exit, will relaunch \(appPath, privacy: .public)")
+logger.notice("Watching PID \(pid, privacy: .public) for exit, will relaunch \(appPath, privacy: .private)")
 
 // Set up the watcher FIRST to close the TOCTOU race window. If the app dies
 // during setup, the source catches it. If it was already dead, the subsequent

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2094,7 +2094,7 @@ struct VMLibraryViewModelTests {
     }
 
     @Test("removeStorageDisk on external disk with trashFile=true trashes the host file")
-    func removeStorageDiskExternalTrashesFile() throws {
+    func removeStorageDiskExternalTrashesFile() async throws {
         let (viewModel, _, _, _, _) = makeViewModel()
         let instance = makeInstance()
         let destination = FileManager.default.temporaryDirectory
@@ -2109,7 +2109,7 @@ struct VMLibraryViewModelTests {
         instance.configuration.storageDisks = [external]
         viewModel.instances.append(instance)
 
-        viewModel.removeStorageDisk(external, from: instance, trashFile: true)
+        await viewModel.removeStorageDisk(external, from: instance, trashFile: true)?.value
 
         #expect(instance.configuration.storageDisks == nil)
         // trashItem moved the file out of its original location.
@@ -2141,7 +2141,7 @@ struct VMLibraryViewModelTests {
     }
 
     @Test("removeStorageDisk with trashFile=true swallows missing-file errors")
-    func removeStorageDiskMissingFileSwallows() {
+    func removeStorageDiskMissingFileSwallows() async {
         // A user can race delete-in-Finder against the confirmation alert,
         // or an external disk's source can be moved between sessions.
         // trashItem failing with `.fileNoSuchFile` should not raise an
@@ -2158,7 +2158,7 @@ struct VMLibraryViewModelTests {
         instance.configuration.storageDisks = [ghost]
         viewModel.instances.append(instance)
 
-        viewModel.removeStorageDisk(ghost, from: instance, trashFile: true)
+        await viewModel.removeStorageDisk(ghost, from: instance, trashFile: true)?.value
 
         #expect(instance.configuration.storageDisks == nil)
         #expect(!viewModel.showError)
@@ -2186,7 +2186,7 @@ struct VMLibraryViewModelTests {
     }
 
     @Test("removeRemovableMedia with trashFile=true trashes the host file")
-    func removeRemovableMediaTrashesFile() throws {
+    func removeRemovableMediaTrashesFile() async throws {
         let (viewModel, _, _, _, _) = makeViewModel()
         let instance = makeInstance()
         let destination = FileManager.default.temporaryDirectory
@@ -2199,7 +2199,7 @@ struct VMLibraryViewModelTests {
         instance.configuration.removableMedia = [item]
         viewModel.instances.append(instance)
 
-        viewModel.removeRemovableMedia(item, from: instance, trashFile: true)
+        await viewModel.removeRemovableMedia(item, from: instance, trashFile: true)?.value
 
         #expect(instance.configuration.removableMedia == nil)
         #expect(!FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
@@ -2207,7 +2207,7 @@ struct VMLibraryViewModelTests {
     }
 
     @Test("removeRemovableMedia with trashFile=true swallows missing-file errors")
-    func removeRemovableMediaMissingFileSwallows() {
+    func removeRemovableMediaMissingFileSwallows() async {
         let (viewModel, _, _, _, _) = makeViewModel()
         let instance = makeInstance()
         let ghostPath = FileManager.default.temporaryDirectory
@@ -2217,7 +2217,7 @@ struct VMLibraryViewModelTests {
         instance.configuration.removableMedia = [item]
         viewModel.instances.append(instance)
 
-        viewModel.removeRemovableMedia(item, from: instance, trashFile: true)
+        await viewModel.removeRemovableMedia(item, from: instance, trashFile: true)?.value
 
         #expect(instance.configuration.removableMedia == nil)
         #expect(!viewModel.showError)

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2148,8 +2148,11 @@ struct VMLibraryViewModelTests {
         // error alert — there's nothing actionable for the user.
         let (viewModel, _, _, _, _) = makeViewModel()
         let instance = makeInstance()
+        let ghostPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kernova-ghost-\(UUID().uuidString).img")
+            .path(percentEncoded: false)
         let ghost = StorageDisk(
-            path: "/var/folders/__kernova_nonexistent/\(UUID().uuidString).img",
+            path: ghostPath,
             readOnly: false, label: "Ghost", isInternal: false, kind: .virtio
         )
         instance.configuration.storageDisks = [ghost]
@@ -2207,9 +2210,10 @@ struct VMLibraryViewModelTests {
     func removeRemovableMediaMissingFileSwallows() {
         let (viewModel, _, _, _, _) = makeViewModel()
         let instance = makeInstance()
-        let item = RemovableMediaItem(
-            path: "/var/folders/__kernova_nonexistent/\(UUID().uuidString).iso",
-            readOnly: true)
+        let ghostPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kernova-ghost-\(UUID().uuidString).iso")
+            .path(percentEncoded: false)
+        let item = RemovableMediaItem(path: ghostPath, readOnly: true)
         instance.configuration.removableMedia = [item]
         viewModel.instances.append(instance)
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2093,15 +2093,17 @@ struct VMLibraryViewModelTests {
         #expect(!viewModel.showError)
     }
 
-    @Test("removeStorageDisk on external disk ignores trashFile flag")
-    func removeStorageDiskExternalIgnoresTrashFlag() {
-        // External disks aren't bundle-owned — the trashFile branch only
-        // applies to `isInternal == true`. Passing `true` for an external
-        // disk should be a no-op for file handling.
+    @Test("removeStorageDisk on external disk with trashFile=true trashes the host file")
+    func removeStorageDiskExternalTrashesFile() throws {
         let (viewModel, _, _, _, _) = makeViewModel()
         let instance = makeInstance()
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-external.img")
+        try Data("payload".utf8).write(to: destination)
+        defer { try? FileManager.default.removeItem(at: destination) }
+
         let external = StorageDisk(
-            path: "/some/host/path/data.img",
+            path: destination.path(percentEncoded: false),
             readOnly: false, label: "External", isInternal: false, kind: .virtio
         )
         instance.configuration.storageDisks = [external]
@@ -2110,7 +2112,110 @@ struct VMLibraryViewModelTests {
         viewModel.removeStorageDisk(external, from: instance, trashFile: true)
 
         #expect(instance.configuration.storageDisks == nil)
-        // No error from a missing-file trash attempt — the branch was skipped.
+        // trashItem moved the file out of its original location.
+        #expect(!FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
+        #expect(!viewModel.showError)
+    }
+
+    @Test("removeStorageDisk on external disk with trashFile=false leaves the host file alone")
+    func removeStorageDiskExternalKeepsFile() throws {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-external.img")
+        try Data("payload".utf8).write(to: destination)
+        defer { try? FileManager.default.removeItem(at: destination) }
+
+        let external = StorageDisk(
+            path: destination.path(percentEncoded: false),
+            readOnly: false, label: "External", isInternal: false, kind: .virtio
+        )
+        instance.configuration.storageDisks = [external]
+        viewModel.instances.append(instance)
+
+        viewModel.removeStorageDisk(external, from: instance, trashFile: false)
+
+        #expect(instance.configuration.storageDisks == nil)
+        #expect(FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
+        #expect(!viewModel.showError)
+    }
+
+    @Test("removeStorageDisk with trashFile=true swallows missing-file errors")
+    func removeStorageDiskMissingFileSwallows() {
+        // A user can race delete-in-Finder against the confirmation alert,
+        // or an external disk's source can be moved between sessions.
+        // trashItem failing with `.fileNoSuchFile` should not raise an
+        // error alert — there's nothing actionable for the user.
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        let ghost = StorageDisk(
+            path: "/var/folders/__kernova_nonexistent/\(UUID().uuidString).img",
+            readOnly: false, label: "Ghost", isInternal: false, kind: .virtio
+        )
+        instance.configuration.storageDisks = [ghost]
+        viewModel.instances.append(instance)
+
+        viewModel.removeStorageDisk(ghost, from: instance, trashFile: true)
+
+        #expect(instance.configuration.storageDisks == nil)
+        #expect(!viewModel.showError)
+    }
+
+    @Test("removeRemovableMedia with trashFile=false removes the entry without touching the file")
+    func removeRemovableMediaKeepsFile() throws {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-media.iso")
+        try Data("payload".utf8).write(to: destination)
+        defer { try? FileManager.default.removeItem(at: destination) }
+
+        let item = RemovableMediaItem(
+            path: destination.path(percentEncoded: false), readOnly: true)
+        instance.configuration.removableMedia = [item]
+        viewModel.instances.append(instance)
+
+        viewModel.removeRemovableMedia(item, from: instance, trashFile: false)
+
+        #expect(instance.configuration.removableMedia == nil)
+        #expect(FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
+        #expect(!viewModel.showError)
+    }
+
+    @Test("removeRemovableMedia with trashFile=true trashes the host file")
+    func removeRemovableMediaTrashesFile() throws {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-media.iso")
+        try Data("payload".utf8).write(to: destination)
+        defer { try? FileManager.default.removeItem(at: destination) }
+
+        let item = RemovableMediaItem(
+            path: destination.path(percentEncoded: false), readOnly: true)
+        instance.configuration.removableMedia = [item]
+        viewModel.instances.append(instance)
+
+        viewModel.removeRemovableMedia(item, from: instance, trashFile: true)
+
+        #expect(instance.configuration.removableMedia == nil)
+        #expect(!FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
+        #expect(!viewModel.showError)
+    }
+
+    @Test("removeRemovableMedia with trashFile=true swallows missing-file errors")
+    func removeRemovableMediaMissingFileSwallows() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        let item = RemovableMediaItem(
+            path: "/var/folders/__kernova_nonexistent/\(UUID().uuidString).iso",
+            readOnly: true)
+        instance.configuration.removableMedia = [item]
+        viewModel.instances.append(instance)
+
+        viewModel.removeRemovableMedia(item, from: instance, trashFile: true)
+
+        #expect(instance.configuration.removableMedia == nil)
         #expect(!viewModel.showError)
     }
 


### PR DESCRIPTION
## Summary
- Removable disc removal in VM Details now opens a three-button confirmation (Move to Trash / Remove from VM / Cancel), matching the existing Storage Disks flow. A misclick on the minus button can no longer hot-eject silently.
- "Move to Trash" on an **external** Storage Disk now actually trashes the host file — previously the destructive-styled button silently no-oped while the alert message claimed the file would be left alone.
- Codebase-wide logging policy fix: full user filesystem paths are no longer logged at `privacy: .public` in persisted log levels. Applied to `ConfigurationBuilder`, `USBDeviceService`, `RelaunchHelper`, and the new `VMLibraryViewModel` methods.

## Changes
- **Feature** (commit 1): Adds `VMLibraryViewModel.removeRemovableMedia(_:from:trashFile:)` mirroring `removeStorageDisk`. Routes config mutation through `updateConfiguration` so existing `applyLiveRemovableMediaChange` hot-detach reconciliation runs for free on running VMs. Trashes unconditionally on `trashFile: true`; swallows `.fileNoSuchFile` / `.fileReadNoSuchFile` at `.notice` so a user-deleted source doesn't raise an unactionable error alert. Rewrites `removeStorageDisk` to drop the `isInternal && trashFile` guard, resolve the file URL conditionally (bundle-relative for internal, absolute for external), and apply the same missing-file swallow. Adds `removableMediaToRemove` / `showingRemoveRemovableMediaAlert` state and a second `.alert(...)` modifier in `VMSettingsView`; rewires the removable-media minus button to present it. Updates the external storage-disc alert message so it no longer claims the file is left alone when Move to Trash is the actual behavior.
- **Logging policy** (commit 2): `ConfigurationBuilder` (`resolveFile` / `resolveDirectory` error branches) switches full-path interpolations to `privacy: .private` so the full path stays available during local debugging but is redacted in collected logs. `USBDeviceService` error branches use `URL(fileURLWithPath: diskImagePath).lastPathComponent` to match the file's own precedent. `KernovaRelaunchHelper` `appPath` interpolations switch to `privacy: .private`. `VMLibraryViewModel` trash logs use `lastPathComponent` since the disk/item label is already in the message.
- **Test hygiene** (commit 3): `removeStorageDiskMissingFileSwallows` and `removeRemovableMediaMissingFileSwallows` now generate the ghost path via `FileManager.default.temporaryDirectory + UUID` instead of a hardcoded `/var/folders/__kernova_nonexistent/...` path. No collision risk.

## Tests
- Adds `removeRemovableMediaKeepsFile`, `removeRemovableMediaTrashesFile`, `removeRemovableMediaMissingFileSwallows`.
- Replaces `removeStorageDiskExternalIgnoresTrashFlag` with `removeStorageDiskExternalTrashesFile` (asserts the trash now actually fires) and adds `removeStorageDiskExternalKeepsFile`.
- Adds `removeStorageDiskMissingFileSwallows`.

## Test plan
- [x] \`make build\`
- [x] \`make test\` (full suite green)
- [ ] Manual smoke (stopped VM): attach an ISO from \`~/Downloads\` as removable media → minus → confirm three-button alert appears → Move to Trash → verify ISO in Trash; re-attach → Remove from VM → verify ISO untouched; Cancel → no change
- [ ] Manual smoke (running VM): repeat the three flows → verify hot-eject completes (no stuck phantom device) and file outcome matches each button
- [ ] Manual smoke (external storage disk): minus → Move to Trash → verify the host file is now actually trashed (behavior change)
- [ ] Manual smoke (missing file): attach removable disc → delete the file in Finder → minus → Move to Trash → no error alert, item removed cleanly

## Notes
- **Behavior change**: external Storage Disks that previously stayed on disk after "Move to Trash" will now be trashed. Matches the button label and the new alert wording.
- Logging policy fix was surfaced during code review of the feature work; bundled here so the inconsistency doesn't persist across the codebase. Sites: 11 in \`ConfigurationBuilder\`, 5 in \`USBDeviceService\`, 2 in \`RelaunchHelper\`, 3 in the new \`VMLibraryViewModel\` code.
- \`RemovableMediaItem\` is unchanged — every entry remains an absolute user-picked path, so the new method has no internal/external branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)