### PR TITLE
test: Standardize test-runner timeout deadlines to 5s and 2s

### DIFF
--- a/KernovaGuestAgentTests/VsockGuestClientTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClientTests.swift
@@ -234,7 +234,7 @@ struct VsockGuestClientTests {
             do { for try await _ in channel.incoming {} } catch {}
         }
 
-        _ = try await awaitFirst(servedStream, timeout: .seconds(3))
+        _ = try await awaitFirst(servedStream, timeout: .seconds(2))
 
         #expect(attemptCounter.value >= targetAttempt)
         #expect(client.liveChannel != nil)

--- a/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
@@ -217,7 +217,7 @@ struct VsockGuestClipboardAgentTests {
         try await waitUntil { agent.liveChannelForTesting == nil }
 
         // Wait for second connection
-        try await waitUntil(timeout: .seconds(3)) { agent.liveChannelForTesting != nil }
+        try await waitUntil(timeout: .seconds(2)) { agent.liveChannelForTesting != nil }
 
         // After reconnect, lastSeenText is cleared — next poll should re-offer
         await MainActor.run { agent.checkClipboardChange() }
@@ -333,7 +333,7 @@ struct VsockGuestClipboardAgentTests {
         // logs .error, and attempts a best-effort error frame (also fails,
         // swallowed). It must not crash and liveChannel must be cleared once
         // the receive loop observes EOF.
-        try await waitUntil(timeout: .seconds(3)) { agent.liveChannelForTesting == nil }
+        try await waitUntil(timeout: .seconds(2)) { agent.liveChannelForTesting == nil }
         #expect(agent.liveChannelForTesting == nil, "liveChannel should be nil after peer EOF")
     }
 

--- a/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
@@ -170,7 +170,7 @@ struct VsockGuestControlAgentTests {
         // The agent should still be sending heartbeats: read the next frame
         // and expect either a heartbeat or — at worst — a successful round
         // trip without a thrown error.
-        let frame = try await nextFrame(from: host, timeout: .milliseconds(800))
+        let frame = try await nextFrame(from: host, timeout: .seconds(2))
         switch frame.payload {
         case .heartbeat:
             break


### PR DESCRIPTION
## Summary
- Collapse the assortment of wait/timeout deadlines used in the test runners down to two consistent values: **5s** for the helper defaults and **2s** for every explicit per-call-site override.
- Removes the lone `.seconds(3)` and `.milliseconds(800)` outliers so reviewers see one generous default and one consistent override, not a spread of ad-hoc numbers.

This follows on from #264, which bumped the only `.milliseconds(200)` deadline up to `.seconds(2)` — this PR finishes the job by aligning the remaining stragglers.

## Changes
- `VsockGuestClientTests`: `awaitFirst` `.seconds(3)` → `.seconds(2)`
- `VsockGuestControlAgentTests`: `nextFrame` `.milliseconds(800)` → `.seconds(2)`
- `VsockGuestClipboardAgentTests`: two `waitUntil` `.seconds(3)` → `.seconds(2)`

Helper defaults (the `.seconds(5)` values in `TestHelpers.swift` and friends) are intentionally left untouched.

## Test plan
- [x] `xcodebuild test` of the three affected guest-agent suites (29 tests) passes
- [x] `make lint --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)