### PR TITLE
refactor: Convert detail-pane display placeholder to pure AppKit

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,8 +87,8 @@ Kernova/
 │   │   ├── DeleteVMSheetModifier.swift # SwiftUI bridge — `.deleteVMSheet(isPresented:instance:externals:onCancel:onConfirm:)` modifier matching the prior SwiftUI sheet's call surface; uses `SheetPresenter` + `WindowAccessor` to present as a window-modal sheet on the host `NSWindow`
 │   │   └── MacOSInstallProgressView.swift # Two-phase install progress (download + install)
 │   ├── Console/
-│   │   ├── VMConsoleView.swift         # SwiftUI `NSViewControllerRepresentable` shim — preserves the existing `VMConsoleView(instance:)` call surface used by `VMDetailView` while delegating all rendering and observation to AppKit
-│   │   ├── VMConsoleContentViewController.swift # Concrete `NSViewController` for the detail-pane "console" placeholder — centered empty-state (SF Symbol + title + description + optional action button) for the non-inline display states (Fullscreen / Popped Out / Suspended / No Display), inert black fill behind it for the `.live` case (covered by `VMDisplayBackingView`). Observes `VMInstance.displayMode`, `isColdPaused`, and `virtualMachine` via `observeRecurring`. Action buttons dispatch through `NSApp.sendAction(_:to:from:)` to `AppDelegate.toggleFullscreen(_:)` / `togglePopOut(_:)`. The reusable `ConsoleEmptyStateView` lives privately in the same file (one consumer today; no premature extraction).
+│   │   ├── VMDisplayPlaceholderView.swift # SwiftUI `NSViewControllerRepresentable` shim — preserves a stable `VMDisplayPlaceholderView(instance:)` call surface for `VMDetailView` while delegating all rendering and observation to AppKit
+│   │   ├── VMDisplayPlaceholderContentViewController.swift # Concrete `NSViewController` for the detail-pane placeholder shown when the VM display is unavailable inline — centered empty-state (SF Symbol + title + description + optional action button) for the non-inline display states (Fullscreen / Popped Out / Suspended / No Display), inert black fill behind it for the `.live` case (covered by `VMDisplayBackingView`). Observes `VMInstance.displayMode`, `isColdPaused`, and `virtualMachine` via `observeRecurring`. Action buttons dispatch through `NSApp.sendAction(_:to:from:)` to `AppDelegate.toggleFullscreen(_:)` / `togglePopOut(_:)`. The reusable `DisplayPlaceholderEmptyStateView` lives privately in the same file (one consumer today; no premature extraction).
 │   │   └── VMDisplayBackingView.swift  # Pure AppKit VM display with pause/transition overlays
 │   └── Creation/
 │       ├── VMCreationWizardView.swift  # Multi-step wizard container
@@ -317,7 +317,7 @@ NSSplitViewController (MainWindowController)
     │   └── VZVirtualMachineView + pause/transition overlays
     └── NSHostingController (SwiftUI, always present behind)
         └── MainDetailView → VMDetailView
-            ├── VMConsoleView (SwiftUI shim → AppKit VMConsoleContentViewController; placeholder when display is external, suspended, or unavailable)
+            ├── VMDisplayPlaceholderView (SwiftUI shim → AppKit VMDisplayPlaceholderContentViewController; placeholder when display is external, suspended, or unavailable)
             ├── VMSettingsView
             └── MacOSInstallProgressView
 VMCreationWizardView (modal sheet on detail pane)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,7 +87,8 @@ Kernova/
 │   │   ├── DeleteVMSheetModifier.swift # SwiftUI bridge — `.deleteVMSheet(isPresented:instance:externals:onCancel:onConfirm:)` modifier matching the prior SwiftUI sheet's call surface; uses `SheetPresenter` + `WindowAccessor` to present as a window-modal sheet on the host `NSWindow`
 │   │   └── MacOSInstallProgressView.swift # Two-phase install progress (download + install)
 │   ├── Console/
