### PR TITLE
refactor: Gate test-only seams behind #if DEBUG and drop redundant accessor

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,6 +62,15 @@ When adding new functionality or modifying existing behavior, include unit tests
 - Reuse shared test helpers and factories (e.g., `makeInstance()`) rather than duplicating setup logic across test files
 - Run the full test suite before committing to ensure nothing is broken
 
+#### Test-only seams
+
+When a test needs to observe state that is `private` in production, pick the tightest exposure that still works:
+
+1. **`private(set) var x`** — internal getter, private setter. The idiomatic choice when production code reading the state is harmless; tests reach it via `@testable import`, no extra accessor needed.
+2. **`#if DEBUG`-gated read accessor** — when the state is a test-only implementation detail that production code should *not* read. Keep the field `private` and add a `…ForTesting` computed getter wrapped in `#if DEBUG`, so the seam is physically absent from Release builds and test-only access becomes a compile-time guarantee rather than a naming convention. Place `#if DEBUG` before the doc comment and `#endif` after the accessor.
+
+`AttachmentFileMonitor.watchedParentsForTesting` is the canonical example; the `…ForTesting` accessors in `VsockClipboardService`, `VsockGuestClipboardAgent`, and `VsockHostConnection` follow the same pattern. Because this rationale is shared, the gate itself is the documentation — don't repeat a "DEBUG-only so it can't leak" note at each site.
+
 ### Logging
 
 The app uses Apple's `os.Logger` (subsystem `com.kernova.app`) with per-component categories. Each service, view model, or model that logs declares a `private static let logger`. When adding or modifying functionality, include log calls at appropriate levels:

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -78,6 +78,7 @@ final class VsockClipboardService: ClipboardServicing {
     /// `grabIfChanged()` is called repeatedly with the same content.
     private var lastGrabbedText: String?
 
+    #if DEBUG
     /// Exposes `pendingInboundGeneration` for tests that need to assert the
     /// inbound-request lifecycle without relying on observable side effects.
     ///
@@ -87,6 +88,7 @@ final class VsockClipboardService: ClipboardServicing {
     /// via `stop()`. That reset would satisfy a behavioral assertion for the
     /// wrong reason, masking a regression in the generation commit logic itself.
     var pendingInboundGenerationForTesting: UInt64? { pendingInboundGeneration }
+    #endif
 
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VsockClipboardService")
 

--- a/Kernova/Views/Detail/StorageDiskReorderSheetContentViewController.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheetContentViewController.swift
@@ -86,11 +86,6 @@ final class StorageDiskReorderSheetContentViewController: NSViewController {
         fatalError("StorageDiskReorderSheetContentViewController does not support NSCoder")
     }
 
-    /// Latest known disk ordering.
-    ///
-    /// Useful for tests asserting on state after a simulated drop.
-    var currentOrdering: [StorageDisk] { disks }
-
     override func loadView() {
         let container = NSView()
         container.translatesAutoresizingMaskIntoConstraints = false

--- a/KernovaGuestAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaGuestAgent/VsockGuestClipboardAgent.swift
@@ -58,6 +58,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// the host isn't reachable.
     private var liveChannel: VsockChannel?
 
+    #if DEBUG
     /// Exposes `liveChannel` as an internal read for tests that need to wait
     /// until the main-queue async assignment completes before driving polls.
     var liveChannelForTesting: VsockChannel? { liveChannel }
@@ -72,6 +73,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// assertion for the wrong reason, masking a regression in the generation
     /// commit logic itself.
     var pendingInboundGenerationForTesting: UInt64? { pendingInboundGeneration }
+    #endif
 
     /// Counter for outbound offer generations.
     ///
@@ -112,8 +114,10 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// on the main queue.
     private var enabled: Bool = false
 
+    #if DEBUG
     /// Test seam.
     var isEnabledForTesting: Bool { enabled }
+    #endif
 
     // MARK: - Init
 

--- a/KernovaGuestAgent/VsockHostConnection.swift
+++ b/KernovaGuestAgent/VsockHostConnection.swift
@@ -41,10 +41,12 @@ final class VsockHostConnection: @unchecked Sendable {
     /// initial `PolicyUpdate` says otherwise. Toggled by `setEnabled(_:)`.
     private var enabled: Bool = false
 
+    #if DEBUG
     /// Test seam: read the current enabled state without exposing the mutator.
     var isEnabledForTesting: Bool {
         lock.withLock { enabled }
     }
+    #endif
 
     init() {
         self.client = VsockGuestClient(port: KernovaVsockPort.log, label: "log")

--- a/KernovaTests/StorageDiskReorderSheetContentViewControllerTests.swift
+++ b/KernovaTests/StorageDiskReorderSheetContentViewControllerTests.swift
@@ -39,7 +39,7 @@ struct StorageDiskReorderSheetContentViewControllerTests {
         // last row." After the downward shift A should land at index 2.
         let didReorder = vc.performReorder(sourceRow: 0, proposedRow: 3)
         #expect(didReorder)
-        #expect(vc.currentOrdering.map(\.label) == ["B", "C", "A"])
+        #expect(vc.disks.map(\.label) == ["B", "C", "A"])
         #expect(delegate.reorderedOrderings.count == 1)
         #expect(delegate.reorderedOrderings.last?.map(\.label) == ["B", "C", "A"])
     }
@@ -56,7 +56,7 @@ struct StorageDiskReorderSheetContentViewControllerTests {
         // the first row." Target stays at 0 (upward drag).
         let didReorder = vc.performReorder(sourceRow: 2, proposedRow: 0)
         #expect(didReorder)
-        #expect(vc.currentOrdering.map(\.label) == ["C", "A", "B"])
+        #expect(vc.disks.map(\.label) == ["C", "A", "B"])
         #expect(delegate.reorderedOrderings.last?.map(\.label) == ["C", "A", "B"])
     }
 
@@ -74,7 +74,7 @@ struct StorageDiskReorderSheetContentViewControllerTests {
         // Drag row 1 to proposedRow 2 — target == 2 - 1 == 1 == source.
         let droppedJustAfter = vc.performReorder(sourceRow: 1, proposedRow: 2)
         #expect(!droppedJustAfter)
-        #expect(vc.currentOrdering.map(\.label) == ["A", "B", "C"])
+        #expect(vc.disks.map(\.label) == ["A", "B", "C"])
         #expect(delegate.reorderedOrderings.isEmpty)
     }
 
@@ -118,7 +118,7 @@ struct StorageDiskReorderSheetContentViewControllerTests {
             table, acceptDrop: dragInfo, row: 3, dropOperation: .above
         )
         #expect(accepted)
-        #expect(vc.currentOrdering.map(\.label) == ["B", "C", "A"])
+        #expect(vc.disks.map(\.label) == ["B", "C", "A"])
         #expect(delegate.reorderedOrderings.last?.map(\.label) == ["B", "C", "A"])
     }
 


### PR DESCRIPTION
## Summary
- Fence five read-only test seams off from Release builds so production code cannot depend on test-only state, matching the existing `watchedParentsForTesting` pattern. Gating makes test-only access a **compile-time guarantee** rather than a naming convention.
- Remove the redundant `currentOrdering` accessor, which merely aliased the already-`private(set)` `disks` property it wrapped — the idiomatic read seam was already present.

## Background
A survey of DEBUG-vs-RELEASE divergence turned up five `*ForTesting` accessors that follow the same shape as the project's gated `watchedParentsForTesting` seam (read-only getter over a `private` field, consumed only by test targets) but were missing the `#if DEBUG` gate. This brings them in line. `currentOrdering` was a separate finding: it was a redundant alias, since `disks` is `private(set)` and therefore already readable by tests via `@testable import`.

## Changes
- Wrap in `#if DEBUG`:
  - `pendingInboundGenerationForTesting` — `VsockClipboardService`
  - `liveChannelForTesting`, `pendingInboundGenerationForTesting`, `isEnabledForTesting` — `VsockGuestClipboardAgent` (the first two share one gate block)
  - `isEnabledForTesting` — `VsockHostConnection`
- Delete `currentOrdering` from `StorageDiskReorderSheetContentViewController`; repoint its four test call-sites to `vc.disks`.
- Document the "test-only seam" convention once in `CLAUDE.md` (`private(set)` vs `#if DEBUG`-gated accessor, with `watchedParentsForTesting` as the canonical example) and trim the per-site rationale to rely on it instead of repeating a "DEBUG-only so it can't leak" note at each gate.

## Test plan
- [x] `make lint` — clean
- [x] `make test` (Debug) — `** TEST SUCCEEDED **`, 0 failures; the four edited StorageDiskReorder tests and every consumer of the gated accessors pass
- [x] `make build CONFIGURATION=Release` — `** BUILD SUCCEEDED **`, with no references to the gated or deleted symbols (proves clean exclusion from the shipping binary)

## Notes
- No behavior change and no non-test API surface change.
- Neutral for the Periphery dead-code scan: it scans the Debug build (where the gated symbols are present and active), and these symbols were already referenced only by test targets before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
