### PR TITLE
chore: Bump swift-protobuf 1.37.0 → 1.38.0

### DIFF
--- a/Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "9927fdb55ace802f44f7ac3463cce125d19946cc52b2505b2a3c8adc93449394",
+  "originHash" : "981895f686d5401565d16985c3edc486d1604387b8593e1be93962b98b94bfe7",
   "pins" : [
     {
       "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "81558271e243f8f47dfe8e9fdd55f3c2b5413f68",
-        "version" : "1.37.0"
+        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
+        "version" : "1.38.0"
       }
     }
   ],

--- a/KernovaProtocol/Package.swift
+++ b/KernovaProtocol/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "KernovaProtocol", targets: ["KernovaProtocol"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.37.0")
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.38.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
- Pull in [apple/swift-protobuf 1.38.0](https://github.com/apple/swift-protobuf/releases/tag/1.38.0) (released 2026-05-15), one minor ahead of the prior pin.
- Headline upstream change relevant to Kernova: generated code now carries `nonisolated` ([apple/swift-protobuf#2055](https://github.com/apple/swift-protobuf/pull/2055)), so `KernovaProtocol`-derived types compile cleanly under modules whose default actor isolation is `MainActor`. Strictly additive vs. 1.37.0 codegen.
- Other 1.38.0 highlights (no action needed here): well-known proto types now resolvable in the SwiftPM plugin (#2044), WKT import path baked into the `protoc` binary (#2060), an experimental generator option to suppress field/enum/message names (#2062), and dropped Swift 6.0 from the support matrix — Kernova requires Swift 6.x so we remain on a supported toolchain.

## Changes
- `KernovaProtocol/Package.swift`: bump dependency floor `from: "1.37.0"` → `"1.38.0"`.
- `Kernova.xcodeproj/.../Package.resolved`: regenerated; swift-protobuf now pinned to `1.38.0` (revision `f6506eaa`).

## Test plan
- [x] `xcodebuild -resolvePackageDependencies` checks out 1.38.0
- [x] `make test` → `** TEST SUCCEEDED **` (all three targets via `Kernova.xctestplan`)

Full upstream diff: https://github.com/apple/swift-protobuf/compare/1.37.0...1.38.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)