### PR TITLE
refactor: Remove invalid nonisolated workaround in SidebarVMRowCellView

### DIFF
--- a/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
+++ b/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
@@ -35,15 +35,9 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
 
     // MARK: - Subviews
 
-    // RATIONALE: `iconView` and `subtitleField` are `nonisolated(unsafe)` so the
-    // `nonisolated` `backgroundStyle` override (below) can recolor them without
-    // a Swift main-actor executor check. AppKit only touches them on the main
-    // thread, so the access is safe; the `unsafe` opts out of the Sendable check.
-    // Assigned in `init` (not inline) because a `nonisolated(unsafe)` property
-    // can't take a main-actor-isolated default value.
-    nonisolated(unsafe) private let iconView: NSImageView
+    private let iconView = NSImageView()
     private let nameField = NSTextField()
-    nonisolated(unsafe) private let subtitleField: NSTextField
+    private let subtitleField = NSTextField(labelWithString: "")
     private let agentButton = SidebarAgentStatusButtonView()
     private let statusDot = NSView()
     private let spinner = NSProgressIndicator()
@@ -51,8 +45,6 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
     // MARK: - Init
 
     init() {
-        iconView = NSImageView()
-        subtitleField = NSTextField(labelWithString: "")
         super.init(frame: .zero)
         identifier = Self.reuseIdentifier
         buildLayout()
@@ -322,18 +314,7 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
 
     // MARK: - Selection appearance
 
-    // RATIONALE: AppKit sets `backgroundStyle` via `objc_msgSend` from
-    // `-[NSTableRowView _updateBackgroundStylesForReals]` during window
-    // key-state changes — a plain main-thread call with no Swift concurrency
-    // context. A `@MainActor`-isolated `@objc` setter inserts a
-    // `_checkExpectedExecutor` precondition there, and on macOS 26 that
-    // executor-identity check (`swift_task_isCurrentExecutor`) can fault
-    // (EXC_BAD_ACCESS in `swift_getObjectType`) when invoked from that context.
-    // Declaring the override `nonisolated` removes the executor check entirely;
-    // the recolored subviews are `nonisolated(unsafe)` so we touch them directly
-    // (NOT via `MainActor.assumeIsolated`, which routes through the same faulting
-    // check). AppKit only sets this on the main thread, so the access is safe.
-    override nonisolated var backgroundStyle: NSView.BackgroundStyle {
+    override var backgroundStyle: NSView.BackgroundStyle {
         get { super.backgroundStyle }
         set {
             super.backgroundStyle = newValue


### PR DESCRIPTION
## Summary
- Restores standard `@MainActor` isolation to the sidebar VM-row cell, removing a `nonisolated` `backgroundStyle` override and `nonisolated(unsafe)` subview refs that were added to dodge a phantom `swift_task_isCurrentExecutor` crash on app activation.
- That crash was an **invalid causation conclusion** from a prior session chasing a rare/flaky activation crash. The workaround's own notes admitted the cause was mis-attributed twice from underpowered samples and that the baseline crash stopped reproducing — so it left the cell as permanently non-standard code with no verified justification.
- Surfaced because the Xcode 26.5 SDK made AppKit `@MainActor`-annotated, turning the workaround into 6 `@preconcurrency` warnings.

## Changes
- `SidebarVMRowCellView.backgroundStyle`: drop `nonisolated`, now a plain `@MainActor` override.
- `iconView`/`subtitleField`: drop `nonisolated(unsafe)`, declare as plain `private let`s with inline initializers; remove the now-obsolete `init` assignments.
- Remove the two `RATIONALE:` comment blocks documenting the workaround.

## Test plan
- [x] `xcodebuild build` succeeds with zero warnings on the file
- [x] Full suite (28 tests) passes with `-parallel-testing-enabled NO`
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)