-│   │   ├── VMConsoleView.swift         # Placeholder for non-inline display states (popped out, fullscreen, suspended, no display)
+│   │   ├── VMConsoleView.swift         # SwiftUI `NSViewControllerRepresentable` shim — preserves the existing `VMConsoleView(instance:)` call surface used by `VMDetailView` while delegating all rendering and observation to AppKit
+│   │   ├── VMConsoleContentViewController.swift # Concrete `NSViewController` for the detail-pane "console" placeholder — centered empty-state (SF Symbol + title + description + optional action button) for the non-inline display states (Fullscreen / Popped Out / Suspended / No Display), inert black fill behind it for the `.live` case (covered by `VMDisplayBackingView`). Observes `VMInstance.displayMode`, `isColdPaused`, and `virtualMachine` via `observeRecurring`. Action buttons dispatch through `NSApp.sendAction(_:to:from:)` to `AppDelegate.toggleFullscreen(_:)` / `togglePopOut(_:)`. The reusable `ConsoleEmptyStateView` lives privately in the same file (one consumer today; no premature extraction).
 │   │   └── VMDisplayBackingView.swift  # Pure AppKit VM display with pause/transition overlays
 │   └── Creation/
 │       ├── VMCreationWizardView.swift  # Multi-step wizard container
@@ -316,7 +317,7 @@ NSSplitViewController (MainWindowController)
     │   └── VZVirtualMachineView + pause/transition overlays
     └── NSHostingController (SwiftUI, always present behind)
         └── MainDetailView → VMDetailView
-            ├── VMConsoleView (placeholder when display is external, suspended, or unavailable)
+            ├── VMConsoleView (SwiftUI shim → AppKit VMConsoleContentViewController; placeholder when display is external, suspended, or unavailable)
             ├── VMSettingsView
             └── MacOSInstallProgressView
 VMCreationWizardView (modal sheet on detail pane)

--- a/Kernova/Views/Console/VMConsoleContentViewController.swift
+++ b/Kernova/Views/Console/VMConsoleContentViewController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import os
 
 /// AppKit content view controller for the detail-pane "console" placeholder.
 ///
