### PR TITLE
feat: Auto-start VM after wizard creation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -139,7 +139,7 @@ KernovaTests/
 ├── VMToolbarManagerTests.swift          # Toolbar manager item creation and state update tests
 ├── VMConfigurationCloneTests.swift     # Clone-specific configuration tests
 ├── VMLibraryViewModelTests.swift       # 39 tests for the central view model
-├── VMCreationViewModelTests.swift      # 44 tests for the creation wizard
+├── VMCreationViewModelTests.swift      # 49 tests for the creation wizard
 ├── VMLifecycleCoordinatorTests.swift   # Coordinator orchestration tests
 ├── VMInstanceTests.swift               # Runtime instance behavior tests
 ├── ConfigurationBuilderTests.swift     # VZ configuration translation tests
@@ -424,7 +424,7 @@ No third-party (non-Apple) package dependencies. No CocoaPods or Carthage.
 |-----------|-------|-------|
 | `VMConfiguration` | 49+ tests + clone suite | Encoding/decoding, defaults, validation, `lastSeenAgentVersion` migration, `storageDisks` / `removableMedia` round-trip + nil-decode, `liveEditableFieldsChanged` covering hot-toggle booleans + `removableMediaChanged` list-diff, clone regenerates all `StorageDisk.id` / `RemovableMediaItem.id` while preserving paths/labels |
 | `VMLibraryViewModel` | 90+ tests | Add/remove/rename/reorder VMs, selection, auto-select on load, selection preservation on reload, delegation to coordinator, sleep/wake, clone/import phantom rows, cancel preparing, force-stop confirmation, stop escalation timing, custom order persistence, guest agent installer mount/unmount (via the `removableMedia` config path), centralized `updateConfiguration` dispatcher, removable-media list-diff reconcile (add / remove / mutate / reorder-noop / rapid-fire coalesce / `deviceNotFound` continues / `noVirtualMachine` silent bail / transient-error fail-fast), rollback-to-live-state on unexpected detach / attach / swap failure, `removeStorageDisk` trash-vs-remove paths, `createStorageDisk` async append, synthetic main disk removal works against the stable derived UUID, delete-VM external-attachment enumeration (sharing detection across VMs) and the `deleteConfirmed(trashExternals:)` trash-fan-out path |
-| `VMCreationViewModel` | 44 tests | All wizard steps, validation, OS-specific paths |
+| `VMCreationViewModel` | 49 tests | All wizard steps, validation, OS-specific paths, post-creation auto-start preference |
 | `VMLifecycleCoordinator` | Yes | Multi-step orchestration, error handling, service delegation, token-based operation serialization, stop/forceStop bypass, stale-token race condition coverage |
 | `VMInstance` | Yes | Status transitions, configuration updates, bundle layout, preparing state display properties, post-start agent watchdog (firing/cancellation/no-op guards/idempotency), `recordObservedAgentVersion` persistence + dedup |
 | `ConfigurationBuilder` | Yes | All three boot paths, device configuration, path validation (symlinks resolved for external storage disks → VZ gets the followed URL, missing kernel/initrd/ISO/storage-disk, directory rejection, non-writable rejection, internal-path-traversal containment), storage-topology dispatch (`storageDisks` → ordered `storageDevices` with kind-based virtio/USB; `removableMedia` → XHCI; `coldRemovableMedia` `USBDeviceInfo`s match persisted UUIDs), synthesized main-disk UUID is stable across calls and distinct across bundles |

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -65,6 +65,16 @@ final class VMCreationViewModel {
     var diskSizeInGB: Int = 100
     var networkEnabled: Bool = true
 
+    // MARK: - Step 4: Review
+
+    /// Whether to auto-start the VM immediately after the wizard creates it.
+    ///
+    /// When `true` (the default), `VMLibraryViewModel.createVM` calls
+    /// `start(_:)` on the newly created instance so the user can jump
+    /// straight from the wizard into the VM. Backs the "Start this VM
+    /// after creation" toggle on the Review step.
+    var startAfterCreate: Bool = true
+
     // MARK: - Navigation
 
     var validationMessage: String? {

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -239,6 +239,19 @@ final class VMLibraryViewModel {
             Self.logger.notice(
                 "Created VM '\(config.name, privacy: .public)' (status: \(initialStatus.displayName, privacy: .public))"
             )
+
+            if wizard.startAfterCreate {
+                // For macOS VMs with an installContext, `start(_:)` routes
+                // through `installAndAutoBoot` which kicks off an install
+                // Task and returns immediately. For other VMs, it awaits
+                // the VZ start. Errors are surfaced by `start(_:)` via
+                // `presentError`, so the wizard's caller can dismiss as
+                // soon as `createVM` returns.
+                Self.logger.notice(
+                    "Auto-starting VM '\(config.name, privacy: .public)' from wizard"
+                )
+                await start(instance)
+            }
         } catch {
             Self.logger.error("Failed to create VM: \(error.localizedDescription, privacy: .public)")
             presentError(error)

--- a/Kernova/Views/Creation/ReviewStep.swift
+++ b/Kernova/Views/Creation/ReviewStep.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Step 4: Review the VM configuration before creation.
 struct ReviewStep: View {
-    let creationVM: VMCreationViewModel
+    @Bindable var creationVM: VMCreationViewModel
 
     var body: some View {
         VStack(spacing: 24) {
@@ -55,6 +55,10 @@ struct ReviewStep: View {
                             LabeledContent("Kernel", value: URL(fileURLWithPath: path).lastPathComponent)
                         }
                     }
+                }
+
+                Section {
+                    Toggle("Start this VM after creation", isOn: $creationVM.startAfterCreate)
                 }
             }
             .formStyle(.grouped)

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -676,4 +676,12 @@ struct VMCreationViewModelTests {
         #expect(!context.requestedFreshDownload)
     }
     #endif
+
+    // MARK: - Start After Create
+
+    @Test("startAfterCreate defaults to true")
+    func startAfterCreateDefaultsTrue() {
+        let vm = VMCreationViewModel()
+        #expect(vm.startAfterCreate == true)
+    }
 }

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -846,6 +846,57 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.errorMessage != nil)
     }
 
