### PR TITLE
fix: Exclude bundled Guest Agent DMG from VM deletion

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -539,7 +539,17 @@ final class VMLibraryViewModel {
     /// the library that reference the same path. The shared-with list
     /// lets the delete confirmation warn before trashing a file that
     /// another VM still depends on (e.g., a shared installer ISO).
+    ///
+    /// The bundled Guest Agent installer DMG is deliberately excluded: it
+    /// is mounted as a read-only `RemovableMediaItem` whose path points
+    /// *inside the app bundle* (see ``mountGuestAgentInstaller(on:)``), so
+    /// it is never a user-owned file. Surfacing it in the delete sheet is
+    /// meaningless, and trashing it would corrupt the app bundle and break
+    /// Guest Agent installation for every VM in the library. Identified by
+    /// path equality with `KernovaGuestAgentInfo.installerDiskImageURL`,
+    /// the same mechanism ``unmountGuestAgentInstaller(from:)`` uses.
     func externalAttachments(for instance: VMInstance) -> [ExternalAttachment] {
+        let agentPath = Self.guestAgentInstallerPath
         let otherInstances = instances.filter { $0.id != instance.id }
         func vmsSharing(path: String) -> [String] {
             otherInstances.compactMap { other -> String? in
@@ -566,7 +576,7 @@ final class VMLibraryViewModel {
                 )
             )
         }
-        for item in instance.configuration.removableMedia ?? [] {
+        for item in instance.configuration.removableMedia ?? [] where item.path != agentPath {
             attachments.append(
                 ExternalAttachment(
                     id: item.id,
@@ -578,6 +588,17 @@ final class VMLibraryViewModel {
             )
         }
         return attachments
+    }
+
+    /// Filesystem path of the bundled Guest Agent installer DMG, if present.
+    ///
+    /// Resolved at the call site (not cached) so it always reflects the
+    /// running app bundle's location. `nil` when the DMG is missing — in
+    /// that case nothing is filtered, which is correct: there is no bundled
+    /// resource to protect. Mirrors the path-equality identity used by
+    /// ``mountGuestAgentInstaller(on:)`` / ``unmountGuestAgentInstaller(from:)``.
+    private static var guestAgentInstallerPath: String? {
+        KernovaGuestAgentInfo.installerDiskImageURL?.path(percentEncoded: false)
     }
 
     /// Trashes any in-progress IPSW download bundle for a VM that's being deleted.
@@ -603,17 +624,18 @@ final class VMLibraryViewModel {
         #endif
     }
 
-    /// Flat list of external (label, URL) pairs to feed the trash helper —
-    /// mirrors `externalAttachments(for:)` but drops the sharing metadata.
+    /// Flat list of external (label, URL) pairs to feed the trash helper.
+    ///
+    /// Derived from `externalAttachments(for:)` so the set of files shown
+    /// in the delete sheet and the set actually trashed can never diverge —
+    /// in particular, the bundled Guest Agent DMG is excluded in exactly one
+    /// place. External attachment paths are always absolute (external disks
+    /// and removable media), so `URL(fileURLWithPath:)` is the correct
+    /// resolution; the sharing metadata is dropped here.
     private func externalURLs(for instance: VMInstance) -> [(label: String, url: URL)] {
-        var result: [(label: String, url: URL)] = []
-        for disk in instance.configuration.storageDisks ?? [] where !disk.isInternal {
-            result.append((label: disk.label, url: URL(fileURLWithPath: disk.path)))
+        externalAttachments(for: instance).map { attachment in
+            (label: attachment.label, url: URL(fileURLWithPath: attachment.path))
         }
-        for item in instance.configuration.removableMedia ?? [] {
-            result.append((label: item.label, url: URL(fileURLWithPath: item.path)))
-        }
-        return result
     }
 
     /// Detached trash for a single external attachment.

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -315,6 +315,66 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.externalAttachments(for: instance).isEmpty)
     }
 
+    @Test("externalAttachments excludes the bundled Guest Agent DMG")
+    func externalAttachmentsExcludesGuestAgentDMG() throws {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let agentPath = try #require(KernovaGuestAgentInfo.installerDiskImageURL)
+            .path(percentEncoded: false)
+        let instance = makeInstance()
+        instance.configuration.removableMedia = [
+            RemovableMediaItem(path: agentPath, readOnly: true, label: "Kernova Guest Agent"),
+            RemovableMediaItem(path: "/Volumes/External/installer.iso", readOnly: true, label: "Installer"),
+        ]
+        viewModel.instances.append(instance)
+
+        let attachments = viewModel.externalAttachments(for: instance)
+
+        // The app-owned DMG is filtered out; only the user's ISO remains —
+        // so it can never be surfaced for, or moved to, the Trash.
+        #expect(attachments.count == 1)
+        #expect(attachments[0].path == "/Volumes/External/installer.iso")
+        #expect(!attachments.contains { $0.path == agentPath })
+    }
+
+    @Test("externalAttachments is empty when the only external is the Guest Agent DMG")
+    func externalAttachmentsEmptyForGuestAgentOnly() throws {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let agentPath = try #require(KernovaGuestAgentInfo.installerDiskImageURL)
+            .path(percentEncoded: false)
+        let instance = makeInstance()
+        instance.configuration.removableMedia = [
+            RemovableMediaItem(path: agentPath, readOnly: true, label: "Kernova Guest Agent")
+        ]
+        viewModel.instances.append(instance)
+
+        // Empty means confirmDelete routes to the simple alert, not the
+        // file-trashing sheet.
+        #expect(viewModel.externalAttachments(for: instance).isEmpty)
+    }
+
+    @Test("deleteConfirmed with trashExternals=true never trashes the Guest Agent DMG")
+    func deleteConfirmedNeverTrashesGuestAgentDMG() throws {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        let agentPath = try #require(KernovaGuestAgentInfo.installerDiskImageURL)
+            .path(percentEncoded: false)
+        let instance = makeInstance()
+        instance.configuration.removableMedia = [
+            RemovableMediaItem(path: agentPath, readOnly: true, label: "Kernova Guest Agent")
+        ]
+        viewModel.instances.append(instance)
+        storage.bundles[instance.bundleURL] = instance.configuration
+
+        let tasks = viewModel.deleteConfirmed(instance, trashExternals: true)
+
+        // No trash task is spawned for the bundled DMG. Require this *before*
+        // awaiting any task: a regression that did enqueue one would
+        // otherwise move the real app-bundle DMG to the Trash.
+        try #require(tasks.isEmpty)
+        #expect(viewModel.instances.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: agentPath))
+        #expect(!presenter.showError)
+    }
+
     @Test("deleteConfirmed with trashExternals=false leaves external files untouched")
     func deleteConfirmedKeepsExternalsByDefault() throws {
         let (viewModel, storage, _, _, _) = makeViewModel()


### PR DESCRIPTION
## Summary
Deleting a VM no longer offers to trash the bundled **Kernova Guest Agent** installer DMG, and can never move it to the Trash.

Previously, any VM that had the Guest Agent mounted surfaced the DMG as a deletable file in the delete confirmation sheet (it's mounted as a read-only `RemovableMediaItem` whose path points *inside the app bundle*). Checking "Also move these files to Trash" would attempt to `trashItem` a resource inside `Kernova.app/Contents/Resources/`, breaking Guest Agent installation for **every** VM in the library and corrupting the app bundle. It was also wrongly flagged as "shared" with every other VM that had it mounted.

This is fix #1 from a broader audit of inconsistent storage-disk / removable-media handling on VM delete; the remaining items (per-row trash control for shared files) are tracked separately for follow-up.

## Changes
- `VMLibraryViewModel`: add `guestAgentInstallerPath` and filter it out of `externalAttachments(for:)`, identified by path equality with `KernovaGuestAgentInfo.installerDiskImageURL` — the same identity `mountGuestAgentInstaller` / `unmountGuestAgentInstaller` already use. A VM whose only external is the Guest Agent now routes to the simple delete alert instead of the file-trashing sheet.
- Derive `externalURLs(for:)` from `externalAttachments(for:)` so the files shown in the sheet and the files actually trashed share one source of truth and cannot diverge — the structural cause of the original bug.
- Add tests: exclusion from the attachment list, the guest-agent-only empty case, and that a trash-externals delete never enqueues a trash task for the DMG.

## Test plan
- [x] `make test-suite SUITE=KernovaTests/VMLibraryViewModelTests` — TEST SUCCEEDED (3 new tests)
- [x] `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)