### PR TITLE
fix: Right-align VM name field while editing

### DIFF
--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -438,6 +438,7 @@ extension VMSettingsViewController {
         nameDisplayRow = makeGroupedFormCardRow("Name", control: nameButton)
 
         nameField.placeholderString = "Name"
+        nameField.alignment = .right
         nameField.delegate = self
         nameEditRow = makeGroupedFormCardRow("Name", control: nameField, fillsControl: true)
         nameEditRow.isHidden = true


### PR DESCRIPTION
## Summary
- The Name value in the General section is right-aligned when displayed, but jumped to the left the moment the field entered edit mode. It now stays right-aligned throughout, matching the read-only display.

## Changes
- Set `nameField.alignment = .right` on the editable name `NSTextField` in `VMSettingsViewController.buildGeneralSection()`, matching the `.right` alignment of the read-only `nameButton`.

## Test plan
- [ ] Build succeeds on macOS 26
- [ ] Click the VM name to edit; the text stays right-aligned instead of shifting left

🤖 Generated with [Claude Code](https://claude.com/claude-code)