### PR TITLE
chore: Bump swift-protobuf to 1.38.0

### DIFF
--- a/Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "9927fdb55ace802f44f7ac3463cce125d19946cc52b2505b2a3c8adc93449394",
+  "originHash" : "981895f686d5401565d16985c3edc486d1604387b8593e1be93962b98b94bfe7",
   "pins" : [
     {
       "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "81558271e243f8f47dfe8e9fdd55f3c2b5413f68",
-        "version" : "1.37.0"
+        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
+        "version" : "1.38.0"
       }
     }
   ],

--- a/KernovaProtocol/Package.swift
+++ b/KernovaProtocol/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "KernovaProtocol", targets: ["KernovaProtocol"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.37.0")
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.38.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
- Bumps the KernovaProtocol dependency from swift-protobuf **1.37.0 → 1.38.0**.
- Brings in upstream's nonisolated generated code, well-known-types support in the SwiftPM plugin, and the latest sync with upstream proto files.

## Changes
- `KernovaProtocol/Package.swift`: `from: "1.37.0"` → `from: "1.38.0"`.
- `Kernova.xcodeproj/.../Package.resolved`: pin refreshed to 1.38.0 (`f6506eaa86ed`).

## Notes
- swift-protobuf 1.38.0 raises its `swift-tools-version` to `6.2`. The repo already requires macOS 26 / Xcode 26 / Swift 6, and CI runs on Xcode 26.5 (Swift 6.3.2), so no toolchain or platform bump is required.
- Generated code (`KernovaProtocol/Sources/KernovaProtocol/Generated/kernova.pb.swift`) was not regenerated — the existing output is still compatible with the 1.38.0 runtime.

## Test plan
- [x] `make build` succeeds (macOS 26, Xcode 26.5, Swift 6.3.2)
- [x] `make test` — full suite (Kernova + KernovaGuestAgent + KernovaProtocol) passes
- [x] `make lint` clean