### PR TITLE
fix: Add bottom margin below running-VM lock warning banner

### DIFF
--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -419,7 +419,9 @@ extension VMSettingsViewController {
         let inset = GroupedFormStyle.contentSideInset
         NSLayoutConstraint.activate([
             banner.topAnchor.constraint(equalTo: container.topAnchor, constant: inset),
-            banner.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            // Buffer below the banner so it doesn't crowd the first section title;
+            // matches the inter-section rhythm of the form below.
+            banner.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Spacing.section),
             banner.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: inset),
             banner.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -inset),
         ])


### PR DESCRIPTION
## Summary
- While a VM is running, the lock warning banner ("Sections marked with a lock are locked while the VM is running…") sat flush against the first section title ("General"), looking cramped.
- Adds a buffer below the banner so it no longer crowds the form.

## Changes
- In `VMSettingsViewController.makeBannerContainer()`, add a `-Spacing.section` (18pt) bottom inset to the banner's bottom constraint, matching the inter-section rhythm of the form below.

## Test plan
- [x] Built successfully on macOS 26
- [ ] Start a VM and confirm the lock warning banner has visible breathing room above the General section

🤖 Generated with [Claude Code](https://claude.com/claude-code)