### PR TITLE
refactor: Address SwiftUI-residue audit findings (tokens, list rebuilds, imperative presentation)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Kernova/
 │   ├── AppDelegate.swift               # NSApplicationDelegate — startup, window tracking, menu, suspend-on-quit
 │   ├── MainWindowController.swift      # NSSplitViewController + NSToolbar with native items
 │   ├── VMDisplayWindowController.swift  # Per-VM display window (pop-out or fullscreen), auto-closes on VM stop
-│   ├── DetailContainerViewController.swift # Layers AppKit VM display over the AppKit detail content (empty-state view ⇆ `VMDetailRouterViewController`); respects per-instance detailPaneMode; owns `DetailAlertsPresenter`; also presents the AppKit creation wizard as a sheet (observes viewModel.showCreationWizard via SheetPresenter)
+│   ├── DetailContainerViewController.swift # Layers AppKit VM display over the AppKit detail content (empty-state view ⇆ `VMDetailRouterViewController`); respects per-instance detailPaneMode; owns `DetailAlertsPresenter`; conforms to `VMLibraryPresenting` (the view model's presentation delegate), forwarding lifecycle alerts to `DetailAlertsPresenter` and presenting the creation-wizard sheet via `SheetPresenter`
 │   ├── VMToolbarManager.swift          # Shared toolbar logic for lifecycle, suspend, display, and settings-toggle items
 │   ├── SerialConsoleWindowController.swift # Per-VM serial console window, auto-closes on VM stop
 │   ├── SerialConsoleContentViewController.swift # Pure AppKit serial terminal + status bar (contains SerialTextView)
@@ -52,7 +52,8 @@ Kernova/
 │       ├── MacOSInstallProviding.swift
 │       └── IPSWProviding.swift
 ├── ViewModels/                         # Observable view models and coordinators
-│   ├── VMLibraryViewModel.swift        # Central view model — owns [VMInstance], delegates to coordinator
+│   ├── VMLibraryViewModel.swift        # Central view model — owns [VMInstance], delegates to coordinator; surfaces alerts/sheets/wizard imperatively via the `VMLibraryPresenting` delegate
+│   ├── VMLibraryPresenting.swift       # Presentation delegate protocol the view model calls (implemented by `DetailContainerViewController`)
 │   ├── VMLifecycleCoordinator.swift    # Owns services, orchestrates multi-step operations (@MainActor)
 │   ├── VMCreationViewModel.swift       # Drives the multi-step VM creation wizard
 │   └── VMDirectoryWatcher.swift        # DispatchSource monitor for external filesystem changes
@@ -71,7 +72,7 @@ Kernova/
 │   │   ├── VMSettingsViewController.swift # VM configuration editor (9 grouped-form sections) in pure AppKit; observation-driven idempotent `apply()`; lockable sections disabled while running with their headers/info still live; writes route through `VMLibraryViewModel.updateConfiguration`; reuses the AppKit popovers/sheets/alerts below. Rebuilds the form on VM switch
 │   │   ├── DetailStatusPlaceholderViewController.swift # Centered spinner + status label for transient states (starting/suspending/restoring) and clone/import preparing
 │   │   ├── InitialBootBannerView.swift # Orange "Initial Boot" banner with install-context-aware subtitle, stacked above the settings form for not-yet-booted macOS VMs
-│   │   ├── DetailEmptyStateView.swift  # Centered "No Virtual Machine Selected" empty state with a New Virtual Machine button (sets `viewModel.showCreationWizard`)
+│   │   ├── DetailEmptyStateView.swift  # Centered "No Virtual Machine Selected" empty state with a New Virtual Machine button (calls the container's `presentCreationWizard()`)
 │   │   ├── MacOSInstallProgressViewController.swift # Two-step (download → install) progress UI in pure AppKit — numbered step circles + connector, linear progress bar, monospaced detail text; observes `instance.installState`; Cancel confirms via `presentSheetAlert`
 │   │   ├── MicPermissionPresentation.swift # Pure helpers (unit-tested): `micPermissionPresentation(_:micEnabled:)` status→warning mapping, `externalAttachmentPaths(for:)`, `isGuestAgentSectionVisible(guestOS:)`
 │   │   ├── DiskSizePopoverCoordinator.swift # Pure-AppKit coordinator owning a `PopoverPresenter`; shows `DiskSizePopoverContentViewController` and forwards the confirmed size to an `onConfirm` closure (the settings VC wires in-bundle disk creation vs. the removable-media save panel). Replaces the former SwiftUI Create* anchors
@@ -106,11 +107,12 @@ Kernova/
 │   ├── DataFormatters.swift            # Human-readable formatting for bytes, CPU counts, etc.
 │   ├── NSImageExtensions.swift         # Nil-safe SF Symbol image loading
 │   ├── NSViewExtensions.swift          # Full-size subview constraint helper
+│   ├── DesignTokens.swift              # Centralized `Spacing` scale, `StatusColor` palette, and shared `Typography` font token
 │   ├── ObservationLoop.swift           # observeRecurring(track:apply:) helper wrapping withObservationTracking
 │   ├── PopoverPresenter.swift          # `NSPopover` lifecycle wrapper — one instance per anchor, refreshes content in place if shown again, fires `onClose` after dismissal
 │   ├── SheetPresenter.swift            # Custom-content sheet lifecycle wrapper — wraps an `NSViewController` in an `NSWindow` and attaches it as a sheet via `parent.beginSheet(_:completionHandler:)`. Use for richer sheets than `NSAlert` can express (e.g. `DeleteVMSheetContentViewController`, `StorageDiskReorderSheetContentViewController`).
 │   ├── SheetAlert.swift                # AppKit `NSAlert` presenter — `AlertConfiguration` (title + message + ordered `[AlertButton]`) + role enum (`.default` / `.cancel` / `.destructive` / `.standard`) maps to key-equivalents and `hasDestructiveAction`. `presentSheetAlert(_:in:completion:)` shows the alert as a window-modal sheet on the supplied `NSWindow`.
-│   └── DetailAlertsPresenter.swift     # Observes the seven detail-pane alert flags on `VMLibraryViewModel` (delete confirmation/sheet, cancel-preparing, force-stop, stop-paused, error, installer-mounted) and presents each via `presentSheetAlert` / `SheetPresenter(DeleteVMSheetContentViewController)`. Owned by `DetailContainerViewController` so alerts survive while the VM display is showing
+│   └── DetailAlertsPresenter.swift     # Imperative presenter for the detail-pane lifecycle alerts + delete sheet (delete confirmation/sheet, cancel-preparing, force-stop, stop-paused, error, installer-mounted). `DetailContainerViewController` forwards `VMLibraryPresenting` calls here; it serializes presentations (one at a time, queueing the rest) and shows each via `presentSheetAlert` / `SheetPresenter(DeleteVMSheetContentViewController)`. Owned by `DetailContainerViewController` so alerts survive while the VM display is showing
 └── Resources/
     ├── Assets.xcassets/                # App icons and image assets
     └── Kernova.entitlements            # com.apple.security.virtualization entitlement
@@ -153,7 +155,7 @@ Tools/
 └── regen-proto.sh                      # Regenerates kernova.pb.swift via protoc + protoc-gen-swift
 
 KernovaTests/
-├── Mocks/                              # Mock service implementations (8 files)
+├── Mocks/                              # Mock service implementations (9 files)
 │   ├── MockVirtualizationService.swift
 │   ├── SuspendingMockVirtualizationService.swift
 │   ├── MockVMStorageService.swift
@@ -161,7 +163,8 @@ KernovaTests/
 │   ├── MockMacOSInstallService.swift
 │   ├── MockIPSWService.swift
 │   ├── MockUSBDeviceService.swift
-│   └── SuspendingMockUSBDeviceService.swift
+│   ├── SuspendingMockUSBDeviceService.swift
+│   └── MockVMLibraryPresenting.swift   # Records VMLibraryViewModel presentation requests for test assertions
 ├── VMConfigurationTests.swift          # 43 tests for VMConfiguration
 ├── VMToolbarManagerTests.swift          # Toolbar manager item creation and state update tests
 ├── VMConfigurationCloneTests.swift     # Clone-specific configuration tests
