### PR TITLE
test: Bump frame-read timeout in skipsPolicyWhenProviderAbsent to fix CI flake

### DIFF
--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -524,9 +524,12 @@ struct VsockControlServiceTests {
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
         try await waitUntil { service.isConnected }
 
-        // Read a few frames; none should be PolicyUpdate.
+        // Read a few frames; none should be PolicyUpdate. Each read returns as
+        // soon as a frame arrives (heartbeats fire every 40 ms), so the timeout
+        // only bounds the worst case — keep it generous so a CI scheduling
+        // stall between heartbeats doesn't time out and flake the test.
         for _ in 0..<3 {
-            let next = try await nextFrame(from: guest, timeout: .milliseconds(200))
+            let next = try await nextFrame(from: guest, timeout: .seconds(2))
             if case .policyUpdate = next.payload {
                 Issue.record("Unexpected PolicyUpdate when no provider was supplied")
                 return


### PR DESCRIPTION
## Summary
- `VsockControlServiceTests.skipsPolicyWhenProviderAbsent` intermittently fails in CI (it flaked on PR #262's first `build-and-test` run). The failure is a frame-read **timeout**, not an assertion — the test's `Issue.record` for an unexpected `PolicyUpdate` never fired.
- The per-read timeout was 200 ms. With the 40 ms heartbeat cadence a frame normally arrives well inside that window, but a CI scheduling stall between heartbeats can exceed 200 ms, so `nextFrame` throws and the test flakes.

## Changes
- Raise the per-read `nextFrame` timeout in the 3-frame loop from `.milliseconds(200)` to `.seconds(2)`. Each read returns as soon as a frame arrives, so the larger value only widens the worst case and never slows the passing path.
- Add a comment explaining why the timeout is intentionally generous.

## Test plan
- [x] `make test-suite SUITE=KernovaTests/VsockControlServiceTests` passes (`skipsPolicyWhenProviderAbsent` ~0.13s)
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)