### PR TITLE
chore: Make `make install-hooks` discoverable on fresh clones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SWIFT_FORMAT      := xcrun swift-format
 SWIFT_SOURCE_DIRS := Kernova KernovaTests KernovaGuestAgent KernovaGuestAgentTests KernovaProtocol KernovaRelaunchHelper
 
 .DEFAULT_GOAL := help
-.PHONY: help build test test-suite test-package clean format lint install-hooks
+.PHONY: help build test test-suite test-package clean format lint install-hooks check-hooks
 
 help:
 	@printf 'Kernova build targets:\n\n'
@@ -34,10 +34,10 @@ help:
 	@printf '  make install-hooks       Point git at .githooks/ (runs lint on pre-push)\n'
 	@printf '  make clean               Remove the DerivedData directory\n'
 
-build:
+build: check-hooks
 	xcodebuild $(XCODEBUILD_FLAGS) build
 
-test:
+test: check-hooks
 	xcodebuild $(XCODEBUILD_FLAGS) test
 
 # `xcrun` so the toolchain matches the one selected via `xcode-select`
@@ -65,6 +65,16 @@ lint:
 install-hooks:
 	git config core.hooksPath .githooks
 	@echo 'Hooks installed. Pre-push will now run `make lint`.'
+
+# Silent when the hook is wired up; otherwise a one-line nudge. Runs as a
+# prerequisite of `build` and `test` so contributors who skipped the
+# install step see the reminder on their first build instead of only when
+# CI fails on their PR.
+check-hooks:
+	@hp=$$(git config --get core.hooksPath 2>/dev/null || true); \
+	if [ "$$hp" != ".githooks" ]; then \
+		printf 'Note: pre-push lint hook is not installed. Run `make install-hooks` (one-time per clone) to catch swift-format issues locally.\n'; \
+	fi
 
 clean:
 	rm -rf $(DERIVED_DATA)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ A macOS GUI application for creating and managing virtual machines using Apple's
 - Xcode 26 or later
 - Swift 6
 
+## Development setup
+
+After cloning, run:
+
+```bash
+make install-hooks
+```
+
+This points the repo at the checked-in `.githooks/` directory so a pre-push hook runs `make lint` locally and matches the swift-format check enforced on `main`. It's a one-time setup per clone (Git does not auto-activate checked-in hooks). Bypass an individual push with `git push --no-verify`.
+
+Other useful Makefile targets: `make build`, `make test`, `make format`, `make lint`. Run `make` with no arguments for the full list.
+
 ## Building
 
 1. Open `Kernova.xcodeproj` in Xcode 26


### PR DESCRIPTION
## Summary
- New contributors don't read `.claude/CLAUDE.md` on their first clone, so the pre-push hook setup step was easy to miss
- Document the step in the README and surface a one-line nudge on `make build` / `make test` when `core.hooksPath` isn't wired up

## Changes
- Add a "Development setup" section to README.md pointing at `make install-hooks` and explaining why Git can't auto-activate checked-in hooks (would be RCE-on-clone)
- Add a `check-hooks` Makefile target that prints a reminder when `core.hooksPath != .githooks`; wire it as a prerequisite of `build` and `test` (silent when installed)
- `check-hooks` is intentionally omitted from `make help` — it's an auto-fired prereq, not something contributors invoke directly

## Test plan
- [x] `make check-hooks` is silent when the hook is installed
- [x] `make check-hooks` prints the reminder when `core.hooksPath` is unset
- [x] Neither path exits non-zero, so it never breaks `build` / `test`
- [ ] CI `swift-format` job is green on this PR