@@ -16,6 +17,8 @@ final class VMConsoleContentViewController: NSViewController {
     private let emptyState = ConsoleEmptyStateView()
     private var observation: ObservationLoop?
 
+    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMConsoleVC")
+
     init(instance: VMInstance) {
         self.instance = instance
         super.init(nibName: nil, bundle: nil)
@@ -30,8 +33,10 @@ final class VMConsoleContentViewController: NSViewController {
 
     override func loadView() {
         let container = NSView()
+        // Layer-backed so `apply()` can paint a black fill for the `.live`
+        // case where the AppKit VM display layer is expected to cover this
+        // view. Background is set per state in `apply()` — never here.
         container.wantsLayer = true
-        container.layer?.backgroundColor = NSColor.black.cgColor
 
         emptyState.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(emptyState)
@@ -61,6 +66,9 @@ final class VMConsoleContentViewController: NSViewController {
     /// the controller stops tracking the previous instance's properties.
     func reconfigure(instance newInstance: VMInstance) {
         guard newInstance !== instance else { return }
+        Self.logger.debug(
+            "Reconfigured to instance '\(newInstance.name, privacy: .public)'"
+        )
         instance = newInstance
         observation?.cancel()
         observation = nil
@@ -108,7 +116,16 @@ final class VMConsoleContentViewController: NSViewController {
     }
 
     private func apply() {
-        switch consoleState() {
+        let state = consoleState()
+        // Paint black only for `.live`: that case is meant to sit underneath
+        // the AppKit VM display layer in `DetailContainerViewController`, so a
+        // black fill is the right inert appearance. For every other state we
+        // render the empty-state on the system background like the SwiftUI
+        // `ContentUnavailableView` predecessor did — otherwise `.labelColor`
+        // text becomes unreadable on a black panel in Light Appearance.
+        view.layer?.backgroundColor = (state == .live) ? NSColor.black.cgColor : nil
+
+        switch state {
         case .fullscreen:
             emptyState.isHidden = false
             emptyState.configure(
@@ -148,8 +165,6 @@ final class VMConsoleContentViewController: NSViewController {
                 action: nil
             )
         case .live:
-            // The AppKit VM display covers this layer in DetailContainerViewController.
-            // Hide the placeholder so the black background is fully inert.
             emptyState.isHidden = true
         }
     }
@@ -161,9 +176,10 @@ final class VMConsoleContentViewController: NSViewController {
 /// and optional action button.
 ///
 /// Approximates SwiftUI's `ContentUnavailableView` styling without inheriting
-/// any of its declarative machinery. Action buttons dispatch through the
-/// responder chain via `NSApp.sendAction(_:to:from:)`, matching how the
-/// SwiftUI predecessor reached the `AppDelegate` selectors.
+/// any of its declarative machinery. Action buttons use `target = nil` so
+/// `NSControl`'s built-in responder-chain dispatch routes through `NSApp`
+/// to the configured selector (matching how the SwiftUI predecessor reached
+/// `AppDelegate.toggleFullscreen(_:)` / `togglePopOut(_:)`).
 @MainActor
 private final class ConsoleEmptyStateView: NSView {
     struct Action {
@@ -176,8 +192,6 @@ private final class ConsoleEmptyStateView: NSView {
     private let descriptionLabel = NSTextField(wrappingLabelWithString: "")
     private let actionButton = NSButton(title: "", target: nil, action: nil)
     private let stack = NSStackView()
-
-    private var currentSelector: Selector?
 
     /// Soft cap so multi-line descriptions wrap reasonably instead of stretching
     /// to the full detail-pane width.
@@ -204,14 +218,12 @@ private final class ConsoleEmptyStateView: NSView {
 
         actionButton.bezelStyle = .rounded
         actionButton.controlSize = .regular
-        actionButton.target = self
-        actionButton.action = #selector(actionButtonClicked(_:))
 
         stack.orientation = .vertical
         stack.alignment = .centerX
         stack.spacing = 12
         stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.setViews([imageView, titleLabel, descriptionLabel, actionButton], in: .leading)
+        stack.setViews([imageView, titleLabel, descriptionLabel, actionButton], in: .top)
         // Tighten the gap between the icon and title so the cluster reads as a unit.
         stack.setCustomSpacing(8, after: imageView)
         stack.setCustomSpacing(4, after: titleLabel)
@@ -235,36 +247,22 @@ private final class ConsoleEmptyStateView: NSView {
     }
 
     func configure(symbolName: String, title: String, description: String, action: Action?) {
-        let symbolConfig = NSImage.SymbolConfiguration(pointSize: 44, weight: .regular)
-        guard
-            let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
-                .withSymbolConfiguration(symbolConfig)
-        else {
-            assertionFailure("Missing SF Symbol '\(symbolName)' for console empty state")
-            imageView.image = nil
-            titleLabel.stringValue = title
-            descriptionLabel.stringValue = description
-            return
-        }
-        imageView.image = symbol
+        // `NSImage.systemSymbol` already logs at `.fault` and asserts on miss;
+        // no need to re-implement the defensive unwrap here.
+        imageView.image = NSImage.systemSymbol(symbolName, accessibilityDescription: "")
+            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 44, weight: .regular))
         titleLabel.stringValue = title
         descriptionLabel.stringValue = description
 
         if let action {
             actionButton.title = action.title
-            currentSelector = action.selector
+            actionButton.target = nil
+            actionButton.action = action.selector
             actionButton.isHidden = false
         } else {
-            currentSelector = nil
+            actionButton.target = nil
+            actionButton.action = nil
             actionButton.isHidden = true
         }
-    }
-
-    @objc private func actionButtonClicked(_ sender: Any?) {
-        guard let selector = currentSelector else { return }
-        // Route through the responder chain so AppDelegate (or whichever
-        // responder handles the selector) receives the action — same dispatch
-        // strategy the SwiftUI predecessor used.
-        NSApp.sendAction(selector, to: nil, from: sender)
     }
 }

--- a/Kernova/Views/Console/VMConsoleContentViewController.swift
+++ b/Kernova/Views/Console/VMConsoleContentViewController.swift
@@ -1,0 +1,270 @@
+import AppKit
+
+/// AppKit content view controller for the detail-pane "console" placeholder.
+///
+/// Shows a centered empty-state (icon + title + description + optional action
+/// button) for the non-inline display states — `Fullscreen`, `Popped Out`,
+/// `Suspended` (cold-paused), and `No Display` — and falls back to an inert
+/// black fill while a live VM display is layered on top by
+/// `DetailContainerViewController`.
+///
+/// Observes `VMInstance.displayMode`, `isColdPaused`, and `virtualMachine` via
+/// `observeRecurring` and recomputes the visible state in `apply()`.
+@MainActor
+final class VMConsoleContentViewController: NSViewController {
+    private var instance: VMInstance
+    private let emptyState = ConsoleEmptyStateView()
+    private var observation: ObservationLoop?
+
+    init(instance: VMInstance) {
+        self.instance = instance
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("VMConsoleContentViewController does not support NSCoder")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func loadView() {
+        let container = NSView()
+        container.wantsLayer = true
+        container.layer?.backgroundColor = NSColor.black.cgColor
+
+        emptyState.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(emptyState)
+        NSLayoutConstraint.activate([
+            emptyState.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            emptyState.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            emptyState.leadingAnchor.constraint(
+                greaterThanOrEqualTo: container.leadingAnchor, constant: 24),
+            emptyState.trailingAnchor.constraint(
+                lessThanOrEqualTo: container.trailingAnchor, constant: -24),
+        ])
+
+        view = container
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        apply()
+        observeInstance()
+    }
+
+    // MARK: - Reconfiguration
+
+    /// Re-bind to a different `VMInstance` (e.g. the user selected a new VM).
+    ///
+    /// No-op when the instance identity is unchanged. Restarts observation so
+    /// the controller stops tracking the previous instance's properties.
+    func reconfigure(instance newInstance: VMInstance) {
+        guard newInstance !== instance else { return }
+        instance = newInstance
+        observation?.cancel()
+        observation = nil
+        if isViewLoaded {
+            apply()
+            observeInstance()
+        }
+    }
+
+    // MARK: - Observation
+
+    private func observeInstance() {
+        observation = observeRecurring(
+            track: { [weak self] in
+                guard let self else { return }
+                _ = self.instance.displayMode
+                _ = self.instance.isColdPaused
+                _ = self.instance.virtualMachine
+            },
+            apply: { [weak self] in
+                self?.apply()
+            }
+        )
+    }
+
+    // MARK: - State
+
+    private enum ConsoleState {
+        case fullscreen
+        case poppedOut
+        case suspended
+        case live
+        case noDisplay
+    }
+
+    private func consoleState() -> ConsoleState {
+        switch instance.displayMode {
+        case .fullscreen: return .fullscreen
+        case .popOut: return .poppedOut
+        case .inline:
+            if instance.isColdPaused { return .suspended }
+            if instance.virtualMachine != nil { return .live }
+            return .noDisplay
+        }
+    }
+
+    private func apply() {
+        switch consoleState() {
+        case .fullscreen:
+            emptyState.isHidden = false
+            emptyState.configure(
+                symbolName: "arrow.up.left.and.arrow.down.right",
+                title: "Fullscreen",
+                description: "The virtual machine display is in fullscreen mode.",
+                action: ConsoleEmptyStateView.Action(
+                    title: "Exit Fullscreen",
+                    selector: #selector(AppDelegate.toggleFullscreen(_:))
+                )
+            )
+        case .poppedOut:
+            emptyState.isHidden = false
+            emptyState.configure(
+                symbolName: "pip.exit",
+                title: "Popped Out",
+                description: "The virtual machine display is in a separate window.",
+                action: ConsoleEmptyStateView.Action(
+                    title: "Pop In",
+                    selector: #selector(AppDelegate.togglePopOut(_:))
+                )
+            )
+        case .suspended:
+            emptyState.isHidden = false
+            emptyState.configure(
+                symbolName: "pause.circle",
+                title: "Suspended",
+                description: "This virtual machine's state is saved to disk. Resume to continue.",
+                action: nil
+            )
+        case .noDisplay:
+            emptyState.isHidden = false
+            emptyState.configure(
+                symbolName: "display",
+                title: "No Display",
+                description: "The virtual machine display is not available.",
+                action: nil
+            )
+        case .live:
+            // The AppKit VM display covers this layer in DetailContainerViewController.
+            // Hide the placeholder so the black background is fully inert.
+            emptyState.isHidden = true
+        }
+    }
+}
+
+// MARK: - ConsoleEmptyStateView
+
+/// AppKit empty-state placeholder: a centered SF Symbol, title, description,
+/// and optional action button.
+///
+/// Approximates SwiftUI's `ContentUnavailableView` styling without inheriting
+/// any of its declarative machinery. Action buttons dispatch through the
+/// responder chain via `NSApp.sendAction(_:to:from:)`, matching how the
+/// SwiftUI predecessor reached the `AppDelegate` selectors.
+@MainActor
+private final class ConsoleEmptyStateView: NSView {
+    struct Action {
+        let title: String
+        let selector: Selector
+    }
+
+    private let imageView = NSImageView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let descriptionLabel = NSTextField(wrappingLabelWithString: "")
+    private let actionButton = NSButton(title: "", target: nil, action: nil)
+    private let stack = NSStackView()
+
+    private var currentSelector: Selector?
+
+    /// Soft cap so multi-line descriptions wrap reasonably instead of stretching
+    /// to the full detail-pane width.
+    private static let maxContentWidth: CGFloat = 360
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        imageView.contentTintColor = .secondaryLabelColor
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+
+        titleLabel.font = NSFont.systemFont(ofSize: NSFont.systemFontSize + 6, weight: .semibold)
+        titleLabel.alignment = .center
+        titleLabel.textColor = .labelColor
+
+        descriptionLabel.font = NSFont.preferredFont(forTextStyle: .body)
+        descriptionLabel.textColor = .secondaryLabelColor
+        descriptionLabel.alignment = .center
+        descriptionLabel.maximumNumberOfLines = 0
+        descriptionLabel.preferredMaxLayoutWidth = Self.maxContentWidth
+        descriptionLabel.lineBreakMode = .byWordWrapping
+
+        actionButton.bezelStyle = .rounded
+        actionButton.controlSize = .regular
+        actionButton.target = self
+        actionButton.action = #selector(actionButtonClicked(_:))
+
+        stack.orientation = .vertical
+        stack.alignment = .centerX
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.setViews([imageView, titleLabel, descriptionLabel, actionButton], in: .leading)
+        // Tighten the gap between the icon and title so the cluster reads as a unit.
+        stack.setCustomSpacing(8, after: imageView)
+        stack.setCustomSpacing(4, after: titleLabel)
+        stack.setCustomSpacing(16, after: descriptionLabel)
+
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            widthAnchor.constraint(lessThanOrEqualToConstant: Self.maxContentWidth),
+            imageView.widthAnchor.constraint(equalToConstant: 52),
+            imageView.heightAnchor.constraint(equalToConstant: 52),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("ConsoleEmptyStateView does not support NSCoder")
+    }
+
+    func configure(symbolName: String, title: String, description: String, action: Action?) {
+        let symbolConfig = NSImage.SymbolConfiguration(pointSize: 44, weight: .regular)
+        guard
+            let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
+                .withSymbolConfiguration(symbolConfig)
+        else {
+            assertionFailure("Missing SF Symbol '\(symbolName)' for console empty state")
+            imageView.image = nil
+            titleLabel.stringValue = title
+            descriptionLabel.stringValue = description
+            return
+        }
+        imageView.image = symbol
+        titleLabel.stringValue = title
+        descriptionLabel.stringValue = description
+
+        if let action {
+            actionButton.title = action.title
+            currentSelector = action.selector
+            actionButton.isHidden = false
+        } else {
+            currentSelector = nil
+            actionButton.isHidden = true
+        }
+    }
+
+    @objc private func actionButtonClicked(_ sender: Any?) {
+        guard let selector = currentSelector else { return }
+        // Route through the responder chain so AppDelegate (or whichever
+        // responder handles the selector) receives the action — same dispatch
+        // strategy the SwiftUI predecessor used.
+        NSApp.sendAction(selector, to: nil, from: sender)
+    }
+}

--- a/Kernova/Views/Console/VMConsoleView.swift
+++ b/Kernova/Views/Console/VMConsoleView.swift
@@ -1,52 +1,27 @@
+import AppKit
 import SwiftUI
 
-/// Console view that displays placeholder content when the VM display is unavailable: popped out,
-/// fullscreen, suspended (cold-paused), or no virtual machine assigned.
+/// SwiftUI shim over the AppKit ``VMConsoleContentViewController``.
 ///
-/// When the display is inline and active, the AppKit `VMDisplayBackingView` layer covers this
-/// view, so the inline branch shows an inert black background.
-struct VMConsoleView: View {
-    @Bindable var instance: VMInstance
+/// `VMDetailView` mounts this view whenever a running VM is showing its
+/// "display" pane but the actual VM display is unavailable for the current
+/// `VMInstance` — fullscreen, popped out, cold-paused ("Suspended"), or no
+/// virtual machine attached. All rendering, layout, and lifecycle observation
+/// is AppKit; the SwiftUI side exists only to preserve the existing
+/// `VMConsoleView(instance:)` call surface during the incremental
+/// SwiftUI→AppKit transition.
+///
+/// When the display is inline and the VM is running, the AppKit
+/// `VMDisplayBackingView` layer covers this view, so the placeholder is
+/// hidden and the controller paints an inert black background.
+struct VMConsoleView: NSViewControllerRepresentable {
+    let instance: VMInstance
 
-    var body: some View {
-        VStack(spacing: 0) {
-            if instance.displayMode == .fullscreen {
-                ContentUnavailableView {
-                    Label("Fullscreen", systemImage: "arrow.up.left.and.arrow.down.right")
-                } description: {
-                    Text("The virtual machine display is in fullscreen mode.")
-                } actions: {
-                    Button("Exit Fullscreen") {
-                        NSApp.sendAction(#selector(AppDelegate.toggleFullscreen(_:)), to: nil, from: nil)
-                    }
-                }
-            } else if instance.displayMode == .popOut {
-                ContentUnavailableView {
-                    Label("Popped Out", systemImage: "pip.exit")
-                } description: {
-                    Text("The virtual machine display is in a separate window.")
-                } actions: {
-                    Button("Pop In") {
-                        NSApp.sendAction(#selector(AppDelegate.togglePopOut(_:)), to: nil, from: nil)
-                    }
-                }
-            } else if instance.isColdPaused {
-                ContentUnavailableView(
-                    "Suspended",
-                    systemImage: "pause.circle",
-                    description: Text("This virtual machine's state is saved to disk. Resume to continue.")
-                )
-            } else if instance.virtualMachine != nil {
-                // Covered by the AppKit VMDisplayBackingView layer in DetailContainerViewController.
-                Color.black
-            } else {
-                ContentUnavailableView(
-                    "No Display",
-                    systemImage: "display",
-                    description: Text("The virtual machine display is not available.")
-                )
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    func makeNSViewController(context: Context) -> VMConsoleContentViewController {
+        VMConsoleContentViewController(instance: instance)
+    }
+
+    func updateNSViewController(_ controller: VMConsoleContentViewController, context: Context) {
+        controller.reconfigure(instance: instance)
     }
 }

--- a/Kernova/Views/Console/VMDisplayPlaceholderContentViewController.swift
+++ b/Kernova/Views/Console/VMDisplayPlaceholderContentViewController.swift
@@ -12,12 +12,14 @@ import os
 /// Observes `VMInstance.displayMode`, `isColdPaused`, and `virtualMachine` via
 /// `observeRecurring` and recomputes the visible state in `apply()`.
 @MainActor
-final class VMConsoleContentViewController: NSViewController {
+final class VMDisplayPlaceholderContentViewController: NSViewController {
     private var instance: VMInstance
-    private let emptyState = ConsoleEmptyStateView()
+    private let emptyState = DisplayPlaceholderEmptyStateView()
     private var observation: ObservationLoop?
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMConsoleVC")
+    private static let logger = Logger(
+        subsystem: "com.kernova.app", category: "VMDisplayPlaceholderVC"
+    )
 
     init(instance: VMInstance) {
         self.instance = instance
@@ -26,7 +28,7 @@ final class VMConsoleContentViewController: NSViewController {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("VMConsoleContentViewController does not support NSCoder")
+        fatalError("VMDisplayPlaceholderContentViewController does not support NSCoder")
     }
 
     // MARK: - View Lifecycle
@@ -132,7 +134,7 @@ final class VMConsoleContentViewController: NSViewController {
                 symbolName: "arrow.up.left.and.arrow.down.right",
                 title: "Fullscreen",
                 description: "The virtual machine display is in fullscreen mode.",
-                action: ConsoleEmptyStateView.Action(
+                action: DisplayPlaceholderEmptyStateView.Action(
                     title: "Exit Fullscreen",
                     selector: #selector(AppDelegate.toggleFullscreen(_:))
                 )
@@ -143,7 +145,7 @@ final class VMConsoleContentViewController: NSViewController {
                 symbolName: "pip.exit",
                 title: "Popped Out",
                 description: "The virtual machine display is in a separate window.",
-                action: ConsoleEmptyStateView.Action(
+                action: DisplayPlaceholderEmptyStateView.Action(
                     title: "Pop In",
                     selector: #selector(AppDelegate.togglePopOut(_:))
                 )
@@ -170,7 +172,7 @@ final class VMConsoleContentViewController: NSViewController {
     }
 }
 
-// MARK: - ConsoleEmptyStateView
+// MARK: - DisplayPlaceholderEmptyStateView
 
 /// AppKit empty-state placeholder: a centered SF Symbol, title, description,
 /// and optional action button.
@@ -181,7 +183,7 @@ final class VMConsoleContentViewController: NSViewController {
 /// to the configured selector (matching how the SwiftUI predecessor reached
 /// `AppDelegate.toggleFullscreen(_:)` / `togglePopOut(_:)`).
 @MainActor
-private final class ConsoleEmptyStateView: NSView {
+private final class DisplayPlaceholderEmptyStateView: NSView {
     struct Action {
         let title: String
         let selector: Selector
@@ -243,7 +245,7 @@ private final class ConsoleEmptyStateView: NSView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("ConsoleEmptyStateView does not support NSCoder")
+        fatalError("DisplayPlaceholderEmptyStateView does not support NSCoder")
     }
 
     func configure(symbolName: String, title: String, description: String, action: Action?) {

--- a/Kernova/Views/Console/VMDisplayPlaceholderView.swift
+++ b/Kernova/Views/Console/VMDisplayPlaceholderView.swift
@@ -1,27 +1,28 @@
 import AppKit
 import SwiftUI
 
-/// SwiftUI shim over the AppKit ``VMConsoleContentViewController``.
+/// SwiftUI shim over the AppKit ``VMDisplayPlaceholderContentViewController``.
 ///
 /// `VMDetailView` mounts this view whenever a running VM is showing its
 /// "display" pane but the actual VM display is unavailable for the current
 /// `VMInstance` — fullscreen, popped out, cold-paused ("Suspended"), or no
 /// virtual machine attached. All rendering, layout, and lifecycle observation
-/// is AppKit; the SwiftUI side exists only to preserve the existing
-/// `VMConsoleView(instance:)` call surface during the incremental
-/// SwiftUI→AppKit transition.
+/// is AppKit; the SwiftUI side exists only to preserve a stable call surface
+/// for `VMDetailView` during the incremental SwiftUI→AppKit transition.
 ///
 /// When the display is inline and the VM is running, the AppKit
 /// `VMDisplayBackingView` layer covers this view, so the placeholder is
 /// hidden and the controller paints an inert black background.
-struct VMConsoleView: NSViewControllerRepresentable {
+struct VMDisplayPlaceholderView: NSViewControllerRepresentable {
     let instance: VMInstance
 
-    func makeNSViewController(context: Context) -> VMConsoleContentViewController {
-        VMConsoleContentViewController(instance: instance)
+    func makeNSViewController(context: Context) -> VMDisplayPlaceholderContentViewController {
+        VMDisplayPlaceholderContentViewController(instance: instance)
     }
 
-    func updateNSViewController(_ controller: VMConsoleContentViewController, context: Context) {
+    func updateNSViewController(
+        _ controller: VMDisplayPlaceholderContentViewController, context: Context
+    ) {
         controller.reconfigure(instance: instance)
     }
 }

--- a/Kernova/Views/Detail/VMDetailView.swift
+++ b/Kernova/Views/Detail/VMDetailView.swift
@@ -45,7 +45,7 @@ struct VMDetailView: View {
                 if instance.detailPaneMode == .settings {
                     VMSettingsView(instance: instance, viewModel: viewModel, isReadOnly: true)
                 } else {
-                    VMConsoleView(instance: instance)
+                    VMDisplayPlaceholderView(instance: instance)
                 }
 
             default:


### PR DESCRIPTION
## Summary
- Continue the SwiftUI→AppKit migration started in #247 by converting the detail-pane placeholder view (shown when a running VM's display is unavailable inline — Fullscreen / Popped Out / Suspended / No Display states) from a SwiftUI `ContentUnavailableView` tree to a pure-AppKit `NSViewController`.
- New `VMDisplayPlaceholderContentViewController` owns layout, observation (`observeRecurring` on `VMInstance.{displayMode, isColdPaused, virtualMachine}`), and action dispatch. Empty-state rendering is its own private `DisplayPlaceholderEmptyStateView` (centered SF Symbol + bold title + wrapping description + optional action button); no shared container base class per the existing AppKit-first convention.
- `VMDisplayPlaceholderView` is a ~27-line `NSViewControllerRepresentable` shim so the call site in `VMDetailView` remains a one-liner.

## Rename
- The view used to be `VMConsoleView` (and the file `VMConsoleView.swift`), but that name was misleading — the view has nothing to do with a terminal/console. It's an empty-state placeholder for the detail pane, in the spirit of SwiftUI's `ContentUnavailableView`. Renamed during this PR (third commit) after surfacing as real test-time confusion.
- File renames done via `git mv` so blame survives.
- The `Kernova/Views/Console/` directory itself is intentionally left as-is; renaming it is a larger decision (it still contains `VMDisplayBackingView.swift`) and out of scope for this PR.

## Implementation notes
- The inert black fill is scoped to the `.live` state only — that's the case where `VMDisplayBackingView` layers the real VZ display on top in `DetailContainerViewController`, and the SwiftUI predecessor's `Color.black` branch existed for exactly that safety reason. Other empty-state cases render against the system background so `.labelColor` text stays readable in Light Appearance.
- Action buttons (`Exit Fullscreen`, `Pop In`) use nil-target dispatch (`actionButton.target = nil; actionButton.action = selector`), so `NSControl`'s built-in responder-chain walk routes them to `AppDelegate.toggleFullscreen(_:)` / `togglePopOut(_:)` — same end target the SwiftUI predecessor reached via `NSApp.sendAction`.
- SF Symbol resolution goes through the project's existing `NSImage.systemSymbol(_:accessibilityDescription:)` helper so the `.fault` log + `assertionFailure` pattern is consistent with the rest of the codebase.
- `private static let logger = Logger(subsystem: "com.kernova.app", category: "VMDisplayPlaceholderVC")`; `.debug` line on `reconfigure(instance:)` so VM-swap events are traceable in Console.app.
- `ARCHITECTURE.md` Console section + detail-pane view-hierarchy diagram updated to reflect the VC + shim split and the new names.

## Test plan
- [x] `make build` succeeds on macOS 26
- [x] `make lint` clean
- [x] `make test` — all three test targets pass
- [x] Manually verified Popped Out placeholder in **both Light and Dark Appearance** (user confirmed light-mode rendering after the self-review fix scoped the black fill to the `.live` state)
- [x] Manually verified the **Pop In** action button dispatches via the responder chain to `AppDelegate.togglePopOut(_:)` (display returned inline on click)

🤖 Generated with [Claude Code](https://claude.com/claude-code)