### PR TITLE
fix: Remap cloned VM's additional disk path to its regenerated id

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -1464,12 +1464,28 @@ final class VMLibraryViewModel {
                     return skipped
                 }.value
 
-                // Remove skipped disks. Internal disk paths are
-                // bundle-relative (`AdditionalDisks/<id>.asif`) so they
-                // travel with the bundle and don't need remapping.
+                // Remove skipped disks and remap each kept internal additional
+                // disk's `path` to its regenerated id-based filename.
+                // `clonedForNewInstance` gives every disk a fresh `id` (so
+                // virtio/USB device identifiers don't collide with the source
+                // bundle) but copies the old `path` verbatim; the file copy
+                // above wrote each disk to `AdditionalDisks/<new-id>.asif`, so
+                // the stored path must follow or boot-time resolution looks for
+                // the source bundle's old id and fails with `storageDiskNotFound`.
                 if !diskMapping.isEmpty {
+                    let remappedPaths: [UUID: String] = Dictionary(
+                        uniqueKeysWithValues: diskMapping.map { mapping in
+                            (mapping.clonedDisk.id, "AdditionalDisks/\(mapping.clonedDisk.id.uuidString).asif")
+                        }
+                    )
                     phantom.configuration.storageDisks = phantom.configuration.storageDisks?
                         .filter { !skippedDiskIDs.contains($0.id) }
+                        .map { disk in
+                            guard let newPath = remappedPaths[disk.id] else { return disk }
+                            var updated = disk
+                            updated.path = newPath
+                            return updated
+                        }
                     if phantom.configuration.storageDisks?.isEmpty == true {
                         phantom.configuration.storageDisks = nil
                     }

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -1738,6 +1738,57 @@ struct VMLibraryViewModelTests {
         #expect(cloned?.name == "VM Copy 2")
     }
 
+    @Test("cloneVM remaps internal additional disk path to its regenerated id and copies the file")
+    func cloneVMRemapsAdditionalDiskPath() async throws {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+
+        // Build a source bundle on disk with a real additional-disk file
+        // living at `AdditionalDisks/<source-disk-id>.asif`.
+        let instance = makeInstance(name: "Original")
+        instance.status = .stopped
+        let sourceDiskID = UUID()
+        let sourceLayout = VMBundleLayout(bundleURL: instance.bundleURL)
+        let fm = FileManager.default
+        try fm.createDirectory(at: sourceLayout.additionalDisksDirectoryURL, withIntermediateDirectories: true)
+        let sourceDiskFile = sourceLayout.additionalDiskURL(id: sourceDiskID)
+        try Data("disk-bytes".utf8).write(to: sourceDiskFile)
+        defer { try? fm.removeItem(at: instance.bundleURL) }
+
+        instance.configuration.storageDisks = [
+            StorageDisk(path: "Disk.asif", isInternal: true),
+            StorageDisk(
+                id: sourceDiskID,
+                path: "AdditionalDisks/\(sourceDiskID.uuidString).asif",
+                label: "Extra",
+                isInternal: true
+            ),
+        ]
+        viewModel.instances.append(instance)
+        storage.bundles[instance.bundleURL] = instance.configuration
+
+        viewModel.cloneVM(instance)
+
+        let phantom = viewModel.instances.first { $0.id != instance.id }
+        #expect(phantom != nil)
+        await phantom?.preparingState?.task.value
+        defer { phantom.map { try? fm.removeItem(at: $0.bundleURL) } }
+
+        let clonedDisks = phantom?.configuration.storageDisks ?? []
+        guard let extra = clonedDisks.first(where: { $0.path.hasPrefix("AdditionalDisks/") }) else {
+            Issue.record("Cloned configuration is missing the additional disk")
+            return
+        }
+
+        // The path must point at the regenerated id, not the source's id,
+        // and the copied file must exist at exactly that resolved location.
+        #expect(extra.id != sourceDiskID)
+        #expect(extra.path == "AdditionalDisks/\(extra.id.uuidString).asif")
+        if let phantom {
+            let resolved = phantom.bundleURL.appendingPathComponent(extra.path)
+            #expect(fm.fileExists(atPath: resolved.path(percentEncoded: false)))
+        }
+    }
+
     // MARK: - Cancel Preparing
 
     @Test("cancelPreparingConfirmed removes phantom instance and cancels task")


### PR DESCRIPTION
> Supersedes #261 (that PR was auto-closed when its `worktree-`-prefixed head branch was renamed to this clean name). Same commit, same content.

## Summary
- Cloning a VM that has an internal **additional** disk produced a clone that failed to boot with `storageDiskNotFound` (e.g. `Storage disk '100 GB Disk' not found at AdditionalDisks/<uuid>.asif`).
- Root cause: `clonedForNewInstance` regenerates each `StorageDisk.id` (so virtio/USB device identifiers don't collide with the source bundle) but copies the old `path` verbatim. The clone's file-copy step writes each additional disk to `AdditionalDisks/<new-id>.asif`, yet the config's `path` still referenced `AdditionalDisks/<old-id>.asif`. At boot, `ConfigurationBuilder.resolvedURL` resolves the stale path → file not found.
- The primary `Disk.asif` was unaffected because its path is fixed and id-independent.

## Changes
- In `VMLibraryViewModel.cloneVM`, after copying internal additional disk files, remap each kept disk's `path` to `AdditionalDisks/<new-id>.asif` so the stored path matches where the file actually landed.
- Replace the stale comment that incorrectly claimed internal disk paths don't need remapping.
- Add `cloneVMRemapsAdditionalDiskPath` regression test: writes a real source disk file, clones, and asserts the cloned disk's path uses the regenerated id and the copied file exists at the resolved location.

## Test plan
- [x] `make test-suite SUITE=KernovaTests/VMLibraryViewModelTests` passes (incl. new test)
- [x] `make lint` clean
- [x] Re-clone a macOS VM with a second disk and confirm the clone boots

## Notes
- This fixes future clones only. A clone created before this fix is already broken on disk (its `config.json` references the old-id path while the file sits under a new-id name) and must be deleted and re-cloned, or repaired manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)