### PR TITLE
docs: Consolidate duplicated build documentation to single sources

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,7 +19,7 @@ make install-hooks       # One-time: enable .githooks/pre-push (runs `make lint`
 make clean               # Remove DerivedData/
 ```
 
-After cloning, run `make install-hooks` once. This sets `core.hooksPath` to the checked-in `.githooks/` directory so a pre-push hook runs `make lint` locally and matches the swift-format check in `.github/workflows/lint.yml`. Bypass an individual push with `git push --no-verify`.
+Run `make install-hooks` once after cloning to enable the pre-push `make lint` hook (see [Development setup](../README.md#development-setup) in the README for the mechanics; bypass an individual push with `git push --no-verify`).
 
 `make test` is the canonical `xcodebuild` invocation:
 
@@ -35,7 +35,7 @@ The `-derivedDataPath DerivedData` flag ensures build output goes to a determini
 
 `CFBundleVersion` is `git rev-list --count HEAD` (the total commit count), substituted into the source `Info.plist` via `INFOPLIST_PREPROCESS`. The `Set Build Number from Git` build phase generates `KernovaBuildNumber.h` with `#define KERNOVA_BUILD_NUMBER N`, and `Kernova/App/Info.plist` references the symbol directly (`<string>KERNOVA_BUILD_NUMBER</string>`). Substitution happens inside `ProcessInfoPlistFile` so build-graph reordering can't clobber it. The `KernovaGuestAgent` target uses the same pattern with its own `AGENT_BUILD_NUMBER` (scoped to `git rev-list --count HEAD -- KernovaGuestAgent/`). When adding a new top-level target that needs a dynamic build number, replicate this pattern instead of patching the built `Info.plist` after the fact.
 
-Requires **macOS 26 (Tahoe)**, **Xcode 26**, **Swift 6**, and **Apple Silicon** (for macOS guest support). The app uses the `com.apple.security.virtualization` entitlement.
+Requires the toolchain listed under [Requirements](../README.md#requirements) in the README (Apple Silicon is needed for macOS guest support). The app uses the `com.apple.security.virtualization` entitlement.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ make install-hooks
 
 This points the repo at the checked-in `.githooks/` directory so a pre-push hook runs `make lint` locally and matches the swift-format check enforced on `main`. It's a one-time setup per clone (Git does not auto-activate checked-in hooks). Bypass an individual push with `git push --no-verify`.
 
-Other useful Makefile targets: `make build`, `make test`, `make format`, `make lint`. Run `make` with no arguments for the full list.
+Run `make` with no arguments to see all build, test, format, and lint targets.
 
 ## Building
 
@@ -66,10 +66,10 @@ The app requires the `com.apple.security.virtualization` entitlement, which is i
 The project has comprehensive test coverage using [Swift Testing](https://developer.apple.com/documentation/testing/) (`@Test`, `#expect`). All services use protocol-based dependency injection with mock implementations for full testability.
 
 ```bash
-xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=macOS' test
+make test
 ```
 
-See the test coverage section in [ARCHITECTURE.md](ARCHITECTURE.md) for details.
+This runs all three test targets via the test plan; it wraps the canonical `xcodebuild` invocation documented in [CLAUDE.md](.claude/CLAUDE.md). See the test coverage section in [ARCHITECTURE.md](ARCHITECTURE.md) for details.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Remove overlapping/divergent build instructions across `README.md` and `.claude/CLAUDE.md` so each build fact has one canonical home, with the others linking to it (mirroring how the README already defers to `ARCHITECTURE.md`).
- Fix the README's test command, which had drifted from the canonical `xcodebuild` invocation (it was missing `-derivedDataPath DerivedData`, the flag CLAUDE.md explicitly calls out to avoid DerivedData glob ambiguity across worktrees).

## Changes
- `README.md`: replace the raw `xcodebuild … test` command with `make test`, pointing at CLAUDE.md for the canonical invocation.
- `README.md`: drop the hand-listed make-target subset in favor of a pointer to `make` (the Makefile `help` target is the source of truth).
- `.claude/CLAUDE.md`: trim the install-hooks paragraph to a one-line pointer into the README's *Development setup* section.
- `.claude/CLAUDE.md`: link the toolchain version matrix to the README's *Requirements* section instead of restating macOS/Xcode/Swift versions, so a toolchain bump only edits one place.

## Test plan
- [ ] README and CLAUDE.md relative links resolve on GitHub (`.claude/CLAUDE.md`, `../README.md#development-setup`, `../README.md#requirements`)
- [ ] `make test` and `make` (help) behave as the docs now describe