### PR TITLE
fix: Widen recoveryFromUnresponsive watchdog cadence for CI

### DIFF
--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -377,12 +377,19 @@ struct VsockControlServiceTests {
         host.start()
         defer { guest.close() }
 
+        // `terminateAfter` is set well beyond the test's wall-clock budget
+        // (two 5 s `waitUntil` calls plus per-test setup overhead) so the
+        // watchdog cannot close the channel before the recovery heartbeat
+        // lands. Same CI-jitter rationale as `terminateClosesChannel`: on
+        // slow runners the original 2 s value occasionally fired between
+        // detecting `.unresponsive` and sending the heartbeat, leaving the
+        // service stuck and timing out the second `waitUntil`.
         let service = makeService(
             channel: host,
             bundledAgentVersion: "0.9.0",
             heartbeatInterval: .milliseconds(60),
             unresponsiveAfter: .milliseconds(100),
-            terminateAfter: .milliseconds(2_000)
+            terminateAfter: .seconds(60)
         )
         service.start()
         defer { service.stop() }


### PR DESCRIPTION
## Summary
- Stop `VsockControlServiceTests.recoveryFromUnresponsive` flaking on slow GitHub Actions runners. The test failed on `a82c5ae` (latest `main`) at 7.482 s — the inner `waitUntil(timeout: .seconds(5))` for `.current` timed out because the watchdog had already closed the channel by then.

## Root cause
The test used `terminateAfter: .milliseconds(2_000)`. Timeline on a slow runner:

1. `service.start()` arms the watchdog
2. `waitUntil` for `.unresponsive` to flip
3. Send recovery heartbeat, `waitUntil` for `.current`

If steps 1–2 take longer than 2 s — entirely plausible given that surrounding tests in this suite were taking 2–3 s each on the failed CI run — `terminateAfter` fires first and closes the channel before the heartbeat in step 3 can land. The heartbeat goes nowhere, `agentStatus` stays `.unresponsive`, and the second `waitUntil` times out.

Neither `a82c5ae` (detail-pane AppKit) nor `e34cb67` (popover migration) touches `VsockControlService` — this is a latent timing flake exposed by runner jitter.

## Changes
- Bump `terminateAfter` from 2 s to 60 s for this test so the watchdog cannot close the channel before the recovery heartbeat lands.
- Leave `unresponsiveAfter: 100 ms` and `heartbeatInterval: 60 ms` intact so the unresponsive → recovery transition is still exercised quickly.
- Add an inline comment cross-referencing the existing `terminateClosesChannel` widening (same CI-jitter rationale, same fix pattern).

## Test plan
- [x] `make test-suite SUITE=KernovaTests/VsockControlServiceTests` passes (`recoveryFromUnresponsive` runs in ~0.15 s locally)
- [x] `make lint` clean
- [ ] CI Build & Test green on this PR