### PR TITLE
feat: Surface missing attachment files in VM settings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,7 +68,8 @@ Kernova/
 │   │   ├── VMSettingsView.swift        # VM configuration editor; mostly read-only when the VM is running, but live-editable fields (clipboard, guest agent, removable media) stay interactive
 │   │   ├── StorageDiskReorderSheet.swift # Modal sheet presenting a native List for reordering storage disks (used because `.onMove` only works in `List`, not in `Form`)
 │   │   ├── StorageDiskSubtitle.swift   # Shared `diskSubtitle(for:in:)` free function used by both VMSettingsView and StorageDiskReorderSheet
-│   │   ├── AttachmentIcon.swift        # Leading-icon helper that swaps SF Symbol for a red warning + tooltip when the attachment's file is missing
+│   │   ├── AttachmentIcon.swift        # Missing-attachment UI primitives: red-triangle Button with click-to-popover (full path + explanation), the bold "Missing —" subtitle helper shared with the reorder sheet, and the popover body
+│   │   ├── CalloutView.swift           # `CalloutBody` shared container for informational popovers (340pt width, top-leading alignment, .callout font) — used by InfoButton, AttachmentIcon's popover, and the mic-permission popover
 │   │   ├── DeleteVMSheet.swift         # Confirmation sheet for deleting a VM that references external storage / removable media; lists each attachment with a "Shared with VM(s)" warning, exposes the "Also move these files to Trash" toggle
 │   │   └── MacOSInstallProgressView.swift # Two-phase install progress (download + install)
 │   ├── Console/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,6 +44,7 @@ Kernova/
 │   ├── VsockClipboardService.swift    # macOS clipboard: vsock-based offer/request/data state machine (@MainActor)
 │   ├── VsockControlService.swift      # macOS always-on control channel: Hello + bidirectional heartbeat, owns AgentStatus (@MainActor, @Observable)
 │   ├── KernovaGuestAgentInfo.swift    # Bundled guest agent version + installer DMG URL accessors
+│   ├── AttachmentFileMonitor.swift    # Reactive existence tracker for external attachments — DispatchSource on each parent dir + NSWorkspace mount notifications (@MainActor, @Observable)
 │   └── Protocols/                      # Service protocol abstractions for DI and testing
 │       ├── VirtualizationProviding.swift
 │       ├── VMStorageProviding.swift
@@ -67,6 +68,7 @@ Kernova/
 │   │   ├── VMSettingsView.swift        # VM configuration editor; mostly read-only when the VM is running, but live-editable fields (clipboard, guest agent, removable media) stay interactive
 │   │   ├── StorageDiskReorderSheet.swift # Modal sheet presenting a native List for reordering storage disks (used because `.onMove` only works in `List`, not in `Form`)
 │   │   ├── StorageDiskSubtitle.swift   # Shared `diskSubtitle(for:in:)` free function used by both VMSettingsView and StorageDiskReorderSheet
+│   │   ├── AttachmentIcon.swift        # Leading-icon helper that swaps SF Symbol for a red warning + tooltip when the attachment's file is missing
 │   │   ├── DeleteVMSheet.swift         # Confirmation sheet for deleting a VM that references external storage / removable media; lists each attachment with a "Shared with VM(s)" warning, exposes the "Also move these files to Trash" toggle
 │   │   └── MacOSInstallProgressView.swift # Two-phase install progress (download + install)
 │   ├── Console/

--- a/Kernova/Services/AttachmentFileMonitor.swift
+++ b/Kernova/Services/AttachmentFileMonitor.swift
@@ -1,0 +1,191 @@
+import AppKit
+import Foundation
+import os
+
+/// Reactive existence tracker for the user-supplied file paths surfaced as
+/// VM attachments (external storage disks, removable media).
+///
+/// The settings view binds to `exists(_:)` to render a missing-file
+/// indicator. Watching avoids both the per-render `fileExists` syscall
+/// and the staleness that comes from only checking on body evaluation:
+///
+/// - Each unique parent directory of a tracked path gets a single
+///   `DispatchSourceFileSystemObject` watching for write / delete /
+///   rename events. On any event we debounce briefly, then re-check
+///   the tracked paths whose parent fired the event.
+/// - `NSWorkspace.didMountNotification` / `didUnmountNotification` trigger
+///   a full refresh so paths on removable volumes flip immediately when
+///   the volume is ejected (FSEvents on the mount point disappears with
+///   the volume itself), and so we can attach a parent watcher we
+///   couldn't open earlier because the volume wasn't mounted yet.
+@MainActor
+@Observable
+final class AttachmentFileMonitor {
+    private static let logger = Logger(subsystem: "com.kernova.app", category: "AttachmentFileMonitor")
+
+    /// Latest known existence flag for each watched path.
+    ///
+    /// Reads inside a SwiftUI `body` register an Observation dependency, so
+    /// updates re-render the row without a synchronous filesystem check.
+    private(set) var existsByPath: [String: Bool] = [:]
+
+    /// Parent directory -> live watcher. `nonisolated(unsafe)` so `deinit`
+    /// can cancel sources; `@ObservationIgnored` keeps the Observation
+    /// macro from synthesizing main-actor-isolated access wrappers around
+    /// this internal bookkeeping (it otherwise re-isolates the storage
+    /// and the directive looks "no-op" to the compiler).
+    @ObservationIgnored
+    nonisolated(unsafe) private var parentSources: [String: DispatchSourceFileSystemObject] = [:]
+
+    /// Parent directory -> tracked paths whose direct parent is that directory.
+    ///
+    /// Enables a targeted re-check on an FS event instead of rescanning every
+    /// tracked path.
+    private var pathsByParent: [String: Set<String>] = [:]
+
+    /// Per-parent debounce so a burst of FS events coalesces into one
+    /// existence re-check.
+    @ObservationIgnored
+    private var debounceTasks: [String: Task<Void, Never>] = [:]
+
+    /// Notification-center tokens for volume mount/unmount observers.
+    ///
+    /// `@ObservationIgnored` + `nonisolated(unsafe)` so `deinit` can hand the
+    /// tokens back to `NSNotificationCenter`; only mutated on the main actor.
+    @ObservationIgnored
+    nonisolated(unsafe) private var volumeObservers: [NSObjectProtocol] = []
+
+    init() {
+        let center = NSWorkspace.shared.notificationCenter
+        for name in [NSWorkspace.didMountNotification, NSWorkspace.didUnmountNotification] {
+            let token = center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                // RATIONALE: `queue: .main` guarantees this fires on the
+                // main thread; `assumeIsolated` lets a `@Sendable` block
+                // call MainActor-isolated state under strict concurrency.
+                MainActor.assumeIsolated {
+                    self?.refreshAll()
+                }
+            }
+            volumeObservers.append(token)
+        }
+    }
+
+    deinit {
+        for source in parentSources.values {
+            source.cancel()
+        }
+        let center = NSWorkspace.shared.notificationCenter
+        for token in volumeObservers {
+            center.removeObserver(token)
+        }
+    }
+
+    /// Latest known existence flag for `path`.
+    ///
+    /// Returns `true` for paths that aren't being watched so the UI does
+    /// not flash a missing-file indicator during the brief window between
+    /// the view appearing and the first `setPaths(_:)` call.
+    func exists(_ path: String) -> Bool {
+        existsByPath[path] ?? true
+    }
+
+    /// Replaces the set of paths being watched.
+    ///
+    /// Idempotent: only diff churn (added / removed paths) triggers FS
+    /// work. Existence flags for newly added paths are populated
+    /// synchronously here so the first row render shows the correct
+    /// state.
+    func setPaths(_ paths: Set<String>) {
+        let nextPaths = paths.filter { !$0.isEmpty }
+        let currentPaths = Set(existsByPath.keys)
+        let added = nextPaths.subtracting(currentPaths)
+        let removed = currentPaths.subtracting(nextPaths)
+
+        for path in removed {
+            existsByPath.removeValue(forKey: path)
+            let parent = (path as NSString).deletingLastPathComponent
+            guard var siblings = pathsByParent[parent] else { continue }
+            siblings.remove(path)
+            if siblings.isEmpty {
+                pathsByParent.removeValue(forKey: parent)
+                parentSources[parent]?.cancel()
+                parentSources.removeValue(forKey: parent)
+                debounceTasks[parent]?.cancel()
+                debounceTasks.removeValue(forKey: parent)
+            } else {
+                pathsByParent[parent] = siblings
+            }
+        }
+
+        for path in added {
+            existsByPath[path] = FileManager.default.fileExists(atPath: path)
+            let parent = (path as NSString).deletingLastPathComponent
+            pathsByParent[parent, default: []].insert(path)
+            if parentSources[parent] == nil {
+                startWatching(parent: parent)
+            }
+        }
+    }
+
+    private func startWatching(parent: String) {
+        let fd = open(parent, O_EVTONLY)
+        guard fd >= 0 else {
+            // Parent directory unreachable (e.g. unmounted volume). Tracked
+            // existence stays `false`; a volume-mount notification will
+            // retry this path's parent.
+            Self.logger.debug(
+                "Could not open parent for monitoring (errno=\(errno, privacy: .public)): \(parent, privacy: .public)"
+            )
+            return
+        }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .delete, .rename],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            self?.scheduleRefresh(for: parent)
+        }
+        source.setCancelHandler {
+            close(fd)
+        }
+        source.resume()
+        parentSources[parent] = source
+
+        Self.logger.debug("Started attachment watcher on \(parent, privacy: .public)")
+    }
+
+    private func scheduleRefresh(for parent: String) {
+        debounceTasks[parent]?.cancel()
+        debounceTasks[parent] = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(250))
+            guard !Task.isCancelled else { return }
+            self?.refreshPaths(in: parent)
+        }
+    }
+
+    private func refreshPaths(in parent: String) {
+        guard let paths = pathsByParent[parent] else { return }
+        for path in paths {
+            let exists = FileManager.default.fileExists(atPath: path)
+            if existsByPath[path] != exists {
+                Self.logger.notice(
+                    "Attachment existence changed: \(path, privacy: .public) -> \(exists, privacy: .public)"
+                )
+                existsByPath[path] = exists
+            }
+        }
+    }
+
+    private func refreshAll() {
+        // After a volume mount/unmount, retry parents we couldn't open
+        // earlier and re-check every tracked path.
+        for parent in pathsByParent.keys {
+            if parentSources[parent] == nil {
+                startWatching(parent: parent)
+            }
+            refreshPaths(in: parent)
+        }
+    }
+}