@@ -309,7 +312,7 @@ All service implementations conform to protocols defined in `Services/Protocols/
 
 ### Views
 
-**Files:** the entire app target is pure AppKit — `NSViewController`/`NSView` subclasses plus free `make*` atom-factory functions, with no `import SwiftUI` anywhere. The detail pane (settings, router, install progress, placeholders, empty state) was the last SwiftUI surface and is now AppKit: `VMDetailRouterViewController` routes by status (via the unit-tested `DetailRoute.resolve`) to `VMSettingsViewController`, `DetailStatusPlaceholderViewController`, `MacOSInstallProgressViewController`, or the display placeholder. **Every popover, sheet, and alert is end-to-end AppKit**: missing-attachment (`AttachmentIconButton` → `MissingAttachmentPopoverContentViewController`), Storage Disk / Removable Media Create (`DiskSizePopoverCoordinator` → `DiskSizePopoverContentViewController`), the generic info-popover surface (`InfoButtonView` → `InfoPopoverContentViewController`), the mic-permission warning popover (`MicrophonePermissionPopoverContentViewController`), the Boot Order and Delete-VM sheets (via `SheetPresenter`), the lifecycle confirmation alerts (`DetailAlertsPresenter` → `presentSheetAlert`), and the sidebar agent-status popover (`SidebarVMRowCellView` → `SidebarAgentStatusButtonView` → `AgentStatusPopoverContentViewController`). Each uses a real `NSPopover`/`NSAlert`/sheet; controllers build their full layouts in `loadView()` using shared token sets (`CalloutStyle` for popovers, `GroupedFormStyle` for grouped forms shared with the wizard) + atom factory functions. **All popover anchors target a wrapper `NSView`** (never an inner control) so `NSPopover.preferredEdge` semantics are interpreted in an unflipped coordinate system. **No shared callout/form container or base class** — visual consistency comes from shared tokens, not inheritance. **Genuinely shareable controllers are reused via init parameterization** (`DiskSizePopoverContentViewController` serves both Create flows via `headline`/`caption`; `InfoPopoverContentViewController` takes `[InfoPopoverParagraph]` distinguishing `.body` from `.code`). AppKit content controllers decouple from `VMLibraryViewModel` via delegate protocols; their hosts (settings VC, alerts presenter) implement the delegates and forward user choices to the view model.
+**Files:** the entire app target is pure AppKit — `NSViewController`/`NSView` subclasses plus free `make*` atom-factory functions, with no `import SwiftUI` anywhere. The detail pane (settings, router, install progress, placeholders, empty state) was the last SwiftUI surface and is now AppKit: `VMDetailRouterViewController` routes by status (via the unit-tested `DetailRoute.resolve`) to `VMSettingsViewController`, `DetailStatusPlaceholderViewController`, `MacOSInstallProgressViewController`, or the display placeholder. **Every popover, sheet, and alert is end-to-end AppKit**: missing-attachment (`AttachmentIconButton` → `MissingAttachmentPopoverContentViewController`), Storage Disk / Removable Media Create (`DiskSizePopoverCoordinator` → `DiskSizePopoverContentViewController`), the generic info-popover surface (`InfoButtonView` → `InfoPopoverContentViewController`), the mic-permission warning popover (`MicrophonePermissionPopoverContentViewController`), the Boot Order and Delete-VM sheets (via `SheetPresenter`), the lifecycle confirmation alerts (`DetailAlertsPresenter` → `presentSheetAlert`), and the sidebar agent-status popover (`SidebarVMRowCellView` → `SidebarAgentStatusButtonView` → `AgentStatusPopoverContentViewController`). Each uses a real `NSPopover`/`NSAlert`/sheet; controllers build their full layouts in `loadView()` using shared token sets (`CalloutStyle` for popovers, `GroupedFormStyle` for grouped forms shared with the wizard) + atom factory functions. **All popover anchors target a wrapper `NSView`** (never an inner control) so `NSPopover.preferredEdge` semantics are interpreted in an unflipped coordinate system. **No shared callout/form container or base class** — visual consistency comes from shared tokens, not inheritance. **Genuinely shareable controllers are reused via init parameterization** (`DiskSizePopoverContentViewController` serves both Create flows via `headline`/`caption`; `InfoPopoverContentViewController` takes `[InfoPopoverParagraph]` distinguishing `.body` from `.code`). AppKit content controllers decouple from `VMLibraryViewModel` via delegate protocols; their hosts (settings VC, alerts presenter) implement the delegates and forward user choices to the view model. Conversely, the view model surfaces alerts, sheets, and the wizard by calling its `VMLibraryPresenting` delegate (`DetailContainerViewController`) imperatively — not by toggling observed `show*` flags. Errors raised before the delegate attaches (e.g. the initial `loadVMs()` in `init`) are buffered on the view model and flushed when it is set.
 
 Views observe `VMLibraryViewModel` and individual `VMInstance`s via the Observation framework (`observeRecurring`). The view hierarchy (AppKit throughout):
 
@@ -325,7 +328,7 @@ NSSplitViewController (MainWindowController)
             ├── DetailStatusPlaceholderViewController          (route: preparing / transition)
             ├── MacOSInstallProgressViewController             (route: installing)
             └── VMDisplayPlaceholderContentViewController      (route: display — placeholder when external/suspended/unavailable)
-VMCreationWizardViewController (pure-AppKit modal sheet; presented by DetailContainerViewController via SheetPresenter when viewModel.showCreationWizard flips true)
+VMCreationWizardViewController (pure-AppKit modal sheet; presented by DetailContainerViewController via SheetPresenter when presentCreationWizard() is called)
 ├── OSSelectionContentViewController
 ├── IPSWSelectionContentViewController / BootConfigContentViewController   (chosen by selectedOS on entry)
 ├── ResourceConfigContentViewController

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -332,7 +332,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     // MARK: - Menu Actions
 
     @objc func newVM(_ sender: Any?) {
-        viewModel.showCreationWizard = true
+        showLibraryWindow(bringToFront: true)
+        viewModel.presenter?.presentCreationWizard()
     }
 
     @objc func showLibrary(_ sender: Any?) {

--- a/Kernova/App/ClipboardContentViewController.swift
+++ b/Kernova/App/ClipboardContentViewController.swift
@@ -252,7 +252,7 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
 
         let stack = NSStackView(views: [statusCircle, statusLabel, spacer, actionButton])
         stack.orientation = .horizontal
-        stack.spacing = 6
+        stack.spacing = Spacing.small
         stack.edgeInsets = NSEdgeInsets(top: 6, left: 12, bottom: 6, right: 12)
         stack.alignment = .centerY
 

--- a/Kernova/App/DetailContainerViewController.swift
+++ b/Kernova/App/DetailContainerViewController.swift
@@ -25,7 +25,7 @@ final class DetailContainerViewController: NSViewController {
 
     private let contentContainer = NSView()
     private lazy var emptyStateView = DetailEmptyStateView { [weak self] in
-        self?.viewModel.showCreationWizard = true
+        self?.presentCreationWizard()
     }
     private var routerVC: VMDetailRouterViewController?
     private var currentContentView: NSView?
@@ -36,7 +36,9 @@ final class DetailContainerViewController: NSViewController {
 
     /// Drives the AppKit creation-wizard sheet.
     private let wizardPresenter = SheetPresenter()
-    private var wizardObservation: ObservationLoop?
+    /// Set when a wizard presentation is requested before the window exists;
+    /// `viewDidAppear` honors it once the window is available.
+    private var pendingWizard = false
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "DetailContainerVC")
 
@@ -46,6 +48,7 @@ final class DetailContainerViewController: NSViewController {
         self.viewModel = viewModel
         self.alertsPresenter = DetailAlertsPresenter(viewModel: viewModel)
         super.init(nibName: nil, bundle: nil)
+        viewModel.presenter = self
     }
 
     required init?(coder: NSCoder) {
@@ -78,18 +81,14 @@ final class DetailContainerViewController: NSViewController {
         updateContent()
         updateDisplayState()
         if stateObservation == nil { observeState() }
-        if wizardObservation == nil { observeWizardPresentation() }
         if let window = view.window { alertsPresenter.start(window: window) }
-        // Handle the case where the flag was set before the window existed.
-        syncWizardPresentation()
+        if pendingWizard { presentCreationWizard() }
     }
 
     override func viewWillDisappear() {
         super.viewWillDisappear()
         stateObservation?.cancel()
         stateObservation = nil
-        wizardObservation?.cancel()
-        wizardObservation = nil
         alertsPresenter.stop()
         if wizardPresenter.isShown { wizardPresenter.close() }
         for id in Array(backingViews.keys) {
@@ -194,38 +193,6 @@ final class DetailContainerViewController: NSViewController {
         )
     }
 
-    // MARK: - Creation Wizard Presentation
-
-    private func observeWizardPresentation() {
-        wizardObservation = observeRecurring(
-            track: { [weak self] in
-                _ = self?.viewModel.showCreationWizard
-            },
-            apply: { [weak self] in
-                self?.syncWizardPresentation()
-            }
-        )
-    }
-
-    private func syncWizardPresentation() {
-        if viewModel.showCreationWizard {
-            guard !wizardPresenter.isShown, let window = view.window else { return }
-            let creationVM = VMCreationViewModel()
-            let wizard = VMCreationWizardViewController(creationVM: creationVM)
-            wizard.delegate = self
-            wizardPresenter.onClose = { [weak self] in
-                // Resetting the flag re-fires the observation; the `isShown`
-                // guard above makes the resulting `syncWizardPresentation()` a
-                // no-op (the sheet is already gone).
-                self?.viewModel.showCreationWizard = false
-            }
-            wizardPresenter.show(content: wizard, in: window)
-            Self.logger.notice("Presented creation wizard")
-        } else if wizardPresenter.isShown {
-            wizardPresenter.close()
-        }
-    }
-
     private func updateDisplayState() {
         // Evict backing views for VMs no longer running inline
         let activeInlineIDs = Set(
@@ -288,24 +255,65 @@ extension DetailContainerViewController: VMCreationWizardViewControllerDelegate 
         _ vc: VMCreationWizardViewController,
         creationVM: VMCreationViewModel
     ) {
-        // Keep the sheet up until creation completes. On success, dismiss it. On
-        // failure, take over the error that `createVM` surfaced via
-        // `showError`/`errorMessage` and re-present it on the wizard's own window:
-        // the alerts presenter lives on this same main window, so letting it
-        // fire would race the still-open AppKit wizard sheet (two sheets on one
-        // window). Keeping the wizard up also lets the user retry without
-        // re-entering everything.
+        // Keep the sheet up until creation completes. On success, dismiss it; on
+        // failure, present the error on the wizard's own window and keep it open
+        // for a retry. `createVM` returns the error rather than presenting it, so
+        // the global alerts presenter on this same window can't race the
+        // still-open wizard sheet.
         Task { [weak self] in
             guard let self else { return }
-            let succeeded = await self.viewModel.createVM(from: creationVM)
-            if succeeded {
+            switch await self.viewModel.createVM(from: creationVM) {
+            case .success:
                 self.wizardPresenter.close()
-            } else {
-                let message = self.viewModel.errorMessage
-                self.viewModel.showError = false
-                self.viewModel.errorMessage = nil
-                vc.presentCreationFailure(message: message)
+            case .failure(let error):
+                vc.presentCreationFailure(message: error.localizedDescription)
             }
         }
+    }
+}
+
+// MARK: - VMLibraryPresenting
+
+extension DetailContainerViewController: VMLibraryPresenting {
+    func presentError(_ message: String) {
+        alertsPresenter.presentError(message)
+    }
+
+    func presentDeleteConfirmation(for instance: VMInstance) {
+        alertsPresenter.presentDeleteConfirmation(for: instance)
+    }
+
+    func presentDeleteSheet(for instance: VMInstance) {
+        alertsPresenter.presentDeleteSheet(for: instance)
+    }
+
+    func presentForceStop(for instance: VMInstance) {
+        alertsPresenter.presentForceStop(for: instance)
+    }
+
+    func presentStopPaused(for instance: VMInstance) {
+        alertsPresenter.presentStopPaused(for: instance)
+    }
+
+    func presentCancelPreparing(for instance: VMInstance) {
+        alertsPresenter.presentCancelPreparing(for: instance)
+    }
+
+    func presentInstallerMounted(vmName: String) {
+        alertsPresenter.presentInstallerMounted(vmName: vmName)
+    }
+
+    func presentCreationWizard() {
+        guard !wizardPresenter.isShown else { return }
+        guard let window = view.window else {
+            pendingWizard = true
+            return
+        }
+        pendingWizard = false
+        let creationVM = VMCreationViewModel()
+        let wizard = VMCreationWizardViewController(creationVM: creationVM)
+        wizard.delegate = self
+        wizardPresenter.show(content: wizard, in: window)
+        Self.logger.notice("Presented creation wizard")
     }
 }

--- a/Kernova/App/SerialConsoleContentViewController.swift
+++ b/Kernova/App/SerialConsoleContentViewController.swift
@@ -178,7 +178,7 @@ final class SerialConsoleContentViewController: NSViewController {
     private func makeStatusBar() -> NSView {
         let leftStack = NSStackView(views: [statusCircle, statusLabel])
         leftStack.orientation = .horizontal
-        leftStack.spacing = 6
+        leftStack.spacing = Spacing.small
 
         let stack = NSStackView(views: [leftStack, characterCountLabel])
         stack.orientation = .horizontal

--- a/Kernova/Models/StorageDisk.swift
+++ b/Kernova/Models/StorageDisk.swift
@@ -19,7 +19,7 @@ enum StorageDiskKind: String, Codable, Sendable, Equatable {
 /// configuration, which EFI uses for boot order. Includes both the
 /// bundle's primary disk (`Disk.asif`) and any user-added internal /
 /// external disks or installer images — all rendered identically in the UI.
-struct StorageDisk: Codable, Sendable, Equatable, Identifiable {
+struct StorageDisk: Codable, Sendable, Equatable {
     var id: UUID
     /// Bundle-relative for internal disks (e.g. `"Disk.asif"`,
     /// `"AdditionalDisks/<id>.asif"`); absolute for external disks.
@@ -95,7 +95,7 @@ struct StorageDisk: Codable, Sendable, Equatable, Identifiable {
 /// media. Each item's `id` becomes the `VZUSBMassStorageDeviceConfiguration.uuid`
 /// so save-state restore can match the configured item against the
 /// saved-state device list.
-struct RemovableMediaItem: Codable, Sendable, Equatable, Identifiable {
+struct RemovableMediaItem: Codable, Sendable, Equatable {
     var id: UUID
     var path: String
     var readOnly: Bool
@@ -123,7 +123,7 @@ struct RemovableMediaItem: Codable, Sendable, Equatable, Identifiable {
 /// when one or more other VMs in the library reference the same path —
 /// the UI uses that to warn before the user opts in to trashing a shared
 /// file (e.g., a Windows installer ISO referenced by several VMs).
-struct ExternalAttachment: Identifiable, Sendable, Equatable {
+struct ExternalAttachment: Sendable, Equatable {
     enum Kind: Sendable, Equatable {
         case storageDisk
         case removableMedia

--- a/Kernova/Models/USBDeviceInfo.swift
+++ b/Kernova/Models/USBDeviceInfo.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// This is a runtime-only type — not persisted to disk. USB devices are
 /// transient and detach automatically when the VM stops.
-struct USBDeviceInfo: Identifiable, Sendable, Equatable {
+struct USBDeviceInfo: Sendable, Equatable {
     let id: UUID
     let path: String
     let readOnly: Bool

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -17,7 +17,7 @@ enum VMDisplayPreference: String, Codable, Sendable, Equatable {
 /// > the custom `init(from:)` as well.** Optional properties decoded via
 /// > synthesized `init(from:)` would default to `nil` silently; the manual
 /// > initializer makes that decision explicit.
-struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
+struct VMConfiguration: Codable, Sendable, Equatable {
     // MARK: - Identity
 
     var id: UUID
@@ -388,7 +388,7 @@ struct VMConfiguration: Codable, Identifiable, Sendable, Equatable {
 // MARK: - SharedDirectory
 
 /// A host directory shared with the guest VM via VirtioFS.
-struct SharedDirectory: Codable, Sendable, Equatable, Identifiable {
+struct SharedDirectory: Codable, Sendable, Equatable {
     var id: UUID
     var path: String
     var readOnly: Bool

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -23,7 +23,7 @@ enum DetailPaneMode: Sendable {
 /// Runtime wrapper around a VM configuration, its backing virtual machine, and current status.
 @MainActor
 @Observable
-final class VMInstance: Identifiable {
+final class VMInstance {
     // MARK: - Properties
 
     let instanceID: UUID

--- a/Kernova/Services/AttachmentFileMonitor.swift
+++ b/Kernova/Services/AttachmentFileMonitor.swift
@@ -25,8 +25,8 @@ final class AttachmentFileMonitor {
 
     /// Latest known existence flag for each watched path.
     ///
-    /// Reads inside a SwiftUI `body` register an Observation dependency, so
-    /// updates re-render the row without a synchronous filesystem check.
+    /// Reads inside a `withObservationTracking` block register an Observation
+    /// dependency, so updates refresh the affected rows without a sync check.
     private(set) var existsByPath: [String: Bool] = [:]
 
     /// Parent directory -> live watcher. `nonisolated(unsafe)` so `deinit`

--- a/Kernova/Services/ClipboardServicing.swift
+++ b/Kernova/Services/ClipboardServicing.swift
@@ -10,7 +10,7 @@ import Foundation
 ///
 /// Both implementations are `@Observable` classes so consumers can observe
 /// `clipboardText` and `isConnected` through the existential type without losing
-/// SwiftUI / `withObservationTracking` integration: the `@Observable` macro
+/// `withObservationTracking` integration: the `@Observable` macro
 /// installs the registrar on the concrete type, so reading or writing through
 /// the protocol witness still fires observation.
 ///

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -461,9 +461,8 @@ struct ConfigurationBuilder: Sendable {
     /// the bundle path.
     ///
     /// The synthesizer fires whenever `storageDisks` is nil/empty.
-    /// Without stable identity, SwiftUI's `ForEach` would tear down the
-    /// main-disk row on every re-render, and `removeStorageDisk`'s
-    /// entry-lookup-by-id would miss the row the user just clicked —
+    /// Without stable identity, `removeStorageDisk`'s entry-lookup-by-id
+    /// would miss the row the user just clicked —
     /// silently no-op'ing the entry removal while still trashing the
     /// underlying file. Once the user makes any edit, the list is
     /// persisted with this id and the synthesizer is no longer

--- a/Kernova/Utilities/DesignTokens.swift
+++ b/Kernova/Utilities/DesignTokens.swift
@@ -1,0 +1,63 @@
+import AppKit
+
+/// Centralized design tokens for the AppKit UI.
+///
+/// These replace scattered magic numbers and ad-hoc `NSColor` choices so the
+/// visual language lives in one place. They are the AppKit realization of the
+/// design rhythm described in `SPEC.md`. Prefer these over inline literals when
+/// building view hierarchies.
+
+/// Standard inter-element spacing for `NSStackView`s and manual layout.
+///
+/// The names describe magnitude, not a single fixed purpose — the same value is
+/// reused across contexts. Values are the deliberate tiers already in use across
+/// the app; do not introduce off-scale values without a reason.
+enum Spacing {
+    /// Flush — no gap (`0`).
+    static let none: CGFloat = 0
+    /// Hairline gap between tightly-related text lines, e.g. title over subtitle (`2`).
+    static let hairline: CGFloat = 2
+    /// Tight grouping, e.g. a field and its stepper (`4`).
+    static let tight: CGFloat = 4
+    /// Small gap, e.g. icon-to-label or section-header elements (`6`).
+    static let small: CGFloat = 6
+    /// Standard inline / row spacing — the default (`8`).
+    static let standard: CGFloat = 8
+    /// Relaxed spacing for grouped card content rows (`10`).
+    static let relaxed: CGFloat = 10
+    /// Medium gap between grouped elements and containers (`12`).
+    static let medium: CGFloat = 12
+    /// Large gap between major wizard options / blocks (`16`).
+    static let large: CGFloat = 16
+    /// Spacing between settings-form sections (`18`).
+    static let section: CGFloat = 18
+    /// Major separation, e.g. install-progress hero blocks (`20`).
+    static let major: CGFloat = 20
+}
+
+/// Status → color mapping shared by VM-status and guest-agent-status indicators.
+///
+/// Single source of truth for the semantic status palette so VM-status dots and
+/// the agent-status icon stay visually consistent and can be retuned in one place.
+enum StatusColor {
+    /// Inert / not-yet-connected (stopped VM, agent waiting/connecting).
+    static let inactive = NSColor.secondaryLabelColor
+    /// Transitional or attention-needed (preparing/starting/saving/restoring/
+    /// installing/cold-paused; agent outdated/unresponsive/expected-missing).
+    static let warning = NSColor.systemOrange
+    /// Healthy / running (running VM, agent current).
+    static let running = NSColor.systemGreen
+    /// Paused in memory.
+    static let pausedInMemory = NSColor.systemYellow
+    /// Error state.
+    static let error = NSColor.systemRed
+}
+
+/// Shared text styles.
+///
+/// Wraps the common `NSFont.preferredFont(forTextStyle:)` choices that were
+/// otherwise duplicated inline across view controllers.
+enum Typography {
+    /// Primary body text — the default for form labels and list-row titles.
+    static var body: NSFont { .preferredFont(forTextStyle: .body) }
+}

--- a/Kernova/Utilities/DetailAlertsPresenter.swift
+++ b/Kernova/Utilities/DetailAlertsPresenter.swift
@@ -1,23 +1,29 @@
 import AppKit
 
 /// Presents the detail pane's lifecycle confirmation alerts and the delete
-/// sheet, driven by the view model's flags.
+/// sheet on behalf of `DetailContainerViewController`.
 ///
 /// AppKit replacement for the SwiftUI `LifecycleAlerts` modifier (on the former
 /// `VMDetailView`) plus the error / installer-mounted alerts that lived on
-/// `MainDetailView`. Because these were hosted on the always-present SwiftUI
-/// layer so they survived while the VM display was showing, the AppKit home is
-/// here — owned by `DetailContainerViewController`, which is always present and
-/// owns the window. One `ObservationLoop` watches the flags; each `false→true`
-/// transition presents the matching alert (or the rich delete sheet) and resets
-/// the flag on dismissal.
+/// `MainDetailView`. These are owned by `DetailContainerViewController` — which
+/// is always present and owns the window — so they survive while the VM display
+/// is showing.
+///
+/// Presentation is imperative: the container forwards each request here. One
+/// alert/sheet shows at a time; requests that arrive while one is up (or before
+/// the window exists) are queued and run in order.
 @MainActor
 final class DetailAlertsPresenter: NSObject {
     private let viewModel: VMLibraryViewModel
     private weak var window: NSWindow?
     private let deleteSheetPresenter = SheetPresenter()
-    private var observation: ObservationLoop?
     private var isShowingAlert = false
+    /// The VM the delete sheet is currently presenting for, read by the sheet
+    /// delegate on confirm.
+    private var deleteSheetInstance: VMInstance?
+    /// Presentation requests deferred because the presenter was busy (an alert
+    /// or sheet was up) or had no window yet; drained in order once free.
+    private var pending: [(DetailAlertsPresenter) -> Void] = []
 
     init(viewModel: VMLibraryViewModel) {
         self.viewModel = viewModel
@@ -26,95 +32,77 @@ final class DetailAlertsPresenter: NSObject {
 
     func start(window: NSWindow) {
         self.window = window
-        guard observation == nil else { return }
-        observation = observeRecurring(
-            track: { [weak self] in
-                guard let self else { return }
-                _ = self.viewModel.showDeleteConfirmation
-                _ = self.viewModel.showDeleteSheet
-                _ = self.viewModel.showCancelPreparingConfirmation
-                _ = self.viewModel.showForceStopConfirmation
-                _ = self.viewModel.showStopPausedConfirmation
-                _ = self.viewModel.showError
-                _ = self.viewModel.showInstallerMountedAlert
-            },
-            apply: { [weak self] in self?.apply() }
-        )
-        apply()
+        runNext()
     }
 
     func stop() {
-        observation?.cancel()
-        observation = nil
         if deleteSheetPresenter.isShown { deleteSheetPresenter.close() }
+        pending.removeAll()
     }
 
-    // MARK: - Presentation
+    // MARK: - Imperative presentation
 
-    private func apply() {
-        guard let window, !isShowingAlert, !deleteSheetPresenter.isShown else { return }
-
-        if viewModel.showDeleteSheet, let vm = viewModel.instanceToDelete {
-            presentDeleteSheet(vm: vm, window: window)
-            return
-        }
-        if viewModel.showDeleteConfirmation, let vm = viewModel.instanceToDelete {
-            present(deleteConfirmationConfig(vm)) { [weak self] in
-                self?.viewModel.showDeleteConfirmation = false
-            }
-            return
-        }
-        if viewModel.showCancelPreparingConfirmation, let instance = viewModel.preparingInstanceToCancel {
-            present(cancelPreparingConfig(instance)) { [weak self] in
-                self?.viewModel.showCancelPreparingConfirmation = false
-            }
-            return
-        }
-        if viewModel.showForceStopConfirmation, let vm = viewModel.instanceToForceStop {
-            present(forceStopConfig(vm)) { [weak self] in
-                self?.viewModel.showForceStopConfirmation = false
-            }
-            return
-        }
-        if viewModel.showStopPausedConfirmation, let vm = viewModel.instanceToStopPaused {
-            present(stopPausedConfig(vm)) { [weak self] in
-                self?.viewModel.showStopPausedConfirmation = false
-            }
-            return
-        }
-        if viewModel.showError, let message = viewModel.errorMessage {
-            present(errorConfig(message)) { [weak self] in
-                self?.viewModel.showError = false
-            }
-            return
-        }
-        if viewModel.showInstallerMountedAlert, let name = viewModel.installerMountedVMName {
-            present(installerMountedConfig(name)) { [weak self] in
-                self?.viewModel.showInstallerMountedAlert = false
-            }
-            return
-        }
+    func presentError(_ message: String) {
+        enqueue { $0.present($0.errorConfig(message)) }
     }
 
-    private func present(_ config: AlertConfiguration, reset: @escaping () -> Void) {
+    func presentDeleteConfirmation(for instance: VMInstance) {
+        enqueue { $0.present($0.deleteConfirmationConfig(instance)) }
+    }
+
+    func presentDeleteSheet(for instance: VMInstance) {
+        enqueue { $0.showDeleteSheet(for: instance) }
+    }
+
+    func presentForceStop(for instance: VMInstance) {
+        enqueue { $0.present($0.forceStopConfig(instance)) }
+    }
+
+    func presentStopPaused(for instance: VMInstance) {
+        enqueue { $0.present($0.stopPausedConfig(instance)) }
+    }
+
+    func presentCancelPreparing(for instance: VMInstance) {
+        enqueue { $0.present($0.cancelPreparingConfig(instance)) }
+    }
+
+    func presentInstallerMounted(vmName: String) {
+        enqueue { $0.present($0.installerMountedConfig(vmName)) }
+    }
+
+    // MARK: - Serialization queue
+
+    private func enqueue(_ work: @escaping (DetailAlertsPresenter) -> Void) {
+        pending.append(work)
+        runNext()
+    }
+
+    private func runNext() {
+        guard window != nil, !isShowingAlert, !deleteSheetPresenter.isShown, !pending.isEmpty else {
+            return
+        }
+        let next = pending.removeFirst()
+        next(self)
+    }
+
+    private func present(_ config: AlertConfiguration) {
         guard let window else { return }
         isShowingAlert = true
         presentSheetAlert(config, in: window) { [weak self] in
             self?.isShowingAlert = false
-            reset()
-            // Another flag may have been set meanwhile; re-evaluate.
-            self?.apply()
+            self?.runNext()
         }
     }
 
-    private func presentDeleteSheet(vm: VMInstance, window: NSWindow) {
-        let externals = viewModel.externalAttachments(for: vm)
-        let content = DeleteVMSheetContentViewController(vmName: vm.name, externals: externals)
+    private func showDeleteSheet(for instance: VMInstance) {
+        guard let window else { return }
+        let externals = viewModel.externalAttachments(for: instance)
+        let content = DeleteVMSheetContentViewController(vmName: instance.name, externals: externals)
         content.delegate = self
+        deleteSheetInstance = instance
         deleteSheetPresenter.onClose = { [weak self] in
-            self?.viewModel.showDeleteSheet = false
-            self?.viewModel.instanceToDelete = nil
-            self?.apply()
+            self?.deleteSheetInstance = nil
+            self?.runNext()
         }
         deleteSheetPresenter.show(content: content, in: window)
     }
@@ -210,16 +198,14 @@ final class DetailAlertsPresenter: NSObject {
 
 extension DetailAlertsPresenter: DeleteVMSheetContentViewControllerDelegate {
     func deleteVMSheetDidCancel(_ vc: DeleteVMSheetContentViewController) {
-        viewModel.showDeleteSheet = false
-        viewModel.instanceToDelete = nil
         deleteSheetPresenter.close()
     }
 
     func deleteVMSheet(
         _ vc: DeleteVMSheetContentViewController, didConfirmTrashExternals trashExternals: Bool
     ) {
-        if let vm = viewModel.instanceToDelete {
-            _ = viewModel.deleteConfirmed(vm, trashExternals: trashExternals)
+        if let instance = deleteSheetInstance {
+            _ = viewModel.deleteConfirmed(instance, trashExternals: trashExternals)
         }
         deleteSheetPresenter.close()
     }

--- a/Kernova/Utilities/SheetAlert.swift
+++ b/Kernova/Utilities/SheetAlert.swift
@@ -37,8 +37,7 @@ struct AlertButton {
 
 /// Declarative description of a sheet alert.
 ///
-/// Passed to ``presentSheetAlert(_:in:completion:)`` (or the SwiftUI
-/// `.sheetAlert(...)` modifier). Buttons appear in `NSAlert` in the order
+/// Passed to ``presentSheetAlert(_:in:completion:)``. Buttons appear in `NSAlert` in the order
 /// listed; the first button added is the AppKit "default" by convention,
 /// but ``presentSheetAlert(_:in:completion:)`` overrides the default
 /// key-equivalent based on roles so the user's chosen `.default` (or none
@@ -59,12 +58,9 @@ struct AlertConfiguration {
 ///
 /// - Parameters:
 ///   - config: Title, message, and buttons.
-///   - window: The window the sheet attaches to. Typically the host view's
-///     own `view.window`, captured via the
-///     `.sheetAlert(...)` SwiftUI modifier's `WindowAccessor`.
+///   - window: The window the sheet attaches to — typically the presenting
+///     view controller's own `view.window`.
 ///   - completion: Fired after the user's chosen button action has run.
-///     The bridge modifier uses this to reset the SwiftUI `isPresented`
-///     binding.
 @MainActor
 func presentSheetAlert(
     _ config: AlertConfiguration,

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -2,13 +2,11 @@ import Foundation
 import Virtualization
 
 /// Wizard steps for creating a new VM.
-enum VMCreationStep: String, CaseIterable, Identifiable, Sendable {
+enum VMCreationStep: String, CaseIterable, Sendable {
     case osSelection
     case bootConfig
     case resources
     case review
-
-    var id: String { rawValue }
 
     var title: String {
         switch self {

--- a/Kernova/ViewModels/VMLibraryPresenting.swift
+++ b/Kernova/ViewModels/VMLibraryPresenting.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Imperative presentation interface the view model calls to surface alerts,
+/// sheets, and the creation wizard.
+///
+/// Replaces the former observed `show*` boolean flags on `VMLibraryViewModel`.
+/// Instead of flipping observable state and having a presenter react to it, the
+/// view model calls these methods directly. `DetailContainerViewController` (the
+/// always-present window owner) implements them — forwarding alerts and the
+/// delete sheet to `DetailAlertsPresenter` and owning the wizard sheet itself.
+@MainActor
+protocol VMLibraryPresenting: AnyObject {
+    /// Show a generic error alert with `message`.
+    func presentError(_ message: String)
+    /// Show the simple delete confirmation for a VM with no external attachments.
+    func presentDeleteConfirmation(for instance: VMInstance)
+    /// Show the richer delete sheet (which offers trashing external files) for a
+    /// VM that references external storage or removable media.
+    func presentDeleteSheet(for instance: VMInstance)
+    /// Show the force-stop / discard-saved-state confirmation.
+    func presentForceStop(for instance: VMInstance)
+    /// Show the stop-paused confirmation (resume-and-shut-down vs. force stop).
+    func presentStopPaused(for instance: VMInstance)
+    /// Show the cancel-preparing (clone/import) confirmation.
+    func presentCancelPreparing(for instance: VMInstance)
+    /// Show the "guest agent installer mounted, here are the next steps" alert.
+    func presentInstallerMounted(vmName: String)
+    /// Present the VM creation wizard sheet.
+    func presentCreationWizard()
+}

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -1086,7 +1086,7 @@ final class VMLibraryViewModel {
     /// agent-status popover, and the menubar item.
     ///
     /// On successful mount, sets `installerMountedVMName` to drive an
-    /// SwiftUI `.alert()` that explains the next step (open the disk in the
+    /// alert that explains the next step (open the disk in the
     /// guest's Finder, run install.command). The alert unifies the
     /// post-click experience across all three entry points.
     ///
@@ -1225,8 +1225,8 @@ final class VMLibraryViewModel {
     /// file open, so we don't need to wait for the detach to complete.
     ///
     /// The trash runs in `Task.detached` (see `removeStorageDisk` for the
-    /// reasoning). The returned Task lets tests await completion; the
-    /// SwiftUI caller uses `@discardableResult` and ignores it.
+    /// reasoning). The returned Task lets tests await completion;
+    /// `@discardableResult` lets the UI callers ignore it.
     @discardableResult
     func removeRemovableMedia(
         _ item: RemovableMediaItem, from instance: VMInstance, trashFile: Bool
@@ -1772,7 +1772,7 @@ final class VMLibraryViewModel {
 
     /// Moves VMs in the sidebar list and persists the new order.
     ///
-    /// Called by SwiftUI's onMove handler.
+    /// Called by the sidebar outline view's drag-drop `acceptDrop`.
     func moveVM(fromOffsets source: IndexSet, toOffset destination: Int) {
         instances.move(fromOffsets: source, toOffset: destination)
         persistOrder()

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -29,28 +29,24 @@ final class VMLibraryViewModel {
             }
         }
     }
-    var showCreationWizard = false
-    var showDeleteConfirmation = false
-    /// Drives the richer delete sheet for VMs with external attachments.
-    ///
-    /// Appears in place of `showDeleteConfirmation`'s alert when the
-    /// VM-to-delete references external files (storage disks or removable
-    /// media) that the user may also want to send to Trash. Mutually
-    /// exclusive with `showDeleteConfirmation`; `confirmDelete(_:)` picks
-    /// exactly one.
-    var showDeleteSheet = false
 
-    var showError = false
-    var errorMessage: String?
-
-    /// Drives the post-mount instructions alert.
+    /// Presentation delegate for alerts, sheets, and the creation wizard.
     ///
-    /// Set after a successful
-    /// `mountGuestAgentInstaller(on:)` so the user gets unified guidance no
-    /// matter which entry point (sidebar popover, clipboard window button, or
-    /// menubar item) triggered the mount.
-    var showInstallerMountedAlert = false
-    var installerMountedVMName: String?
+    /// Set by `DetailContainerViewController`. The view model calls these
+    /// methods imperatively instead of toggling observed `show*` flags. Errors
+    /// raised before a presenter is attached (e.g. the initial `loadVMs()` in
+    /// `init`) are buffered and flushed when one is set.
+    @ObservationIgnored weak var presenter: (any VMLibraryPresenting)? {
+        didSet {
+            guard presenter != nil, !bufferedErrorMessages.isEmpty else { return }
+            let buffered = bufferedErrorMessages
+            bufferedErrorMessages.removeAll()
+            buffered.forEach { presenter?.presentError($0) }
+        }
+    }
+
+    /// Error messages raised while `presenter` was nil, flushed when it is set.
+    @ObservationIgnored private var bufferedErrorMessages: [String] = []
 
     /// VMs with an in-flight removable-media reconciliation Task.
     ///
@@ -67,14 +63,7 @@ final class VMLibraryViewModel {
     /// time `applyLivePolicy` sees a list change on a running/paused VM
     /// and drained by `runRemovableMediaReconciliation` until empty.
     private var pendingRemovableMediaTarget: [UUID: [RemovableMediaItem]] = [:]
-    var instanceToDelete: VMInstance?
     var activeRename: RenameTarget?
-    var showCancelPreparingConfirmation = false
-    var preparingInstanceToCancel: VMInstance?
-    var showForceStopConfirmation = false
-    var instanceToForceStop: VMInstance?
-    var showStopPausedConfirmation = false
-    var instanceToStopPaused: VMInstance?
 
     /// `true` when any instance is mid-clone or mid-import.
     var hasPreparing: Bool { instances.contains(where: \.isPreparing) }
@@ -206,12 +195,11 @@ final class VMLibraryViewModel {
     /// Creates a VM bundle and disk image from a wizard model, optionally
     /// auto-starting it.
     ///
-    /// Returns `true` on success and `false` if bundle/disk creation failed. On
-    /// failure the error is also surfaced via `presentError` (so non-wizard
-    /// callers get the standard alert); the wizard host inspects the return value
-    /// to keep its sheet open for a retry instead.
+    /// Returns `.success` on success, or `.failure(error)` if bundle/disk
+    /// creation failed. The error is returned (not presented) so the wizard host
+    /// can show it on the wizard's own sheet and keep it open for a retry.
     @discardableResult
-    func createVM(from wizard: VMCreationViewModel) async -> Bool {
+    func createVM(from wizard: VMCreationViewModel) async -> Result<Void, Error> {
         do {
             var config = wizard.buildConfiguration()
 
@@ -256,11 +244,10 @@ final class VMLibraryViewModel {
                 )
                 await start(instance)
             }
-            return true
+            return .success(())
         } catch {
             Self.logger.error("Failed to create VM: \(error.localizedDescription, privacy: .public)")
-            presentError(error)
-            return false
+            return .failure(error)
         }
     }
 
@@ -384,8 +371,7 @@ final class VMLibraryViewModel {
         // VZ rejects requestStop() on paused VMs ("Invalid virtual machine state").
         // Surface a confirmation sheet offering resume-and-shutdown or force-stop instead.
         if instance.status == .paused && !instance.isColdPaused {
-            instanceToStopPaused = instance
-            showStopPausedConfirmation = true
+            presenter?.presentStopPaused(for: instance)
             return
         }
         do {
@@ -417,16 +403,12 @@ final class VMLibraryViewModel {
             )
             presentError(error)
         }
-        instanceToStopPaused = nil
-        showStopPausedConfirmation = false
     }
 
     /// Force-stops a paused VM via the stop-paused confirmation sheet's "Force Stop" action.
     /// Wrapper around `forceStop` that clears the alert state, matching `deleteConfirmed`'s pattern.
     func forceStopFromPaused(_ instance: VMInstance) async {
         await forceStop(instance)
-        instanceToStopPaused = nil
-        showStopPausedConfirmation = false
     }
 
     func forceStop(_ instance: VMInstance) async {
@@ -444,8 +426,7 @@ final class VMLibraryViewModel {
     // MARK: - Force Stop Confirmation
 
     func confirmForceStop(_ instance: VMInstance) {
-        instanceToForceStop = instance
-        showForceStopConfirmation = true
+        presenter?.presentForceStop(for: instance)
     }
 
     func forceStopConfirmed(_ instance: VMInstance) async {
@@ -504,11 +485,10 @@ final class VMLibraryViewModel {
     /// or removable media (so the user can opt to trash those files too);
     /// falls back to the simple alert otherwise.
     func confirmDelete(_ instance: VMInstance) {
-        instanceToDelete = instance
         if externalAttachments(for: instance).isEmpty {
-            showDeleteConfirmation = true
+            presenter?.presentDeleteConfirmation(for: instance)
         } else {
-            showDeleteSheet = true
+            presenter?.presentDeleteSheet(for: instance)
         }
     }
 
@@ -550,9 +530,6 @@ final class VMLibraryViewModel {
             )
             presentError(error)
         }
-        instanceToDelete = nil
-        showDeleteConfirmation = false
-        showDeleteSheet = false
         return tasks
     }
 
@@ -662,9 +639,7 @@ final class VMLibraryViewModel {
                     "Failed to trash external attachment '\(label, privacy: .public)' (\(url.lastPathComponent, privacy: .public)) on deleted VM '\(vmName, privacy: .public)': \(message, privacy: .public)"
                 )
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
-                    self.errorMessage = message
-                    self.showError = true
+                    self?.surfaceError(message)
                 }
             }
         }
@@ -1085,10 +1060,10 @@ final class VMLibraryViewModel {
     /// clipboard window's "Install Guest Agent…" affordance, the sidebar's
     /// agent-status popover, and the menubar item.
     ///
-    /// On successful mount, sets `installerMountedVMName` to drive an
-    /// alert that explains the next step (open the disk in the
-    /// guest's Finder, run install.command). The alert unifies the
-    /// post-click experience across all three entry points.
+    /// On mount (or when the disk is already mounted), asks the presenter to
+    /// show an alert explaining the next step (open the disk in the guest's
+    /// Finder, run install.command). The alert unifies the post-click
+    /// experience across all three entry points.
     ///
     /// No-op if the bundled DMG is already present in this VM's
     /// `removableMedia` list — duplicate mounts don't help the user.
@@ -1105,8 +1080,7 @@ final class VMLibraryViewModel {
             // Still surface the instructions — the user just clicked an
             // install/update affordance and is owed feedback even if the
             // disk happens to already be mounted from a prior click.
-            installerMountedVMName = instance.name
-            showInstallerMountedAlert = true
+            presenter?.presentInstallerMounted(vmName: instance.name)
             return
         }
         Self.logger.notice("Mounting guest agent installer on '\(instance.name, privacy: .public)'")
@@ -1120,8 +1094,7 @@ final class VMLibraryViewModel {
                     )
                 ]
         }
-        installerMountedVMName = instance.name
-        showInstallerMountedAlert = true
+        presenter?.presentInstallerMounted(vmName: instance.name)
     }
 
     /// Marks this VM's `.waiting` install nudge as dismissed and persists the choice.
@@ -1200,9 +1173,7 @@ final class VMLibraryViewModel {
                     "Failed to trash disk '\(label, privacy: .public)' (\(diskURL.lastPathComponent, privacy: .public)): \(message, privacy: .public)"
                 )
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
-                    self.errorMessage = message
-                    self.showError = true
+                    self?.surfaceError(message)
                 }
             }
         }
@@ -1257,9 +1228,7 @@ final class VMLibraryViewModel {
                     "Failed to trash removable media '\(label, privacy: .public)' (\(url.lastPathComponent, privacy: .public)): \(message, privacy: .public)"
                 )
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
-                    self.errorMessage = message
-                    self.showError = true
+                    self?.surfaceError(message)
                 }
             }
         }
@@ -1741,8 +1710,7 @@ final class VMLibraryViewModel {
     // MARK: - Cancel Preparing
 
     func confirmCancelPreparing(_ instance: VMInstance) {
-        preparingInstanceToCancel = instance
-        showCancelPreparingConfirmation = true
+        presenter?.presentCancelPreparing(for: instance)
     }
 
     func cancelPreparingConfirmed(_ instance: VMInstance) {
@@ -1750,9 +1718,6 @@ final class VMLibraryViewModel {
 
         instance.preparingState?.task.cancel()
         cleanupPhantomInstance(instance)
-
-        preparingInstanceToCancel = nil
-        showCancelPreparingConfirmation = false
 
         Self.logger.notice("Cancelled \(operationLabel, privacy: .public) for '\(instance.name, privacy: .public)'")
     }
@@ -1864,7 +1829,16 @@ final class VMLibraryViewModel {
     }
 
     func presentError(_ error: Error) {
-        errorMessage = error.localizedDescription
-        showError = true
+        surfaceError(error.localizedDescription)
+    }
+
+    /// Routes an error message to the presenter, buffering it if none is
+    /// attached yet (e.g. during the initial `loadVMs()` in `init`).
+    private func surfaceError(_ message: String) {
+        if let presenter {
+            presenter.presentError(message)
+        } else {
+            bufferedErrorMessages.append(message)
+        }
     }
 }

--- a/Kernova/Views/Console/VMDisplayBackingView.swift
+++ b/Kernova/Views/Console/VMDisplayBackingView.swift
@@ -155,7 +155,7 @@ final class VMDisplayBackingView: NSView {
         let stack = NSStackView(views: arrangedSubviews)
         stack.orientation = .vertical
         stack.alignment = .centerX
-        stack.spacing = 12
+        stack.spacing = Spacing.medium
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
     }

--- a/Kernova/Views/Console/VMDisplayPlaceholderContentViewController.swift
+++ b/Kernova/Views/Console/VMDisplayPlaceholderContentViewController.swift
@@ -211,7 +211,7 @@ private final class DisplayPlaceholderEmptyStateView: NSView {
         titleLabel.alignment = .center
         titleLabel.textColor = .labelColor
 
-        descriptionLabel.font = NSFont.preferredFont(forTextStyle: .body)
+        descriptionLabel.font = Typography.body
         descriptionLabel.textColor = .secondaryLabelColor
         descriptionLabel.alignment = .center
         descriptionLabel.maximumNumberOfLines = 0
@@ -223,7 +223,7 @@ private final class DisplayPlaceholderEmptyStateView: NSView {
 
         stack.orientation = .vertical
         stack.alignment = .centerX
-        stack.spacing = 12
+        stack.spacing = Spacing.medium
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.setViews([imageView, titleLabel, descriptionLabel, actionButton], in: .top)
         // Tighten the gap between the icon and title so the cluster reads as a unit.

--- a/Kernova/Views/Creation/BootConfigContentViewController.swift
+++ b/Kernova/Views/Creation/BootConfigContentViewController.swift
@@ -42,12 +42,12 @@ final class BootConfigContentViewController: NSViewController, NSTextFieldDelega
 
         conditionalContainer.orientation = .vertical
         conditionalContainer.alignment = .leading
-        conditionalContainer.spacing = 8
+        conditionalContainer.spacing = Spacing.standard
 
         let stack = NSStackView(views: [title, subtitle, bootModeControl, conditionalContainer])
         stack.orientation = .vertical
         stack.alignment = .leading
-        stack.spacing = 8
+        stack.spacing = Spacing.standard
         stack.setCustomSpacing(20, after: subtitle)
         stack.setCustomSpacing(16, after: bootModeControl)
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -131,7 +131,7 @@ final class BootConfigContentViewController: NSViewController, NSTextFieldDelega
         let control = NSStackView(views: [pathLabel, browse])
         control.orientation = .horizontal
         control.alignment = .centerY
-        control.spacing = 8
+        control.spacing = Spacing.standard
 
         return makeGroupedFormCardRow(label, control: control, fillsControl: true)
     }

--- a/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
@@ -49,16 +49,16 @@ final class IPSWSelectionContentViewController: NSViewController {
         let options = NSStackView(views: [downloadOption, localOption])
         options.orientation = .vertical
         options.alignment = .leading
-        options.spacing = 16
+        options.spacing = Spacing.large
 
         conditionalContainer.orientation = .vertical
         conditionalContainer.alignment = .leading
-        conditionalContainer.spacing = 12
+        conditionalContainer.spacing = Spacing.medium
 
         let stack = NSStackView(views: [title, subtitle, options, conditionalContainer])
         stack.orientation = .vertical
         stack.alignment = .leading
-        stack.spacing = 8
+        stack.spacing = Spacing.standard
         stack.setCustomSpacing(20, after: subtitle)
         stack.setCustomSpacing(20, after: options)
         stack.translatesAutoresizingMaskIntoConstraints = false

--- a/Kernova/Views/Creation/OSSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/OSSelectionContentViewController.swift
@@ -50,12 +50,12 @@ final class OSSelectionContentViewController: NSViewController {
         let options = NSStackView(views: VMGuestOS.allCases.map(makeOSOption))
         options.orientation = .vertical
         options.alignment = .leading
-        options.spacing = 16
+        options.spacing = Spacing.large
 
         let stack = NSStackView(views: [heading, subtitle, options])
         stack.orientation = .vertical
         stack.alignment = .leading
-        stack.spacing = 8
+        stack.spacing = Spacing.standard
         stack.setCustomSpacing(20, after: subtitle)
         stack.translatesAutoresizingMaskIntoConstraints = false
 

--- a/Kernova/Views/Creation/ResourceConfigContentViewController.swift
+++ b/Kernova/Views/Creation/ResourceConfigContentViewController.swift
@@ -42,7 +42,7 @@ final class ResourceConfigContentViewController: NSViewController {
         let stack = NSStackView(views: [title, subtitle, form])
         stack.orientation = .vertical
         stack.alignment = .leading
-        stack.spacing = 8
+        stack.spacing = Spacing.standard
         stack.setCustomSpacing(20, after: subtitle)
         stack.translatesAutoresizingMaskIntoConstraints = false
 
@@ -67,7 +67,7 @@ final class ResourceConfigContentViewController: NSViewController {
         let form = NSStackView()
         form.orientation = .vertical
         form.alignment = .leading
-        form.spacing = 8
+        form.spacing = Spacing.standard
         form.translatesAutoresizingMaskIntoConstraints = false
 
         addCard([makeGroupedFormCardRow("Name", control: nameField, fillsControl: true)], to: form)
@@ -119,7 +119,7 @@ final class ResourceConfigContentViewController: NSViewController {
         -> NSStackView
     {
         let unitLabel = NSTextField(labelWithString: unit)
-        unitLabel.font = .preferredFont(forTextStyle: .body)
+        unitLabel.font = Typography.body
         unitLabel.textColor = .secondaryLabelColor
         unitLabel.isSelectable = false
         unitLabel.widthAnchor.constraint(equalToConstant: 22).isActive = true
@@ -127,7 +127,7 @@ final class ResourceConfigContentViewController: NSViewController {
         let control = NSStackView(views: [field, stepper, unitLabel])
         control.orientation = .horizontal
         control.alignment = .centerY
-        control.spacing = 4
+        control.spacing = Spacing.tight
         return control
     }
 

--- a/Kernova/Views/Creation/ReviewContentViewController.swift
+++ b/Kernova/Views/Creation/ReviewContentViewController.swift
@@ -32,7 +32,7 @@ final class ReviewContentViewController: NSViewController {
         let stack = NSStackView(views: [title, subtitle, summary])
         stack.orientation = .vertical
         stack.alignment = .leading
-        stack.spacing = 8
+        stack.spacing = Spacing.standard
         stack.setCustomSpacing(20, after: subtitle)
         stack.translatesAutoresizingMaskIntoConstraints = false
 
@@ -49,7 +49,7 @@ final class ReviewContentViewController: NSViewController {
         let form = NSStackView()
         form.orientation = .vertical
         form.alignment = .leading
-        form.spacing = 8
+        form.spacing = Spacing.standard
         form.translatesAutoresizingMaskIntoConstraints = false
 
         addSection(

--- a/Kernova/Views/Creation/VMCreationWizardViewController.swift
+++ b/Kernova/Views/Creation/VMCreationWizardViewController.swift
@@ -200,7 +200,7 @@ final class VMCreationWizardViewController: NSViewController {
         ])
         row.orientation = .horizontal
         row.alignment = .centerY
-        row.spacing = 8
+        row.spacing = Spacing.standard
         row.translatesAutoresizingMaskIntoConstraints = false
 
         container.addSubview(row)

--- a/Kernova/Views/Creation/WizardStepIndicatorView.swift
+++ b/Kernova/Views/Creation/WizardStepIndicatorView.swift
@@ -47,7 +47,7 @@ final class WizardStepIndicatorView: NSView {
         let mainStack = NSStackView()
         mainStack.orientation = .horizontal
         mainStack.alignment = .centerY
-        mainStack.spacing = 4
+        mainStack.spacing = Spacing.tight
         mainStack.translatesAutoresizingMaskIntoConstraints = false
 
         let steps = VMCreationStep.allCases
@@ -75,7 +75,7 @@ final class WizardStepIndicatorView: NSView {
         let group = NSStackView(views: [dot, label])
         group.orientation = .horizontal
         group.alignment = .centerY
-        group.spacing = 4
+        group.spacing = Spacing.tight
         return group
     }
 

--- a/Kernova/Views/Creation/WizardStyle.swift
+++ b/Kernova/Views/Creation/WizardStyle.swift
@@ -83,7 +83,7 @@ let wizardRadioDescriptionIndent: CGFloat = 20
 func makeWizardRadioOption(radio: NSButton, iconSymbol: String, description descriptionText: String)
     -> NSView
 {
-    radio.font = .preferredFont(forTextStyle: .body)
+    radio.font = Typography.body
     radio.translatesAutoresizingMaskIntoConstraints = false
 
     let icon = NSImageView(image: .systemSymbol(iconSymbol, accessibilityDescription: ""))
@@ -153,7 +153,7 @@ func makeWizardPathBadge(path: String, changeButton: NSButton) -> NSView {
     let row = NSStackView(views: [icon, pathLabel, changeButton])
     row.orientation = .horizontal
     row.alignment = .firstBaseline
-    row.spacing = 6
+    row.spacing = Spacing.small
 
     return makeGroupedFormBox(
         content: row,

--- a/Kernova/Views/Detail/AttachmentSubtitleLabel.swift
+++ b/Kernova/Views/Detail/AttachmentSubtitleLabel.swift
@@ -1,17 +1,15 @@
 import AppKit
 
-/// AppKit counterpart of the SwiftUI `attachmentSubtitle` helper.
+/// Single-line, middle-truncating caption `NSTextField` for an attachment's
+/// path/stats subtitle.
 ///
-/// Produces a single-line, middle-truncating `NSTextField` styled as a
-/// caption. When `isMissing` is `true` the field is colored red and
-/// prefixed with a bold "Missing — " so the broken state is obvious
-/// without relying on a hover tooltip. Otherwise the field renders the
-/// path in secondary label color.
+/// When `isMissing` is `true` the field is colored red and prefixed with a
+/// bold "Missing — " so the broken state is obvious without relying on a hover
+/// tooltip. Otherwise it renders the path in secondary label color.
 ///
-/// Used by the AppKit Boot Order sheet
-/// (``StorageDiskReorderSheetContentViewController``) so its rows match
-/// the SwiftUI `attachmentSubtitle` rendering used by
-/// `VMSettingsView`.
+/// Used by the settings pane (``VMSettingsViewController``) and the Boot Order
+/// sheet (``StorageDiskReorderSheetContentViewController``) so their attachment
+/// rows render identically.
 ///
 /// - Parameters:
 ///   - path: Absolute file path of the backing attachment.
@@ -28,7 +26,16 @@ func makeAttachmentSubtitleLabel(path: String, isMissing: Bool) -> NSTextField {
     field.translatesAutoresizingMaskIntoConstraints = false
     field.setContentHuggingPriority(.defaultLow, for: .horizontal)
     field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    applyAttachmentSubtitle(to: field, path: path, isMissing: isMissing)
+    return field
+}
 
+/// Updates an existing subtitle field's content in place.
+///
+/// Applies the missing-state red "Missing — " prefix, or the normal secondary
+/// path, so a reused table cell can refresh without recreating the label.
+@MainActor
+func applyAttachmentSubtitle(to field: NSTextField, path: String, isMissing: Bool) {
     if isMissing {
         let attributed = NSMutableAttributedString(
             string: "Missing — ",
@@ -52,7 +59,6 @@ func makeAttachmentSubtitleLabel(path: String, isMissing: Bool) -> NSTextField {
         field.stringValue = path
         field.textColor = .secondaryLabelColor
     }
-    return field
 }
 
 extension NSFont {

--- a/Kernova/Views/Detail/DeleteVMSheetContentViewController.swift
+++ b/Kernova/Views/Detail/DeleteVMSheetContentViewController.swift
@@ -3,8 +3,8 @@ import AppKit
 /// Delegate for ``DeleteVMSheetContentViewController``.
 ///
 /// The view controller is intentionally decoupled from `VMLibraryViewModel`.
-/// The host (the SwiftUI bridge modifier) implements these methods and
-/// forwards the user's choice to the view model.
+/// The host (the presenter, e.g. `DetailAlertsPresenter`) implements these
+/// methods and forwards the user's choice to the view model.
 @MainActor
 protocol DeleteVMSheetContentViewControllerDelegate: AnyObject {
     /// Invoked when the user clicks Cancel (or presses Escape).
@@ -158,7 +158,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
         let textStack = NSStackView(views: [title, body])
         textStack.orientation = .vertical
         textStack.alignment = .leading
-        textStack.spacing = 4
+        textStack.spacing = Spacing.tight
 
         // `.firstBaseline` alignment matches the icon's effective baseline
         // to the title's first-line baseline — looks right regardless of
@@ -168,7 +168,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
         let headerStack = NSStackView(views: [icon, textStack])
         headerStack.orientation = .horizontal
         headerStack.alignment = .firstBaseline
-        headerStack.spacing = 12
+        headerStack.spacing = Spacing.medium
         headerStack.translatesAutoresizingMaskIntoConstraints = false
 
         let container = NSView()
@@ -206,7 +206,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
         let listStack = NSStackView()
         listStack.orientation = .vertical
         listStack.alignment = .leading
-        listStack.spacing = 12
+        listStack.spacing = Spacing.medium
         // 16pt all around inside the scroll view — matches the SwiftUI
         // behavioral spec (`.padding(16)` on the inner VStack) and gives
         // the rows the same breathing room from the dividers that the
@@ -267,7 +267,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
         icon.widthAnchor.constraint(equalToConstant: Self.iconColumnWidth).isActive = true
 
         let label = NSTextField(labelWithString: external.label)
-        label.font = .preferredFont(forTextStyle: .body)
+        label.font = Typography.body
         label.lineBreakMode = .byWordWrapping
         label.maximumNumberOfLines = 0
         label.isSelectable = false
@@ -294,7 +294,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
         let textStack = NSStackView(views: textViews)
         textStack.orientation = .vertical
         textStack.alignment = .leading
-        textStack.spacing = 2
+        textStack.spacing = Spacing.hairline
 
         // `.firstBaseline` anchors the icon to the label's first-line
         // baseline — the canonical AppKit pattern for an icon row with a
@@ -305,7 +305,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
         let row = NSStackView(views: [icon, textStack])
         row.orientation = .horizontal
         row.alignment = .firstBaseline
-        row.spacing = 12
+        row.spacing = Spacing.medium
         return row
     }
 
@@ -326,7 +326,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
         let stack = NSStackView(views: [icon, label])
         stack.orientation = .horizontal
         stack.alignment = .centerY
-        stack.spacing = 6
+        stack.spacing = Spacing.small
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
     }
@@ -350,7 +350,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
             "Files marked as shared will become unavailable to the VMs listed above."
         )
         trashExternalsWarningRow.orientation = .horizontal
-        trashExternalsWarningRow.spacing = 0
+        trashExternalsWarningRow.spacing = Spacing.none
         trashExternalsWarningRow.alignment = .top
         trashExternalsWarningRow.addArrangedSubview(warning)
         trashExternalsWarningRow.isHidden = true
@@ -375,7 +375,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
 
         let buttonRow = NSStackView(views: [spacer, cancelButton, confirmButton])
         buttonRow.orientation = .horizontal
-        buttonRow.spacing = 8
+        buttonRow.spacing = Spacing.standard
         buttonRow.alignment = .centerY
         buttonRow.translatesAutoresizingMaskIntoConstraints = false
 
@@ -384,7 +384,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
         ])
         stack.orientation = .vertical
         stack.alignment = .leading
-        stack.spacing = 8
+        stack.spacing = Spacing.standard
         stack.translatesAutoresizingMaskIntoConstraints = false
 
         container.addSubview(stack)

--- a/Kernova/Views/Detail/DetailEmptyStateView.swift
+++ b/Kernova/Views/Detail/DetailEmptyStateView.swift
@@ -34,7 +34,7 @@ final class DetailEmptyStateView: NSView {
 
         let description = NSTextField(
             wrappingLabelWithString: "Select a virtual machine from the sidebar or create a new one.")
-        description.font = .preferredFont(forTextStyle: .body)
+        description.font = Typography.body
         description.textColor = .secondaryLabelColor
         description.alignment = .center
         description.isSelectable = false
@@ -46,7 +46,7 @@ final class DetailEmptyStateView: NSView {
         let stack = NSStackView(views: [icon, title, description, button])
         stack.orientation = .vertical
         stack.alignment = .centerX
-        stack.spacing = 8
+        stack.spacing = Spacing.standard
         stack.setCustomSpacing(16, after: description)
         stack.translatesAutoresizingMaskIntoConstraints = false
 

--- a/Kernova/Views/Detail/DetailStatusPlaceholderViewController.swift
+++ b/Kernova/Views/Detail/DetailStatusPlaceholderViewController.swift
@@ -25,7 +25,7 @@ final class DetailStatusPlaceholderViewController: NSViewController {
         let stack = NSStackView(views: [spinner, label])
         stack.orientation = .vertical
         stack.alignment = .centerX
-        stack.spacing = 12
+        stack.spacing = Spacing.medium
         stack.translatesAutoresizingMaskIntoConstraints = false
 
         let container = NSView()

--- a/Kernova/Views/Detail/DiskSizePopoverContentViewController.swift
+++ b/Kernova/Views/Detail/DiskSizePopoverContentViewController.swift
@@ -3,9 +3,9 @@ import AppKit
 /// Delegate for ``DiskSizePopoverContentViewController``.
 ///
 /// The view controller is intentionally decoupled from `VMLibraryViewModel`
-/// — the host (typically a SwiftUI/AppKit bridge representable) implements
-/// these methods to forward the user's choice to the appropriate view-model
-/// action and to close the surrounding popover.
+/// — the host (a presenter or coordinator, e.g. `DiskSizePopoverCoordinator`)
+/// implements these methods to forward the user's choice to the appropriate
+/// view-model action and to close the surrounding popover.
 @MainActor
 protocol DiskSizePopoverContentViewControllerDelegate: AnyObject {
     /// Invoked when the user clicks the confirm (Create) button.
@@ -128,7 +128,7 @@ final class DiskSizePopoverContentViewController: NSViewController {
     private func makeSizeRow() -> NSView {
         let row = NSStackView()
         row.orientation = .horizontal
-        row.spacing = 8
+        row.spacing = Spacing.standard
         row.alignment = .firstBaseline
 
         let label = NSTextField(labelWithString: "Size:")
@@ -152,7 +152,7 @@ final class DiskSizePopoverContentViewController: NSViewController {
     private func makeButtonRow() -> NSView {
         let row = NSStackView()
         row.orientation = .horizontal
-        row.spacing = 8
+        row.spacing = Spacing.standard
         row.alignment = .centerY
 
         let spacer = NSView()

--- a/Kernova/Views/Detail/InfoButtonView.swift
+++ b/Kernova/Views/Detail/InfoButtonView.swift
@@ -56,9 +56,8 @@ final class InfoButtonView: NSView {
     /// Set the info-circle icon, hover tooltip, VoiceOver label, and the
     /// popover paragraph payload that fires on click.
     ///
-    /// Safe to call repeatedly — used both by the SwiftUI shim
-    /// (re-invoked on every `updateNSView`) and by pure-AppKit callers
-    /// during view-controller setup.
+    /// Safe to call repeatedly — re-invoked by callers during
+    /// view-controller setup or reuse.
     ///
     /// - Parameters:
     ///   - label: Section or control name; rendered as "About \(label)"

--- a/Kernova/Views/Detail/InitialBootBannerView.swift
+++ b/Kernova/Views/Detail/InitialBootBannerView.swift
@@ -55,7 +55,7 @@ final class InitialBootBannerView: NSView {
         let textStack = NSStackView(views: [title, subtitle])
         textStack.orientation = .vertical
         textStack.alignment = .leading
-        textStack.spacing = 2
+        textStack.spacing = Spacing.hairline
 
         let spacer = NSView()
         spacer.translatesAutoresizingMaskIntoConstraints = false
@@ -64,7 +64,7 @@ final class InitialBootBannerView: NSView {
         let row = NSStackView(views: [icon, textStack, spacer])
         row.orientation = .horizontal
         row.alignment = .centerY
-        row.spacing = 12
+        row.spacing = Spacing.medium
         row.translatesAutoresizingMaskIntoConstraints = false
 
         addSubview(row)

--- a/Kernova/Views/Detail/MacOSInstallProgressViewController.swift
+++ b/Kernova/Views/Detail/MacOSInstallProgressViewController.swift
@@ -86,7 +86,7 @@ final class MacOSInstallProgressViewController: NSViewController {
         let stack = NSStackView(views: arranged)
         stack.orientation = .vertical
         stack.alignment = .centerX
-        stack.spacing = 20
+        stack.spacing = Spacing.major
         stack.translatesAutoresizingMaskIntoConstraints = false
 
         let container = NSView()
@@ -146,7 +146,7 @@ final class MacOSInstallProgressViewController: NSViewController {
         let indicator = NSStackView(views: [downloadRow, connectorRow, installRow])
         indicator.orientation = .vertical
         indicator.alignment = .leading
-        indicator.spacing = 0
+        indicator.spacing = Spacing.none
         indicator.translatesAutoresizingMaskIntoConstraints = false
         indicator.widthAnchor.constraint(equalToConstant: 240).isActive = true
         downloadRow.widthAnchor.constraint(equalTo: indicator.widthAnchor).isActive = true
@@ -163,7 +163,7 @@ final class MacOSInstallProgressViewController: NSViewController {
         circle.heightAnchor.constraint(equalToConstant: 24).isActive = true
         circle.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 22, weight: .regular)
 
-        label.font = .preferredFont(forTextStyle: .body)
+        label.font = Typography.body
         label.isSelectable = false
 
         spinner.style = .spinning
@@ -182,7 +182,7 @@ final class MacOSInstallProgressViewController: NSViewController {
         let row = NSStackView(views: [circle, label, spacer, spinner, check])
         row.orientation = .horizontal
         row.alignment = .centerY
-        row.spacing = 10
+        row.spacing = Spacing.relaxed
         return row
     }
 
@@ -227,7 +227,7 @@ final class MacOSInstallProgressViewController: NSViewController {
             circle.image = .systemSymbol("checkmark.circle.fill", accessibilityDescription: "Completed")
             circle.contentTintColor = .controlAccentColor
             label.textColor = .labelColor
-            label.font = .preferredFont(forTextStyle: .body)
+            label.font = Typography.body
             spinner.stopAnimation(nil)
             spinner.isHidden = true
             check.isHidden = false
@@ -244,7 +244,7 @@ final class MacOSInstallProgressViewController: NSViewController {
             circle.image = .systemSymbol("\(number).circle", accessibilityDescription: "")
             circle.contentTintColor = .secondaryLabelColor
             label.textColor = .secondaryLabelColor
-            label.font = .preferredFont(forTextStyle: .body)
+            label.font = Typography.body
             spinner.stopAnimation(nil)
             spinner.isHidden = true
             check.isHidden = true

--- a/Kernova/Views/Detail/MissingAttachmentPopoverContentViewController.swift
+++ b/Kernova/Views/Detail/MissingAttachmentPopoverContentViewController.swift
@@ -63,7 +63,7 @@ final class MissingAttachmentPopoverContentViewController: NSViewController {
     private func makeHeader() -> NSView {
         let header = NSStackView()
         header.orientation = .horizontal
-        header.spacing = 6
+        header.spacing = Spacing.small
         header.alignment = .centerY
 
         let icon = NSImageView(

--- a/Kernova/Views/Detail/StorageDiskReorderSheetContentViewController.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheetContentViewController.swift
@@ -408,9 +408,10 @@ extension StorageDiskReorderSheetContentViewController: NSTableViewDelegate {
 final class StorageDiskReorderRowCellView: NSTableCellView {
     private let iconButton = AttachmentIconButton()
     private let titleLabel = NSTextField(labelWithString: "")
-    private let subtitleStack = NSStackView()
+    private let subtitleLabel: NSTextField
 
     init() {
+        subtitleLabel = makeAttachmentSubtitleLabel(path: "", isMissing: false)
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
 
@@ -423,12 +424,7 @@ final class StorageDiskReorderRowCellView: NSTableCellView {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
-        subtitleStack.orientation = .vertical
-        subtitleStack.alignment = .leading
-        subtitleStack.spacing = Spacing.none
-        subtitleStack.translatesAutoresizingMaskIntoConstraints = false
-
-        let textStack = NSStackView(views: [titleLabel, subtitleStack])
+        let textStack = NSStackView(views: [titleLabel, subtitleLabel])
         textStack.orientation = .vertical
         textStack.alignment = .leading
         textStack.spacing = Spacing.hairline
@@ -457,24 +453,19 @@ final class StorageDiskReorderRowCellView: NSTableCellView {
 
     /// Apply the disk's icon + label + subtitle to the cell.
     ///
-    /// Rebuilds the subtitle field on every call so the missing-file
+    /// Updates the icon, label, and subtitle in place so the missing-file
     /// color/weight updates as the live ``AttachmentFileMonitor`` flips
-    /// a path's `exists` state.
+    /// a path's `exists` state — without tearing down the reused cell's views.
     func configure(disk: StorageDisk, instance: VMInstance, isMissing: Bool) {
         iconButton.configure(
             systemName: diskIconSystemName(for: disk),
             missingPath: isMissing ? disk.path : nil
         )
         titleLabel.stringValue = disk.label
-
-        subtitleStack.arrangedSubviews.forEach {
-            subtitleStack.removeArrangedSubview($0)
-            $0.removeFromSuperview()
-        }
-        let subtitle = makeAttachmentSubtitleLabel(
+        applyAttachmentSubtitle(
+            to: subtitleLabel,
             path: diskSubtitle(for: disk, in: instance),
             isMissing: isMissing
         )
-        subtitleStack.addArrangedSubview(subtitle)
     }
 }

--- a/Kernova/Views/Detail/StorageDiskReorderSheetContentViewController.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheetContentViewController.swift
@@ -3,9 +3,9 @@ import AppKit
 /// Delegate for ``StorageDiskReorderSheetContentViewController``.
 ///
 /// The view controller is intentionally decoupled from
-/// `VMLibraryViewModel`; the host (the SwiftUI bridge modifier)
-/// implements these methods and forwards the user's choice to the
-/// view model.
+/// `VMLibraryViewModel`; the host (the presenting view controller, e.g.
+/// `VMSettingsViewController`) implements these methods and forwards the
+/// user's choice to the view model.
 @MainActor
 protocol StorageDiskReorderSheetContentViewControllerDelegate: AnyObject {
     /// Invoked after a successful drag-reorder.
@@ -171,7 +171,7 @@ final class StorageDiskReorderSheetContentViewController: NSViewController {
         let stack = NSStackView(views: [title, info, spacer])
         stack.orientation = .horizontal
         stack.alignment = .centerY
-        stack.spacing = 6
+        stack.spacing = Spacing.small
         stack.translatesAutoresizingMaskIntoConstraints = false
 
         container.addSubview(stack)
@@ -244,7 +244,7 @@ final class StorageDiskReorderSheetContentViewController: NSViewController {
 
         let stack = NSStackView(views: [spacer, done])
         stack.orientation = .horizontal
-        stack.spacing = 8
+        stack.spacing = Spacing.standard
         stack.alignment = .centerY
         stack.translatesAutoresizingMaskIntoConstraints = false
 
@@ -416,7 +416,7 @@ final class StorageDiskReorderRowCellView: NSTableCellView {
 
         iconButton.translatesAutoresizingMaskIntoConstraints = false
 
-        titleLabel.font = .preferredFont(forTextStyle: .body)
+        titleLabel.font = Typography.body
         titleLabel.lineBreakMode = .byTruncatingTail
         titleLabel.maximumNumberOfLines = 1
         titleLabel.isSelectable = false
@@ -425,19 +425,19 @@ final class StorageDiskReorderRowCellView: NSTableCellView {
 
         subtitleStack.orientation = .vertical
         subtitleStack.alignment = .leading
-        subtitleStack.spacing = 0
+        subtitleStack.spacing = Spacing.none
         subtitleStack.translatesAutoresizingMaskIntoConstraints = false
 
         let textStack = NSStackView(views: [titleLabel, subtitleStack])
         textStack.orientation = .vertical
         textStack.alignment = .leading
-        textStack.spacing = 2
+        textStack.spacing = Spacing.hairline
         textStack.translatesAutoresizingMaskIntoConstraints = false
 
         let row = NSStackView(views: [iconButton, textStack])
         row.orientation = .horizontal
         row.alignment = .centerY
-        row.spacing = 12
+        row.spacing = Spacing.medium
         row.translatesAutoresizingMaskIntoConstraints = false
 
         addSubview(row)

--- a/Kernova/Views/Detail/VMDetailRouterViewController.swift
+++ b/Kernova/Views/Detail/VMDetailRouterViewController.swift
@@ -49,7 +49,7 @@ final class VMDetailRouterViewController: NSViewController {
     override func loadView() {
         contentStack.orientation = .vertical
         contentStack.alignment = .leading
-        contentStack.spacing = 0
+        contentStack.spacing = Spacing.none
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         view = contentStack
     }

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -113,6 +113,25 @@ final class VMSettingsViewController: NSViewController {
     private var clipboardSwitch = NSSwitch()
     private var clipboardCaption = NSView()
 
+    // MARK: - Rendered-list snapshots (early-out keys)
+
+    /// Value snapshot of one attachment row's rendered appearance, used to
+    /// skip rebuilding a list when nothing it displays has changed.
+    private struct RenderedRow: Equatable {
+        let id: UUID
+        let iconSystemName: String
+        let title: String
+        let subtitle: String
+        let isMissing: Bool
+        let missingPath: String?
+        let readOnly: Bool
+        let controlsEnabled: Bool
+    }
+    private var renderedStorageRows: [RenderedRow]?
+    private var renderedRemovableRows: [RenderedRow]?
+    private var renderedSharedRows: [RenderedRow]?
+    private var renderedAudioWarning: MicWarningState?
+
     // MARK: - Init
 
     init(instance: VMInstance, viewModel: VMLibraryViewModel, isReadOnly: Bool) {
@@ -313,6 +332,12 @@ extension VMSettingsViewController {
         lockIcons.removeAll()
         persistentLockableControls.removeAll()
         nameRowIsEditing = false
+        // The list stacks and audio-warning container are recreated below, so
+        // invalidate the render snapshots that guard their refreshes.
+        renderedStorageRows = nil
+        renderedRemovableRows = nil
+        renderedSharedRows = nil
+        renderedAudioWarning = nil
 
         addSection(buildGeneralSection())
         addSection(buildResourcesSection())
@@ -884,9 +909,13 @@ extension VMSettingsViewController {
 
     private func refreshAudio() {
         micSwitch.state = instance.configuration.microphoneEnabled ? .on : .off
+        let warning = micPermissionPresentation(
+            micPermission, micEnabled: instance.configuration.microphoneEnabled)
+        guard warning != renderedAudioWarning else { return }
+        renderedAudioWarning = warning
         audioWarningContainer.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
-        switch micPermissionPresentation(micPermission, micEnabled: instance.configuration.microphoneEnabled) {
+        switch warning {
         case .none:
             break
         case .willPrompt:
@@ -923,45 +952,68 @@ extension VMSettingsViewController {
 
     private func refreshStorageList() {
         let disks = currentStorageDisks
-        clear(storageListStack)
-        for disk in disks {
+        editBootOrderButton.isHidden = disks.count <= 1
+        let models = disks.map { disk -> RenderedRow in
             let isMissing = !disk.isInternal && !fileMonitor.exists(disk.path)
+            return RenderedRow(
+                id: disk.id,
+                iconSystemName: diskIconSystemName(for: disk),
+                title: disk.label,
+                subtitle: diskSubtitle(for: disk, in: instance),
+                isMissing: isMissing,
+                missingPath: isMissing ? disk.path : nil,
+                readOnly: disk.readOnly,
+                controlsEnabled: !isReadOnly)
+        }
+        guard models != renderedStorageRows else { return }
+        renderedStorageRows = models
+        clear(storageListStack)
+        for model in models {
             let icon = AttachmentIconButton()
-            icon.configure(
-                systemName: diskIconSystemName(for: disk), missingPath: isMissing ? disk.path : nil)
+            icon.configure(systemName: model.iconSystemName, missingPath: model.missingPath)
             let row = makeListRow(
                 icon: icon,
-                title: disk.label,
-                subtitle: makeAttachmentSubtitleLabel(
-                    path: diskSubtitle(for: disk, in: instance), isMissing: isMissing),
-                id: disk.id,
-                readOnly: disk.readOnly,
-                controlsEnabled: !isReadOnly,
+                title: model.title,
+                subtitle: makeAttachmentSubtitleLabel(path: model.subtitle, isMissing: model.isMissing),
+                id: model.id,
+                readOnly: model.readOnly,
+                controlsEnabled: model.controlsEnabled,
                 readOnlySelector: #selector(storageReadOnlyToggled),
                 deleteSelector: #selector(storageDeleteTapped))
             addFullWidth(row, to: storageListStack)
         }
-        editBootOrderButton.isHidden = disks.count <= 1
     }
 
     private func refreshRemovableList() {
-        let items = currentRemovableMedia
+        let models = currentRemovableMedia.map { item -> RenderedRow in
+            let isMissing = !fileMonitor.exists(item.path)
+            return RenderedRow(
+                id: item.id,
+                iconSystemName: "opticaldisc",
+                title: item.label,
+                subtitle: item.path,
+                isMissing: isMissing,
+                missingPath: isMissing ? item.path : nil,
+                readOnly: item.readOnly,
+                controlsEnabled: true)
+        }
+        guard models != renderedRemovableRows else { return }
+        renderedRemovableRows = models
         clear(removableListStack)
-        if items.isEmpty {
+        if models.isEmpty {
             addFullWidth(makeSecondaryLabel("No removable media attached"), to: removableListStack)
             return
         }
-        for item in items {
-            let isMissing = !fileMonitor.exists(item.path)
+        for model in models {
             let icon = AttachmentIconButton()
-            icon.configure(systemName: "opticaldisc", missingPath: isMissing ? item.path : nil)
+            icon.configure(systemName: model.iconSystemName, missingPath: model.missingPath)
             let row = makeListRow(
                 icon: icon,
-                title: item.label,
-                subtitle: makeAttachmentSubtitleLabel(path: item.path, isMissing: isMissing),
-                id: item.id,
-                readOnly: item.readOnly,
-                controlsEnabled: true,
+                title: model.title,
+                subtitle: makeAttachmentSubtitleLabel(path: model.subtitle, isMissing: model.isMissing),
+                id: model.id,
+                readOnly: model.readOnly,
+                controlsEnabled: model.controlsEnabled,
                 readOnlySelector: #selector(removableReadOnlyToggled),
                 deleteSelector: #selector(removableDeleteTapped))
             addFullWidth(row, to: removableListStack)
@@ -969,24 +1021,35 @@ extension VMSettingsViewController {
     }
 
     private func refreshSharedList() {
-        let directories = currentSharedDirectories
+        let models = currentSharedDirectories.map { directory in
+            RenderedRow(
+                id: directory.id,
+                iconSystemName: "folder",
+                title: directory.displayName,
+                subtitle: directory.path,
+                isMissing: false,
+                missingPath: nil,
+                readOnly: directory.readOnly,
+                controlsEnabled: !isReadOnly)
+        }
+        guard models != renderedSharedRows else { return }
+        renderedSharedRows = models
         clear(sharedListStack)
-        if directories.isEmpty {
+        if models.isEmpty {
             addFullWidth(makeSecondaryLabel("No shared directories"), to: sharedListStack)
             return
         }
-        for directory in directories {
+        for model in models {
             let icon = NSImageView(image: .systemSymbol("folder", accessibilityDescription: ""))
             icon.contentTintColor = .secondaryLabelColor
             icon.setContentHuggingPriority(.required, for: .horizontal)
-            let subtitle = makeAttachmentSubtitleLabel(path: directory.path, isMissing: false)
             let row = makeListRow(
                 icon: icon,
-                title: directory.displayName,
-                subtitle: subtitle,
-                id: directory.id,
-                readOnly: directory.readOnly,
-                controlsEnabled: !isReadOnly,
+                title: model.title,
+                subtitle: makeAttachmentSubtitleLabel(path: model.subtitle, isMissing: false),
+                id: model.id,
+                readOnly: model.readOnly,
+                controlsEnabled: model.controlsEnabled,
                 readOnlySelector: #selector(sharedReadOnlyToggled),
                 deleteSelector: #selector(sharedDeleteTapped))
             addFullWidth(row, to: sharedListStack)

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -162,7 +162,7 @@ final class VMSettingsViewController: NSViewController {
     override func loadView() {
         formStack.orientation = .vertical
         formStack.alignment = .leading
-        formStack.spacing = 18
+        formStack.spacing = Spacing.section
         formStack.translatesAutoresizingMaskIntoConstraints = false
 
         // Margin only at the bottom; the top sits flush under the toolbar.
@@ -174,7 +174,7 @@ final class VMSettingsViewController: NSViewController {
         let root = NSStackView(views: [bannerContainer, scrollView])
         root.orientation = .vertical
         root.alignment = .leading
-        root.spacing = 0
+        root.spacing = Spacing.none
         root.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             bannerContainer.widthAnchor.constraint(equalTo: root.widthAnchor),
@@ -336,7 +336,7 @@ extension VMSettingsViewController {
         let stack = NSStackView(views: subviews)
         stack.orientation = .vertical
         stack.alignment = .leading
-        stack.spacing = 6
+        stack.spacing = Spacing.small
         stack.translatesAutoresizingMaskIntoConstraints = false
         for view in subviews {
             view.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
@@ -377,7 +377,7 @@ extension VMSettingsViewController {
         let header = NSStackView(views: views)
         header.orientation = .horizontal
         header.alignment = .centerY
-        header.spacing = 6
+        header.spacing = Spacing.small
         return header
     }
 
@@ -418,7 +418,7 @@ extension VMSettingsViewController {
         let nameRow = NSStackView(views: [nameDisplayRow, nameEditRow])
         nameRow.orientation = .vertical
         nameRow.alignment = .leading
-        nameRow.spacing = 0
+        nameRow.spacing = Spacing.none
         nameDisplayRow.widthAnchor.constraint(equalTo: nameRow.widthAnchor).isActive = true
         nameEditRow.widthAnchor.constraint(equalTo: nameRow.widthAnchor).isActive = true
 
@@ -594,7 +594,7 @@ extension VMSettingsViewController {
         audioWarningContainer = NSStackView()
         audioWarningContainer.orientation = .vertical
         audioWarningContainer.alignment = .leading
-        audioWarningContainer.spacing = 6
+        audioWarningContainer.spacing = Spacing.small
         audioWarningContainer.translatesAutoresizingMaskIntoConstraints = false
 
         var paragraphs: [InfoPopoverParagraph] = [
@@ -670,7 +670,7 @@ extension VMSettingsViewController {
         let stack = NSStackView()
         stack.orientation = .vertical
         stack.alignment = .leading
-        stack.spacing = 8
+        stack.spacing = Spacing.standard
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
     }
@@ -689,7 +689,7 @@ extension VMSettingsViewController {
         let row = NSStackView(views: buttons + [spacer])
         row.orientation = .horizontal
         row.alignment = .centerY
-        row.spacing = 8
+        row.spacing = Spacing.standard
         return row
     }
 
@@ -705,7 +705,7 @@ extension VMSettingsViewController {
         _ title: String, control: NSControl, paragraphs: [InfoPopoverParagraph]
     ) -> NSView {
         let label = NSTextField(labelWithString: title)
-        label.font = .preferredFont(forTextStyle: .body)
+        label.font = Typography.body
         label.isSelectable = false
         label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
 
@@ -719,13 +719,13 @@ extension VMSettingsViewController {
         let row = NSStackView(views: [label, info, spacer, control])
         row.orientation = .horizontal
         row.alignment = .centerY
-        row.spacing = 6
+        row.spacing = Spacing.small
         return row
     }
 
     private func steppedControl(_ field: NSTextField, _ stepper: NSStepper, unit: String) -> NSStackView {
         let unitLabel = NSTextField(labelWithString: unit)
-        unitLabel.font = .preferredFont(forTextStyle: .body)
+        unitLabel.font = Typography.body
         unitLabel.textColor = .secondaryLabelColor
         unitLabel.isSelectable = false
         unitLabel.widthAnchor.constraint(equalToConstant: 22).isActive = true
@@ -733,7 +733,7 @@ extension VMSettingsViewController {
         let control = NSStackView(views: [field, stepper, unitLabel])
         control.orientation = .horizontal
         control.alignment = .centerY
-        control.spacing = 4
+        control.spacing = Spacing.tight
         return control
     }
 
@@ -787,7 +787,7 @@ extension VMSettingsViewController {
         controlsEnabled: Bool, readOnlySelector: Selector, deleteSelector: Selector
     ) -> NSView {
         let titleLabel = NSTextField(labelWithString: title)
-        titleLabel.font = .preferredFont(forTextStyle: .body)
+        titleLabel.font = Typography.body
         titleLabel.lineBreakMode = .byTruncatingTail
         titleLabel.maximumNumberOfLines = 1
         titleLabel.isSelectable = false
@@ -795,7 +795,7 @@ extension VMSettingsViewController {
         let textStack = NSStackView(views: [titleLabel, subtitle])
         textStack.orientation = .vertical
         textStack.alignment = .leading
-        textStack.spacing = 2
+        textStack.spacing = Spacing.hairline
 
         let readOnlyToggle = makeReadOnlySwitch(
             id: id, isOn: readOnly, enabled: controlsEnabled, action: readOnlySelector)
@@ -814,7 +814,7 @@ extension VMSettingsViewController {
         let row = NSStackView(views: [icon, textStack, spacer, readOnlyToggle, readOnlyCaption, delete])
         row.orientation = .horizontal
         row.alignment = .centerY
-        row.spacing = 8
+        row.spacing = Spacing.standard
         return row
     }
 

--- a/Kernova/Views/Shared/GroupedFormStyle.swift
+++ b/Kernova/Views/Shared/GroupedFormStyle.swift
@@ -119,7 +119,7 @@ func makeGroupedFormCardRow(
     fillsControl: Bool = false
 ) -> NSView {
     let label = NSTextField(labelWithString: labelText)
-    label.font = .preferredFont(forTextStyle: .body)
+    label.font = Typography.body
     label.isSelectable = false
     label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     label.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -139,7 +139,7 @@ func makeGroupedFormCardRow(
     let row = NSStackView(views: views)
     row.orientation = .horizontal
     row.alignment = alignment
-    row.spacing = 8
+    row.spacing = Spacing.standard
     return row
 }
 
@@ -150,7 +150,7 @@ func makeGroupedFormCard(rows: [NSView]) -> NSView {
     let content = NSStackView()
     content.orientation = .vertical
     content.alignment = .leading
-    content.spacing = 10
+    content.spacing = Spacing.relaxed
     content.translatesAutoresizingMaskIntoConstraints = false
 
     for (index, row) in rows.enumerated() {
@@ -188,7 +188,7 @@ func makeGroupedFormCard(rows: [NSView]) -> NSView {
 @MainActor
 func makeGroupedFormValueLabel(_ text: String) -> NSTextField {
     let label = NSTextField(labelWithString: text)
-    label.font = .preferredFont(forTextStyle: .body)
+    label.font = Typography.body
     label.textColor = .secondaryLabelColor
     label.lineBreakMode = .byTruncatingMiddle
     label.isSelectable = false
@@ -292,7 +292,7 @@ func makeGroupedFormBanner(
     let row = NSStackView(views: views)
     row.orientation = .horizontal
     row.alignment = .centerY
-    row.spacing = 8
+    row.spacing = Spacing.standard
 
     return makeGroupedFormBox(
         content: row,

--- a/Kernova/Views/Sidebar/AgentStatusPopoverContentViewController.swift
+++ b/Kernova/Views/Sidebar/AgentStatusPopoverContentViewController.swift
@@ -82,7 +82,7 @@ final class AgentStatusPopoverContentViewController: NSViewController {
 
         let actionRow = NSStackView()
         actionRow.orientation = .horizontal
-        actionRow.spacing = 8
+        actionRow.spacing = Spacing.standard
         actionRow.alignment = .centerY
         dismissSpacer.translatesAutoresizingMaskIntoConstraints = false
         dismissSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)

--- a/Kernova/Views/Sidebar/SidebarAgentStatusButtonView.swift
+++ b/Kernova/Views/Sidebar/SidebarAgentStatusButtonView.swift
@@ -173,12 +173,12 @@ final class SidebarAgentStatusButtonView: NSView,
 
     static func symbolColor(for status: AgentStatus) -> NSColor {
         switch status {
-        case .waiting: .secondaryLabelColor
-        case .outdated: .systemOrange
-        case .connecting: .secondaryLabelColor
-        case .current: .systemGreen
-        case .unresponsive: .systemOrange
-        case .expectedMissing: .systemOrange
+        case .waiting: StatusColor.inactive
+        case .outdated: StatusColor.warning
+        case .connecting: StatusColor.inactive
+        case .current: StatusColor.running
+        case .unresponsive: StatusColor.warning
+        case .expectedMissing: StatusColor.warning
         }
     }
 

--- a/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
+++ b/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
@@ -64,7 +64,7 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
         nameField.drawsBackground = false
         nameField.isEditable = false
         nameField.isSelectable = false
-        nameField.font = .preferredFont(forTextStyle: .body)
+        nameField.font = Typography.body
         nameField.lineBreakMode = .byTruncatingTail
         nameField.maximumNumberOfLines = 1
         nameField.cell?.usesSingleLineMode = true
@@ -94,7 +94,7 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
         row.orientation = .horizontal
         row.alignment = .centerY
         row.distribution = .fill
-        row.spacing = 6
+        row.spacing = Spacing.small
         row.translatesAutoresizingMaskIntoConstraints = false
         addSubview(row)
 

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -13,15 +13,15 @@ extension VMInstance {
     /// Preparing and cold-paused are orange, live-paused is yellow, and the
     /// remaining states follow `status`.
     var statusDisplayNSColor: NSColor {
-        if isPreparing || isColdPaused { return .systemOrange }
+        if isPreparing || isColdPaused { return StatusColor.warning }
         switch status {
         // A concrete gray (not `.secondaryLabelColor`) so the icon keeps its
         // stopped color on the selection highlight instead of inverting to white.
         case .stopped: return .systemGray
-        case .starting, .saving, .restoring, .installing, .initialBoot: return .systemOrange
-        case .running: return .systemGreen
-        case .paused: return .systemYellow
-        case .error: return .systemRed
+        case .starting, .saving, .restoring, .installing, .initialBoot: return StatusColor.warning
+        case .running: return StatusColor.running
+        case .paused: return StatusColor.pausedInMemory
+        case .error: return StatusColor.error
         }
     }
 

--- a/KernovaTests/Mocks/MockVMLibraryPresenting.swift
+++ b/KernovaTests/Mocks/MockVMLibraryPresenting.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+@testable import Kernova
+
+/// Records presentation requests made by `VMLibraryViewModel` so tests can
+/// assert which alert/sheet/wizard the view model asked for, without a real
+/// window.
+///
+/// Exposes mirror accessors (`showError`, `instanceToDelete`, …) matching the
+/// view model's former observed flags so existing assertions read naturally.
+@MainActor
+final class MockVMLibraryPresenting: VMLibraryPresenting {
+    private(set) var errors: [String] = []
+    private(set) var deleteConfirmationInstances: [VMInstance] = []
+    private(set) var deleteSheetInstances: [VMInstance] = []
+    private(set) var forceStopInstances: [VMInstance] = []
+    private(set) var stopPausedInstances: [VMInstance] = []
+    private(set) var cancelPreparingInstances: [VMInstance] = []
+    private(set) var installerMountedNames: [String] = []
+    private(set) var creationWizardCount = 0
+
+    func presentError(_ message: String) { errors.append(message) }
+    func presentDeleteConfirmation(for instance: VMInstance) { deleteConfirmationInstances.append(instance) }
+    func presentDeleteSheet(for instance: VMInstance) { deleteSheetInstances.append(instance) }
+    func presentForceStop(for instance: VMInstance) { forceStopInstances.append(instance) }
+    func presentStopPaused(for instance: VMInstance) { stopPausedInstances.append(instance) }
+    func presentCancelPreparing(for instance: VMInstance) { cancelPreparingInstances.append(instance) }
+    func presentInstallerMounted(vmName: String) { installerMountedNames.append(vmName) }
+    func presentCreationWizard() { creationWizardCount += 1 }
+
+    // MARK: - Mirror accessors (read like the former VM flags)
+
+    var showError: Bool { !errors.isEmpty }
+    var errorMessage: String? { errors.last }
+    var showDeleteConfirmation: Bool { !deleteConfirmationInstances.isEmpty }
+    var showDeleteSheet: Bool { !deleteSheetInstances.isEmpty }
+    var instanceToDelete: VMInstance? { deleteConfirmationInstances.last ?? deleteSheetInstances.last }
+    var showForceStopConfirmation: Bool { !forceStopInstances.isEmpty }
+    var instanceToForceStop: VMInstance? { forceStopInstances.last }
+    var showStopPausedConfirmation: Bool { !stopPausedInstances.isEmpty }
+    var instanceToStopPaused: VMInstance? { stopPausedInstances.last }
+    var showCancelPreparingConfirmation: Bool { !cancelPreparingInstances.isEmpty }
+    var preparingInstanceToCancel: VMInstance? { cancelPreparingInstances.last }
+    var showInstallerMountedAlert: Bool { !installerMountedNames.isEmpty }
+    var installerMountedVMName: String? { installerMountedNames.last }
+    var showCreationWizard: Bool { creationWizardCount > 0 }
+
+    /// Clears all recorded requests (mirrors resetting the former flags).
+    func reset() {
+        errors.removeAll()
+        deleteConfirmationInstances.removeAll()
+        deleteSheetInstances.removeAll()
+        forceStopInstances.removeAll()
+        stopPausedInstances.removeAll()
+        cancelPreparingInstances.removeAll()
+        installerMountedNames.removeAll()
+        creationWizardCount = 0
+    }
+}

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -5,6 +5,7 @@ import Foundation
 @Suite("VMLibraryViewModel Tests", .serialized)
 @MainActor
 struct VMLibraryViewModelTests {
+    private let presenter = MockVMLibraryPresenting()
     private func makeViewModel(
         storageService: MockVMStorageService = MockVMStorageService(),
         diskImageService: MockDiskImageService = MockDiskImageService(),
@@ -24,6 +25,7 @@ struct VMLibraryViewModelTests {
             ipswService: MockIPSWService(),
             usbDeviceService: usbDeviceService
         )
+        vm.presenter = presenter
         return (vm, storageService, diskImageService, virtualizationService, usbDeviceService)
     }
 
@@ -45,8 +47,8 @@ struct VMLibraryViewModelTests {
         let (viewModel, _, _, _, _) = makeViewModel()
         #expect(viewModel.instances.isEmpty)
         #expect(viewModel.selectedID == nil)
-        #expect(viewModel.showCreationWizard == false)
-        #expect(viewModel.showError == false)
+        #expect(presenter.showCreationWizard == false)
+        #expect(presenter.showError == false)
     }
 
     // MARK: - Load
@@ -140,6 +142,7 @@ struct VMLibraryViewModelTests {
             installService: MockMacOSInstallService(),
             ipswService: MockIPSWService()
         )
+        viewModel.presenter = presenter
 
         #expect(viewModel.selectedID == config2.id)
     }
@@ -165,8 +168,8 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.instances.count == 1)
         #expect(viewModel.instances.first?.name == "Good VM")
         // Error surfaced to user about the failed bundle
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage != nil)
     }
 
     @Test("loadVMs falls back to first VM when stored ID is invalid")
@@ -188,6 +191,7 @@ struct VMLibraryViewModelTests {
             installService: MockMacOSInstallService(),
             ipswService: MockIPSWService()
         )
+        viewModel.presenter = presenter
 
         #expect(viewModel.selectedID == config.id)
     }
@@ -202,8 +206,8 @@ struct VMLibraryViewModelTests {
 
         viewModel.confirmDelete(instance)
 
-        #expect(viewModel.instanceToDelete?.id == instance.id)
-        #expect(viewModel.showDeleteConfirmation == true)
+        #expect(presenter.instanceToDelete?.id == instance.id)
+        #expect(presenter.showDeleteConfirmation == true)
     }
 
     @Test("deleteConfirmed removes instance and clears selection")
@@ -220,8 +224,8 @@ struct VMLibraryViewModelTests {
 
         #expect(viewModel.instances.isEmpty)
         #expect(viewModel.selectedID == nil)
-        #expect(viewModel.showDeleteConfirmation == false)
-        #expect(viewModel.instanceToDelete == nil)
+        #expect(presenter.showDeleteConfirmation == false)
+        #expect(presenter.instanceToDelete == nil)
         #expect(storage.deleteVMBundleCallCount == 1)
     }
 
@@ -252,9 +256,9 @@ struct VMLibraryViewModelTests {
 
         viewModel.confirmDelete(instance)
 
-        #expect(viewModel.instanceToDelete?.id == instance.id)
-        #expect(viewModel.showDeleteSheet == true)
-        #expect(viewModel.showDeleteConfirmation == false)
+        #expect(presenter.instanceToDelete?.id == instance.id)
+        #expect(presenter.showDeleteSheet == true)
+        #expect(presenter.showDeleteConfirmation == false)
     }
 
     @Test("externalAttachments returns external disks and removable media with sharing info")
@@ -344,7 +348,7 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.instances.isEmpty)
         #expect(FileManager.default.fileExists(atPath: externalDisk.path(percentEncoded: false)))
         #expect(FileManager.default.fileExists(atPath: externalISO.path(percentEncoded: false)))
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("deleteConfirmed with trashExternals=true trashes external disks and removable media")
@@ -381,8 +385,8 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.instances.isEmpty)
         #expect(!FileManager.default.fileExists(atPath: externalDisk.path(percentEncoded: false)))
         #expect(!FileManager.default.fileExists(atPath: externalISO.path(percentEncoded: false)))
-        #expect(!viewModel.showError)
-        #expect(viewModel.showDeleteSheet == false)
+        #expect(!presenter.showError)
+        #expect(presenter.showDeleteSheet == false)
     }
 
     #if arch(arm64)
@@ -397,7 +401,7 @@ struct VMLibraryViewModelTests {
     ) -> VMLibraryViewModel {
         UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
         UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.vmOrderKey)
-        return VMLibraryViewModel(
+        let vm = VMLibraryViewModel(
             storageService: storage,
             diskImageService: MockDiskImageService(),
             virtualizationService: MockVirtualizationService(),
@@ -405,6 +409,8 @@ struct VMLibraryViewModelTests {
             ipswService: ipswService,
             usbDeviceService: MockUSBDeviceService()
         )
+        vm.presenter = presenter
+        return vm
     }
 
     @Test("deleteConfirmed discards the IPSW resume-data sidecar")
@@ -465,7 +471,7 @@ struct VMLibraryViewModelTests {
         for task in tasks { await task.value }
 
         #expect(viewModel.instances.isEmpty)
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     // MARK: - Lifecycle Delegation
@@ -558,8 +564,8 @@ struct VMLibraryViewModelTests {
 
         await viewModel.start(instance)
 
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage != nil)
     }
 
     @Test("forceStop presents error on service failure")
@@ -571,8 +577,8 @@ struct VMLibraryViewModelTests {
 
         await viewModel.forceStop(instance)
 
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage != nil)
     }
 
     @Test("stop presents error on service failure")
@@ -584,8 +590,8 @@ struct VMLibraryViewModelTests {
 
         viewModel.stop(instance)
 
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage != nil)
     }
 
     // MARK: - Stop Paused Confirmation
@@ -618,13 +624,11 @@ struct VMLibraryViewModelTests {
         let instance = makeInstance()
         instance.status = .paused
         viewModel.instances.append(instance)
-        viewModel.instanceToStopPaused = instance
-        viewModel.showStopPausedConfirmation = true
 
         await viewModel.resumeAndStop(instance)
 
-        #expect(viewModel.instanceToStopPaused == nil)
-        #expect(viewModel.showStopPausedConfirmation == false)
+        #expect(presenter.instanceToStopPaused == nil)
+        #expect(presenter.showStopPausedConfirmation == false)
     }
 
     @Test("forceStopFromPaused dispatches forceStop and clears state")
@@ -633,14 +637,12 @@ struct VMLibraryViewModelTests {
         let instance = makeInstance()
         instance.status = .paused
         viewModel.instances.append(instance)
-        viewModel.instanceToStopPaused = instance
-        viewModel.showStopPausedConfirmation = true
 
         await viewModel.forceStopFromPaused(instance)
 
         #expect(virtService.forceStopCallCount == 1)
-        #expect(viewModel.instanceToStopPaused == nil)
-        #expect(viewModel.showStopPausedConfirmation == false)
+        #expect(presenter.instanceToStopPaused == nil)
+        #expect(presenter.showStopPausedConfirmation == false)
     }
 
     @Test("resumeAndStop presents error if resume fails")
@@ -653,7 +655,7 @@ struct VMLibraryViewModelTests {
 
         await viewModel.resumeAndStop(instance)
 
-        #expect(viewModel.showError == true)
+        #expect(presenter.showError == true)
         #expect(virtService.stopCallCount == 0)
     }
 
@@ -667,8 +669,8 @@ struct VMLibraryViewModelTests {
         viewModel.stop(instance)
 
         #expect(virtService.stopCallCount == 1)
-        #expect(viewModel.showStopPausedConfirmation == false)
-        #expect(viewModel.instanceToStopPaused == nil)
+        #expect(presenter.showStopPausedConfirmation == false)
+        #expect(presenter.instanceToStopPaused == nil)
     }
 
     @Test("pause presents error on service failure")
@@ -680,8 +682,8 @@ struct VMLibraryViewModelTests {
 
         await viewModel.pause(instance)
 
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage != nil)
     }
 
     @Test("resume presents error on service failure")
@@ -693,8 +695,8 @@ struct VMLibraryViewModelTests {
 
         await viewModel.resume(instance)
 
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage != nil)
     }
 
     @Test("save presents error on service failure")
@@ -706,8 +708,8 @@ struct VMLibraryViewModelTests {
 
         await viewModel.save(instance)
 
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage != nil)
     }
 
     // MARK: - Save Configuration
@@ -730,8 +732,8 @@ struct VMLibraryViewModelTests {
 
         viewModel.saveConfiguration(for: instance)
 
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage != nil)
     }
 
     // MARK: - trySave / tryForceStop
@@ -821,10 +823,9 @@ struct VMLibraryViewModelTests {
         wizard.selectedBootMode = .efi
         wizard.vmName = "Fail VM"
 
-        await viewModel.createVM(from: wizard)
+        let result = await viewModel.createVM(from: wizard)
 
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
+        #expect(result.isFailure)
         #expect(viewModel.instances.isEmpty)
     }
 
@@ -838,10 +839,9 @@ struct VMLibraryViewModelTests {
         wizard.selectedBootMode = .efi
         wizard.vmName = "Disk Fail VM"
 
-        await viewModel.createVM(from: wizard)
+        let result = await viewModel.createVM(from: wizard)
 
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
+        #expect(result.isFailure)
     }
 
     @Test("createVM auto-starts the new VM when startAfterCreate is true (default)")
@@ -1050,21 +1050,19 @@ struct VMLibraryViewModelTests {
         storage.bundles[badURL] = VMConfiguration(name: "Bad VM", guestOS: .linux, bootMode: .efi)
         storage.loadConfigurationFailURLs.insert(badURL)
 
-        viewModel.showError = false
-        viewModel.errorMessage = nil
+        presenter.reset()
 
         viewModel.reconcileWithDisk()
 
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage?.contains("broken-vm") == true)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage?.contains("broken-vm") == true)
         #expect(viewModel.instances.contains { $0.name == "Good VM" })
     }
 
     @Test("reconcileWithDisk presents error when listing bundles fails")
     func reconcilePresentsErrorForFilesystemFailure() {
         let (viewModel, storage, _, _, _) = makeViewModel()
-        viewModel.showError = false
-        viewModel.errorMessage = nil
+        presenter.reset()
 
         storage.listVMBundlesError = VMStorageError.bundleNotFound(
             FileManager.default.temporaryDirectory
@@ -1072,8 +1070,8 @@ struct VMLibraryViewModelTests {
 
         viewModel.reconcileWithDisk()
 
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage?.contains("VM bundle not found") == true)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage?.contains("VM bundle not found") == true)
     }
 
     @Test("reconcileWithDisk does not re-present error for already-reported corrupted bundles")
@@ -1088,18 +1086,16 @@ struct VMLibraryViewModelTests {
         storage.loadConfigurationFailURLs.insert(badURL)
 
         // First reconciliation should present the error
-        viewModel.showError = false
-        viewModel.errorMessage = nil
+        presenter.reset()
         viewModel.reconcileWithDisk()
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage?.contains("broken-vm") == true)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage?.contains("broken-vm") == true)
 
         // Second reconciliation should NOT re-present the same error
-        viewModel.showError = false
-        viewModel.errorMessage = nil
+        presenter.reset()
         viewModel.reconcileWithDisk()
-        #expect(viewModel.showError == false)
-        #expect(viewModel.errorMessage == nil)
+        #expect(presenter.showError == false)
+        #expect(presenter.errorMessage == nil)
     }
 
     @Test("reconcileWithDisk suppression is maintained after full reload")
@@ -1112,25 +1108,23 @@ struct VMLibraryViewModelTests {
 
         // loadVMs() in init reports the error and seeds reportedFailedBundles
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage?.contains("broken-vm") == true)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage?.contains("broken-vm") == true)
 
         // First reconcile after init is suppressed
-        viewModel.showError = false
-        viewModel.errorMessage = nil
+        presenter.reset()
         viewModel.reconcileWithDisk()
-        #expect(viewModel.showError == false)
+        #expect(presenter.showError == false)
 
         // Full reload resets suppression, then re-seeds from its own failures
         viewModel.loadVMs()
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage?.contains("broken-vm") == true)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage?.contains("broken-vm") == true)
 
         // Reconciliation should still be suppressed since loadVMs re-seeded the set
-        viewModel.showError = false
-        viewModel.errorMessage = nil
+        presenter.reset()
         viewModel.reconcileWithDisk()
-        #expect(viewModel.showError == false)
+        #expect(presenter.showError == false)
     }
 
     @Test("reconcileWithDisk does not re-present errors already reported by loadVMs")
@@ -1143,17 +1137,16 @@ struct VMLibraryViewModelTests {
 
         // loadVMs() runs in init and should report the error
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage?.contains("broken-vm") == true)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage?.contains("broken-vm") == true)
 
         // Clear the alert state (simulating user dismissing the dialog)
-        viewModel.showError = false
-        viewModel.errorMessage = nil
+        presenter.reset()
 
         // First reconcileWithDisk should NOT re-present the same error
         viewModel.reconcileWithDisk()
-        #expect(viewModel.showError == false)
-        #expect(viewModel.errorMessage == nil)
+        #expect(presenter.showError == false)
+        #expect(presenter.errorMessage == nil)
     }
 
     @Test("reconcileWithDisk re-presents error after previously-failed bundle loads successfully")
@@ -1169,20 +1162,18 @@ struct VMLibraryViewModelTests {
         storage.loadConfigurationFailURLs.insert(bundleURL)
 
         // First reconciliation reports the error
-        viewModel.showError = false
-        viewModel.errorMessage = nil
+        presenter.reset()
         viewModel.reconcileWithDisk()
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage?.contains("recoverable") == true)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage?.contains("recoverable") == true)
 
         // "Fix" the bundle by removing it from the fail set
         storage.loadConfigurationFailURLs.remove(bundleURL)
 
         // Reconciliation succeeds — no error, and the bundle is cleared from reported set
-        viewModel.showError = false
-        viewModel.errorMessage = nil
+        presenter.reset()
         viewModel.reconcileWithDisk()
-        #expect(viewModel.showError == false)
+        #expect(presenter.showError == false)
 
         // Re-corrupt it
         storage.loadConfigurationFailURLs.insert(bundleURL)
@@ -1191,8 +1182,8 @@ struct VMLibraryViewModelTests {
 
         // Should report the error again since it was cleared from the reported set
         viewModel.reconcileWithDisk()
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage?.contains("recoverable") == true)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage?.contains("recoverable") == true)
     }
 
     // MARK: - Initial Boot status assignment
@@ -1339,6 +1330,7 @@ struct VMLibraryViewModelTests {
             ipswService: MockIPSWService(),
             usbDeviceService: MockUSBDeviceService()
         )
+        viewModel.presenter = presenter
         let instance = makeInstance(name: "Race VM")
         instance.configuration.installContext = MacOSInstallContext(
             source: .localFile, localIPSWPath: "/tmp/foo.ipsw"
@@ -1366,7 +1358,7 @@ struct VMLibraryViewModelTests {
         // to .initialBoot, no error dialog, error message cleared.
         #expect(instance.status == .initialBoot)
         #expect(instance.errorMessage == nil)
-        #expect(viewModel.showError == false)
+        #expect(presenter.showError == false)
     }
 
     @Test("cancelInstallation does not change selection")
@@ -1548,8 +1540,8 @@ struct VMLibraryViewModelTests {
         await viewModel.pauseAllForSleep()
 
         // Error is surfaced to the user
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage?.contains("Running") == true)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage?.contains("Running") == true)
         // Failed pause should not track the instance
         #expect(viewModel.sleepPausedInstanceIDs.isEmpty)
     }
@@ -1568,8 +1560,8 @@ struct VMLibraryViewModelTests {
 
         #expect(viewModel.sleepPausedInstanceIDs.isEmpty)
         // Error is surfaced to the user
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage?.contains("Sleep Paused") == true)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage?.contains("Sleep Paused") == true)
     }
 
     @Test("pauseAllForSleep is no-op when no running VMs")
@@ -1698,8 +1690,8 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.instances.count == 1)
         #expect(viewModel.instances.first?.id == instance.id)
         #expect(viewModel.selectedID == instance.id)
-        #expect(viewModel.showError == true)
-        #expect(viewModel.errorMessage != nil)
+        #expect(presenter.showError == true)
+        #expect(presenter.errorMessage != nil)
     }
 
     @Test("cloneVM is skipped when VM is running")
@@ -1728,7 +1720,7 @@ struct VMLibraryViewModelTests {
 
         // No new instance added, error shown
         #expect(viewModel.instances.count == 2)
-        #expect(viewModel.showError == true)
+        #expect(presenter.showError == true)
     }
 
     @Test("cloneVM increments name when Copy already exists")
@@ -1760,8 +1752,8 @@ struct VMLibraryViewModelTests {
 
         #expect(viewModel.instances.isEmpty)
         #expect(phantom.preparingState == nil)
-        #expect(viewModel.showCancelPreparingConfirmation == false)
-        #expect(viewModel.preparingInstanceToCancel == nil)
+        #expect(presenter.showCancelPreparingConfirmation == false)
+        #expect(presenter.preparingInstanceToCancel == nil)
     }
 
     @Test("cancelPreparingConfirmed selects remaining instance")
@@ -1788,8 +1780,8 @@ struct VMLibraryViewModelTests {
 
         viewModel.confirmCancelPreparing(phantom)
 
-        #expect(viewModel.showCancelPreparingConfirmation == true)
-        #expect(viewModel.preparingInstanceToCancel?.id == phantom.id)
+        #expect(presenter.showCancelPreparingConfirmation == true)
+        #expect(presenter.preparingInstanceToCancel?.id == phantom.id)
     }
 
     // MARK: - Force Stop Confirmation
@@ -1803,8 +1795,8 @@ struct VMLibraryViewModelTests {
 
         viewModel.confirmForceStop(instance)
 
-        #expect(viewModel.instanceToForceStop?.id == instance.id)
-        #expect(viewModel.showForceStopConfirmation == true)
+        #expect(presenter.instanceToForceStop?.id == instance.id)
+        #expect(presenter.showForceStopConfirmation == true)
     }
 
     @Test("forceStopConfirmed delegates to lifecycle")
@@ -1932,6 +1924,7 @@ struct VMLibraryViewModelTests {
             installService: MockMacOSInstallService(),
             ipswService: MockIPSWService()
         )
+        viewModel.presenter = presenter
 
         #expect(viewModel.instances.map(\.name) == ["Third", "First", "Second"])
     }
@@ -2020,6 +2013,7 @@ struct VMLibraryViewModelTests {
             installService: MockMacOSInstallService(),
             ipswService: MockIPSWService()
         )
+        viewModel.presenter = presenter
 
         #expect(viewModel.instances.count == 1)
         #expect(viewModel.instances.first?.name == "Only VM")
@@ -2039,8 +2033,8 @@ struct VMLibraryViewModelTests {
         viewModel.mountGuestAgentInstaller(on: instance)
 
         // Alert is set synchronously; reconcile attach is async.
-        #expect(viewModel.showInstallerMountedAlert == true)
-        #expect(viewModel.installerMountedVMName == instance.name)
+        #expect(presenter.showInstallerMountedAlert == true)
+        #expect(presenter.installerMountedVMName == instance.name)
         #expect(instance.configuration.removableMedia?.count == 1)
         #expect(instance.configuration.removableMedia?.first?.path == installerURL.path(percentEncoded: false))
 
@@ -2064,8 +2058,8 @@ struct VMLibraryViewModelTests {
         viewModel.mountGuestAgentInstaller(on: instance)
 
         #expect(mock.attachCallCount == 0)
-        #expect(viewModel.showInstallerMountedAlert == true)
-        #expect(viewModel.installerMountedVMName == instance.name)
+        #expect(presenter.showInstallerMountedAlert == true)
+        #expect(presenter.installerMountedVMName == instance.name)
         // List unchanged
         #expect(instance.configuration.removableMedia?.count == 1)
     }
@@ -2283,10 +2277,10 @@ struct VMLibraryViewModelTests {
 
         viewModel.applyLivePolicy(for: instance, old: old, new: new)
 
-        while !viewModel.showError { await Task.yield() }
+        while !presenter.showError { await Task.yield() }
 
         #expect(mock.attachCallCount == 1)
-        #expect(viewModel.errorMessage != nil)
+        #expect(presenter.errorMessage != nil)
         #expect(instance.liveRemovableMedia.isEmpty)
     }
 
@@ -2341,7 +2335,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.applyLivePolicy(for: instance, old: old, new: new)
 
-        while !viewModel.showError { await Task.yield() }
+        while !presenter.showError { await Task.yield() }
         for _ in 0..<5 { await Task.yield() }
 
         #expect(mock.detachCallCount == 1)
@@ -2371,7 +2365,7 @@ struct VMLibraryViewModelTests {
 
         #expect(mock.detachCallCount == 1)
         #expect(mock.attachCallCount == 0)
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("Attach noVirtualMachine error bails the reconcile silently")
@@ -2391,7 +2385,7 @@ struct VMLibraryViewModelTests {
 
         #expect(mock.attachCallCount == 1)
         #expect(mock.detachCallCount == 0)
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
         #expect(instance.liveRemovableMedia.isEmpty)
     }
 
@@ -2418,7 +2412,7 @@ struct VMLibraryViewModelTests {
 
         #expect(mock.attachCallCount == 1)
         #expect(mock.lastAttachedPath == "/tmp/A.iso")
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("Rapid-fire media swaps coalesce — one Task drains to the latest target")
@@ -2479,7 +2473,7 @@ struct VMLibraryViewModelTests {
         #expect(disks.count == 1)
         #expect(disks.first?.id == mainDisk.id)
         // No presentError side effect — no file op was attempted.
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("removeStorageDisk on external disk with trashFile=true trashes the host file")
@@ -2503,7 +2497,7 @@ struct VMLibraryViewModelTests {
         #expect(instance.configuration.storageDisks == nil)
         // trashItem moved the file out of its original location.
         #expect(!FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("removeStorageDisk on external disk with trashFile=false leaves the host file alone")
@@ -2526,7 +2520,7 @@ struct VMLibraryViewModelTests {
 
         #expect(instance.configuration.storageDisks == nil)
         #expect(FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("removeStorageDisk with trashFile=true swallows missing-file errors")
@@ -2550,7 +2544,7 @@ struct VMLibraryViewModelTests {
         await viewModel.removeStorageDisk(ghost, from: instance, trashFile: true)?.value
 
         #expect(instance.configuration.storageDisks == nil)
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("removeRemovableMedia with trashFile=false removes the entry without touching the file")
@@ -2571,7 +2565,7 @@ struct VMLibraryViewModelTests {
 
         #expect(instance.configuration.removableMedia == nil)
         #expect(FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("removeRemovableMedia with trashFile=true trashes the host file")
@@ -2592,7 +2586,7 @@ struct VMLibraryViewModelTests {
 
         #expect(instance.configuration.removableMedia == nil)
         #expect(!FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("removeRemovableMedia with trashFile=true swallows missing-file errors")
@@ -2609,7 +2603,7 @@ struct VMLibraryViewModelTests {
         await viewModel.removeRemovableMedia(item, from: instance, trashFile: true)?.value
 
         #expect(instance.configuration.removableMedia == nil)
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("createStorageDisk appends an internal virtio disk with the expected fields")
@@ -2642,7 +2636,7 @@ struct VMLibraryViewModelTests {
 
         #expect(diskService.createDiskImageCallCount == 1)
         #expect(diskService.lastCreatedSizeInGB == 32)
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("createRemovableMedia appends an external item with the chosen path and read-write default")
@@ -2670,7 +2664,7 @@ struct VMLibraryViewModelTests {
 
         #expect(diskService.createDiskImageCallCount == 1)
         #expect(diskService.lastCreatedSizeInGB == 16)
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("createRemovableMedia surfaces errors and leaves the list unchanged")
@@ -2686,7 +2680,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.createRemovableMedia(for: instance, sizeInGB: 16, destinationURL: destination)
 
-        while !viewModel.showError { await Task.yield() }
+        while !presenter.showError { await Task.yield() }
 
         #expect(instance.configuration.removableMedia == nil)
         #expect(diskService.createDiskImageCallCount == 1)
@@ -2711,7 +2705,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.createRemovableMedia(for: instance, sizeInGB: 16, destinationURL: destination)
 
-        while !viewModel.showError { await Task.yield() }
+        while !presenter.showError { await Task.yield() }
 
         // `trashItem` moved the file out of its original location.
         #expect(!FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
@@ -2736,7 +2730,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.createRemovableMedia(for: instance, sizeInGB: 16, destinationURL: destination)
 
-        while !viewModel.showError { await Task.yield() }
+        while !presenter.showError { await Task.yield() }
 
         // Pre-existing file is intact.
         #expect(FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
@@ -2779,7 +2773,7 @@ struct VMLibraryViewModelTests {
         #expect(mock.detachCallCount == 0)
         #expect(mock.attachCallCount == 0)
         #expect(instance.liveRemovableMedia.count == 2)
-        #expect(!viewModel.showError)
+        #expect(!presenter.showError)
     }
 
     @Test("Failed detach rolls config back to live state (item stays attached)")
@@ -2808,7 +2802,7 @@ struct VMLibraryViewModelTests {
         instance.configuration = new
 
         viewModel.applyLivePolicy(for: instance, old: old, new: new)
-        while !viewModel.showError { await Task.yield() }
+        while !presenter.showError { await Task.yield() }
         for _ in 0..<5 { await Task.yield() }
 
         // Detach failed → device still mounted → config must reflect that.
@@ -2843,7 +2837,7 @@ struct VMLibraryViewModelTests {
         instance.configuration = new
 
         viewModel.applyLivePolicy(for: instance, old: old, new: new)
-        while !viewModel.showError { await Task.yield() }
+        while !presenter.showError { await Task.yield() }
         for _ in 0..<5 { await Task.yield() }
 
         // Attach failed → device never mounted → config rolled back to nil.
@@ -2878,7 +2872,7 @@ struct VMLibraryViewModelTests {
         instance.configuration = new
 
         viewModel.applyLivePolicy(for: instance, old: old, new: new)
-        while !viewModel.showError { await Task.yield() }
+        while !presenter.showError { await Task.yield() }
         for _ in 0..<5 { await Task.yield() }
 
         let rolled = try #require(instance.configuration.removableMedia)
@@ -2950,3 +2944,10 @@ private final class CancelRaceInstallService: MacOSInstallProviding {
     }
 }
 #endif
+
+extension Result {
+    fileprivate var isFailure: Bool {
+        if case .failure = self { return true }
+        return false
+    }
+}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A macOS GUI application for creating and managing virtual machines using Apple's
 
 ### Display and Console
 
-- **Native UI** — AppKit app with SwiftUI views, Liquid Glass design language
+- **Native UI** — Pure-AppKit app, Liquid Glass design language
 - **Fullscreen mode** — Dedicated fullscreen window per VM
 - **Serial console** — Terminal window for serial port access
 
@@ -80,7 +80,7 @@ Kernova/
 ├── App/          # AppDelegate, MainWindowController
 ├── Models/       # VMConfiguration, VMInstance, enums
 ├── Services/     # VM lifecycle, storage, disk images, IPSW, installation
-├── Views/        # SwiftUI views (sidebar, detail, console, creation wizard)
+├── Views/        # AppKit view controllers (sidebar, detail, console, creation wizard)
 ├── ViewModels/   # Observable view models
 └── Utilities/    # Formatters, extensions
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,7 +8,7 @@ Design philosophy and guidelines for Kernova.
 - Aggressively identify code that looks like a shortcut or band-aid. Either fix it in scope or file a GitHub issue for a future pass.
 - GitHub issues serve as durable context — when a fix is deferred, the issue should capture enough detail to address it later without rediscovery.
 - Prefer the simpler path first. Always attempt or plan the straightforward solution before introducing complexity through flags, intercepts, overrides, special cases, shims, or conditional branching.
-- When working on window layout issues, verify that the implementation follows AppKit/SwiftUI best practices. Cross-reference Apple documentation and well-known code examples where possible before settling on an approach.
+- When working on window layout issues, verify that the implementation follows AppKit best practices. Cross-reference Apple documentation and well-known code examples where possible before settling on an approach.
 
 ## GUI Design
 
@@ -20,49 +20,53 @@ Design philosophy and guidelines for Kernova.
 
 ### Layout
 
-- AppKit owns structural layout (`NSSplitViewController`, `NSToolbar`, `NSWindow`); SwiftUI renders content via `NSHostingController`.
+- AppKit owns the entire view layer — `NSSplitViewController`, `NSToolbar`, `NSWindow`, and concrete `NSViewController`s render all content (no SwiftUI / `NSHostingController`).
 - Main window: 1100×700 default, 800×500 minimum.
 - Sidebar: 200–350pt width.
 - Creation wizard sheet: 550×480.
 
 ### Typography
 
-- `.title2` + `.fontWeight(.semibold)` — section/page headings
-- `.headline` — important labels and step indicators
-- `.body` — primary form content
-- `.caption` / `.caption2` — secondary text, metadata, step numbers
-- `.system(.caption, design: .monospaced)` — code snippets and paths
+Use `NSFont.preferredFont(forTextStyle:)` so type scales with the system setting.
+
+- `.title2` at `.semibold` — section/page headings (`WizardStyle.titleFont`)
+- `.headline` — important labels and step indicators (`CalloutStyle.headlineFont`)
+- `.body` — primary form content (`Typography.body`)
+- `.caption1` / `.caption2` — secondary text, metadata, step numbers
+- monospaced `.caption1` (`NSFont.monospacedSystemFont`) — code snippets and paths (`CalloutStyle.makeCalloutCode`)
 
 ### Spacing
 
-- `VStack(spacing: 24)` — between major sections
-- `VStack(spacing: 12)` — between grouped elements
-- `VStack(spacing: 8)` — compact grouping (icon + label)
-- `VStack(spacing: 2–4)` — tightly related items
-- `HStack(spacing: 8)` — standard inline spacing
+Set `NSStackView.spacing` from the `Spacing` token scale (`Utilities/DesignTokens.swift`):
+
+- `Spacing.section` (18) / `Spacing.major` (20) — between settings-form / hero sections
+- `Spacing.medium` (12) — between grouped elements and containers
+- `Spacing.standard` (8) — default inline / row spacing
+- `Spacing.small` (6) — icon-to-label and section-header elements
+- `Spacing.tight` (4) / `Spacing.hairline` (2) — tightly related items
 
 ### Colors
 
-- Status mapping: `stopped` = `.secondary`, `starting`/`saving`/`restoring`/`installing` = `.orange`, `running` = `.green`, `paused` = `.yellow`, `error` = `.red`
-- Use semantic system colors (`.primary`, `.secondary`, `.accentColor`) — no hardcoded RGB values.
-- Destructive actions: `.red` foreground.
-- Selection highlights: `accentColor` at 0.1 opacity fill, 0.3 opacity border.
+- Status mapping lives in the `StatusColor` palette (`Utilities/DesignTokens.swift`): `inactive` = `.secondaryLabelColor` (stopped / agent idle), `warning` = `.systemOrange` (preparing/starting/saving/restoring/installing/suspended), `running` = `.systemGreen`, `pausedInMemory` = `.systemYellow`, `error` = `.systemRed`.
+- Use semantic `NSColor`s (`.labelColor`, `.secondaryLabelColor`, `.controlAccentColor`) — no hardcoded RGB values.
+- Destructive actions: `.systemRed` foreground.
+- Selection highlights: `.controlAccentColor` at 0.1 opacity fill, 0.3 opacity border.
 
 ### Controls
 
-- `.formStyle(.grouped)` for settings forms.
-- `.listStyle(.sidebar)` for navigation lists.
-- Default button style (`.plain`) in lists; `.bordered` for dialog actions.
-- `role: .destructive` for delete/stop confirmations.
-- `ProgressView`: `.controlSize(.large)` for major operations, `.controlSize(.mini)` for inline status.
+- Grouped settings forms: build with the `GroupedFormStyle` factories (`makeGroupedFormCard`, `makeGroupedFormCardRow`, …).
+- Navigation list: source-list `NSOutlineView` (`SidebarViewController`).
+- Borderless `NSButton` in lists; `.rounded` bezel for dialog actions.
+- `AlertButtonRole.destructive` for delete/stop confirmations (`SheetAlert`).
+- `NSProgressIndicator`: `.controlSize = .large` for major operations, `.mini` for inline status.
 
 ### Overlays
 
-- `.ultraThinMaterial` for temporary state overlays (pause, saving/restoring).
-- `.animation(.easeInOut(duration: 0.25))` for overlay transitions.
+- `NSVisualEffectView` for temporary state overlays (pause, saving/restoring).
+- `NSAnimationContext` (0.25s) for overlay transitions.
 - Large hero icons (64pt) centered on overlays.
 
 ### Cards and Containers
 
-- Selection cards: `RoundedRectangle(cornerRadius: 12)`, accent-tinted fill when selected.
-- Code blocks: `.background(.quaternary)`, `cornerRadius: 4`, `padding: 8`, monospaced font.
+- Selection cards: layer-backed `NSView` with `cornerRadius: 12`, accent-tinted fill when selected.
+- Code blocks: `CalloutStyle.makeCalloutCode` — quaternary fill, `cornerRadius: 4`, `Spacing.standard` padding, monospaced font.


### PR DESCRIPTION
## Summary

Follows up an audit of the SwiftUI→AppKit migration that found the app is compiler-level SwiftUI-free but still carried four classes of residue. This addresses all of them in three independently-reviewable commits.

## Phase 1 — Design tokens + docs/cosmetic scrub (`5d67efa`)
- New `DesignTokens.swift`: a `Spacing` scale, a `StatusColor` palette, and `Typography.body`.
- Replaced all 64 `.spacing` literals with tokens (value-preserving), routed both status→color maps through `StatusColor`, and swapped 15 duplicated body-font calls.
- Dropped 8 now-vestigial `Identifiable` conformances (kept the `id`s; the protocol's only consumer was SwiftUI) plus a dead `var id`.
- Fixed factually-stale SwiftUI comments (e.g. `moveVM`'s "SwiftUI onMove", the "SwiftUI bridge modifier" delegate docs) while keeping accurate port-lineage breadcrumbs.
- Rewrote README + SPEC.md design sections from SwiftUI syntax into AppKit vocabulary (including SPEC's now-false `NSHostingController` claim).

## Phase 2 — Stop rebuilding list rows on every tick (`38f0692`)
- `VMSettingsViewController`: the storage / removable / shared / audio refreshes now early-out on a `RenderedRow` value snapshot instead of tearing down and recreating rows on every observation tick. The snapshot captures the rendered subtitle string, so disk-usage polling still refreshes correctly; this mirrors `VMDetailRouterViewController`'s existing `route != displayedRoute` guard.
- `StorageDiskReorderRowCellView`: holds a persistent subtitle label mutated in place instead of recreated on every cell reuse.

## Phase 3 — Fully imperative presentation (`20c2966`)
- Removed the SwiftUI `isPresented`-style model from `VMLibraryViewModel`: the 13 observed `show*`/payload properties are gone. The view model now calls a `VMLibraryPresenting` delegate directly.
- `DetailContainerViewController` implements the protocol (forwarding alerts/delete-sheet to an imperative `DetailAlertsPresenter` and owning the wizard); `DetailAlertsPresenter` drops its observation loop for imperative `present*` methods with a serialization queue.
- `createVM` now returns `Result<Void, Error>` so the wizard shows creation failures on its own sheet — removing the prior global-error suppression hack.
- **Fixed a latent regression found along the way:** `loadVMs()` runs in `init` before any presenter is attached, so initial load errors would have silently vanished. The view model now buffers errors raised pre-attach and flushes them when the presenter is set.
- Tests: added `MockVMLibraryPresenting`; converted ~99 flag assertions to the mock spy / `Result` checks.

## Test plan
- [x] `make build` succeeds on macOS 26
- [x] `make lint` (swift-format --strict) passes
- [x] `make test` — 898 tests pass, 0 failures
- [ ] Manual: trigger each alert path (delete with/without external attachments, force-stop, stop-paused, cancel clone/import, installer-mounted, lifecycle error)
- [ ] Manual: open the creation wizard from both the New VM toolbar item and the empty-state button; confirm a creation failure shows on the wizard sheet (not the main window)
- [ ] Manual: open a multi-disk VM, let disk-usage poll while renaming — rows do not flicker or lose focus

## Notes
- All spacing/token changes are strictly value-preserving (no layout shift).
- ARCHITECTURE.md updated (new protocol + tokens, imperative data flow); CLAUDE.md unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
