### PR TITLE
fix: De-flake streamBytesCancellation test

### DIFF
--- a/KernovaTests/IPSWServiceDownloadTests.swift
+++ b/KernovaTests/IPSWServiceDownloadTests.swift
@@ -603,12 +603,36 @@ struct IPSWServiceDownloadTests {
 
     @Test("streamBytes throws CancellationError when the surrounding Task is cancelled")
     func streamBytesCancellation() async throws {
-        // We bypass URLSession here — the prior URLProtocol-driven cancellation
-        // test was timing-dependent because URLProtocol cleanup races with
-        // session lifecycle across tests. Driving `streamBytes` directly with
-        // a hand-controlled `AsyncThrowingStream` lets us coordinate cancel +
-        // yield deterministically: the producer yields a chunk to unblock the
-        // for-await, then the next iteration's `Task.checkCancellation()` fires.
+        // We bypass URLSession here — driving `streamBytes` directly with a
+        // hand-controlled `AsyncThrowingStream` keeps URLProtocol cleanup out
+        // of the picture.
+        //
+        // No synchronization with the consumer's for-await suspension is
+        // attempted, on purpose. Earlier revisions tried to use a `SignalGate`
+        // + `AsyncStream` driven off the first `progressHandler` invocation
+        // as a "consumer is now parked on next()" proxy. That proxy was
+        // always a fiction: the initial-progress emission in `streamBytes`
+        // happens *before* the for-await loop is entered, so the signal
+        // raced with the actual suspension and the test flaked when the
+        // race went the wrong way. The synchronization is also unnecessary —
+        // Task cancellation is sticky, and the only legal outcomes of cancel
+        // + yield(non-empty chunk) + finish, regardless of interleaving, all
+        // route through the loop body's `try Task.checkCancellation()` (or
+        // the catch handler that re-throws `CancellationError`):
+        //
+        //   • Consumer hasn't entered the loop yet → it picks up the buffered
+        //     chunk on first `next()`, body runs `checkCancellation()`, throws.
+        //   • Consumer is parked on `next()` → `AsyncThrowingStream.next()`
+        //     doesn't auto-observe cancellation (see RATIONALE in production
+        //     code), so the buffered chunk is delivered, body throws.
+        //   • Consumer is mid-MainActor-hop from initial progress → same as
+        //     the first case after the hop completes.
+        //
+        // If a future refactor removes the in-loop `checkCancellation()`,
+        // none of those paths throw — the chunk gets written, the stream
+        // finishes cleanly, `streamBytes` returns success, and the
+        // `Issue.record("Expected CancellationError")` below fires. That's
+        // the regression this test guards against.
         let temp = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }
         let bundleURL = temp.appendingPathComponent("R.kernovadownload")
@@ -625,33 +649,16 @@ struct IPSWServiceDownloadTests {
         let (stream, continuation) = AsyncThrowingStream<Data, any Error>.makeStream()
         let service = IPSWService()
 
-        // Coordination signal: fires when streamBytes emits its initial-offset
-        // progress, proving it's now sitting inside the for-await waiting for
-        // the next yield.
-        let firstProgress = AsyncStream<Void>.makeStream()
-        let firstProgressContinuation = firstProgress.continuation
-        let signaled = SignalGate()
-
-        let streamTask = Task { [signaled] in
+        let streamTask = Task {
             try await service.streamBytes(
                 from: stream,
                 into: bundle,
                 startingAt: 0,
                 expectedTotal: 4096,
-                progressHandler: { @Sendable [signaled, firstProgressContinuation] _ in
-                    if signaled.fireOnce() {
-                        firstProgressContinuation.yield()
-                        firstProgressContinuation.finish()
-                    }
-                }
+                progressHandler: { _ in }
             )
         }
 
-        // Wait for streamBytes to reach the for-await.
-        for await _ in firstProgress.stream { break }
-
-        // Cancel, then yield one chunk so the loop body wakes and runs its
-        // `try Task.checkCancellation()`.
         streamTask.cancel()
         continuation.yield(Data(repeating: 0xBB, count: 128))
         continuation.finish()
@@ -712,21 +719,6 @@ final class ProgressRecorder {
     private var samples: [Int64] = []
     func record(_ bytes: Int64) { samples.append(bytes) }
     func snapshot() -> [Int64] { samples }
-}
-
-/// One-shot, thread-safe latch used by the cancellation test to fire its
-/// "first progress arrived" signal exactly once even if the handler is
-/// invoked more than once before the test observes the signal.
-final class SignalGate: @unchecked Sendable {
-    private let lock = NSLock()
-    private var fired = false
-    func fireOnce() -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        guard !fired else { return false }
-        fired = true
-        return true
-    }
 }
 
 /// Stub URLProtocol that intercepts requests for tests.


### PR DESCRIPTION
## Summary
- Strips the SignalGate / firstProgress synchronization scaffolding from `IPSWServiceDownloadTests.streamBytesCancellation`. The proxy ("wait for the first progress callback before cancelling") was always a fiction: the initial-progress emission in `streamBytes` happens *before* the for-await loop is entered, so the signal raced with the actual suspension and the test flaked on CI when the race went the wrong way — witnessed on the previous PR's CI run as a `0.000s` failure with no recorded-issue body.

## Why this is the right fix (not just deletion)
The test guards a real, easily-overlooked property: that `streamBytes` responds to `Task.cancel()` despite `AsyncThrowingStream.next()` not auto-observing cancellation. The production code has a dedicated `try Task.checkCancellation()` in the for-await loop *specifically* to provide that responsiveness (with a RATIONALE comment explaining why). Without this test, a future refactor could quietly remove that check and break the multi-GB-IPSW cancel button without anyone noticing.

What the simplified test actually verifies, given Swift's sticky cancellation: with `cancel + yield(non-empty chunk) + finish` issued in any order relative to the consumer's for-await suspension, all three reachable interleavings route through the loop body's `checkCancellation()` (or the catch handler that re-throws `CancellationError`). If a future refactor removes the in-loop check, the chunk gets written, the stream finishes cleanly, `streamBytes` returns success, and the `Issue.record("Expected CancellationError")` assertion fires. The regression we care about is still caught.

The trade-off is intentional looseness: the test no longer pins down *which specific* `checkCancellation()` call inside `streamBytes` fires. Doing that deterministically would require making `streamBytes` generic over `AsyncSequence` so the test could inject a sequence that signals on `next()` — an API change for the sake of one test. Not worth it.

## Changes
- Rewrote `streamBytesCancellation` to drop the synchronization machinery; the new in-test comment block enumerates the three legal orderings and names the production regression the test still guards against.
- Removed the now-unused `SignalGate` helper class.

## Test plan
- [x] `make lint` clean (also enforced by pre-push hook)
- [x] `make build` succeeds
- [x] `make test` — full suite green
- [x] `streamBytesCancellation` run in isolation 30 times — 30/30 PASS