+    @Test("createVM auto-starts the new VM when startAfterCreate is true (default)")
+    func createVMAutoStartsByDefault() async {
+        let (viewModel, _, _, virtService, _) = makeViewModel()
+        let wizard = VMCreationViewModel()
+        wizard.selectedOS = .linux
+        wizard.selectedBootMode = .efi
+        wizard.vmName = "Auto Start VM"
+        // startAfterCreate defaults to true
+
+        await viewModel.createVM(from: wizard)
+
+        #expect(viewModel.instances.count == 1)
+        #expect(virtService.startCallCount == 1)
+        #expect(viewModel.instances.first?.status == .running)
+    }
+
+    @Test("createVM does not auto-start when startAfterCreate is false")
+    func createVMSkipsAutoStartWhenDisabled() async {
+        let (viewModel, _, _, virtService, _) = makeViewModel()
+        let wizard = VMCreationViewModel()
+        wizard.selectedOS = .linux
+        wizard.selectedBootMode = .efi
+        wizard.vmName = "Manual Start VM"
+        wizard.startAfterCreate = false
+
+        await viewModel.createVM(from: wizard)
+
+        #expect(viewModel.instances.count == 1)
+        #expect(virtService.startCallCount == 0)
+        // VM should be in its initial post-creation state, not running
+        #expect(viewModel.instances.first?.status != .running)
+    }
+
+    @Test("createVM does not auto-start when bundle creation fails")
+    func createVMNoAutoStartOnBundleError() async {
+        let storage = MockVMStorageService()
+        storage.createVMBundleError = VMStorageError.bundleAlreadyExists(UUID())
+        let (viewModel, _, _, virtService, _) = makeViewModel(storageService: storage)
+        let wizard = VMCreationViewModel()
+        wizard.selectedOS = .linux
+        wizard.selectedBootMode = .efi
+        wizard.vmName = "Fail Start VM"
+        // startAfterCreate is true by default — but creation fails, so start
+        // must not be called.
+
+        await viewModel.createVM(from: wizard)
+
+        #expect(viewModel.instances.isEmpty)
+        #expect(virtService.startCallCount == 0)
+    }
+
     #if arch(arm64)
     @Test("createVM forwards requestedFreshDownload from a wizard that confirmed overwrite")
     func createVMForwardsRequestedFreshDownload() async throws {


### PR DESCRIPTION
## Summary
- Add a pre-checked "Start this VM after creation" toggle to the Review step of the new-VM wizard so users can jump straight from configuring a new VM into a running one.
- The default is on; unchecking leaves the VM in its post-creation state for the user to start manually later.

## Changes
- `VMCreationViewModel`: new `startAfterCreate: Bool = true` property.
- `ReviewStep`: switches to `@Bindable creationVM` and adds a `Toggle` bound to the new property at the bottom of the form.
- `VMLibraryViewModel.createVM`: after the new instance is appended, persisted, and selected, `await start(instance)` when the flag is set. Routing is unchanged: macOS-install VMs go through `installAndAutoBoot` (kicks off an install Task and returns immediately); Linux/EFI VMs await VZ start. Errors surface via the existing `presentError` path.
- `ARCHITECTURE.md`: surgical bump of the `VMCreationViewModel` test count and a one-phrase note about the new coverage.

## Test plan
- [x] `make lint` clean (also enforced by pre-push hook)
- [x] `make build` succeeds
- [x] `make test` — all suites pass, including:
  - `startAfterCreate defaults to true` (wizard view model)
  - `createVM auto-starts the new VM when startAfterCreate is true (default)`
  - `createVM does not auto-start when startAfterCreate is false`
  - `createVM does not auto-start when bundle creation fails`

## Notes
- The wizard's "Create" button still awaits `createVM` before dismissing. For macOS install (the typical wizard outcome) the auto-start path is essentially instant; for Linux it adds the brief VZ-start window before the sheet closes. This matches how the sidebar Start button already feels and keeps `createVM` testable without yielding to a fire-and-forget Task.