### PR TITLE
ci: Harmonize proto-drift cache key with build-test workflow

### DIFF
--- a/.github/workflows/proto-drift.yml
+++ b/.github/workflows/proto-drift.yml
@@ -19,6 +19,7 @@ on:
       - 'Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'
       - 'Tools/regen-proto.sh'
       - '.github/workflows/proto-drift.yml'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -39,6 +40,7 @@ jobs:
           sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
           xcodebuild -version
           swift --version
+          echo "XCODE_BUILD=$(xcodebuild -version | awk '/Build version/ {print $3}')" >> "$GITHUB_ENV"
 
       - name: Install protoc
         run: |
@@ -49,7 +51,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: KernovaProtocol/.build
-          key: ${{ runner.os }}-proto-drift-${{ hashFiles('KernovaProtocol/Package.swift') }}
+          key: ${{ runner.os }}-proto-drift-${{ env.XCODE_BUILD }}-${{ hashFiles('Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
 
       - name: Build protoc-gen-swift from resolved swift-protobuf
         run: |


### PR DESCRIPTION
## Summary
Three small tightenings to `.github/workflows/proto-drift.yml` so it matches the conventions already established by `xcodebuild-test.yml` and `dead-code.yml`:

1. **Capture `XCODE_BUILD` in the cache key.** When GitHub bumps the `macos-26` image's Xcode/Swift toolchain, the cached `protoc-gen-swift` binary becomes potentially incompatible with the new linker/runtime. Including `XCODE_BUILD` in the cache key auto-invalidates the cache on Xcode bumps — matching the pattern in `xcodebuild-test.yml`.

2. **Hash `Kernova.xcodeproj/.../Package.resolved` instead of `KernovaProtocol/Package.swift`.** `Package.swift` carries the `from: "1.38.0"` *constraint*, not the actual *pin*. The resolved revision lives in the xcworkspace `Package.resolved` (which the workflow already copies into place to drive the SPM resolve). Hashing the pin means the cache invalidates the moment `swift-protobuf` actually moves, not just when the constraint widens.

3. **Add `workflow_dispatch:`.** Lets the drift check be re-triggered manually from the Actions tab — useful after fixing a local `protoc-gen-swift` install or to confirm an upstream brew bump didn't introduce drift. `dead-code.yml` already has this.

## Audit notes
Reviewed the workflow line-by-line against `xcodebuild-test.yml`, `lint.yml`, and `dead-code.yml`. Beyond the three above, no other consistency drift found:
- `actions/checkout@v6`, `actions/cache@v5`, `macos-26` runner, `fetch-depth: 1`, `concurrency` group, Xcode-select pattern — all already match.
- No `permissions:` block, matching `lint.yml` / `xcodebuild-test.yml` (default read-only is correct here).
- No `GITHUB_STEP_SUMMARY` write, no artifact upload on failure — neither convention is used elsewhere in the repo, and `::error::` already surfaces failures cleanly.

## Test plan
- [ ] CI's `Proto Drift` job is green on this PR
- [ ] First run misses the cache (cache key changed); subsequent runs on the same image hit it