### PR TITLE
chore: Add pre-push hook to run swift-format lint locally

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,8 +13,13 @@ make build               # Build for macOS
 make test                # Run the full test suite (all three test targets via Kernova.xctestplan)
 make test-suite SUITE=KernovaTests/VMConfigurationTests   # Run a single suite
 make test-package        # Run only the KernovaProtocol SwiftPM package tests
+make format              # Rewrite Swift sources in place via swift-format
+make lint                # Check Swift sources with swift-format --strict
+make install-hooks       # One-time: enable .githooks/pre-push (runs `make lint` before push)
 make clean               # Remove DerivedData/
 ```
+
+After cloning, run `make install-hooks` once. This sets `core.hooksPath` to the checked-in `.githooks/` directory so a pre-push hook runs `make lint` locally and matches the swift-format check in `.github/workflows/lint.yml`. Bypass an individual push with `git push --no-verify`.
 
 `make test` is the canonical `xcodebuild` invocation:
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,11 +7,12 @@
 set -euo pipefail
 
 # Skip when nothing real is being pushed (e.g. branch deletion: local sha
-# is all zeros). Each stdin line is: <local-ref> <local-sha> <remote-ref> <remote-sha>
-zero="0000000000000000000000000000000000000000"
+# is all zeros). Each stdin line is: <local-ref> <local-sha> <remote-ref> <remote-sha>.
+# Glob match is hash-agnostic so this works for both SHA-1 (40 chars) and
+# SHA-256 (64 chars) repositories.
 has_work=0
 while read -r _local_ref local_sha _remote_ref _remote_sha; do
-    if [ "$local_sha" != "$zero" ]; then
+    if [[ "$local_sha" == *[!0]* ]]; then
         has_work=1
         break
     fi
@@ -29,6 +30,6 @@ echo "pre-push: running 'make lint' (bypass with git push --no-verify)"
 if ! make lint; then
     echo ""
     echo "pre-push: swift-format lint failed."
-    echo "          Run 'make format' to auto-fix, then re-stage and push again."
+    echo "          Run 'make format' to auto-fix, then commit the changes and push again."
     exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Run `make lint` before pushing. Mirrors the swift-format check that runs
+# in CI (.github/workflows/lint.yml) so formatting failures are caught
+# locally instead of on the PR. Bypass with `git push --no-verify`.
+
+set -euo pipefail
+
+# Skip when nothing real is being pushed (e.g. branch deletion: local sha
+# is all zeros). Each stdin line is: <local-ref> <local-sha> <remote-ref> <remote-sha>
+zero="0000000000000000000000000000000000000000"
+has_work=0
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+    if [ "$local_sha" != "$zero" ]; then
+        has_work=1
+        break
+    fi
+done
+
+if [ "$has_work" -eq 0 ]; then
+    exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+echo "pre-push: running 'make lint' (bypass with git push --no-verify)"
+
+if ! make lint; then
+    echo ""
+    echo "pre-push: swift-format lint failed."
+    echo "          Run 'make format' to auto-fix, then re-stage and push again."
+    exit 1
+fi

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SWIFT_FORMAT      := xcrun swift-format
 SWIFT_SOURCE_DIRS := Kernova KernovaTests KernovaGuestAgent KernovaGuestAgentTests KernovaProtocol KernovaRelaunchHelper
 
 .DEFAULT_GOAL := help
-.PHONY: help build test test-suite test-package clean format lint
+.PHONY: help build test test-suite test-package clean format lint install-hooks
 
 help:
 	@printf 'Kernova build targets:\n\n'
@@ -31,6 +31,7 @@ help:
 	@printf '  make test-package        Run only the KernovaProtocol SwiftPM package tests\n'
 	@printf '  make format              Rewrite Swift sources in place via swift-format\n'
 	@printf '  make lint                Check Swift sources with swift-format (--strict)\n'
+	@printf '  make install-hooks       Point git at .githooks/ (runs lint on pre-push)\n'
 	@printf '  make clean               Remove the DerivedData directory\n'
 
 build:
@@ -57,6 +58,13 @@ format:
 
 lint:
 	$(SWIFT_FORMAT) lint --strict --recursive $(SWIFT_SOURCE_DIRS)
+
+# One-time per clone: point this repo's git at the checked-in hooks so
+# `.githooks/pre-push` runs `make lint` before each push. Per-repo config
+# (no `--global`); bypass an individual push with `git push --no-verify`.
+install-hooks:
+	git config core.hooksPath .githooks
+	@echo 'Hooks installed. Pre-push will now run `make lint`.'
 
 clean:
 	rm -rf $(DERIVED_DATA)


### PR DESCRIPTION
## Summary
- Catch swift-format failures locally before they reach CI, mirroring the `make lint` check that already runs in `.github/workflows/lint.yml`
- Pairs with a planned branch-protection rule on `main` that will make the `swift-format` job a required status check — once that's in place, format failures cannot land in `main` via PR

## Changes
- Add `.githooks/pre-push` that runs `make lint` (skips branch deletes; bypassable with `git push --no-verify`)
- Add `make install-hooks` target that sets `core.hooksPath` to `.githooks/` (per-repo, no `--global`)
- Document the one-time post-clone `make install-hooks` step in `.claude/CLAUDE.md`

## Test plan
- [x] `make install-hooks` wires `core.hooksPath` correctly
- [x] Pre-push hook invokes `make lint` and forwards a non-zero exit
- [x] Pre-push hook is a no-op when only deleting refs
- [x] Hook ran on this branch's push and passed
- [ ] CI `swift-format` job is green on this PR