### PR TITLE
chore: Pass build configuration explicitly and make it overridable

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,7 +24,7 @@ Run `make install-hooks` once after cloning to enable the pre-push `make lint` h
 `make test` is the canonical `xcodebuild` invocation:
 
 ```bash
-xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=macOS' -derivedDataPath DerivedData <build|test>
+xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=macOS' -derivedDataPath DerivedData -configuration Debug <build|test>
 ```
 
 A single `xcodebuild test -scheme Kernova` runs all three test targets (`KernovaTests`, `KernovaGuestAgentTests`, `KernovaProtocolTests`) via `Kernova.xctestplan`. This works because `KernovaProtocol` is referenced as a top-level peer in the project (a `PBXFileReference` in `Kernova.xcodeproj`'s main group) rather than as an `XCLocalSwiftPackageReference` under Package Dependencies. In the dependency form, Xcode treats the package as upstream and hides its `.testTarget`s from the test-plan picker; in the peer form, the package's tests appear in `Edit Scheme → Test → +` as first-class targets and can be added to the test plan. If `KernovaProtocol` ever needs to be re-added, drag the folder into the Project Navigator from Finder rather than using `Add Package Dependencies → Add Local`. `make test-package` exists as a focused shortcut for iterating on package tests in isolation.

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,16 @@ SCHEME       := Kernova
 DESTINATION  := platform=macOS
 DERIVED_DATA := DerivedData
 
+# Build configuration, passed explicitly rather than relying on the scheme's
+# per-action default (Debug). Override on the command line to build/test in
+# Release, e.g. `make build CONFIGURATION=Release`.
+CONFIGURATION ?= Debug
+
 XCODEBUILD_FLAGS := -project $(PROJECT) \
                     -scheme $(SCHEME) \
                     -destination '$(DESTINATION)' \
-                    -derivedDataPath $(DERIVED_DATA)
+                    -derivedDataPath $(DERIVED_DATA) \
+                    -configuration $(CONFIGURATION)
 
 # swift-format ships with the Xcode toolchain (Xcode 26+); use xcrun so the
 # command resolves the same binary in CI and locally without a brew install.
@@ -33,6 +39,8 @@ help:
 	@printf '  make lint                Check Swift sources with swift-format (--strict)\n'
 	@printf '  make install-hooks       Point git at .githooks/ (runs lint on pre-push)\n'
 	@printf '  make clean               Remove the DerivedData directory\n'
+	@printf '\n'
+	@printf '  Append CONFIGURATION=Release to build/test in Release (default: Debug)\n'
 
 build: check-hooks
 	xcodebuild $(XCODEBUILD_FLAGS) build


### PR DESCRIPTION
## Summary
- `make build`/`make test` now state their build configuration explicitly instead of relying on the scheme's implicit Debug default, so it's clear which configuration is compiled.
- Release becomes a self-documenting one-flag override (`make build CONFIGURATION=Release`) — no separate target and no extra prose needed.

## Changes
- `Makefile`: add a `CONFIGURATION ?= Debug` variable and thread `-configuration $(CONFIGURATION)` into the shared `XCODEBUILD_FLAGS`.
- `Makefile`: add a `help` line documenting the `CONFIGURATION=Release` override.

## Notes
- The default path is a true no-op: `-configuration Debug` matches the scheme's existing Run/Test action default (see `Kernova.xcscheme`), so normal `make build`/`make test` behavior is unchanged — it just becomes legible.
- Independent of #268 (docs consolidation); this branch is cut from `main`.

## Test plan
- [x] `make test` passes with the explicit `-configuration Debug` flag (`** TEST SUCCEEDED **`)
- [x] `make help` renders the new CONFIGURATION line
- [ ] CI build-and-test is green