### PR TITLE
ci: Make proto-drift always report status (compatible with required check)

### DIFF
--- a/.github/workflows/proto-drift.yml
+++ b/.github/workflows/proto-drift.yml
@@ -1,24 +1,18 @@
 name: Proto Drift
 
+# Triggers are intentionally NOT path-filtered at the workflow level — when
+# `proto-drift` is a required status check, a workflow-level `paths:` filter
+# would skip the run entirely on PRs that don't touch proto files, leaving
+# GitHub waiting forever for a status that's never reported. Instead the
+# first job step diffs the changed paths against this workflow's relevance
+# pattern and short-circuits the remaining steps when nothing relevant
+# changed; the job still reports a green status so the required check is
+# satisfied. The early-exit path adds <30s of macOS runner time per PR.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'KernovaProtocol/Proto/**'
-      - 'KernovaProtocol/Sources/KernovaProtocol/Generated/**'
-      - 'KernovaProtocol/Package.swift'
-      - 'Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'
-      - 'Tools/regen-proto.sh'
-      - '.github/workflows/proto-drift.yml'
   push:
     branches: [main]
-    paths:
-      - 'KernovaProtocol/Proto/**'
-      - 'KernovaProtocol/Sources/KernovaProtocol/Generated/**'
-      - 'KernovaProtocol/Package.swift'
-      - 'Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'
-      - 'Tools/regen-proto.sh'
-      - '.github/workflows/proto-drift.yml'
   workflow_dispatch:
 
 concurrency:
@@ -33,9 +27,54 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          # Full history needed so the relevance-filter step below can
+          # `git diff` against the PR base (or the push parent).
+          fetch-depth: 0
+
+      - name: Check for proto-relevant changes
+        id: filter
+        run: |
+          set -euo pipefail
+          # Files whose changes warrant a real drift check. Mirrors what
+          # the workflow-level `paths:` filter used to enumerate.
+          pattern='^(KernovaProtocol/(Proto/|Sources/KernovaProtocol/Generated/|Package\.swift)|Kernova\.xcodeproj/project\.xcworkspace/xcshareddata/swiftpm/Package\.resolved|Tools/regen-proto\.sh|\.github/workflows/proto-drift\.yml)'
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "workflow_dispatch — always running the full check"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.event.after }}"
+          fi
+
+          # First push to a new branch (or rewritten history) has no
+          # usable base — default to running the full check rather than
+          # silently skipping.
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            echo "No base SHA available — running the full check"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files=$(git diff --name-only "$base" "$head")
+          echo "Changed files:"
+          echo "$changed_files"
+          if echo "$changed_files" | grep -qE "$pattern"; then
+            echo "Proto-relevant files changed — running the full drift check"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No proto-relevant files changed — reporting success without running the drift check"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Select Xcode
+        if: steps.filter.outputs.changed == 'true'
         run: |
           sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
           xcodebuild -version
@@ -43,17 +82,20 @@ jobs:
           echo "XCODE_BUILD=$(xcodebuild -version | awk '/Build version/ {print $3}')" >> "$GITHUB_ENV"
 
       - name: Install protoc
+        if: steps.filter.outputs.changed == 'true'
         run: |
           brew install protobuf
           protoc --version
 
       - name: Cache SwiftPM build for protoc-gen-swift
+        if: steps.filter.outputs.changed == 'true'
         uses: actions/cache@v5
         with:
           path: KernovaProtocol/.build
           key: ${{ runner.os }}-proto-drift-${{ env.XCODE_BUILD }}-${{ hashFiles('Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
 
       - name: Build protoc-gen-swift from resolved swift-protobuf
+        if: steps.filter.outputs.changed == 'true'
         run: |
           set -euo pipefail
           # Mirror the xcworkspace's Package.resolved into the SwiftPM
@@ -76,9 +118,11 @@ jobs:
           "$BIN_DIR/protoc-gen-swift" --version || true
 
       - name: Regenerate Swift bindings
+        if: steps.filter.outputs.changed == 'true'
         run: Tools/regen-proto.sh
 
       - name: Check for drift
+        if: steps.filter.outputs.changed == 'true'
         run: |
           set -euo pipefail
           if ! git diff --quiet KernovaProtocol/Sources/KernovaProtocol/Generated; then


### PR DESCRIPTION
## Summary
- Restructure the Proto Drift workflow so it always reports a status. Currently the workflow-level `paths:` filter skips the run entirely on PRs that don't touch proto files, which leaves a required-status-check rule on `proto-drift` waiting forever ("Expected — Waiting for status to be reported") and blocks merge.
- Discovered while trying to merge #247 — the AppKit migration touches no proto files, so the existing workflow was never queued, and adding `proto-drift` to the required-check Ruleset turned that into a permanent merge block.

## Changes
- `.github/workflows/proto-drift.yml`
  - Remove the `paths:` filters from both `on.pull_request` and `on.push` so the workflow always runs.
  - Bump `actions/checkout`'s `fetch-depth` from `1` to `0` so the new filter step can `git diff` against the PR base (or push parent).
  - Add a first step `Check for proto-relevant changes` that diffs the changed files against the same pattern the old workflow-level filter enumerated (`KernovaProtocol/Proto/**`, `KernovaProtocol/Sources/KernovaProtocol/Generated/**`, `KernovaProtocol/Package.swift`, `Package.resolved`, `Tools/regen-proto.sh`, this workflow file) and writes `steps.filter.outputs.changed`. `workflow_dispatch` and the missing-base-SHA case default to running the full check (safer than wrongly skipping).
  - Gate every remaining step on `if: steps.filter.outputs.changed == 'true'`.

## Behavior
- **PRs that touch proto files** → the filter step matches, the full drift check runs as before (regenerate bindings, fail if they diverge).
- **PRs that don't touch proto files** → the filter step reports "no proto-relevant files changed", the rest of the job is skipped, and the job reports green in under ~30s of macOS runner time (just checkout + the filter step).
- Either way, a status is always reported, satisfying the required-check rule.

## Test plan
- [ ] This PR itself touches `.github/workflows/proto-drift.yml`, which is in the relevance pattern — so the full drift check should fire and pass (covers the "real check still works" branch).
- [ ] After merge: verify on a follow-up non-proto PR (e.g. unblocking #247) that the workflow runs, the filter step reports "no proto-relevant files changed", and the job reports success in under ~30s (covers the "early exit reports green" branch — the missing case today).

## Notes
- Split out from #247 (the AppKit migration) per separation of concerns — #247 doesn't touch proto files and surfacing this CI fix here keeps both PRs reviewable in isolation.
- Alternative approaches considered: a noop sibling workflow (more files to keep in sync; check-name collision behavior is fragile across GitHub UI changes) and removing the required-check rule (defeats the purpose of having added it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)