### PR TITLE
chore: Send check-hooks reminder to stderr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ install-hooks:
 check-hooks:
 	@hp=$$(git config --get core.hooksPath 2>/dev/null || true); \
 	if [ "$$hp" != ".githooks" ]; then \
-		printf 'Note: pre-push lint hook is not installed. Run `make install-hooks` (one-time per clone) to catch swift-format issues locally.\n'; \
+		printf 'Note: pre-push lint hook is not installed. Run `make install-hooks` (one-time per clone) to catch swift-format issues locally.\n' >&2; \
 	fi
 
 clean:


### PR DESCRIPTION
## Summary
- Follow-up to #233 (Gemini review nit): diagnostic/auxiliary output belongs on stderr, not stdout
- Keeps the install-hooks reminder out of any pipeline that captures `make build` / `make test` stdout

## Changes
- Append `>&2` to the `printf` in the `check-hooks` Makefile target

## Test plan
- [x] `make check-hooks 2>/dev/null` (hook uninstalled) emits nothing on stdout
- [x] `make check-hooks 2>&1 >/dev/null` (hook uninstalled) emits the note on stderr
- [x] `make check-hooks` (hook installed) remains silent
- [ ] CI `swift-format` job is green on this PR