--- a/Kernova/Services/AttachmentFileMonitor.swift
+++ b/Kernova/Services/AttachmentFileMonitor.swift
@@ -40,7 +40,9 @@ final class AttachmentFileMonitor {
     /// Parent directory -> tracked paths whose direct parent is that directory.
     ///
     /// Enables a targeted re-check on an FS event instead of rescanning every
-    /// tracked path.
+    /// tracked path. `@ObservationIgnored` because nothing outside this class
+    /// reads it — wrapping it in observation accessors would only waste cycles.
+    @ObservationIgnored
     private var pathsByParent: [String: Set<String>] = [:]
 
     /// Per-parent debounce so a burst of FS events coalesces into one
@@ -54,6 +56,16 @@ final class AttachmentFileMonitor {
     /// tokens back to `NSNotificationCenter`; only mutated on the main actor.
     @ObservationIgnored
     nonisolated(unsafe) private var volumeObservers: [NSObjectProtocol] = []
+
+    /// Most recent path set requested via `setPaths(_:)`.
+    ///
+    /// Recorded synchronously at the start of each call so that, after an
+    /// `await` for the off-main existence probe, we can drop work whose
+    /// path the caller has since un-requested. This is the single source of
+    /// truth for "what the UI currently wants tracked" during the window
+    /// when a stale-mount syscall is in flight.
+    @ObservationIgnored
+    private var desiredPaths: Set<String> = []
 
     init() {
         let center = NSWorkspace.shared.notificationCenter
@@ -82,63 +94,119 @@ final class AttachmentFileMonitor {
 
     /// Latest known existence flag for `path`.
     ///
-    /// Returns `true` for paths that aren't being watched so the UI does
-    /// not flash a missing-file indicator during the brief window between
-    /// the view appearing and the first `setPaths(_:)` call.
+    /// Returns `true` for paths whose existence has not yet been determined
+    /// (either never requested via `setPaths(_:)`, or requested but still
+    /// in flight on the off-main probe). The optimistic default means the
+    /// UI does not flash a missing-file indicator while the first probe
+    /// settles.
     func exists(_ path: String) -> Bool {
         existsByPath[path] ?? true
     }
 
     /// Replaces the set of paths being watched.
     ///
-    /// Idempotent: only diff churn (added / removed paths) triggers FS
-    /// work. Existence flags for newly added paths are populated
-    /// synchronously here so the first row render shows the correct
-    /// state.
-    func setPaths(_ paths: Set<String>) {
-        let nextPaths = paths.filter { !$0.isEmpty }
-        let currentPaths = Set(existsByPath.keys)
-        let added = nextPaths.subtracting(currentPaths)
-        let removed = currentPaths.subtracting(nextPaths)
+    /// Idempotent: only diff churn (added / removed paths) triggers FS work.
+    /// The synchronous portion (computing the diff, dropping removed paths,
+    /// cancelling their watchers) runs immediately on the main actor; the
+    /// blocking syscalls (`FileManager.fileExists`, `open(O_EVTONLY)` on
+    /// each new parent directory) run on a detached utility-priority Task
+    /// so a stale network mount cannot freeze the UI.
+    ///
+    /// Concurrent calls coalesce safely: the last call wins for *desired
+    /// state*, and any in-flight probe whose paths have been un-desired by
+    /// a later call has its results discarded on resume.
+    func setPaths(_ paths: Set<String>) async {
+        let next = paths.filter { !$0.isEmpty }
+        desiredPaths = next
 
+        // Drop entries no longer wanted. All in-memory, runs immediately.
+        let removed = Set(existsByPath.keys).subtracting(next)
         for path in removed {
-            existsByPath.removeValue(forKey: path)
-            let parent = (path as NSString).deletingLastPathComponent
-            guard var siblings = pathsByParent[parent] else { continue }
-            siblings.remove(path)
-            if siblings.isEmpty {
-                pathsByParent.removeValue(forKey: parent)
-                parentSources[parent]?.cancel()
-                parentSources.removeValue(forKey: parent)
-                debounceTasks[parent]?.cancel()
-                debounceTasks.removeValue(forKey: parent)
-            } else {
-                pathsByParent[parent] = siblings
-            }
+            detach(path: path)
         }
 
-        for path in added {
-            existsByPath[path] = FileManager.default.fileExists(atPath: path)
-            let parent = (path as NSString).deletingLastPathComponent
-            pathsByParent[parent, default: []].insert(path)
-            if parentSources[parent] == nil {
-                startWatching(parent: parent)
+        // Identify the off-main work needed: any path whose existence we
+        // don't yet know, and any parent directory we don't yet watch.
+        let added = next.subtracting(Set(existsByPath.keys))
+        let newParents = Set(added.map { Self.parent(of: $0) })
+            .subtracting(Set(parentSources.keys))
+        guard !added.isEmpty || !newParents.isEmpty else { return }
+
+        let probe = await Task.detached(priority: .utility) { [added, newParents] in
+            ProbeResult(
+                existence: Dictionary(
+                    uniqueKeysWithValues: added.map {
+                        ($0, FileManager.default.fileExists(atPath: $0))
+                    }
+                ),
+                parentFDs: Dictionary(
+                    uniqueKeysWithValues: newParents.compactMap { parent -> (String, Int32)? in
+                        let fd = open(parent, O_EVTONLY)
+                        return fd >= 0 ? (parent, fd) : nil
+                    }
+                )
+            )
+        }.value
+
+        // Apply results — filtered through the *current* desire so that any
+        // path un-requested during the await is silently dropped.
+        for (path, exists) in probe.existence
+        where desiredPaths.contains(path) && existsByPath[path] == nil {
+            existsByPath[path] = exists
+            pathsByParent[Self.parent(of: path), default: []].insert(path)
+        }
+        for (parent, fd) in probe.parentFDs {
+            // Close the fd if the parent is no longer wanted, or if a
+            // concurrent setPaths already installed a watcher for it.
+            guard pathsByParent[parent] != nil, parentSources[parent] == nil else {
+                close(fd)
+                continue
             }
+            installWatcher(fd: fd, parent: parent)
         }
     }
 
+    /// Tear-down for a single path.
+    ///
+    /// Used by the `setPaths` removal branch (and reserved for future
+    /// targeted removals).
+    private func detach(path: String) {
+        existsByPath.removeValue(forKey: path)
+        let parent = Self.parent(of: path)
+        guard var siblings = pathsByParent[parent] else { return }
+        siblings.remove(path)
+        if siblings.isEmpty {
+            pathsByParent.removeValue(forKey: parent)
+            parentSources[parent]?.cancel()
+            parentSources.removeValue(forKey: parent)
+            debounceTasks[parent]?.cancel()
+            debounceTasks.removeValue(forKey: parent)
+        } else {
+            pathsByParent[parent] = siblings
+        }
+    }
+
+    /// Synchronous watcher attachment.
+    ///
+    /// Used by `refreshAll` after a volume mount notification — the
+    /// directory just became reachable, so `open()` is hot-cache fast.
+    /// `setPaths` instead opens the fd inside its detached probe.
     private func startWatching(parent: String) {
         let fd = open(parent, O_EVTONLY)
         guard fd >= 0 else {
             // Parent directory unreachable (e.g. unmounted volume). Tracked
-            // existence stays `false`; a volume-mount notification will
-            // retry this path's parent.
+            // existence stays `false`; the next mount notification retries.
             Self.logger.debug(
                 "Could not open parent for monitoring (errno=\(errno, privacy: .public)): \(parent, privacy: .public)"
             )
             return
         }
+        installWatcher(fd: fd, parent: parent)
+    }
 
+    /// No-syscall step: takes an already-open `O_EVTONLY` fd and wires it
+    /// into a `DispatchSource` registered against the main queue.
+    private func installWatcher(fd: Int32, parent: String) {
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: fd,
             eventMask: [.write, .delete, .rename],
@@ -154,6 +222,20 @@ final class AttachmentFileMonitor {
         parentSources[parent] = source
 
         Self.logger.debug("Started attachment watcher on \(parent, privacy: .public)")
+    }
+
+    /// Parent directory of `path` as a string.
+    ///
+    /// Wrapping the `NSString` idiom in one place keeps call sites compact.
+    private static func parent(of path: String) -> String {
+        (path as NSString).deletingLastPathComponent
+    }
+
+    /// Result of one off-main probe batch. `Sendable` because the detached
+    /// Task hands it back across actor boundaries.
+    private struct ProbeResult: Sendable {
+        let existence: [String: Bool]
+        let parentFDs: [String: Int32]
     }
 
     private func scheduleRefresh(for parent: String) {

--- a/Kernova/Services/AttachmentFileMonitor.swift
+++ b/Kernova/Services/AttachmentFileMonitor.swift
@@ -71,11 +71,11 @@ final class AttachmentFileMonitor {
     ///
     /// Default implementation hops to a detached utility-priority task and
     /// performs the blocking syscalls (`FileManager.fileExists` and
-    /// `open(O_EVTONLY)` on each new parent) there. Exposed as a mutable
-    /// property so tests can substitute a stub that signals/awaits a
-    /// continuation, making race-coalescing assertions deterministic.
+    /// `open(O_EVTONLY)` on each new parent) there. Tests inject a stub
+    /// via the initializer so race-coalescing assertions can be made
+    /// deterministic.
     @ObservationIgnored
-    var probe: Probe = AttachmentFileMonitor.defaultProbe
+    private let probe: Probe
 
     /// Type of the off-main probe step.
     ///
@@ -83,16 +83,29 @@ final class AttachmentFileMonitor {
     /// a detached task without violating strict concurrency.
     typealias Probe = @Sendable (_ paths: Set<String>, _ parents: Set<String>) async -> ProbeResult
 
-    init() {
+    /// Single-flight coordination for volume mount/unmount refreshes.
+    ///
+    /// `inFlight` is set while a `refreshAll` is running; `pending` is set
+    /// when a new notification arrives during that window. The draining
+    /// loop in `drainRefreshAll` keeps running until no new notifications
+    /// landed during the previous pass, collapsing a burst of mount
+    /// events (one per volume) into a single refresh sweep.
+    @ObservationIgnored
+    private var refreshAllInFlight: Bool = false
+    @ObservationIgnored
+    private var refreshAllPending: Bool = false
+
+    init(probe: @escaping Probe = AttachmentFileMonitor.defaultProbe) {
+        self.probe = probe
         let center = NSWorkspace.shared.notificationCenter
         for name in [NSWorkspace.didMountNotification, NSWorkspace.didUnmountNotification] {
             let token = center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
                 // RATIONALE: `queue: .main` runs the block on the main
                 // thread; spawning an explicitly `@MainActor`-isolated
-                // Task starts the async refresh on the same actor without
-                // an extra hop.
+                // Task lets us call `requestRefreshAll` (sync, MainActor)
+                // without an extra hop.
                 Task { @MainActor [weak self] in
-                    await self?.refreshAll()
+                    self?.requestRefreshAll()
                 }
             }
             volumeObservers.append(token)
@@ -158,21 +171,46 @@ final class AttachmentFileMonitor {
             existsByPath[path] = exists
             pathsByParent[Self.parent(of: path), default: []].insert(path)
         }
+
+        var newlyWatched: [String] = []
         for (parent, fd) in result.parentFDs {
             // Close the fd if the parent is no longer wanted, or if a
             // concurrent setPaths already installed a watcher for it.
+            // `close` can briefly block on a network mount, so hop off
+            // main to release the descriptor.
             guard pathsByParent[parent] != nil, parentSources[parent] == nil else {
-                close(fd)
+                Self.closeOffMain(fd)
                 continue
             }
             installWatcher(fd: fd, parent: parent)
+            newlyWatched.append(parent)
+        }
+
+        // Close the staleness window between the probe's `fileExists` and
+        // the watcher's `source.resume()`: any change that happened in that
+        // gap would be invisible to the freshly-installed source, so do
+        // one more off-main check now that the watcher is live.
+        for parent in newlyWatched {
+            await refreshPaths(in: parent)
+        }
+    }
+
+    /// Releases a file descriptor on a detached utility-priority task.
+    ///
+    /// `close()` can block briefly on a network mount even for an
+    /// `O_EVTONLY` descriptor (the kernel may need to release locks or
+    /// flush state), so every `close` call site hops off the main actor.
+    private static func closeOffMain(_ fd: Int32) {
+        Task.detached(priority: .utility) {
+            close(fd)
         }
     }
 
     /// Default `probe` implementation: runs the blocking syscalls on a
     /// detached utility-priority task so a stale network mount cannot
-    /// freeze the main actor.
-    private static let defaultProbe: Probe = { added, newParents in
+    /// freeze the main actor. `nonisolated` so it can be used as a
+    /// default value for the `init` parameter.
+    nonisolated private static let defaultProbe: Probe = { added, newParents in
         await Task.detached(priority: .utility) { [added, newParents] in
             ProbeResult(
                 existence: Dictionary(
@@ -234,7 +272,7 @@ final class AttachmentFileMonitor {
         // Recheck after the await: the parent could have been dropped
         // or a concurrent caller could have already installed a watcher.
         guard pathsByParent[parent] != nil, parentSources[parent] == nil else {
-            close(fd)
+            Self.closeOffMain(fd)
             return
         }
         installWatcher(fd: fd, parent: parent)
@@ -265,7 +303,12 @@ final class AttachmentFileMonitor {
             self?.scheduleRefresh(for: parent)
         }
         source.setCancelHandler {
-            close(fd)
+            // `setCancelHandler` runs on the source's main queue; spawn
+            // a detached task so the close can't stall the UI if the
+            // underlying mount is slow to respond.
+            Task.detached(priority: .utility) {
+                close(fd)
+            }
         }
         source.resume()
         parentSources[parent] = source
@@ -338,13 +381,37 @@ final class AttachmentFileMonitor {
         }
     }
 
+    /// Entry point from the volume mount/unmount observers.
+    ///
+    /// Coalesces a burst of notifications (one per mounted volume when a
+    /// USB hub or disk image arrives all at once, say) into a single
+    /// refresh sweep. If a refresh is already in flight, sets a "pending"
+    /// flag so the drain loop runs one more pass when the current one
+    /// finishes; otherwise kicks off the drain.
+    private func requestRefreshAll() {
+        refreshAllPending = true
+        guard !refreshAllInFlight else { return }
+        refreshAllInFlight = true
+        Task { @MainActor [weak self] in
+            await self?.drainRefreshAll()
+        }
+    }
+
+    private func drainRefreshAll() async {
+        while refreshAllPending {
+            refreshAllPending = false
+            await runRefreshAllPass()
+        }
+        refreshAllInFlight = false
+    }
+
     /// After a volume mount/unmount, retry parents we couldn't open
     /// earlier and re-check every tracked path.
     ///
     /// Snapshots `pathsByParent.keys` up front so concurrent mutations
     /// during the awaits (a `setPaths` call landing between mount events,
     /// say) can't dereference a missing entry.
-    private func refreshAll() async {
+    private func runRefreshAllPass() async {
         let parents = Array(pathsByParent.keys)
         for parent in parents where pathsByParent[parent] != nil {
             if parentSources[parent] == nil {
@@ -357,4 +424,14 @@ final class AttachmentFileMonitor {
             await refreshPaths(in: parent)
         }
     }
+
+    #if DEBUG
+    /// Snapshot of currently-watched parent directories.
+    ///
+    /// DEBUG-only so tests can verify watcher lifecycle (install / cancel)
+    /// without promoting `parentSources` to internal access.
+    var watchedParentsForTesting: Set<String> {
+        Set(parentSources.keys)
+    }
+    #endif
 }

--- a/Kernova/Services/AttachmentFileMonitor.swift
+++ b/Kernova/Services/AttachmentFileMonitor.swift
@@ -67,15 +67,32 @@ final class AttachmentFileMonitor {
     @ObservationIgnored
     private var desiredPaths: Set<String> = []
 
+    /// Off-main probe step invoked by `setPaths(_:)`.
+    ///
+    /// Default implementation hops to a detached utility-priority task and
+    /// performs the blocking syscalls (`FileManager.fileExists` and
+    /// `open(O_EVTONLY)` on each new parent) there. Exposed as a mutable
+    /// property so tests can substitute a stub that signals/awaits a
+    /// continuation, making race-coalescing assertions deterministic.
+    @ObservationIgnored
+    var probe: Probe = AttachmentFileMonitor.defaultProbe
+
+    /// Type of the off-main probe step.
+    ///
+    /// `@Sendable` so the default implementation can dispatch its body to
+    /// a detached task without violating strict concurrency.
+    typealias Probe = @Sendable (_ paths: Set<String>, _ parents: Set<String>) async -> ProbeResult
+
     init() {
         let center = NSWorkspace.shared.notificationCenter
         for name in [NSWorkspace.didMountNotification, NSWorkspace.didUnmountNotification] {
             let token = center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
-                // RATIONALE: `queue: .main` guarantees this fires on the
-                // main thread; `assumeIsolated` lets a `@Sendable` block
-                // call MainActor-isolated state under strict concurrency.
-                MainActor.assumeIsolated {
-                    self?.refreshAll()
+                // RATIONALE: `queue: .main` runs the block on the main
+                // thread; spawning an explicitly `@MainActor`-isolated
+                // Task starts the async refresh on the same actor without
+                // an extra hop.
+                Task { @MainActor [weak self] in
+                    await self?.refreshAll()
                 }
             }
             volumeObservers.append(token)
@@ -132,7 +149,31 @@ final class AttachmentFileMonitor {
             .subtracting(Set(parentSources.keys))
         guard !added.isEmpty || !newParents.isEmpty else { return }
 
-        let probe = await Task.detached(priority: .utility) { [added, newParents] in
+        let result = await probe(added, newParents)
+
+        // Apply results — filtered through the *current* desire so that any
+        // path un-requested during the await is silently dropped.
+        for (path, exists) in result.existence
+        where desiredPaths.contains(path) && existsByPath[path] == nil {
+            existsByPath[path] = exists
+            pathsByParent[Self.parent(of: path), default: []].insert(path)
+        }
+        for (parent, fd) in result.parentFDs {
+            // Close the fd if the parent is no longer wanted, or if a
+            // concurrent setPaths already installed a watcher for it.
+            guard pathsByParent[parent] != nil, parentSources[parent] == nil else {
+                close(fd)
+                continue
+            }
+            installWatcher(fd: fd, parent: parent)
+        }
+    }
+
+    /// Default `probe` implementation: runs the blocking syscalls on a
+    /// detached utility-priority task so a stale network mount cannot
+    /// freeze the main actor.
+    private static let defaultProbe: Probe = { added, newParents in
+        await Task.detached(priority: .utility) { [added, newParents] in
             ProbeResult(
                 existence: Dictionary(
                     uniqueKeysWithValues: added.map {
@@ -147,23 +188,6 @@ final class AttachmentFileMonitor {
                 )
             )
         }.value
-
-        // Apply results — filtered through the *current* desire so that any
-        // path un-requested during the await is silently dropped.
-        for (path, exists) in probe.existence
-        where desiredPaths.contains(path) && existsByPath[path] == nil {
-            existsByPath[path] = exists
-            pathsByParent[Self.parent(of: path), default: []].insert(path)
-        }
-        for (parent, fd) in probe.parentFDs {
-            // Close the fd if the parent is no longer wanted, or if a
-            // concurrent setPaths already installed a watcher for it.
-            guard pathsByParent[parent] != nil, parentSources[parent] == nil else {
-                close(fd)
-                continue
-            }
-            installWatcher(fd: fd, parent: parent)
-        }
     }
 
     /// Tear-down for a single path.
@@ -186,19 +210,31 @@ final class AttachmentFileMonitor {
         }
     }
 
-    /// Synchronous watcher attachment.
+    /// Async watcher attachment.
     ///
-    /// Used by `refreshAll` after a volume mount notification — the
-    /// directory just became reachable, so `open()` is hot-cache fast.
-    /// `setPaths` instead opens the fd inside its detached probe.
-    private func startWatching(parent: String) {
-        let fd = open(parent, O_EVTONLY)
+    /// Opens the parent directory's `O_EVTONLY` fd on a detached
+    /// utility-priority task — `open()` on a stale network mount can
+    /// block, and we never want that on the main actor. Callers must
+    /// already hold the main actor; this method `await`s the open then
+    /// re-checks invariants before installing the watcher.
+    private func startWatching(parent: String) async {
+        let (fd, openErrno) = await Task.detached(priority: .utility) {
+            let result = open(parent, O_EVTONLY)
+            return (result, errno)
+        }.value
+
         guard fd >= 0 else {
             // Parent directory unreachable (e.g. unmounted volume). Tracked
             // existence stays `false`; the next mount notification retries.
             Self.logger.debug(
-                "Could not open parent for monitoring (errno=\(errno, privacy: .public)): \(parent, privacy: .public)"
+                "Could not open parent for monitoring (errno=\(openErrno, privacy: .public)): \(parent, privacy: .public)"
             )
+            return
+        }
+        // Recheck after the await: the parent could have been dropped
+        // or a concurrent caller could have already installed a watcher.
+        guard pathsByParent[parent] != nil, parentSources[parent] == nil else {
+            close(fd)
             return
         }
         installWatcher(fd: fd, parent: parent)
@@ -206,7 +242,20 @@ final class AttachmentFileMonitor {
 
     /// No-syscall step: takes an already-open `O_EVTONLY` fd and wires it
     /// into a `DispatchSource` registered against the main queue.
+    ///
+    /// Callers must verify `parentSources[parent] == nil` first — if an
+    /// existing source is found we cancel it (closing its fd via the
+    /// cancel handler) to avoid a silent leak, and trap in debug builds
+    /// so the misuse is caught at the call site.
     private func installWatcher(fd: Int32, parent: String) {
+        if let existing = parentSources[parent] {
+            Self.logger.fault(
+                "installWatcher called with an existing source for parent \(parent, privacy: .public)"
+            )
+            assertionFailure("installWatcher: parent already watched: \(parent)")
+            existing.cancel()
+        }
+
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: fd,
             eventMask: [.write, .delete, .rename],
@@ -231,11 +280,24 @@ final class AttachmentFileMonitor {
         (path as NSString).deletingLastPathComponent
     }
 
-    /// Result of one off-main probe batch. `Sendable` because the detached
-    /// Task hands it back across actor boundaries.
-    private struct ProbeResult: Sendable {
+    /// Result of one off-main probe batch.
+    ///
+    /// `Sendable` because the detached probe hands it back across actor
+    /// boundaries. `internal` because the test target injects a custom
+    /// `probe` closure and needs to construct this directly.
+    struct ProbeResult: Sendable {
+        /// Existence flag for each path passed in `paths`.
         let existence: [String: Bool]
+        /// Open `O_EVTONLY` fd for each parent in `parents` that was reachable.
+        ///
+        /// Caller takes ownership and is responsible for closing fds that
+        /// don't get adopted by a watcher.
         let parentFDs: [String: Int32]
+
+        init(existence: [String: Bool], parentFDs: [String: Int32]) {
+            self.existence = existence
+            self.parentFDs = parentFDs
+        }
     }
 
     private func scheduleRefresh(for parent: String) {
@@ -243,14 +305,30 @@ final class AttachmentFileMonitor {
         debounceTasks[parent] = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(250))
             guard !Task.isCancelled else { return }
-            self?.refreshPaths(in: parent)
+            await self?.refreshPaths(in: parent)
         }
     }
 
-    private func refreshPaths(in parent: String) {
-        guard let paths = pathsByParent[parent] else { return }
-        for path in paths {
-            let exists = FileManager.default.fileExists(atPath: path)
+    /// Re-checks every tracked path under `parent` after an FS event.
+    ///
+    /// The `fileExists` syscalls run on a detached utility-priority task
+    /// so an unmount-in-flight (where the path's stat may briefly block)
+    /// cannot stall the main actor. After the probe completes we re-read
+    /// `pathsByParent` to drop any path the caller un-requested mid-await.
+    private func refreshPaths(in parent: String) async {
+        guard let snapshot = pathsByParent[parent] else { return }
+
+        let existence = await Task.detached(priority: .utility) { [snapshot] in
+            Dictionary(
+                uniqueKeysWithValues: snapshot.map {
+                    ($0, FileManager.default.fileExists(atPath: $0))
+                }
+            )
+        }.value
+
+        // Re-check the parent — it may have been emptied during the await.
+        guard let currentPaths = pathsByParent[parent] else { return }
+        for (path, exists) in existence where currentPaths.contains(path) {
             if existsByPath[path] != exists {
                 Self.logger.notice(
                     "Attachment existence changed: \(path, privacy: .public) -> \(exists, privacy: .public)"
@@ -260,14 +338,23 @@ final class AttachmentFileMonitor {
         }
     }
 
-    private func refreshAll() {
-        // After a volume mount/unmount, retry parents we couldn't open
-        // earlier and re-check every tracked path.
-        for parent in pathsByParent.keys {
+    /// After a volume mount/unmount, retry parents we couldn't open
+    /// earlier and re-check every tracked path.
+    ///
+    /// Snapshots `pathsByParent.keys` up front so concurrent mutations
+    /// during the awaits (a `setPaths` call landing between mount events,
+    /// say) can't dereference a missing entry.
+    private func refreshAll() async {
+        let parents = Array(pathsByParent.keys)
+        for parent in parents where pathsByParent[parent] != nil {
             if parentSources[parent] == nil {
-                startWatching(parent: parent)
+                await startWatching(parent: parent)
             }
-            refreshPaths(in: parent)
+            // Re-check after the await: `startWatching` may have hopped
+            // through a detached task during which the parent's last
+            // tracked path could have been dropped.
+            guard pathsByParent[parent] != nil else { continue }
+            await refreshPaths(in: parent)
         }
     }
 }

--- a/Kernova/Views/Detail/AttachmentIcon.swift
+++ b/Kernova/Views/Detail/AttachmentIcon.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Leading icon for an attachment row (storage disk, removable media).
+///
+/// Renders the normal SF Symbol when the backing file is present;
+/// swaps in a red warning triangle with a tooltip when the file is
+/// missing. Centralising the swap keeps the icon contract consistent
+/// across `VMSettingsView`'s storage disk and removable media lists.
+struct AttachmentIcon: View {
+    let systemName: String
+    /// Non-nil only when the file backing the row cannot be found.
+    ///
+    /// The string is shown as the hover tooltip on the warning icon.
+    let missingTooltip: String?
+
+    var body: some View {
+        if let tooltip = missingTooltip {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+                .help(tooltip)
+        } else {
+            Image(systemName: systemName)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/Kernova/Views/Detail/AttachmentIcon.swift
+++ b/Kernova/Views/Detail/AttachmentIcon.swift
@@ -1,5 +1,36 @@
 import SwiftUI
 
+/// Hover tooltip text shown on a missing-attachment icon.
+///
+/// Free-standing so both the settings view and the boot-order reorder
+/// sheet show the same string.
+let missingAttachmentTooltip =
+    "Kernova can't find this file. It may have been moved, renamed, or its volume unmounted."
+
+/// Caption-sized subtitle for an attachment row.
+///
+/// Prefixes a bold "Missing —" when the file backing the row can't be
+/// found so the broken state is obvious without relying on a hover
+/// tooltip (invisible to keyboard users, screen readers, and anyone
+/// glancing at the list). Renders identically across `VMSettingsView`
+/// and `StorageDiskReorderSheet`.
+@ViewBuilder
+func attachmentSubtitle(path: String, isMissing: Bool) -> some View {
+    if isMissing {
+        Text("\(Text("Missing — ").fontWeight(.semibold))\(path)")
+            .font(.caption)
+            .foregroundStyle(.red)
+            .lineLimit(1)
+            .truncationMode(.middle)
+    } else {
+        Text(path)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+    }
+}
+
 /// Leading icon for an attachment row (storage disk, removable media).
 ///
 /// Renders the normal SF Symbol when the backing file is present;
@@ -17,6 +48,11 @@ struct AttachmentIcon: View {
         if let tooltip = missingTooltip {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.red)
+                // RATIONALE: SF Symbols hit-test on their opaque pixels by
+                // default, leaving the corners of a small triangle dead
+                // for `.help`. Expand the hover region to the full
+                // bounding rectangle so the tooltip is reliably reachable.
+                .contentShape(Rectangle())
                 .help(tooltip)
         } else {
             Image(systemName: systemName)

--- a/Kernova/Views/Detail/AttachmentIcon.swift
+++ b/Kernova/Views/Detail/AttachmentIcon.swift
@@ -29,7 +29,7 @@ func attachmentSubtitle(path: String, isMissing: Bool) -> some View {
 /// Renders the normal SF Symbol when the backing file is present;
 /// swaps in a red warning button with a hover tooltip and click-to-open
 /// popover when the file is missing. The popover mirrors the affordance
-/// pattern of [[InfoButton]]: brief hover label, full detail on click.
+/// pattern of `InfoButton`: brief hover label, full detail on click.
 struct AttachmentIcon: View {
     let systemName: String
     /// Absolute path of the missing file, or `nil` when the file is

--- a/Kernova/Views/Detail/AttachmentIcon.swift
+++ b/Kernova/Views/Detail/AttachmentIcon.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Caption-sized subtitle for an attachment row.
@@ -82,16 +83,47 @@ private struct MissingAttachmentPopover: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("Kernova can't find:")
-                Text(path)
-                    .font(.callout.monospaced())
-                    .textSelection(.enabled)
-                    .foregroundStyle(.secondary)
+                WrappingPathLabel(path: path)
             }
 
             Text("It may have been moved, renamed, or its volume unmounted.")
         }
         .font(.callout)
         .padding()
-        .frame(width: 340)
+        .frame(width: 380)
+    }
+}
+
+/// Selectable, monospaced path label that wraps long path-like tokens at
+/// any character.
+///
+/// SwiftUI's `Text` truncates rather than character-wraps when a single
+/// token (an unbroken path component) is wider than its container, so a
+/// path like `/Users/.../some-long-filename.iso` ends with an ellipsis
+/// instead of breaking across lines. `NSTextField` with the
+/// `byCharWrapping` line-break mode does the right thing, so we wrap
+/// one and feed it back to SwiftUI.
+private struct WrappingPathLabel: NSViewRepresentable {
+    let path: String
+
+    func makeNSView(context: Context) -> NSTextField {
+        let field = NSTextField(wrappingLabelWithString: path)
+        field.font = .monospacedSystemFont(
+            ofSize: NSFont.systemFontSize - 1,
+            weight: .regular
+        )
+        field.textColor = .secondaryLabelColor
+        field.cell?.lineBreakMode = .byCharWrapping
+        // Hug the available width; let SwiftUI's frame drive horizontal size,
+        // and grow vertically as the text wraps.
+        field.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return field
+    }
+
+    func updateNSView(_ field: NSTextField, context: Context) {
+        if field.stringValue != path {
+            field.stringValue = path
+        }
     }
 }

--- a/Kernova/Views/Detail/AttachmentIcon.swift
+++ b/Kernova/Views/Detail/AttachmentIcon.swift
@@ -83,47 +83,37 @@ private struct MissingAttachmentPopover: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("Kernova can't find:")
-                WrappingPathLabel(path: path)
+                Text(Self.wrappingPath(path))
+                    .font(.callout.monospaced())
+                    .textSelection(.enabled)
+                    .foregroundStyle(.secondary)
             }
 
             Text("It may have been moved, renamed, or its volume unmounted.")
         }
         .font(.callout)
         .padding()
-        .frame(width: 380)
+        .frame(width: 340)
     }
-}
 
-/// Selectable, monospaced path label that wraps long path-like tokens at
-/// any character.
-///
-/// SwiftUI's `Text` truncates rather than character-wraps when a single
-/// token (an unbroken path component) is wider than its container, so a
-/// path like `/Users/.../some-long-filename.iso` ends with an ellipsis
-/// instead of breaking across lines. `NSTextField` with the
-/// `byCharWrapping` line-break mode does the right thing, so we wrap
-/// one and feed it back to SwiftUI.
-private struct WrappingPathLabel: NSViewRepresentable {
-    let path: String
-
-    func makeNSView(context: Context) -> NSTextField {
-        let field = NSTextField(wrappingLabelWithString: path)
-        field.font = .monospacedSystemFont(
-            ofSize: NSFont.systemFontSize - 1,
-            weight: .regular
+    /// Wraps a filesystem path so SwiftUI's `Text` will break it across
+    /// multiple lines instead of truncating with an ellipsis.
+    ///
+    /// SwiftUI's default `byWordWrapping` only allows breaks at whitespace
+    /// and a few punctuation characters, which leaves a deep path like
+    /// `/Users/.../ubuntu-...-arm64 2.iso` as a single overlong line that
+    /// gets cut. Attaching an `NSParagraphStyle` with `byCharWrapping`
+    /// switches the layout engine to break at any glyph boundary, so the
+    /// full path is always visible inside the popover's fixed-width frame.
+    private static func wrappingPath(_ path: String) -> AttributedString {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = .byCharWrapping
+        let ns = NSMutableAttributedString(string: path)
+        ns.addAttribute(
+            .paragraphStyle,
+            value: paragraphStyle,
+            range: NSRange(location: 0, length: ns.length)
         )
-        field.textColor = .secondaryLabelColor
-        field.cell?.lineBreakMode = .byCharWrapping
-        // Hug the available width; let SwiftUI's frame drive horizontal size,
-        // and grow vertically as the text wraps.
-        field.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        return field
-    }
-
-    func updateNSView(_ field: NSTextField, context: Context) {
-        if field.stringValue != path {
-            field.stringValue = path
-        }
+        return AttributedString(ns)
     }
 }

--- a/Kernova/Views/Detail/AttachmentIcon.swift
+++ b/Kernova/Views/Detail/AttachmentIcon.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 /// Caption-sized subtitle for an attachment row.
@@ -73,7 +72,7 @@ private struct MissingAttachmentPopover: View {
     let path: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        CalloutBody {
             HStack(spacing: 6) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.red)
@@ -81,39 +80,28 @@ private struct MissingAttachmentPopover: View {
                     .font(.headline)
             }
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Kernova can't find:")
-                Text(Self.wrappingPath(path))
-                    .font(.callout.monospaced())
-                    .textSelection(.enabled)
-                    .foregroundStyle(.secondary)
-            }
+            Text("Kernova can't find:")
+
+            Text(Self.wrappingPath(path))
+                .font(.callout.monospaced())
+                .textSelection(.enabled)
+                .foregroundStyle(.secondary)
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
 
             Text("It may have been moved, renamed, or its volume unmounted.")
         }
-        .font(.callout)
-        .padding()
-        .frame(width: 340)
     }
 
     /// Wraps a filesystem path so SwiftUI's `Text` will break it across
     /// multiple lines instead of truncating with an ellipsis.
     ///
-    /// SwiftUI's default `byWordWrapping` only allows breaks at whitespace
-    /// and a few punctuation characters, which leaves a deep path like
-    /// `/Users/.../ubuntu-...-arm64 2.iso` as a single overlong line that
-    /// gets cut. Attaching an `NSParagraphStyle` with `byCharWrapping`
-    /// switches the layout engine to break at any glyph boundary, so the
-    /// full path is always visible inside the popover's fixed-width frame.
-    private static func wrappingPath(_ path: String) -> AttributedString {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineBreakMode = .byCharWrapping
-        let ns = NSMutableAttributedString(string: path)
-        ns.addAttribute(
-            .paragraphStyle,
-            value: paragraphStyle,
-            range: NSRange(location: 0, length: ns.length)
-        )
-        return AttributedString(ns)
+    /// Since SwiftUI's `Text` view ignores `NSParagraphStyle` attributes like
+    /// `lineBreakMode` (it uses its own internal layout engine), we force
+    /// wrapping by inserting zero-width spaces after slashes. This allows the
+    /// path to break at any directory boundary when it hits the edge of the
+    /// popover's fixed-width frame.
+    private static func wrappingPath(_ path: String) -> String {
+        path.replacingOccurrences(of: "/", with: "/\u{200B}")
     }
 }

--- a/Kernova/Views/Detail/AttachmentIcon.swift
+++ b/Kernova/Views/Detail/AttachmentIcon.swift
@@ -1,12 +1,5 @@
 import SwiftUI
 
-/// Hover tooltip text shown on a missing-attachment icon.
-///
-/// Free-standing so both the settings view and the boot-order reorder
-/// sheet show the same string.
-let missingAttachmentTooltip =
-    "Kernova can't find this file. It may have been moved, renamed, or its volume unmounted."
-
 /// Caption-sized subtitle for an attachment row.
 ///
 /// Prefixes a bold "Missing —" when the file backing the row can't be
@@ -34,29 +27,71 @@ func attachmentSubtitle(path: String, isMissing: Bool) -> some View {
 /// Leading icon for an attachment row (storage disk, removable media).
 ///
 /// Renders the normal SF Symbol when the backing file is present;
-/// swaps in a red warning triangle with a tooltip when the file is
-/// missing. Centralising the swap keeps the icon contract consistent
-/// across `VMSettingsView`'s storage disk and removable media lists.
+/// swaps in a red warning button with a hover tooltip and click-to-open
+/// popover when the file is missing. The popover mirrors the affordance
+/// pattern of [[InfoButton]]: brief hover label, full detail on click.
 struct AttachmentIcon: View {
     let systemName: String
-    /// Non-nil only when the file backing the row cannot be found.
+    /// Absolute path of the missing file, or `nil` when the file is
+    /// present.
     ///
-    /// The string is shown as the hover tooltip on the warning icon.
-    let missingTooltip: String?
+    /// When non-`nil`, the icon switches to a red-triangle `Button` that
+    /// opens a popover containing the path (so the user can read it
+    /// untruncated and copy it) and a short explanation.
+    let missingPath: String?
+
+    @State private var isPopoverPresented = false
 
     var body: some View {
-        if let tooltip = missingTooltip {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.red)
-                // RATIONALE: SF Symbols hit-test on their opaque pixels by
-                // default, leaving the corners of a small triangle dead
-                // for `.help`. Expand the hover region to the full
-                // bounding rectangle so the tooltip is reliably reachable.
-                .contentShape(Rectangle())
-                .help(tooltip)
+        if let path = missingPath {
+            Button {
+                isPopoverPresented.toggle()
+            } label: {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
+            .help("File missing")
+            .accessibilityLabel("File missing — show details")
+            .popover(isPresented: $isPopoverPresented, arrowEdge: .bottom) {
+                MissingAttachmentPopover(path: path)
+            }
         } else {
             Image(systemName: systemName)
                 .foregroundStyle(.secondary)
         }
+    }
+}
+
+/// Popover body shown when the user clicks a missing-attachment icon.
+///
+/// Pairs a labelled header with the full untruncated, selectable path and
+/// a one-line explanation of the likely cause. Mirrors the visual rhythm
+/// of `InfoButton`'s callout content.
+private struct MissingAttachmentPopover: View {
+    let path: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+                Text("File Missing")
+                    .font(.headline)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Kernova can't find:")
+                Text(path)
+                    .font(.callout.monospaced())
+                    .textSelection(.enabled)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text("It may have been moved, renamed, or its volume unmounted.")
+        }
+        .font(.callout)
+        .padding()
+        .frame(width: 340)
     }
 }

--- a/Kernova/Views/Detail/AttachmentIcon.swift
+++ b/Kernova/Views/Detail/AttachmentIcon.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Caption-sized subtitle for an attachment row.
@@ -82,26 +83,44 @@ private struct MissingAttachmentPopover: View {
 
             Text("Kernova can't find:")
 
-            Text(Self.wrappingPath(path))
-                .font(.callout.monospaced())
-                .textSelection(.enabled)
-                .foregroundStyle(.secondary)
-                .lineLimit(nil)
-                .fixedSize(horizontal: false, vertical: true)
+            WrappingPathLabel(path: path)
 
             Text("It may have been moved, renamed, or its volume unmounted.")
         }
     }
+}
 
-    /// Wraps a filesystem path so SwiftUI's `Text` will break it across
-    /// multiple lines instead of truncating with an ellipsis.
-    ///
-    /// Since SwiftUI's `Text` view ignores `NSParagraphStyle` attributes like
-    /// `lineBreakMode` (it uses its own internal layout engine), we force
-    /// wrapping by inserting zero-width spaces after slashes. This allows the
-    /// path to break at any directory boundary when it hits the edge of the
-    /// popover's fixed-width frame.
-    private static func wrappingPath(_ path: String) -> String {
-        path.replacingOccurrences(of: "/", with: "/\u{200B}")
+/// Selectable, monospaced path label that character-wraps long components.
+///
+/// SwiftUI's `Text` view ignores `NSParagraphStyle.lineBreakMode`, so the
+/// only ways to wrap a path inside a fixed-width container in pure SwiftUI
+/// are either to inject zero-width spaces into the string (which then get
+/// included when the user copies the text — see review of PR #240) or to
+/// truncate. Wrapping a real `NSTextField` configured with
+/// `byCharWrapping` lets the AppKit layout engine break the string for
+/// display without mutating it, so copy-to-clipboard yields the original
+/// path verbatim.
+private struct WrappingPathLabel: NSViewRepresentable {
+    let path: String
+
+    func makeNSView(context: Context) -> NSTextField {
+        let field = NSTextField(wrappingLabelWithString: path)
+        field.font = .monospacedSystemFont(
+            ofSize: NSFont.systemFontSize - 1,
+            weight: .regular
+        )
+        field.textColor = .secondaryLabelColor
+        field.cell?.lineBreakMode = .byCharWrapping
+        // Let SwiftUI's frame drive horizontal sizing; grow vertically as
+        // the text wraps.
+        field.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return field
+    }
+
+    func updateNSView(_ field: NSTextField, context: Context) {
+        if field.stringValue != path {
+            field.stringValue = path
+        }
     }
 }

--- a/Kernova/Views/Detail/CalloutView.swift
+++ b/Kernova/Views/Detail/CalloutView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Standard container for informational popover content.
 ///
 /// Encapsulates the consistent typography, padding, and width used for callouts
-/// across the app (e.g., [[InfoButton]], [[AttachmentIcon]]).
+/// across the app (e.g., `InfoButton`, `AttachmentIcon`).
 struct CalloutBody<Content: View>: View {
     let content: Content
 

--- a/Kernova/Views/Detail/CalloutView.swift
+++ b/Kernova/Views/Detail/CalloutView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Standard container for informational popover content.
+///
+/// Encapsulates the consistent typography, padding, and width used for callouts
+/// across the app (e.g., [[InfoButton]], [[AttachmentIcon]]).
+struct CalloutBody<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            content
+        }
+        .font(.callout)
+        .padding()
+        .frame(width: 340, alignment: .topLeading)
+    }
+}

--- a/Kernova/Views/Detail/StorageDiskReorderSheet.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheet.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct StorageDiskReorderSheet: View {
     @Binding var disks: [StorageDisk]
     let instance: VMInstance
+    let fileMonitor: AttachmentFileMonitor
 
     @Environment(\.dismiss) private var dismiss
 
@@ -59,14 +60,17 @@ struct StorageDiskReorderSheet: View {
                 .foregroundStyle(.secondary)
                 .accessibilityHidden(true)
 
-            Image(systemName: diskIconSystemName(for: disk))
-                .foregroundStyle(.secondary)
+            let isMissing = !disk.isInternal && !fileMonitor.exists(disk.path)
+            AttachmentIcon(
+                systemName: diskIconSystemName(for: disk),
+                missingTooltip: isMissing ? "File not found at this path" : nil
+            )
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(disk.label)
                 Text(diskSubtitle(for: disk, in: instance))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(isMissing ? .red : .secondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }

--- a/Kernova/Views/Detail/StorageDiskReorderSheet.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheet.swift
@@ -63,7 +63,7 @@ struct StorageDiskReorderSheet: View {
             let isMissing = !disk.isInternal && !fileMonitor.exists(disk.path)
             AttachmentIcon(
                 systemName: diskIconSystemName(for: disk),
-                missingTooltip: isMissing ? missingAttachmentTooltip : nil
+                missingPath: isMissing ? disk.path : nil
             )
 
             VStack(alignment: .leading, spacing: 2) {

--- a/Kernova/Views/Detail/StorageDiskReorderSheet.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheet.swift
@@ -63,16 +63,15 @@ struct StorageDiskReorderSheet: View {
             let isMissing = !disk.isInternal && !fileMonitor.exists(disk.path)
             AttachmentIcon(
                 systemName: diskIconSystemName(for: disk),
-                missingTooltip: isMissing ? "File not found at this path" : nil
+                missingTooltip: isMissing ? missingAttachmentTooltip : nil
             )
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(disk.label)
-                Text(diskSubtitle(for: disk, in: instance))
-                    .font(.caption)
-                    .foregroundStyle(isMissing ? .red : .secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+                attachmentSubtitle(
+                    path: diskSubtitle(for: disk, in: instance),
+                    isMissing: isMissing
+                )
             }
 
             Spacer()

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -932,7 +932,7 @@ struct VMSettingsView: View {
 
     @ViewBuilder
     private var micPermissionInfoPopover: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        CalloutBody {
             Text("Microphone Permission")
                 .font(.headline)
 
@@ -949,14 +949,10 @@ struct VMSettingsView: View {
                 Text("2. Go to **Privacy & Security → Microphone**")
                 Text("3. Enable the toggle for **Kernova**")
             }
-            .font(.callout)
 
             Text("You will need to restart Kernova after granting permission.")
-                .font(.callout)
                 .foregroundStyle(.secondary)
         }
-        .padding()
-        .frame(width: 340)
     }
 }
 
@@ -988,10 +984,9 @@ struct InfoButton<Content: View>: View {
         .help("About \(Text(label))")
         .accessibilityLabel("About \(Text(label))")
         .popover(isPresented: $isPresented, arrowEdge: .bottom) {
-            content()
-                .font(.callout)
-                .padding()
-                .frame(width: 340)
+            CalloutBody {
+                content()
+            }
         }
     }
 }

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -27,6 +27,8 @@ struct VMSettingsView: View {
     @State private var fileMonitor = AttachmentFileMonitor()
     @FocusState private var isNameFieldFocused: Bool
 
+    private static let missingFileTooltip = "File not found at this path"
+
     /// Absolute paths of every user-supplied attachment (external storage disks + removable media).
     ///
     /// Bundle-relative internal disks are excluded — they live inside the
@@ -209,14 +211,12 @@ struct VMSettingsView: View {
             )
         }
         .onAppear {
-            fileMonitor.setPaths(externalAttachmentPaths)
+            Task { await fileMonitor.setPaths(externalAttachmentPaths) }
         }
         .onChange(of: externalAttachmentPaths) { _, newValue in
-            fileMonitor.setPaths(newValue)
+            Task { await fileMonitor.setPaths(newValue) }
         }
     }
-
-    private let missingFileTooltip = "File not found at this path"
 
     @ViewBuilder
     private var readOnlyBanner: some View {
@@ -364,7 +364,7 @@ struct VMSettingsView: View {
                     HStack {
                         AttachmentIcon(
                             systemName: "opticaldisc",
-                            missingTooltip: isMissing ? missingFileTooltip : nil
+                            missingTooltip: isMissing ? Self.missingFileTooltip : nil
                         )
 
                         VStack(alignment: .leading, spacing: 2) {
@@ -526,7 +526,7 @@ struct VMSettingsView: View {
         HStack {
             AttachmentIcon(
                 systemName: diskIconSystemName(for: disk.wrappedValue),
-                missingTooltip: isMissing ? missingFileTooltip : nil
+                missingTooltip: isMissing ? Self.missingFileTooltip : nil
             )
 
             VStack(alignment: .leading, spacing: 2) {

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -24,7 +24,27 @@ struct VMSettingsView: View {
     @State private var showingRemoveDiskAlert = false
     @State private var removableMediaToRemove: RemovableMediaItem?
     @State private var showingRemoveRemovableMediaAlert = false
+    @State private var fileMonitor = AttachmentFileMonitor()
     @FocusState private var isNameFieldFocused: Bool
+
+    /// Absolute paths of every user-supplied attachment (external storage disks + removable media).
+    ///
+    /// Bundle-relative internal disks are excluded — they live inside the
+    /// VM bundle and can't be moved out from under the app.
+    private var externalAttachmentPaths: Set<String> {
+        var paths: Set<String> = []
+        if let disks = instance.configuration.storageDisks {
+            for disk in disks where !disk.isInternal {
+                paths.insert(disk.path)
+            }
+        }
+        if let media = instance.configuration.removableMedia {
+            for item in media {
+                paths.insert(item.path)
+            }
+        }
+        return paths
+    }
 
     private var currentMicPermission: AVAuthorizationStatus {
         AVCaptureDevice.authorizationStatus(for: .audio)
@@ -188,7 +208,15 @@ struct VMSettingsView: View {
                 "Move to Trash will send \(item.path) to the Trash. Remove from VM will detach the disc and leave the file alone."
             )
         }
+        .onAppear {
+            fileMonitor.setPaths(externalAttachmentPaths)
+        }
+        .onChange(of: externalAttachmentPaths) { _, newValue in
+            fileMonitor.setPaths(newValue)
+        }
     }
+
+    private let missingFileTooltip = "File not found at this path"
 
     @ViewBuilder
     private var readOnlyBanner: some View {
@@ -332,15 +360,18 @@ struct VMSettingsView: View {
                     .foregroundStyle(.secondary)
             } else {
                 ForEach(removableMediaBinding) { $item in
+                    let isMissing = !fileMonitor.exists(item.path)
                     HStack {
-                        Image(systemName: "opticaldisc")
-                            .foregroundStyle(.secondary)
+                        AttachmentIcon(
+                            systemName: "opticaldisc",
+                            missingTooltip: isMissing ? missingFileTooltip : nil
+                        )
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(item.label)
                             Text(item.path)
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(isMissing ? .red : .secondary)
                                 .lineLimit(1)
                                 .truncationMode(.middle)
                         }
@@ -480,22 +511,29 @@ struct VMSettingsView: View {
             }
             .disabled(isReadOnly)
             .sheet(isPresented: $showingReorderDisksSheet) {
-                StorageDiskReorderSheet(disks: storageDiskBinding, instance: instance)
+                StorageDiskReorderSheet(
+                    disks: storageDiskBinding,
+                    instance: instance,
+                    fileMonitor: fileMonitor
+                )
             }
         }
     }
 
     @ViewBuilder
     private func storageDiskRow(disk: Binding<StorageDisk>) -> some View {
+        let isMissing = !disk.wrappedValue.isInternal && !fileMonitor.exists(disk.wrappedValue.path)
         HStack {
-            Image(systemName: diskIconSystemName(for: disk.wrappedValue))
-                .foregroundStyle(.secondary)
+            AttachmentIcon(
+                systemName: diskIconSystemName(for: disk.wrappedValue),
+                missingTooltip: isMissing ? missingFileTooltip : nil
+            )
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(disk.wrappedValue.label)
                 Text(diskSubtitle(for: disk.wrappedValue, in: instance))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(isMissing ? .red : .secondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -27,8 +27,6 @@ struct VMSettingsView: View {
     @State private var fileMonitor = AttachmentFileMonitor()
     @FocusState private var isNameFieldFocused: Bool
 
-    private static let missingFileTooltip = "File not found at this path"
-
     /// Absolute paths of every user-supplied attachment (external storage disks + removable media).
     ///
     /// Bundle-relative internal disks are excluded — they live inside the
@@ -364,16 +362,12 @@ struct VMSettingsView: View {
                     HStack {
                         AttachmentIcon(
                             systemName: "opticaldisc",
-                            missingTooltip: isMissing ? Self.missingFileTooltip : nil
+                            missingTooltip: isMissing ? missingAttachmentTooltip : nil
                         )
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(item.label)
-                            Text(item.path)
-                                .font(.caption)
-                                .foregroundStyle(isMissing ? .red : .secondary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
+                            attachmentSubtitle(path: item.path, isMissing: isMissing)
                         }
 
                         Spacer()
@@ -526,16 +520,15 @@ struct VMSettingsView: View {
         HStack {
             AttachmentIcon(
                 systemName: diskIconSystemName(for: disk.wrappedValue),
-                missingTooltip: isMissing ? Self.missingFileTooltip : nil
+                missingTooltip: isMissing ? missingAttachmentTooltip : nil
             )
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(disk.wrappedValue.label)
-                Text(diskSubtitle(for: disk.wrappedValue, in: instance))
-                    .font(.caption)
-                    .foregroundStyle(isMissing ? .red : .secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+                attachmentSubtitle(
+                    path: diskSubtitle(for: disk.wrappedValue, in: instance),
+                    isMissing: isMissing
+                )
             }
 
             Spacer()

--- a/Kernova/Views/Detail/VMSettingsView.swift
+++ b/Kernova/Views/Detail/VMSettingsView.swift
@@ -362,7 +362,7 @@ struct VMSettingsView: View {
                     HStack {
                         AttachmentIcon(
                             systemName: "opticaldisc",
-                            missingTooltip: isMissing ? missingAttachmentTooltip : nil
+                            missingPath: isMissing ? item.path : nil
                         )
 
                         VStack(alignment: .leading, spacing: 2) {
@@ -520,7 +520,7 @@ struct VMSettingsView: View {
         HStack {
             AttachmentIcon(
                 systemName: diskIconSystemName(for: disk.wrappedValue),
-                missingTooltip: isMissing ? missingAttachmentTooltip : nil
+                missingPath: isMissing ? disk.wrappedValue.path : nil
             )
 
             VStack(alignment: .leading, spacing: 2) {

--- a/KernovaTests/AttachmentFileMonitorTests.swift
+++ b/KernovaTests/AttachmentFileMonitorTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("AttachmentFileMonitor")
+@MainActor
+struct AttachmentFileMonitorTests {
+    // MARK: - Helpers
+
+    /// Creates a fresh temp directory and registers a cleanup with the
+    /// returned closure (call from a `defer`).
+    private func makeTempDir() throws -> (url: URL, cleanup: () -> Void) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kernova-monitor-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return (url, { try? FileManager.default.removeItem(at: url) })
+    }
+
+    private func path(in dir: URL, _ name: String) -> String {
+        dir.appendingPathComponent(name).path(percentEncoded: false)
+    }
+
+    // MARK: - setPaths
+
+    @Test("setPaths populates existsByPath synchronously for present and missing files")
+    func setPathsPopulatesSynchronously() throws {
+        let tmp = try makeTempDir()
+        defer { tmp.cleanup() }
+
+        let present = path(in: tmp.url, "present.iso")
+        FileManager.default.createFile(atPath: present, contents: Data([0]))
+        let missing = path(in: tmp.url, "missing.iso")
+
+        let monitor = AttachmentFileMonitor()
+        monitor.setPaths([present, missing])
+
+        #expect(monitor.exists(present) == true)
+        #expect(monitor.exists(missing) == false)
+    }
+
+    @Test("exists returns true for paths that have never been set")
+    func existsDefaultsToTrueForUnwatched() {
+        let monitor = AttachmentFileMonitor()
+        #expect(monitor.exists("/not/being/watched") == true)
+    }
+
+    @Test("Empty path strings are ignored")
+    func emptyPathsAreIgnored() throws {
+        let tmp = try makeTempDir()
+        defer { tmp.cleanup() }
+        let present = path(in: tmp.url, "present.iso")
+        FileManager.default.createFile(atPath: present, contents: Data([0]))
+
+        let monitor = AttachmentFileMonitor()
+        monitor.setPaths([present, ""])
+
+        #expect(monitor.existsByPath.keys.contains("") == false)
+        #expect(monitor.exists(present) == true)
+    }
+
+    @Test("setPaths diff removes dropped paths from the map")
+    func setPathsRemovesDroppedPaths() throws {
+        let tmp = try makeTempDir()
+        defer { tmp.cleanup() }
+        let a = path(in: tmp.url, "a.iso")
+        let b = path(in: tmp.url, "b.iso")
+        FileManager.default.createFile(atPath: a, contents: Data([0]))
+        FileManager.default.createFile(atPath: b, contents: Data([0]))
+
+        let monitor = AttachmentFileMonitor()
+        monitor.setPaths([a, b])
+        #expect(Set(monitor.existsByPath.keys) == [a, b])
+
+        monitor.setPaths([a])
+        #expect(Set(monitor.existsByPath.keys) == [a])
+        #expect(monitor.exists(b) == true, "Dropped path falls back to the unwatched default")
+    }
+
+    // MARK: - FS event reactivity
+
+    @Test("File creation in a watched directory flips exists to true")
+    func reactsToFileCreation() async throws {
+        let tmp = try makeTempDir()
+        defer { tmp.cleanup() }
+        let target = path(in: tmp.url, "appears.iso")
+
+        let monitor = AttachmentFileMonitor()
+        monitor.setPaths([target])
+        #expect(monitor.exists(target) == false)
+
+        FileManager.default.createFile(atPath: target, contents: Data([0]))
+
+        try await waitUntil(timeout: .seconds(5)) {
+            monitor.exists(target) == true
+        }
+    }
+
+    @Test("File deletion in a watched directory flips exists to false")
+    func reactsToFileDeletion() async throws {
+        let tmp = try makeTempDir()
+        defer { tmp.cleanup() }
+        let target = path(in: tmp.url, "vanishes.iso")
+        FileManager.default.createFile(atPath: target, contents: Data([0]))
+
+        let monitor = AttachmentFileMonitor()
+        monitor.setPaths([target])
+        #expect(monitor.exists(target) == true)
+
+        try FileManager.default.removeItem(atPath: target)
+
+        try await waitUntil(timeout: .seconds(5)) {
+            monitor.exists(target) == false
+        }
+    }
+}

--- a/KernovaTests/AttachmentFileMonitorTests.swift
+++ b/KernovaTests/AttachmentFileMonitorTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Synchronization
 import Testing
 
 @testable import Kernova
@@ -132,6 +133,52 @@ struct AttachmentFileMonitorTests {
 
     // MARK: - Race coalescing
 
+    /// Stateful probe stub for the race-coalescing test.
+    ///
+    /// The first call blocks on `release`; every subsequent call returns
+    /// immediately. Sharing one probe across the monitor's lifetime lets
+    /// `AttachmentFileMonitor` accept it via init injection (as the only
+    /// way to install a probe) while still letting the test interleave
+    /// two `setPaths` calls deterministically.
+    private final class RaceStubProbe: Sendable {
+        let started: AsyncStream<Void>
+        private let startedContinuation: AsyncStream<Void>.Continuation
+        let release: AsyncStream<Void>
+        private let releaseContinuation: AsyncStream<Void>.Continuation
+        /// `true` until the first call consumes it.
+        ///
+        /// Subsequent calls see `false` and skip the blocking branch.
+        private let isFirstCallPending: Mutex<Bool> = Mutex(true)
+
+        init() {
+            (self.started, self.startedContinuation) = AsyncStream<Void>.makeStream()
+            (self.release, self.releaseContinuation) = AsyncStream<Void>.makeStream()
+        }
+
+        var probe: AttachmentFileMonitor.Probe {
+            { [self] added, _ in
+                let isFirst = self.isFirstCallPending.withLock { pending in
+                    let wasFirst = pending
+                    pending = false
+                    return wasFirst
+                }
+                if isFirst {
+                    self.startedContinuation.yield()
+                    for await _ in self.release { break }
+                }
+                return AttachmentFileMonitor.ProbeResult(
+                    existence: Dictionary(uniqueKeysWithValues: added.map { ($0, true) }),
+                    parentFDs: [:]
+                )
+            }
+        }
+
+        func releaseFirstProbe() {
+            releaseContinuation.yield()
+            releaseContinuation.finish()
+        }
+    }
+
     @Test("In-flight probe results are discarded when a later setPaths un-requests their paths")
     func inFlightProbeDiscardedOnSupersedingCall() async throws {
         let tmp = try makeTempDir()
@@ -141,45 +188,22 @@ struct AttachmentFileMonitorTests {
         FileManager.default.createFile(atPath: a, contents: Data([0]))
         FileManager.default.createFile(atPath: b, contents: Data([0]))
 
-        let monitor = AttachmentFileMonitor()
-
-        // Channels that drive deterministic interleaving: the test waits
-        // for `probeStarted` after kicking off the first setPaths, then
-        // sends on `release` to let the first probe finish.
-        let probeStarted = AsyncStream<Void>.makeStream()
-        let release = AsyncStream<Void>.makeStream()
-
-        // Stub probe used only by the first call. Skips fd allocation
-        // (parentFDs is empty) so we don't have to manage real fds in
-        // the test.
-        monitor.probe = { added, _ in
-            probeStarted.continuation.yield()
-            for await _ in release.stream { break }
-            return AttachmentFileMonitor.ProbeResult(
-                existence: Dictionary(uniqueKeysWithValues: added.map { ($0, true) }),
-                parentFDs: [:]
-            )
-        }
+        let stub = RaceStubProbe()
+        let monitor = AttachmentFileMonitor(probe: stub.probe)
 
         // Kick off the first call in the background; it suspends inside
         // the probe waiting on `release`.
         let firstCall = Task { await monitor.setPaths([a]) }
-        for await _ in probeStarted.stream { break }
+        for await _ in stub.started { break }
 
-        // Swap to a non-blocking probe and make the superseding call.
-        monitor.probe = { added, _ in
-            AttachmentFileMonitor.ProbeResult(
-                existence: Dictionary(uniqueKeysWithValues: added.map { ($0, true) }),
-                parentFDs: [:]
-            )
-        }
+        // While the first call is parked in its probe, make a superseding
+        // call. The stub returns immediately for every non-first call.
         await monitor.setPaths([b])
         #expect(monitor.exists(b) == true, "Superseding call applies its own probe")
 
         // Let the first probe complete. Its apply step should drop the
         // result for `a` because `desiredPaths` is now `[b]`.
-        release.continuation.yield()
-        release.continuation.finish()
+        stub.releaseFirstProbe()
         await firstCall.value
 
         #expect(monitor.exists(a) == true, "Un-desired path returns the unwatched default")
@@ -191,37 +215,34 @@ struct AttachmentFileMonitorTests {
 
     // MARK: - Watcher / fd lifecycle
 
-    @Test("Dropping a path cancels its parent watcher so no further FS events fire")
+    @Test("Dropping a path cancels its parent watcher and removes it from the watch set")
     func droppingPathTearsDownWatcher() async throws {
         let tmp = try makeTempDir()
         defer { tmp.cleanup() }
         let target = path(in: tmp.url, "target.iso")
         FileManager.default.createFile(atPath: target, contents: Data([0]))
 
+        // Compute the parent the same way the monitor does internally
+        // (NSString.deletingLastPathComponent) so the string comparison
+        // is exact regardless of URL trailing-slash quirks.
+        let expectedParent = (target as NSString).deletingLastPathComponent
+
         let monitor = AttachmentFileMonitor()
         await monitor.setPaths([target])
         #expect(monitor.exists(target) == true)
+        #expect(
+            monitor.watchedParentsForTesting.contains(expectedParent),
+            "Watcher should be installed for the parent directory while the path is tracked"
+        )
 
-        // Drop the path. detach() cancels the DispatchSource, which
-        // fires its setCancelHandler { close(fd) } and removes the
-        // entry from parentSources.
+        // Drop the path. detach() cancels the DispatchSource (which fires
+        // setCancelHandler { close(fd) }) and removes the entry from
+        // parentSources.
         await monitor.setPaths([])
         #expect(monitor.existsByPath.isEmpty)
-
-        // Mutate the previously-watched directory and wait well past
-        // the debounce window. If the watcher had leaked, its handler
-        // would re-fire and write back into existsByPath; with the
-        // watcher torn down, no such write happens.
-        try FileManager.default.removeItem(atPath: target)
-        try await Task.sleep(for: .milliseconds(500))
-
         #expect(
-            monitor.existsByPath.isEmpty,
-            "No state changes should occur after the path is dropped — the watcher is gone"
-        )
-        #expect(
-            monitor.exists(target) == true,
-            "Untracked path falls back to the optimistic default"
+            monitor.watchedParentsForTesting.isEmpty,
+            "Watcher should be removed from the watch set when its last path is dropped"
         )
     }
 }

--- a/KernovaTests/AttachmentFileMonitorTests.swift
+++ b/KernovaTests/AttachmentFileMonitorTests.swift
@@ -129,4 +129,99 @@ struct AttachmentFileMonitorTests {
             monitor.exists(target) == false
         }
     }
+
+    // MARK: - Race coalescing
+
+    @Test("In-flight probe results are discarded when a later setPaths un-requests their paths")
+    func inFlightProbeDiscardedOnSupersedingCall() async throws {
+        let tmp = try makeTempDir()
+        defer { tmp.cleanup() }
+        let a = path(in: tmp.url, "a.iso")
+        let b = path(in: tmp.url, "b.iso")
+        FileManager.default.createFile(atPath: a, contents: Data([0]))
+        FileManager.default.createFile(atPath: b, contents: Data([0]))
+
+        let monitor = AttachmentFileMonitor()
+
+        // Channels that drive deterministic interleaving: the test waits
+        // for `probeStarted` after kicking off the first setPaths, then
+        // sends on `release` to let the first probe finish.
+        let probeStarted = AsyncStream<Void>.makeStream()
+        let release = AsyncStream<Void>.makeStream()
+
+        // Stub probe used only by the first call. Skips fd allocation
+        // (parentFDs is empty) so we don't have to manage real fds in
+        // the test.
+        monitor.probe = { added, _ in
+            probeStarted.continuation.yield()
+            for await _ in release.stream { break }
+            return AttachmentFileMonitor.ProbeResult(
+                existence: Dictionary(uniqueKeysWithValues: added.map { ($0, true) }),
+                parentFDs: [:]
+            )
+        }
+
+        // Kick off the first call in the background; it suspends inside
+        // the probe waiting on `release`.
+        let firstCall = Task { await monitor.setPaths([a]) }
+        for await _ in probeStarted.stream { break }
+
+        // Swap to a non-blocking probe and make the superseding call.
+        monitor.probe = { added, _ in
+            AttachmentFileMonitor.ProbeResult(
+                existence: Dictionary(uniqueKeysWithValues: added.map { ($0, true) }),
+                parentFDs: [:]
+            )
+        }
+        await monitor.setPaths([b])
+        #expect(monitor.exists(b) == true, "Superseding call applies its own probe")
+
+        // Let the first probe complete. Its apply step should drop the
+        // result for `a` because `desiredPaths` is now `[b]`.
+        release.continuation.yield()
+        release.continuation.finish()
+        await firstCall.value
+
+        #expect(monitor.exists(a) == true, "Un-desired path returns the unwatched default")
+        #expect(
+            Set(monitor.existsByPath.keys) == [b],
+            "Only the final desired path should be in the map"
+        )
+    }
+
+    // MARK: - Watcher / fd lifecycle
+
+    @Test("Dropping a path cancels its parent watcher so no further FS events fire")
+    func droppingPathTearsDownWatcher() async throws {
+        let tmp = try makeTempDir()
+        defer { tmp.cleanup() }
+        let target = path(in: tmp.url, "target.iso")
+        FileManager.default.createFile(atPath: target, contents: Data([0]))
+
+        let monitor = AttachmentFileMonitor()
+        await monitor.setPaths([target])
+        #expect(monitor.exists(target) == true)
+
+        // Drop the path. detach() cancels the DispatchSource, which
+        // fires its setCancelHandler { close(fd) } and removes the
+        // entry from parentSources.
+        await monitor.setPaths([])
+        #expect(monitor.existsByPath.isEmpty)
+
+        // Mutate the previously-watched directory and wait well past
+        // the debounce window. If the watcher had leaked, its handler
+        // would re-fire and write back into existsByPath; with the
+        // watcher torn down, no such write happens.
+        try FileManager.default.removeItem(atPath: target)
+        try await Task.sleep(for: .milliseconds(500))
+
+        #expect(
+            monitor.existsByPath.isEmpty,
+            "No state changes should occur after the path is dropped — the watcher is gone"
+        )
+        #expect(
+            monitor.exists(target) == true,
+            "Untracked path falls back to the optimistic default"
+        )
+    }
 }

--- a/KernovaTests/AttachmentFileMonitorTests.swift
+++ b/KernovaTests/AttachmentFileMonitorTests.swift
@@ -23,8 +23,8 @@ struct AttachmentFileMonitorTests {
 
     // MARK: - setPaths
 
-    @Test("setPaths populates existsByPath synchronously for present and missing files")
-    func setPathsPopulatesSynchronously() throws {
+    @Test("setPaths populates existsByPath once it returns for present and missing files")
+    func setPathsPopulatesAfterAwait() async throws {
         let tmp = try makeTempDir()
         defer { tmp.cleanup() }
 
@@ -33,9 +33,25 @@ struct AttachmentFileMonitorTests {
         let missing = path(in: tmp.url, "missing.iso")
 
         let monitor = AttachmentFileMonitor()
-        monitor.setPaths([present, missing])
+        await monitor.setPaths([present, missing])
 
         #expect(monitor.exists(present) == true)
+        #expect(monitor.exists(missing) == false)
+    }
+
+    @Test("exists defaults to true between calling setPaths and the await returning")
+    func existsIsOptimisticDuringProbe() async throws {
+        let tmp = try makeTempDir()
+        defer { tmp.cleanup() }
+        let missing = path(in: tmp.url, "missing.iso")
+
+        let monitor = AttachmentFileMonitor()
+        // Read exists() before setPaths has had a chance to populate.
+        #expect(monitor.exists(missing) == true)
+
+        await monitor.setPaths([missing])
+        // After the await, the probe has settled and the missing file
+        // reads as missing.
         #expect(monitor.exists(missing) == false)
     }
 
@@ -46,21 +62,21 @@ struct AttachmentFileMonitorTests {
     }
 
     @Test("Empty path strings are ignored")
-    func emptyPathsAreIgnored() throws {
+    func emptyPathsAreIgnored() async throws {
         let tmp = try makeTempDir()
         defer { tmp.cleanup() }
         let present = path(in: tmp.url, "present.iso")
         FileManager.default.createFile(atPath: present, contents: Data([0]))
 
         let monitor = AttachmentFileMonitor()
-        monitor.setPaths([present, ""])
+        await monitor.setPaths([present, ""])
 
         #expect(monitor.existsByPath.keys.contains("") == false)
         #expect(monitor.exists(present) == true)
     }
 
     @Test("setPaths diff removes dropped paths from the map")
-    func setPathsRemovesDroppedPaths() throws {
+    func setPathsRemovesDroppedPaths() async throws {
         let tmp = try makeTempDir()
         defer { tmp.cleanup() }
         let a = path(in: tmp.url, "a.iso")
@@ -69,10 +85,10 @@ struct AttachmentFileMonitorTests {
         FileManager.default.createFile(atPath: b, contents: Data([0]))
 
         let monitor = AttachmentFileMonitor()
-        monitor.setPaths([a, b])
+        await monitor.setPaths([a, b])
         #expect(Set(monitor.existsByPath.keys) == [a, b])
 
-        monitor.setPaths([a])
+        await monitor.setPaths([a])
         #expect(Set(monitor.existsByPath.keys) == [a])
         #expect(monitor.exists(b) == true, "Dropped path falls back to the unwatched default")
     }
@@ -86,7 +102,7 @@ struct AttachmentFileMonitorTests {
         let target = path(in: tmp.url, "appears.iso")
 
         let monitor = AttachmentFileMonitor()
-        monitor.setPaths([target])
+        await monitor.setPaths([target])
         #expect(monitor.exists(target) == false)
 
         FileManager.default.createFile(atPath: target, contents: Data([0]))
@@ -104,7 +120,7 @@ struct AttachmentFileMonitorTests {
         FileManager.default.createFile(atPath: target, contents: Data([0]))
 
         let monitor = AttachmentFileMonitor()
-        monitor.setPaths([target])
+        await monitor.setPaths([target])
         #expect(monitor.exists(target) == true)
 
         try FileManager.default.removeItem(atPath: target)


### PR DESCRIPTION
## Summary
- Adds a reactive missing-attachment indicator (red warning button + bold "Missing —" subtitle + click-to-popover with the full untruncated path and an explanation) to external storage disk and removable media rows in `VMSettingsView` and the boot-order reorder sheet.
- Backs it with a new `AttachmentFileMonitor` service that watches each tracked path's parent directory via `DispatchSource` and responds to `NSWorkspace` volume mount/unmount notifications, so the indicator flips reactively when files appear/disappear or volumes mount/eject — without per-render `fileExists` syscalls.
- Every filesystem syscall in the monitor — `fileExists`, `open(O_EVTONLY)`, and `close(fd)` — runs on a detached utility-priority task, so a stale network mount cannot freeze the UI on any code path (initial probe, FS-event refresh, volume-notification refresh, or fd release).

## Changes

### New
- **`Kernova/Services/AttachmentFileMonitor.swift`** — `@MainActor @Observable` service. Diff-based `setPaths(_:)` (async) batches the off-main `fileExists` + parent `open(O_EVTONLY)` syscalls into one detached probe; a `desiredPaths` tombstone field lets in-flight probes discard their results if the caller un-requests their paths during the await. The probe step is injected through `init(probe:)` so production code gets the default detached implementation and tests can substitute a stateful stub. After installing a watcher the apply step does one more off-main `refreshPaths` to close the gap between the probe's `fileExists` (t₁) and the watcher's `source.resume()` (t₃). FS events fire `refreshPaths(in:)` after a 250 ms debounce — also async, also off-main. Volume mount/unmount notifications drive a single-flight `requestRefreshAll` / `drainRefreshAll` that collapses bursts (e.g. plugging a multi-volume hub) into one refresh sweep. `installWatcher` traps on double-install (`.fault` log + `assertionFailure` + graceful cancel-and-replace). All three `close(fd)` sites — the apply-step "discard unused fd," the `startWatching` post-await recheck, and the `DispatchSource` cancel handler — hop to detached tasks via a `closeOffMain(_:)` helper.
- **`Kernova/Views/Detail/AttachmentIcon.swift`** — `AttachmentIcon` view that swaps the normal SF Symbol for a red-triangle `Button` when given a `missingPath`. Click opens `MissingAttachmentPopover` with the full path, rendered via a `WrappingPathLabel` (`NSViewRepresentable` around `NSTextField(wrappingLabelWithString:)` with `cell.lineBreakMode = .byCharWrapping`). AppKit's text engine wraps at the layout layer without mutating the string, so copy-to-clipboard yields the original path verbatim. Also defines the `attachmentSubtitle(path:isMissing:)` helper shared with the reorder sheet.
- **`Kernova/Views/Detail/CalloutView.swift`** — `CalloutBody` container that captures the standard popover styling (340pt width, top-leading alignment, .callout font, 10pt VStack spacing). Adopted by `MissingAttachmentPopover`, `InfoButton`, and the mic-permission popover.
- **`KernovaTests/AttachmentFileMonitorTests.swift`** — 9 cases: sync population, optimistic-default during probe, unwatched-default, empty-path filtering, diff add/remove, async file create/delete reactivity, race-coalescing via init-time probe injection with a stateful `RaceStubProbe`, and watcher teardown verified directly through a DEBUG-only `watchedParentsForTesting` accessor.

### Modified
- **`Kernova/Views/Detail/VMSettingsView.swift`** — holds `@State fileMonitor`, derives `externalAttachmentPaths` from the configuration, pushes the set on `.onAppear` + `.onChange`. Both `storageDiskRow` (external only — internal in-bundle disks skipped) and the removable-media row read `fileMonitor.exists(_:)` and render through `AttachmentIcon` + `attachmentSubtitle`. `InfoButton` and `micPermissionInfoPopover` adopt `CalloutBody`.
- **`Kernova/Views/Detail/StorageDiskReorderSheet.swift`** — takes the monitor as a parameter so the missing-file indicator follows the row into the boot-order modal.
- **`ARCHITECTURE.md`** — directory-tree entries for `AttachmentFileMonitor.swift`, `AttachmentIcon.swift`, and `CalloutView.swift`.

## Design notes

- **Why async everywhere:** the monitor's correctness invariant is "the main actor never blocks on a filesystem syscall whose latency depends on something unpredictable (network mount, slow disk)." `setPaths`, `refreshPaths`, `startWatching`, `refreshAll`, and `close(fd)` all hop to detached utility-priority tasks for their syscalls and re-check invariants after each await — so concurrent `setPaths` calls, FS event bursts, and volume mount/unmount notifications can interleave without corrupting state.
- **`existsByPath[path] ?? true`** is intentionally optimistic — paths whose probe is still in flight read as present so the UI never flashes a false missing-file indicator during the settling window.
- **AppKit `NSTextField` for the popover path:** SwiftUI's `Text` ignores `NSParagraphStyle.lineBreakMode`. The earlier ZWSP-insertion workaround forced wrapping but polluted the selectable text — pasting the path into Terminal yielded "No such file or directory" because every `/` was followed by an invisible character. Wrapping a real `NSTextField` with `byCharWrapping` keeps the wrapping in the layout layer and the string untouched.
- **Probe injection via `init(probe:)`:** production code constructs `AttachmentFileMonitor()` and gets the default detached probe; tests pass a stateful stub at construction. Matches the existing DI pattern used by `VMLibraryViewModel`.

## Test plan
- [x] `make build`
- [x] `make lint`
- [x] `make test` (full suite; 9 new `AttachmentFileMonitor` cases)
- [ ] Open settings on a VM with at least one external attachment; trash the file in Finder and confirm the row flips to the red-triangle + "Missing — <path>" state within a couple of seconds without any other interaction.
- [ ] Click the red triangle and confirm the popover shows the full path (wrapped if long, selectable), the "It may have been moved, renamed, or its volume unmounted." hint, and dismisses on outside-click. Copy the path and paste into Terminal — it should be the original path verbatim.
- [ ] Eject an external volume that holds a tracked attachment and confirm the row flips to missing without needing to refocus or switch tabs.
- [ ] Restore the file (or remount the volume) and confirm the row flips back to the normal icon.
- [ ] Open the boot-order reorder sheet for a VM with a missing external disk; confirm the indicator appears there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)