### PR TITLE
feat: Render the Serial Console through a VT100/xterm terminal emulator

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,7 +15,7 @@ Kernova/
 │   ├── DetailContainerViewController.swift # Layers AppKit VM display over the AppKit detail content (empty-state view ⇆ `VMDetailRouterViewController`); respects per-instance detailPaneMode; owns `DetailAlertsPresenter`; conforms to `VMLibraryPresenting` (the view model's presentation delegate), forwarding lifecycle alerts to `DetailAlertsPresenter` and presenting the creation-wizard sheet via `SheetPresenter`
 │   ├── VMToolbarManager.swift          # Shared toolbar logic for lifecycle, suspend, display, and settings-toggle items
 │   ├── SerialConsoleWindowController.swift # Per-VM serial console window, auto-closes on VM stop
-│   ├── SerialConsoleContentViewController.swift # Pure AppKit serial terminal + status bar (contains SerialTextView)
+│   ├── SerialConsoleContentViewController.swift # Pure AppKit serial console: hosts `TerminalView` over the VM's `TerminalEmulator`, a connection/grid-size status bar, and a ⌘F find bar
 │   ├── ClipboardWindowController.swift   # Per-VM clipboard sharing window, auto-closes on VM stop
 │   ├── ClipboardContentViewController.swift # Pure AppKit clipboard text editor + status bar
 │   └── Info.plist                        # App configuration and metadata
@@ -51,6 +51,11 @@ Kernova/
 │       ├── DiskImageProviding.swift
 │       ├── MacOSInstallProviding.swift
 │       └── IPSWProviding.swift
+├── Terminal/                           # Pure-logic VT100/xterm terminal emulator (AppKit-free) for the Serial Console
+│   ├── TerminalCell.swift              # Cell value type (glyph + 256-color/truecolor fg/bg + `CellAttributes` SGR flags) and `TerminalColor`
+│   ├── VTParser.swift                  # Paul Williams VT500 escape-sequence DFA + `TerminalPerformer` protocol; incremental UTF-8 decode; bounded params/OSC accumulators for untrusted guest input
+│   ├── TerminalBuffer.swift            # Array-of-arrays cell grid: scroll / erase / line+char insert-delete / resize by explicit coordinates
+│   └── TerminalEmulator.swift          # @MainActor engine conforming to `TerminalPerformer`: CSI/ESC/OSC/DCS handlers, SGR pen, cursor, scroll regions, alt-screen, 5000-row scrollback, DEC line-drawing; answers DSR/DA probes via a `respond` hook; redraw via `onRender`
 ├── ViewModels/                         # Observable view models and coordinators
 │   ├── VMLibraryViewModel.swift        # Central view model — owns [VMInstance], delegates to coordinator; surfaces alerts/sheets/wizard imperatively via the `VMLibraryPresenting` delegate
 │   ├── VMLibraryPresenting.swift       # Presentation delegate protocol the view model calls (implemented by `DetailContainerViewController`)
@@ -91,7 +96,10 @@ Kernova/
 │   │   └── GroupedFormStyle.swift      # Grouped-form design atoms shared by the creation wizard and the settings pane — `makeGroupedFormCard` / `makeGroupedFormCardRow` / `makeGroupedFormSectionHeader` / `makeGroupedFormCaption` / `makeGroupedFormValueLabel` / `makeGroupedFormBanner` / `makeGroupedFormHairline` / `makeGroupedFormBox` + `makeGroupedFormScrollView` (top-anchored, centered, overlay-scroller). Extracted from `WizardStyle`; visual consistency without a shared base class
 │   ├── Console/
 │   │   ├── VMDisplayPlaceholderContentViewController.swift # Concrete `NSViewController` for the detail-pane placeholder shown when the VM display is unavailable inline — centered empty-state (SF Symbol + title + description + optional action button) for the non-inline display states (Fullscreen / Popped Out / Suspended / No Display), inert black fill behind it for the `.live` case (covered by `VMDisplayBackingView`). Observes `VMInstance.displayMode`, `isColdPaused`, and `virtualMachine` via `observeRecurring`. Action buttons dispatch through `NSApp.sendAction(_:to:from:)` to `AppDelegate.toggleFullscreen(_:)` / `togglePopOut(_:)`. The reusable `DisplayPlaceholderEmptyStateView` lives privately in the same file (one consumer today; no premature extraction). Used directly by `VMDetailRouterViewController`
-│   │   └── VMDisplayBackingView.swift  # Pure AppKit VM display with pause/transition overlays
+│   │   ├── VMDisplayBackingView.swift  # Pure AppKit VM display with pause/transition overlays
+│   │   ├── TerminalView.swift          # Custom-drawn `NSView` rendering the emulator grid (run-batched cells, block/hollow cursor), with its own scrollback offset + auto-follow, rubber-band selection + ⌘C copy, scroll-wheel history, key forwarding, find-match highlight, and minimal NSAccessibility
+│   │   ├── TerminalFindBar.swift        # Compact ⌘F bar (search field + match count + prev/next/Done) reporting to a delegate
+│   │   └── TerminalTheme.swift          # `TerminalColor` → `NSColor` over the xterm 256-color palette (RATIONALE-annotated: the one justified hardcoded-RGB site)
 │   └── Creation/                       # Pure AppKit — every wizard step is an NSViewController
 │       ├── VMCreationWizardViewController.swift # Shell: step indicator + swappable child step VCs + nav bar; observes VMCreationViewModel; reports Cancel/Create via VMCreationWizardViewControllerDelegate
 │       ├── OSSelectionContentViewController.swift   # Step 1: Choose macOS or Linux (selectable cards)
@@ -178,6 +186,10 @@ KernovaTests/
 ├── VMBundleLayoutTests.swift           # Bundle path calculation tests
 ├── VMStatusTests.swift                 # Status enum behavior tests
 ├── VMStatusSerialConsoleTests.swift    # Serial console status tests
+├── VTParserTests.swift                 # Escape-sequence DFA: CSI/OSC/DCS parsing, param caps, split-UTF-8, aborts
+├── TerminalBufferTests.swift           # Cell-grid ops: scroll regions, erase, line/char insert-delete, resize
+├── TerminalEmulatorTests.swift         # SGR, cursor clamping, DSR/DA replies, DECSTR, alt-screen scrollback freeze, RIS
+├── TerminalIssue249Tests.swift         # Regression: the exact garbled #249 banner renders with zero escape residue
 ├── VMBootModeTests.swift               # Boot mode enum tests
 ├── VMGuestOSTests.swift                # Guest OS enum tests
 ├── MacOSInstallStateTests.swift        # Install state tracking tests
@@ -333,7 +345,7 @@ VMCreationWizardViewController (pure-AppKit modal sheet; presented by DetailCont
 ├── IPSWSelectionContentViewController / BootConfigContentViewController   (chosen by selectedOS on entry)
 ├── ResourceConfigContentViewController
 └── ReviewContentViewController
-SerialConsoleContentViewController → SerialTextView (in separate window)
+SerialConsoleContentViewController → TerminalView (renders VMInstance.terminal; in separate window)
 ```
 
 ### Data Flow
@@ -476,6 +488,9 @@ No third-party (non-Apple) package dependencies. No CocoaPods or Carthage.
 | `VMBootMode` | Yes | Enum cases and properties |
 | `VMGuestOS` | Yes | Enum cases and properties |
 | `MacOSInstallState` | Yes | Phase tracking, progress calculation |
+| `VTParser` | Yes | CSI/OSC/DCS parsing, 16-param cap, 65535 value clamp, intermediates, private prefix, split-UTF-8-across-feeds, invalid UTF-8, CAN/ESC aborts |
+| `TerminalBuffer` | Yes | Scroll regions, erase spans, line/char insert-delete, resize grow/shrink |
+| `TerminalEmulator` | Yes | SGR→cell attrs, CUP clamping, DSR/DA replies, DECSTR, alt-screen scrollback freeze, RIS, scrollback accumulation, autowrap; plus the #249 garbled-banner regression (zero escape residue + answered probes) |
 | `VMToolbarManager` | 22 tests | Item creation, state updates, configuration flags, label toggling |
 | `DataFormatters` | Yes | Byte formatting, CPU count formatting |
 | `NSImageExtensions` | Yes | SF Symbol loading with known symbol validation |

--- a/Kernova/App/SerialConsoleContentViewController.swift
+++ b/Kernova/App/SerialConsoleContentViewController.swift
@@ -12,7 +12,7 @@ final class SerialConsoleContentViewController: NSViewController, TerminalFindBa
     private let instance: VMInstance
     private let terminalView: TerminalView
     private let findBar = TerminalFindBar()
-    private var findBarHeight: NSLayoutConstraint!
+    private var findBarHeight: NSLayoutConstraint?
     private let statusCircle: NSView
     private let statusLabel: NSTextField
     private let gridSizeLabel: NSTextField
@@ -90,13 +90,14 @@ final class SerialConsoleContentViewController: NSViewController, TerminalFindBa
         statusBar.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(statusBar)
 
-        findBarHeight = findBar.heightAnchor.constraint(equalToConstant: 0)
+        let findBarHeightConstraint = findBar.heightAnchor.constraint(equalToConstant: 0)
+        findBarHeight = findBarHeightConstraint
 
         NSLayoutConstraint.activate([
             findBar.topAnchor.constraint(equalTo: container.topAnchor),
             findBar.leadingAnchor.constraint(equalTo: container.leadingAnchor),
             findBar.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            findBarHeight,
+            findBarHeightConstraint,
 
             terminalView.topAnchor.constraint(equalTo: findBar.bottomAnchor),
             terminalView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
@@ -199,14 +200,14 @@ final class SerialConsoleContentViewController: NSViewController, TerminalFindBa
 
     private func showFindBar() {
         findBar.isHidden = false
-        findBarHeight.constant = 30
+        findBarHeight?.constant = 30
         findBar.focusSearchField()
         recomputeMatches()
     }
 
     private func hideFindBar() {
         findBar.isHidden = true
-        findBarHeight.constant = 0
+        findBarHeight?.constant = 0
         matches.removeAll()
         terminalView.clearFindHighlight()
         view.window?.makeFirstResponder(terminalView)

--- a/Kernova/App/SerialConsoleContentViewController.swift
+++ b/Kernova/App/SerialConsoleContentViewController.swift
@@ -2,57 +2,34 @@ import Cocoa
 
 /// Pure AppKit view controller for the serial console window content.
 ///
-/// Provides a terminal-style `NSTextView` (via `SerialTextView`) that displays
-/// guest serial output and forwards keyboard input, plus a status bar showing
-/// connection state and character count. Observes `VMInstance` properties via
-/// `withObservationTracking`.
+/// Hosts a `TerminalView` that renders the VM's `TerminalEmulator` grid and
+/// forwards keyboard input to the guest, a status bar (connection state + grid
+/// size), and a toggleable ⌘F find bar. Observes `VMInstance.status` via
+/// `observeRecurring` for the connection indicator; the terminal's own redraw
+/// is driven directly by the emulator's `onRender` hook, off the observation path.
 @MainActor
-final class SerialConsoleContentViewController: NSViewController {
+final class SerialConsoleContentViewController: NSViewController, TerminalFindBarDelegate {
     private let instance: VMInstance
-    private let textView: SerialTextView
-    private let scrollView: NSScrollView
+    private let terminalView: TerminalView
+    private let findBar = TerminalFindBar()
+    private var findBarHeight: NSLayoutConstraint!
     private let statusCircle: NSView
     private let statusLabel: NSTextField
-    private let characterCountLabel: NSTextField
-    private var instanceObservation: ObservationLoop?
+    private let gridSizeLabel: NSTextField
+    private var statusObservation: ObservationLoop?
+    private var keyMonitor: Any?
+
+    private struct Match {
+        let line: Int
+        let colStart: Int
+        let colEnd: Int
+    }
+    private var matches: [Match] = []
+    private var currentMatchIndex = 0
 
     init(instance: VMInstance) {
         self.instance = instance
-
-        let textView = SerialTextView()
-        textView.isEditable = false
-        textView.isSelectable = true
-        textView.isRichText = false
-        textView.isFieldEditor = false
-        textView.allowsUndo = false
-        textView.usesFindPanel = true
-        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
-        textView.textColor = .init(white: 0.9, alpha: 1.0)
-        textView.backgroundColor = .init(white: 0.1, alpha: 1.0)
-        textView.insertionPointColor = .init(white: 0.9, alpha: 1.0)
-        textView.isAutomaticQuoteSubstitutionEnabled = false
-        textView.isAutomaticDashSubstitutionEnabled = false
-        textView.isAutomaticTextReplacementEnabled = false
-        textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.isContinuousSpellCheckingEnabled = false
-        textView.isGrammarCheckingEnabled = false
-        textView.isVerticallyResizable = true
-        textView.isHorizontallyResizable = false
-        textView.textContainer?.widthTracksTextView = true
-        textView.textContainer?.containerSize = NSSize(
-            width: 0,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-        self.textView = textView
-
-        let scrollView = NSScrollView()
-        scrollView.documentView = textView
-        scrollView.hasVerticalScroller = true
-        scrollView.hasHorizontalScroller = false
-        scrollView.autohidesScrollers = true
-        scrollView.drawsBackground = true
-        scrollView.backgroundColor = .init(white: 0.1, alpha: 1.0)
-        self.scrollView = scrollView
+        self.terminalView = TerminalView(emulator: instance.terminal)
 
         let circle = NSView()
         circle.wantsLayer = true
@@ -69,17 +46,25 @@ final class SerialConsoleContentViewController: NSViewController {
         label.textColor = .secondaryLabelColor
         self.statusLabel = label
 
-        let countLabel = NSTextField(labelWithString: "")
-        countLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
-        countLabel.textColor = .secondaryLabelColor
-        countLabel.alignment = .right
-        self.characterCountLabel = countLabel
+        let gridLabel = NSTextField(labelWithString: "")
+        gridLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        gridLabel.textColor = .secondaryLabelColor
+        gridLabel.alignment = .right
+        self.gridSizeLabel = gridLabel
 
         super.init(nibName: nil, bundle: nil)
 
-        textView.sendInput = { [weak self] string in
+        terminalView.translatesAutoresizingMaskIntoConstraints = false
+        terminalView.sendInput = { [weak self] string in
             self?.instance.sendSerialInput(string)
         }
+        terminalView.onGridSizeChange = { [weak self] cols, rows in
+            self?.gridSizeLabel.stringValue = "\(cols) × \(rows)"
+        }
+
+        findBar.delegate = self
+        findBar.translatesAutoresizingMaskIntoConstraints = false
+        findBar.isHidden = true
     }
 
     required init?(coder: NSCoder) {
@@ -90,9 +75,11 @@ final class SerialConsoleContentViewController: NSViewController {
 
     override func loadView() {
         let container = NSView()
+        container.wantsLayer = true
+        container.layer?.backgroundColor = TerminalTheme.defaultBackground.cgColor
 
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(scrollView)
+        container.addSubview(findBar)
+        container.addSubview(terminalView)
 
         let divider = NSBox()
         divider.boxType = .separator
@@ -103,12 +90,19 @@ final class SerialConsoleContentViewController: NSViewController {
         statusBar.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(statusBar)
 
-        NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: container.topAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        findBarHeight = findBar.heightAnchor.constraint(equalToConstant: 0)
 
-            divider.topAnchor.constraint(equalTo: scrollView.bottomAnchor),
+        NSLayoutConstraint.activate([
+            findBar.topAnchor.constraint(equalTo: container.topAnchor),
+            findBar.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            findBar.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            findBarHeight,
+
+            terminalView.topAnchor.constraint(equalTo: findBar.bottomAnchor),
+            terminalView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            terminalView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            divider.topAnchor.constraint(equalTo: terminalView.bottomAnchor),
             divider.leadingAnchor.constraint(equalTo: container.leadingAnchor),
             divider.trailingAnchor.constraint(equalTo: container.trailingAnchor),
 
@@ -118,59 +112,45 @@ final class SerialConsoleContentViewController: NSViewController {
             statusBar.bottomAnchor.constraint(equalTo: container.bottomAnchor),
         ])
 
-        scrollView.setContentHuggingPriority(.defaultLow, for: .vertical)
-        scrollView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
-
         self.view = container
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        updateUI()
-        observeInstanceChanges()
+        updateStatusBar()
+        observeStatus()
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        view.window?.makeFirstResponder(terminalView)
+        installKeyMonitor()
+    }
+
+    override func viewWillDisappear() {
+        super.viewWillDisappear()
+        removeKeyMonitor()
     }
 
     // MARK: - Observation
 
-    private func observeInstanceChanges() {
-        instanceObservation = observeRecurring(
+    private func observeStatus() {
+        statusObservation = observeRecurring(
             track: { [weak self] in
-                guard let self else { return }
-                _ = self.instance.serialOutputText
-                _ = self.instance.status
+                _ = self?.instance.status
             },
             apply: { [weak self] in
-                self?.updateUI()
+                self?.updateStatusBar()
             }
         )
     }
 
-    private func updateUI() {
+    private func updateStatusBar() {
         let isConnected = instance.status == .running || instance.status == .paused
-
-        // Sync serial output with scroll-position preservation
-        let currentText = textView.string
-        let newText = instance.serialOutputText
-        if currentText != newText {
-            let clipView = scrollView.contentView
-            let contentHeight = textView.frame.height
-            let scrollOffset = clipView.bounds.origin.y + clipView.bounds.height
-            let isAtBottom = scrollOffset >= contentHeight - 10
-
-            textView.string = newText
-
-            if isAtBottom {
-                textView.scrollToEndOfDocument(nil)
-            }
-        }
-
-        // Update status bar
         statusCircle.layer?.backgroundColor =
-            isConnected
-            ? NSColor.systemGreen.cgColor
-            : NSColor.secondaryLabelColor.cgColor
+            isConnected ? NSColor.systemGreen.cgColor : NSColor.secondaryLabelColor.cgColor
         statusLabel.stringValue = isConnected ? "Connected" : "Disconnected"
-        characterCountLabel.stringValue = "\(newText.count) characters"
+        gridSizeLabel.stringValue = "\(instance.terminal.cols) × \(instance.terminal.rows)"
     }
 
     // MARK: - View Construction
@@ -180,46 +160,112 @@ final class SerialConsoleContentViewController: NSViewController {
         leftStack.orientation = .horizontal
         leftStack.spacing = Spacing.small
 
-        let stack = NSStackView(views: [leftStack, characterCountLabel])
+        let stack = NSStackView(views: [leftStack, gridSizeLabel])
         stack.orientation = .horizontal
         stack.distribution = .fill
         stack.edgeInsets = NSEdgeInsets(top: 5, left: 10, bottom: 5, right: 10)
-
         return stack
     }
-}
 
-// MARK: - SerialTextView
+    // MARK: - Find
 
-/// Custom `NSTextView` that intercepts keyboard input and forwards it
-/// to the guest VM's serial input pipe instead of editing the text buffer.
-final class SerialTextView: NSTextView {
-    /// Closure called with raw input characters to send to the guest VM.
-    var sendInput: ((String) -> Void)?
+    private var isFindBarVisible: Bool { !findBar.isHidden }
 
-    override func keyDown(with event: NSEvent) {
-        if let characters = event.characters, !characters.isEmpty {
-            sendInput?(characters)
+    private func installKeyMonitor() {
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self, self.view.window?.isKeyWindow == true else { return event }
+            if event.modifierFlags.contains(.command),
+                event.charactersIgnoringModifiers?.lowercased() == "f"
+            {
+                self.toggleFindBar()
+                return nil
+            }
+            if event.keyCode == 53, self.isFindBarVisible {  // Escape
+                self.hideFindBar()
+                return nil
+            }
+            return event
+        }
+    }
+
+    private func removeKeyMonitor() {
+        if let keyMonitor { NSEvent.removeMonitor(keyMonitor) }
+        keyMonitor = nil
+    }
+
+    private func toggleFindBar() {
+        if isFindBarVisible { hideFindBar() } else { showFindBar() }
+    }
+
+    private func showFindBar() {
+        findBar.isHidden = false
+        findBarHeight.constant = 30
+        findBar.focusSearchField()
+        recomputeMatches()
+    }
+
+    private func hideFindBar() {
+        findBar.isHidden = true
+        findBarHeight.constant = 0
+        matches.removeAll()
+        terminalView.clearFindHighlight()
+        view.window?.makeFirstResponder(terminalView)
+    }
+
+    private func recomputeMatches() {
+        matches.removeAll()
+        let query = findBar.query
+        guard !query.isEmpty else {
+            terminalView.clearFindHighlight()
+            findBar.updateMatchCount(current: 0, total: 0)
             return
         }
-        super.keyDown(with: event)
+        let lines = terminalView.searchableLines()
+        for (index, line) in lines.enumerated() {
+            var start = line.startIndex
+            while let range = line.range(of: query, options: .caseInsensitive, range: start..<line.endIndex) {
+                let colStart = line.distance(from: line.startIndex, to: range.lowerBound)
+                let colEnd = colStart + line.distance(from: range.lowerBound, to: range.upperBound)
+                matches.append(Match(line: index, colStart: colStart, colEnd: colEnd))
+                start = range.upperBound
+                if start == line.endIndex { break }
+            }
+        }
+        currentMatchIndex = 0
+        if matches.isEmpty {
+            terminalView.clearFindHighlight()
+            findBar.updateMatchCount(current: 0, total: 0)
+        } else {
+            highlightCurrentMatch()
+        }
     }
 
-    override func insertNewline(_ sender: Any?) {
-        sendInput?("\r")
+    private func highlightCurrentMatch() {
+        guard !matches.isEmpty else { return }
+        let match = matches[currentMatchIndex]
+        terminalView.highlightMatch(absoluteLine: match.line, colStart: match.colStart, colEnd: match.colEnd)
+        findBar.updateMatchCount(current: currentMatchIndex + 1, total: matches.count)
     }
 
-    override func deleteBackward(_ sender: Any?) {
-        sendInput?("\u{7f}")
+    // MARK: - TerminalFindBarDelegate
+
+    func findBar(_ bar: TerminalFindBar, didChangeQuery query: String) {
+        recomputeMatches()
     }
 
-    override func insertTab(_ sender: Any?) {
-        sendInput?("\t")
+    func findBarDidRequestNext(_ bar: TerminalFindBar) {
+        guard !matches.isEmpty else { return }
+        currentMatchIndex = (currentMatchIndex + 1) % matches.count
+        highlightCurrentMatch()
     }
 
-    override var acceptsFirstResponder: Bool { true }
+    func findBarDidRequestPrevious(_ bar: TerminalFindBar) {
+        guard !matches.isEmpty else { return }
+        currentMatchIndex = (currentMatchIndex - 1 + matches.count) % matches.count
+        highlightCurrentMatch()
+    }
 
-    override func becomeFirstResponder() -> Bool {
-        super.becomeFirstResponder()
+    func findBarDidClose(_ bar: TerminalFindBar) {
+        hideFindBar()
     }
 }

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -219,12 +219,13 @@ final class VMInstance {
 
     // MARK: - Serial Console
 
-    /// Terminal emulator that interprets the guest serial byte stream into a
-    /// cell grid for the Serial Console. Owned here (not by the console window)
-    /// so it accrues state across window open/close and answers the guest's
-    /// terminal probes (DSR/DA) even when no console window is open. Full raw
-    /// history is still preserved byte-for-byte on disk in `serial.log`; the
-    /// in-memory bound is the emulator's grid plus its capped scrollback.
+    /// Terminal emulator that interprets the guest serial byte stream into a cell grid.
+    ///
+    /// Owned here (not by the console window) so it accrues state across window
+    /// open/close and answers the guest's terminal probes (DSR/DA) even when no
+    /// console window is open. Full raw history is still preserved byte-for-byte
+    /// on disk in `serial.log`; the in-memory bound is the emulator's grid plus
+    /// its capped scrollback.
     let terminal = TerminalEmulator()
 
     /// Bidirectional pipes for serial port communication.

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -219,11 +219,13 @@ final class VMInstance {
 
     // MARK: - Serial Console
 
-    /// Observable text buffer driven by serial port output.
-    ///
-    /// Capped at 1 MB in memory;
-    /// full history is preserved on disk in `serial.log`.
-    var serialOutputText: String = ""
+    /// Terminal emulator that interprets the guest serial byte stream into a
+    /// cell grid for the Serial Console. Owned here (not by the console window)
+    /// so it accrues state across window open/close and answers the guest's
+    /// terminal probes (DSR/DA) even when no console window is open. Full raw
+    /// history is still preserved byte-for-byte on disk in `serial.log`; the
+    /// in-memory bound is the emulator's grid plus its capped scrollback.
+    let terminal = TerminalEmulator()
 
     /// Bidirectional pipes for serial port communication.
     var serialInputPipe: Pipe?
@@ -232,10 +234,16 @@ final class VMInstance {
     /// File handle for writing serial output to the on-disk log.
     private var serialLogFileHandle: FileHandle?
 
+    /// Raw serial bytes received since the last coalesced drain.
+    private var pendingSerialData = Data()
+    /// `true` while a `drainSerialInput()` hop is already scheduled.
+    private var serialDrainScheduled = false
+
     private static let logger = Logger(subsystem: "com.kernova.app", category: "VMInstance")
 
-    /// Maximum in-memory serial buffer size (1 MB).
-    private static let maxSerialBufferSize = 1_000_000
+    /// Max bytes fed to the emulator per drain; the remainder is re-scheduled so
+    /// a large boot-time burst can't stall the main run loop.
+    private static let serialDrainByteBudget = 256 * 1024
 
     nonisolated var id: UUID { instanceID }
     var name: String { configuration.name }
@@ -270,6 +278,11 @@ final class VMInstance {
         self.bundleURL = bundleURL
         self.bundleLayout = VMBundleLayout(bundleURL: bundleURL)
         self.status = status
+
+        // Route the emulator's terminal-probe replies (DSR/DA) back to the guest.
+        terminal.respond = { [weak self] reply in
+            self?.sendSerialInput(reply)
+        }
     }
 
     // MARK: - VM Bundle Paths (forwarded from VMBundleLayout)
@@ -359,6 +372,9 @@ final class VMInstance {
         stopVsockServices()
         stopClipboardService()
         stopSerialReading()
+        terminal.reset()
+        pendingSerialData.removeAll(keepingCapacity: false)
+        serialDrainScheduled = false
         cancelAgentPostStartWatchdog()
         agentExpectedButMissing = false
         serialInputPipe = nil
@@ -409,13 +425,15 @@ final class VMInstance {
 
     /// Begins reading from the serial output pipe.
     ///
-    /// Output is appended to
-    /// `serialOutputText` (for the UI) and written to the on-disk log file.
+    /// Every byte is written to the on-disk `serial.log` (byte-exact) and fed to
+    /// the terminal emulator (which interprets escape sequences into the grid).
     func startSerialReading() {
         guard let outputPipe = serialOutputPipe else { return }
 
-        // Clear text buffer for a fresh session
-        serialOutputText = ""
+        // Reset the terminal so a restarted VM shows no stale output.
+        terminal.reset()
+        pendingSerialData.removeAll(keepingCapacity: false)
+        serialDrainScheduled = false
 
         // Open (or create) the log file for appending
         let logURL = serialLogURL
@@ -440,7 +458,11 @@ final class VMInstance {
 
         outputPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
-            guard !data.isEmpty else { return }
+            guard !data.isEmpty else {
+                // EOF — pipe closed. Nil out the handler to prevent a GCD spin loop.
+                handle.readabilityHandler = nil
+                return
+            }
 
             // Write to disk log (background-safe — FileHandle is thread-safe for sequential writes)
             do {
@@ -449,26 +471,50 @@ final class VMInstance {
                 logger.error("Failed to write to serial log: \(error.localizedDescription, privacy: .public)")
             }
 
-            // Update UI buffer on the main actor
-            if let text = String(data: data, encoding: .utf8) {
-                Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    self.serialOutputText.append(text)
-
-                    // Cap in-memory buffer at 1 MB
-                    if self.serialOutputText.utf8.count > Self.maxSerialBufferSize {
-                        let overflow = self.serialOutputText.utf8.count - Self.maxSerialBufferSize
-                        let idx = self.serialOutputText.utf8.index(
-                            self.serialOutputText.startIndex,
-                            offsetBy: overflow
-                        )
-                        self.serialOutputText = String(self.serialOutputText[idx...])
-                    }
-                }
+            // Hand the raw bytes to the main actor for the terminal emulator.
+            Task { @MainActor [weak self] in
+                self?.enqueueSerialData(data)
             }
         }
 
         Self.logger.info("Serial reading started for '\(self.name, privacy: .public)'")
+    }
+
+    /// Appends freshly-read serial bytes and schedules a coalesced drain so a
+    /// burst of pipe reads collapses into a single emulator feed per run-loop turn.
+    private func enqueueSerialData(_ data: Data) {
+        pendingSerialData.append(data)
+        guard !serialDrainScheduled else { return }
+        serialDrainScheduled = true
+        Task { @MainActor [weak self] in
+            self?.drainSerialInput()
+        }
+    }
+
+    /// Feeds pending serial bytes to the terminal emulator, bounded per pass by
+    /// `serialDrainByteBudget` so a large boot-time burst yields the run loop.
+    private func drainSerialInput() {
+        serialDrainScheduled = false
+        guard !pendingSerialData.isEmpty else { return }
+
+        let chunk: Data
+        if pendingSerialData.count > Self.serialDrainByteBudget {
+            chunk = pendingSerialData.prefix(Self.serialDrainByteBudget)
+            pendingSerialData.removeFirst(Self.serialDrainByteBudget)
+        } else {
+            chunk = pendingSerialData
+            pendingSerialData.removeAll(keepingCapacity: true)
+        }
+
+        terminal.feed(chunk)
+
+        // More remains than the budget allowed — finish on the next turn.
+        if !pendingSerialData.isEmpty {
+            serialDrainScheduled = true
+            Task { @MainActor [weak self] in
+                self?.drainSerialInput()
+            }
+        }
     }
 
     /// Sends a string to the guest via the serial input pipe.

--- a/Kernova/Terminal/TerminalBuffer.swift
+++ b/Kernova/Terminal/TerminalBuffer.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+/// A fixed-size grid of `TerminalCell`s — one screen buffer.
+///
+/// Stored as an array-of-arrays (`rows`) rather than a flat array: the hottest
+/// structural operations in a terminal are full-row scrolls and line
+/// insert/delete, which are O(rows) pointer moves here (`remove`/`insert`) but
+/// would require an O(cells) `memmove` with a flat backing store. Cell writes
+/// stay O(1).
+///
+/// The buffer is cursor-agnostic — all operations take explicit coordinates and
+/// regions. The cursor, scroll margins, and tab stops are owned by
+/// `TerminalEmulator`, which also owns the (primary-only) scrollback.
+struct TerminalBuffer: Sendable {
+    private(set) var rows: [[TerminalCell]]
+    private(set) var cols: Int
+    private(set) var rowCount: Int
+
+    init(cols: Int, rows: Int) {
+        let c = max(1, cols)
+        let r = max(1, rows)
+        self.cols = c
+        self.rowCount = r
+        self.rows = Array(repeating: Self.blankRow(cols: c), count: r)
+    }
+
+    static func blankRow(cols: Int) -> [TerminalCell] {
+        Array(repeating: .blank, count: max(1, cols))
+    }
+
+    private var blankRow: [TerminalCell] { Self.blankRow(cols: cols) }
+
+    // MARK: - Cell access
+
+    func cell(row: Int, col: Int) -> TerminalCell {
+        guard row >= 0, row < rowCount, col >= 0, col < cols else { return .blank }
+        return rows[row][col]
+    }
+
+    mutating func setCell(_ cell: TerminalCell, row: Int, col: Int) {
+        guard row >= 0, row < rowCount, col >= 0, col < cols else { return }
+        rows[row][col] = cell
+    }
+
+    /// Replaces every cell with `fill`.
+    mutating func clear(with fill: TerminalCell = .blank) {
+        rows = Array(repeating: Array(repeating: fill, count: cols), count: rowCount)
+    }
+
+    // MARK: - Scrolling
+
+    /// Scrolls the inclusive region `[top, bottom]` up by `count` lines, filling
+    /// vacated lines at the bottom with `fill`. Returns the lines pushed off the
+    /// top (so the caller can route them to scrollback).
+    @discardableResult
+    mutating func scrollUp(top: Int, bottom: Int, count: Int = 1, fill: TerminalCell = .blank)
+        -> [[TerminalCell]]
+    {
+        let top = max(0, top)
+        let bottom = min(rowCount - 1, bottom)
+        guard top <= bottom else { return [] }
+        let n = min(count, bottom - top + 1)
+        var removed: [[TerminalCell]] = []
+        removed.reserveCapacity(n)
+        let fillRow = Array(repeating: fill, count: cols)
+        for _ in 0..<n {
+            removed.append(rows[top])
+            rows.remove(at: top)
+            rows.insert(fillRow, at: bottom)
+        }
+        return removed
+    }
+
+    /// Scrolls the inclusive region `[top, bottom]` down by `count` lines,
+    /// filling vacated lines at the top with `fill`.
+    mutating func scrollDown(top: Int, bottom: Int, count: Int = 1, fill: TerminalCell = .blank) {
+        let top = max(0, top)
+        let bottom = min(rowCount - 1, bottom)
+        guard top <= bottom else { return }
+        let n = min(count, bottom - top + 1)
+        let fillRow = Array(repeating: fill, count: cols)
+        for _ in 0..<n {
+            rows.remove(at: bottom)
+            rows.insert(fillRow, at: top)
+        }
+    }
+
+    // MARK: - Erase
+
+    /// Erases columns `from...through` (inclusive) of `row` with `fill`.
+    mutating func eraseInRow(_ row: Int, from: Int, through: Int, fill: TerminalCell = .blank) {
+        guard row >= 0, row < rowCount else { return }
+        let lo = max(0, from)
+        let hi = min(cols - 1, through)
+        guard lo <= hi else { return }
+        for col in lo...hi { rows[row][col] = fill }
+    }
+
+    /// Replaces whole rows `from...through` (inclusive) with blank lines of `fill`.
+    mutating func eraseRows(from: Int, through: Int, fill: TerminalCell = .blank) {
+        let lo = max(0, from)
+        let hi = min(rowCount - 1, through)
+        guard lo <= hi else { return }
+        let fillRow = Array(repeating: fill, count: cols)
+        for row in lo...hi { rows[row] = fillRow }
+    }
+
+    // MARK: - Line / character insert & delete (within the scroll region)
+
+    /// Inserts `count` blank lines at `row`, pushing lines below down within
+    /// `[row, bottom]`. Lines pushed past `bottom` are lost.
+    mutating func insertLines(at row: Int, count: Int, bottom: Int, fill: TerminalCell = .blank) {
+        let bottom = min(rowCount - 1, bottom)
+        guard row >= 0, row <= bottom else { return }
+        let n = min(count, bottom - row + 1)
+        let fillRow = Array(repeating: fill, count: cols)
+        for _ in 0..<n {
+            rows.remove(at: bottom)
+            rows.insert(fillRow, at: row)
+        }
+    }
+
+    /// Deletes `count` lines at `row`, pulling lines below up within
+    /// `[row, bottom]` and filling the bottom with blanks.
+    mutating func deleteLines(at row: Int, count: Int, bottom: Int, fill: TerminalCell = .blank) {
+        let bottom = min(rowCount - 1, bottom)
+        guard row >= 0, row <= bottom else { return }
+        let n = min(count, bottom - row + 1)
+        let fillRow = Array(repeating: fill, count: cols)
+        for _ in 0..<n {
+            rows.remove(at: row)
+            rows.insert(fillRow, at: bottom)
+        }
+    }
+
+    /// Inserts `count` blank cells at `(row, col)`, shifting the rest of the line right.
+    mutating func insertChars(row: Int, col: Int, count: Int, fill: TerminalCell = .blank) {
+        guard row >= 0, row < rowCount, col >= 0, col < cols else { return }
+        let n = min(count, cols - col)
+        for _ in 0..<n {
+            rows[row].removeLast()
+            rows[row].insert(fill, at: col)
+        }
+    }
+
+    /// Deletes `count` cells at `(row, col)`, shifting the rest of the line left
+    /// and filling the tail with blanks.
+    mutating func deleteChars(row: Int, col: Int, count: Int, fill: TerminalCell = .blank) {
+        guard row >= 0, row < rowCount, col >= 0, col < cols else { return }
+        let n = min(count, cols - col)
+        for _ in 0..<n {
+            rows[row].remove(at: col)
+            rows[row].append(fill)
+        }
+    }
+
+    // MARK: - Resize
+
+    /// Resizes to `newCols × newRows`. Existing content is preserved top-aligned;
+    /// rows are truncated/padded to the new width, rows are dropped from the
+    /// bottom or appended as blanks. No reflow (matches xterm's default).
+    mutating func resize(cols newCols: Int, rows newRows: Int, fill: TerminalCell = .blank) {
+        let nc = max(1, newCols)
+        let nr = max(1, newRows)
+
+        if nc != cols {
+            for r in 0..<rows.count {
+                if rows[r].count > nc {
+                    rows[r].removeLast(rows[r].count - nc)
+                } else if rows[r].count < nc {
+                    rows[r].append(contentsOf: Array(repeating: fill, count: nc - rows[r].count))
+                }
+            }
+            cols = nc
+        }
+
+        if nr > rowCount {
+            rows.append(contentsOf: Array(repeating: Array(repeating: fill, count: nc), count: nr - rowCount))
+        } else if nr < rowCount {
+            rows.removeLast(rowCount - nr)
+        }
+        rowCount = nr
+    }
+}

--- a/Kernova/Terminal/TerminalBuffer.swift
+++ b/Kernova/Terminal/TerminalBuffer.swift
@@ -50,8 +50,10 @@ struct TerminalBuffer: Sendable {
     // MARK: - Scrolling
 
     /// Scrolls the inclusive region `[top, bottom]` up by `count` lines, filling
-    /// vacated lines at the bottom with `fill`. Returns the lines pushed off the
-    /// top (so the caller can route them to scrollback).
+    /// vacated lines at the bottom with `fill`.
+    ///
+    /// Returns the lines pushed off the top (so the caller can route them to
+    /// scrollback).
     @discardableResult
     mutating func scrollUp(top: Int, bottom: Int, count: Int = 1, fill: TerminalCell = .blank)
         -> [[TerminalCell]]
@@ -108,7 +110,9 @@ struct TerminalBuffer: Sendable {
     // MARK: - Line / character insert & delete (within the scroll region)
 
     /// Inserts `count` blank lines at `row`, pushing lines below down within
-    /// `[row, bottom]`. Lines pushed past `bottom` are lost.
+    /// `[row, bottom]`.
+    ///
+    /// Lines pushed past `bottom` are lost.
     mutating func insertLines(at row: Int, count: Int, bottom: Int, fill: TerminalCell = .blank) {
         let bottom = min(rowCount - 1, bottom)
         guard row >= 0, row <= bottom else { return }
@@ -156,9 +160,11 @@ struct TerminalBuffer: Sendable {
 
     // MARK: - Resize
 
-    /// Resizes to `newCols × newRows`. Existing content is preserved top-aligned;
-    /// rows are truncated/padded to the new width, rows are dropped from the
-    /// bottom or appended as blanks. No reflow (matches xterm's default).
+    /// Resizes to `newCols × newRows`.
+    ///
+    /// Existing content is preserved top-aligned; rows are truncated/padded to
+    /// the new width, rows are dropped from the bottom or appended as blanks. No
+    /// reflow (matches xterm's default).
     mutating func resize(cols newCols: Int, rows newRows: Int, fill: TerminalCell = .blank) {
         let nc = max(1, newCols)
         let nr = max(1, newRows)

--- a/Kernova/Terminal/TerminalCell.swift
+++ b/Kernova/Terminal/TerminalCell.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// A single character cell in the terminal grid: one glyph plus its visual rendition.
+///
+/// Value type so an entire `TerminalBuffer` row is a cheap copy-on-write array.
+/// Wide (CJK/emoji) characters are treated as single-cell in v1 — see the
+/// terminal emulator's known limitations.
+struct TerminalCell: Equatable, Sendable {
+    /// The glyph occupying this cell. Defaults to a space.
+    var scalar: UnicodeScalar
+    /// Foreground (text) color.
+    var foreground: TerminalColor
+    /// Background (fill) color.
+    var background: TerminalColor
+    /// Style flags (bold, underline, inverse, …).
+    var attributes: CellAttributes
+
+    init(
+        scalar: UnicodeScalar = " ",
+        foreground: TerminalColor = .default,
+        background: TerminalColor = .default,
+        attributes: CellAttributes = []
+    ) {
+        self.scalar = scalar
+        self.foreground = foreground
+        self.background = background
+        self.attributes = attributes
+    }
+
+    /// An empty cell: a space with default colors and no attributes.
+    static let blank = TerminalCell()
+}
+
+// MARK: - Cell Attributes
+
+/// SGR style flags applied to a cell. Packed into a `UInt16` option set.
+struct CellAttributes: OptionSet, Equatable, Sendable {
+    let rawValue: UInt16
+    init(rawValue: UInt16) { self.rawValue = rawValue }
+
+    static let bold = CellAttributes(rawValue: 1 << 0)
+    static let dim = CellAttributes(rawValue: 1 << 1)
+    static let italic = CellAttributes(rawValue: 1 << 2)
+    static let underline = CellAttributes(rawValue: 1 << 3)
+    static let blink = CellAttributes(rawValue: 1 << 4)
+    static let inverse = CellAttributes(rawValue: 1 << 5)
+    static let hidden = CellAttributes(rawValue: 1 << 6)
+    static let strikethrough = CellAttributes(rawValue: 1 << 7)
+}
+
+// MARK: - Terminal Color
+
+/// A terminal color: the default fg/bg, one of the 256 indexed xterm colors,
+/// or a 24-bit truecolor value. The concrete `NSColor` mapping lives in the
+/// AppKit render layer (`TerminalTheme`) so this type stays AppKit-free.
+enum TerminalColor: Equatable, Sendable {
+    /// The terminal's default foreground or background (context-dependent).
+    case `default`
+    /// An index into the 256-color xterm palette (0–15 ANSI, 16–231 cube, 232–255 grayscale).
+    case indexed(UInt8)
+    /// A 24-bit truecolor value.
+    case rgb(UInt8, UInt8, UInt8)
+}

--- a/Kernova/Terminal/TerminalCell.swift
+++ b/Kernova/Terminal/TerminalCell.swift
@@ -6,7 +6,7 @@ import Foundation
 /// Wide (CJK/emoji) characters are treated as single-cell in v1 — see the
 /// terminal emulator's known limitations.
 struct TerminalCell: Equatable, Sendable {
-    /// The glyph occupying this cell. Defaults to a space.
+    /// The glyph occupying this cell (a space by default).
     var scalar: UnicodeScalar
     /// Foreground (text) color.
     var foreground: TerminalColor
@@ -33,7 +33,7 @@ struct TerminalCell: Equatable, Sendable {
 
 // MARK: - Cell Attributes
 
-/// SGR style flags applied to a cell. Packed into a `UInt16` option set.
+/// SGR style flags applied to a cell, packed into a `UInt16` option set.
 struct CellAttributes: OptionSet, Equatable, Sendable {
     let rawValue: UInt16
     init(rawValue: UInt16) { self.rawValue = rawValue }
@@ -50,9 +50,10 @@ struct CellAttributes: OptionSet, Equatable, Sendable {
 
 // MARK: - Terminal Color
 
-/// A terminal color: the default fg/bg, one of the 256 indexed xterm colors,
-/// or a 24-bit truecolor value. The concrete `NSColor` mapping lives in the
-/// AppKit render layer (`TerminalTheme`) so this type stays AppKit-free.
+/// A terminal color: default fg/bg, a 256-indexed xterm color, or 24-bit truecolor.
+///
+/// The concrete `NSColor` mapping lives in the AppKit render layer
+/// (`TerminalTheme`) so this type stays AppKit-free.
 enum TerminalColor: Equatable, Sendable {
     /// The terminal's default foreground or background (context-dependent).
     case `default`

--- a/Kernova/Terminal/TerminalEmulator.swift
+++ b/Kernova/Terminal/TerminalEmulator.swift
@@ -205,16 +205,23 @@ final class TerminalEmulator: TerminalPerformer {
 
     /// Scrollback + live screen serialized to text (for find), trailing blanks trimmed.
     func fullText() -> String {
-        rowsToText(scrollback + buffers[activeIndex].rows)
+        historyLines().joined(separator: "\n")
+    }
+
+    /// Scrollback + live screen as one trimmed string per line (for find). The
+    /// last `rows` entries are the live screen; earlier entries are scrollback.
+    func historyLines() -> [String] {
+        (scrollback + buffers[activeIndex].rows).map(Self.trimmedLine)
     }
 
     private func rowsToText(_ rows: [[TerminalCell]]) -> String {
-        rows.map { row in
-            var line = String(String.UnicodeScalarView(row.map { $0.scalar }))
-            while line.hasSuffix(" ") { line.removeLast() }
-            return line
-        }
-        .joined(separator: "\n")
+        rows.map(Self.trimmedLine).joined(separator: "\n")
+    }
+
+    private static func trimmedLine(_ row: [TerminalCell]) -> String {
+        var line = String(String.UnicodeScalarView(row.map { $0.scalar }))
+        while line.hasSuffix(" ") { line.removeLast() }
+        return line
     }
 
     // MARK: - TerminalPerformer

--- a/Kernova/Terminal/TerminalEmulator.swift
+++ b/Kernova/Terminal/TerminalEmulator.swift
@@ -29,10 +29,12 @@ final class TerminalEmulator: TerminalPerformer {
     // MARK: Output hooks
 
     /// Sends a reply (DSR cursor report, device attributes) back to the guest.
+    ///
     /// Wired by `VMInstance` so probes are answered even with the console window closed.
     var respond: ((String) -> Void)?
-    /// Called once after each `feed`/`resize`/`reset` that may have changed the
-    /// visible grid. Set by the render view (and cleared on teardown).
+    /// Called once after each `feed`/`resize`/`reset` that may have changed the visible grid.
+    ///
+    /// Set by the render view (and cleared on teardown).
     var onRender: (() -> Void)?
     /// The most recent window/icon title set via OSC 0/1/2.
     private(set) var title: String = ""
@@ -105,7 +107,7 @@ final class TerminalEmulator: TerminalPerformer {
 
     // MARK: Public API
 
-    /// Feed raw guest bytes. Fires `onRender` once afterward.
+    /// Feeds raw guest bytes, firing `onRender` once afterward.
     func feed(_ data: Data) {
         guard !data.isEmpty else { return }
         parser.feed(data, to: self)
@@ -113,6 +115,7 @@ final class TerminalEmulator: TerminalPerformer {
     }
 
     /// Full reset of contents (RIS-equivalent) while preserving the grid size.
+    ///
     /// Called at serial-session start and teardown so a restarted VM shows no
     /// stale output.
     func reset() {
@@ -143,7 +146,7 @@ final class TerminalEmulator: TerminalPerformer {
         onRender?()
     }
 
-    /// Resize the grid (driven by the render view's font metrics). No scrollback reflow.
+    /// Resizes the grid from the render view's font metrics (no scrollback reflow).
     func resize(cols newCols: Int, rows newRows: Int) {
         let nc = min(max(1, newCols), Self.maxDimension)
         let nr = min(max(1, newRows), Self.maxDimension)
@@ -174,8 +177,9 @@ final class TerminalEmulator: TerminalPerformer {
     var scrollbackCount: Int { activeIndex == 0 ? scrollback.count : 0 }
 
     /// The `rows` lines to display for a given scrollback offset (0 = live screen,
-    /// up to `scrollbackCount` = oldest history at top). O(rows) — indexes rather
-    /// than concatenating the whole history.
+    /// up to `scrollbackCount` = oldest history at top).
+    ///
+    /// O(rows) — indexes rather than concatenating the whole history.
     func displayRows(scrollOffset: Int) -> [[TerminalCell]] {
         let active = buffers[activeIndex].rows
         guard activeIndex == 0, !scrollback.isEmpty else { return active }
@@ -208,8 +212,9 @@ final class TerminalEmulator: TerminalPerformer {
         historyLines().joined(separator: "\n")
     }
 
-    /// Scrollback + live screen as one trimmed string per line (for find). The
-    /// last `rows` entries are the live screen; earlier entries are scrollback.
+    /// Scrollback + live screen as one trimmed string per line (for find).
+    ///
+    /// The last `rows` entries are the live screen; earlier entries are scrollback.
     func historyLines() -> [String] {
         (scrollback + buffers[activeIndex].rows).map(Self.trimmedLine)
     }
@@ -692,6 +697,7 @@ final class TerminalEmulator: TerminalPerformer {
     }
 
     /// Parses `38;5;n` / `38;2;r;g;b` (or `48;…`) starting at the `38`/`48` index.
+    ///
     /// Returns the color and how many extra params it consumed.
     private func parseExtendedColor(_ params: [Int], from i: Int) -> (TerminalColor, Int)? {
         guard i + 1 < params.count else { return nil }

--- a/Kernova/Terminal/TerminalEmulator.swift
+++ b/Kernova/Terminal/TerminalEmulator.swift
@@ -1,0 +1,836 @@
+import Foundation
+import os
+
+/// A hand-rolled VT100/xterm-subset terminal emulator.
+///
+/// Drives a `VTParser` over the raw guest byte stream and applies the decoded
+/// events to an in-memory cell grid: cursor motion, SGR rendition, erase/scroll,
+/// scroll regions, alt-screen, and scrollback. Replies to the guest's cursor
+/// and device-attribute probes through `respond` so serial getty terminal
+/// detection works. The render layer reads the grid and redraws on `onRender`.
+///
+/// `@MainActor`: fed from the main-actor drain in `VMInstance` and read by the
+/// AppKit render view; never touched off the main actor. AppKit-free by design.
+///
+/// Known v1 limitations: wide (CJK/emoji) glyphs are treated as single-cell;
+/// truecolor is preserved but the palette render may quantize; no mouse
+/// reporting, Sixel, or cursor blink.
+@MainActor
+final class TerminalEmulator: TerminalPerformer {
+    private static let logger = Logger(subsystem: "com.kernova.app", category: "TerminalEmulator")
+
+    /// Maximum scrollback lines retained for the primary screen.
+    static let maxScrollbackRows = 5000
+    /// Trim scrollback in batches once the cap is exceeded (amortizes `removeFirst`).
+    private static let scrollbackTrimBatch = 256
+    /// Clamp for grid dimensions (defends against absurd window sizes).
+    private static let maxDimension = 1000
+
+    // MARK: Output hooks
+
+    /// Sends a reply (DSR cursor report, device attributes) back to the guest.
+    /// Wired by `VMInstance` so probes are answered even with the console window closed.
+    var respond: ((String) -> Void)?
+    /// Called once after each `feed`/`resize`/`reset` that may have changed the
+    /// visible grid. Set by the render view (and cleared on teardown).
+    var onRender: (() -> Void)?
+    /// The most recent window/icon title set via OSC 0/1/2.
+    private(set) var title: String = ""
+
+    // MARK: Grid state
+
+    private(set) var cols: Int
+    private(set) var rows: Int
+    private var buffers: [TerminalBuffer]
+    private var activeIndex = 0  // 0 = primary, 1 = alternate
+    private var scrollback: [[TerminalCell]] = []
+
+    private(set) var cursorRow = 0
+    private(set) var cursorCol = 0
+    private var pendingWrap = false
+
+    private var scrollTop = 0
+    private var scrollBottom: Int
+    private var tabStops: Set<Int> = []
+
+    // MARK: Rendition / modes
+
+    private struct Pen {
+        var foreground: TerminalColor = .default
+        var background: TerminalColor = .default
+        var attributes: CellAttributes = []
+    }
+    private var pen = Pen()
+
+    private struct SavedCursor {
+        var row: Int
+        var col: Int
+        var pen: Pen
+        var originMode: Bool
+        var g0Graphics: Bool
+        var g1Graphics: Bool
+        var glSelectsG1: Bool
+    }
+    private var savedCursor: SavedCursor?
+
+    private var autowrap = true
+    private(set) var isCursorVisible = true
+    private var originMode = false
+    private var insertMode = false
+    private var lineFeedNewLineMode = false
+    /// Stored only; honored by the (out-of-scope) input encoder later.
+    private(set) var applicationCursorKeys = false
+    private(set) var bracketedPaste = false
+
+    // Charsets: G0/G1 each ASCII or DEC special graphics; GL selects one of them.
+    private var g0Graphics = false
+    private var g1Graphics = false
+    private var glSelectsG1 = false
+    /// `true` when the charset currently mapped into GL is DEC special graphics.
+    private var glGraphics: Bool { glSelectsG1 ? g1Graphics : g0Graphics }
+
+    private var parser = VTParser()
+
+    // MARK: Init
+
+    init(cols: Int = 80, rows: Int = 24) {
+        let c = min(max(1, cols), Self.maxDimension)
+        let r = min(max(1, rows), Self.maxDimension)
+        self.cols = c
+        self.rows = r
+        self.scrollBottom = r - 1
+        self.buffers = [TerminalBuffer(cols: c, rows: r), TerminalBuffer(cols: c, rows: r)]
+        resetTabStops()
+    }
+
+    // MARK: Public API
+
+    /// Feed raw guest bytes. Fires `onRender` once afterward.
+    func feed(_ data: Data) {
+        guard !data.isEmpty else { return }
+        parser.feed(data, to: self)
+        onRender?()
+    }
+
+    /// Full reset of contents (RIS-equivalent) while preserving the grid size.
+    /// Called at serial-session start and teardown so a restarted VM shows no
+    /// stale output.
+    func reset() {
+        buffers[0].clear()
+        buffers[1].clear()
+        scrollback.removeAll(keepingCapacity: false)
+        activeIndex = 0
+        cursorRow = 0
+        cursorCol = 0
+        pendingWrap = false
+        scrollTop = 0
+        scrollBottom = rows - 1
+        pen = Pen()
+        savedCursor = nil
+        autowrap = true
+        isCursorVisible = true
+        originMode = false
+        insertMode = false
+        lineFeedNewLineMode = false
+        applicationCursorKeys = false
+        bracketedPaste = false
+        g0Graphics = false
+        g1Graphics = false
+        glSelectsG1 = false
+        title = ""
+        resetTabStops()
+        Self.logger.notice("Terminal emulator reset (\(self.cols, privacy: .public)×\(self.rows, privacy: .public))")
+        onRender?()
+    }
+
+    /// Resize the grid (driven by the render view's font metrics). No scrollback reflow.
+    func resize(cols newCols: Int, rows newRows: Int) {
+        let nc = min(max(1, newCols), Self.maxDimension)
+        let nr = min(max(1, newRows), Self.maxDimension)
+        guard nc != cols || nr != rows else { return }
+
+        buffers[0].resize(cols: nc, rows: nr)
+        buffers[1].resize(cols: nc, rows: nr)
+        cols = nc
+        rows = nr
+
+        // Clamp cursor and margins into the new bounds.
+        cursorRow = min(cursorRow, nr - 1)
+        cursorCol = min(cursorCol, nc - 1)
+        pendingWrap = false
+        scrollTop = min(scrollTop, nr - 1)
+        scrollBottom = min(scrollBottom, nr - 1)
+        if scrollTop >= scrollBottom {
+            scrollTop = 0
+            scrollBottom = nr - 1
+        }
+        resetTabStops()
+        onRender?()
+    }
+
+    // MARK: Render reads
+
+    /// Number of scrollback lines available above the live screen (primary only).
+    var scrollbackCount: Int { activeIndex == 0 ? scrollback.count : 0 }
+
+    /// The `rows` lines to display for a given scrollback offset (0 = live screen,
+    /// up to `scrollbackCount` = oldest history at top). O(rows) — indexes rather
+    /// than concatenating the whole history.
+    func displayRows(scrollOffset: Int) -> [[TerminalCell]] {
+        let active = buffers[activeIndex].rows
+        guard activeIndex == 0, !scrollback.isEmpty else { return active }
+
+        let offset = max(0, min(scrollOffset, scrollback.count))
+        guard offset > 0 else { return active }
+
+        let total = scrollback.count + rows
+        let start = total - rows - offset
+        var result: [[TerminalCell]] = []
+        result.reserveCapacity(rows)
+        for i in 0..<rows {
+            let index = start + i
+            if index < scrollback.count {
+                result.append(scrollback[index])
+            } else {
+                result.append(active[index - scrollback.count])
+            }
+        }
+        return result
+    }
+
+    /// The visible live screen serialized to text (for accessibility), trailing blanks trimmed.
+    func visibleText() -> String {
+        rowsToText(buffers[activeIndex].rows)
+    }
+
+    /// Scrollback + live screen serialized to text (for find), trailing blanks trimmed.
+    func fullText() -> String {
+        rowsToText(scrollback + buffers[activeIndex].rows)
+    }
+
+    private func rowsToText(_ rows: [[TerminalCell]]) -> String {
+        rows.map { row in
+            var line = String(String.UnicodeScalarView(row.map { $0.scalar }))
+            while line.hasSuffix(" ") { line.removeLast() }
+            return line
+        }
+        .joined(separator: "\n")
+    }
+
+    // MARK: - TerminalPerformer
+
+    func print(_ scalar: UnicodeScalar) {
+        if pendingWrap && autowrap {
+            cursorCol = 0
+            lineFeed()
+            pendingWrap = false
+        }
+
+        let glyph = glGraphics ? Self.decGraphics(scalar) : scalar
+        if insertMode {
+            buffers[activeIndex].insertChars(row: cursorRow, col: cursorCol, count: 1, fill: eraseCell)
+        }
+        let cell = TerminalCell(
+            scalar: glyph, foreground: pen.foreground, background: pen.background,
+            attributes: pen.attributes)
+        buffers[activeIndex].setCell(cell, row: cursorRow, col: cursorCol)
+
+        if cursorCol >= cols - 1 {
+            if autowrap { pendingWrap = true }
+        } else {
+            cursorCol += 1
+        }
+    }
+
+    func execute(_ control: UInt8) {
+        switch control {
+        case 0x07:  // BEL — no audible bell
+            break
+        case 0x08:  // BS
+            if cursorCol > 0 { cursorCol -= 1 }
+            pendingWrap = false
+        case 0x09:  // HT
+            cursorCol = nextTabStop(after: cursorCol)
+            pendingWrap = false
+        case 0x0A, 0x0B, 0x0C:  // LF, VT, FF
+            lineFeed()
+            if lineFeedNewLineMode { cursorCol = 0 }
+            pendingWrap = false
+        case 0x0D:  // CR
+            cursorCol = 0
+            pendingWrap = false
+        case 0x0E:  // SO — select G1 into GL
+            glSelectsG1 = true
+        case 0x0F:  // SI — select G0 into GL
+            glSelectsG1 = false
+        default:
+            break
+        }
+    }
+
+    func escDispatch(intermediates: [UInt8], final: UInt8) {
+        if intermediates.isEmpty {
+            switch final {
+            case 0x63:  // c — RIS full reset
+                reset()
+            case 0x44:  // D — IND (index)
+                lineFeed()
+                pendingWrap = false
+            case 0x45:  // E — NEL (next line)
+                cursorCol = 0
+                lineFeed()
+                pendingWrap = false
+            case 0x4D:  // M — RI (reverse index)
+                reverseIndex()
+                pendingWrap = false
+            case 0x37:  // 7 — DECSC
+                saveCursor()
+            case 0x38:  // 8 — DECRC
+                restoreCursor()
+            case 0x48:  // H — HTS (set tab stop)
+                tabStops.insert(cursorCol)
+            case 0x3D, 0x3E:  // = DECKPAM / > DECKPNM — keypad mode (no-op)
+                break
+            default:
+                break
+            }
+            return
+        }
+
+        // Charset designation: ESC ( / ) / * / + <final>
+        if intermediates.count == 1 {
+            let graphics = (final == 0x30)  // '0' = DEC special graphics; else ASCII-ish
+            switch intermediates[0] {
+            case 0x28:  // ( — G0
+                g0Graphics = graphics
+            case 0x29:  // ) — G1
+                g1Graphics = graphics
+            default:  // * (G2), + (G3) — accepted but unused
+                break
+            }
+        }
+    }
+
+    func csiDispatch(prefix: UInt8?, params: [Int], intermediates: [UInt8], final: UInt8) {
+        // DECSTR soft reset: CSI ! p
+        if intermediates == [0x21], final == 0x70 {
+            softReset()
+            return
+        }
+
+        if prefix == 0x3F {  // '?' — DEC private modes
+            switch final {
+            case 0x68:  // h — set
+                setPrivateModes(params, enabled: true)
+            case 0x6C:  // l — reset
+                setPrivateModes(params, enabled: false)
+            default:
+                break
+            }
+            return
+        }
+
+        // '>' secondary device attributes
+        if prefix == 0x3E, final == 0x63 {
+            respond?("\u{1B}[>0;0;0c")
+            return
+        }
+        // Other private-prefixed sequences: ignore.
+        guard prefix == nil else { return }
+
+        switch final {
+        case 0x41:  // A — CUU
+            cursorUp(arg(params, 0, 1))
+        case 0x42:  // B — CUD
+            cursorDown(arg(params, 0, 1))
+        case 0x43:  // C — CUF
+            cursorForward(arg(params, 0, 1))
+        case 0x44:  // D — CUB
+            cursorBack(arg(params, 0, 1))
+        case 0x45:  // E — CNL
+            cursorCol = 0
+            cursorDown(arg(params, 0, 1))
+        case 0x46:  // F — CPL
+            cursorCol = 0
+            cursorUp(arg(params, 0, 1))
+        case 0x47, 0x60:  // G / ` — CHA / HPA
+            setCursor(row: cursorRow, col: arg(params, 0, 1) - 1)
+        case 0x64:  // d — VPA
+            setCursorRowAbsolute(arg(params, 0, 1) - 1)
+        case 0x48, 0x66:  // H / f — CUP / HVP
+            let r = arg(params, 0, 1) - 1
+            let c = arg(params, 1, 1) - 1
+            setCursorPosition(row: r, col: c)
+        case 0x4A:  // J — ED
+            eraseInDisplay(arg(params, 0, 0))
+        case 0x4B:  // K — EL
+            eraseInLine(arg(params, 0, 0))
+        case 0x4C:  // L — IL
+            buffers[activeIndex].insertLines(
+                at: cursorRow, count: arg(params, 0, 1), bottom: scrollBottom, fill: eraseCell)
+        case 0x4D:  // M — DL
+            buffers[activeIndex].deleteLines(
+                at: cursorRow, count: arg(params, 0, 1), bottom: scrollBottom, fill: eraseCell)
+        case 0x40:  // @ — ICH
+            buffers[activeIndex].insertChars(
+                row: cursorRow, col: cursorCol, count: arg(params, 0, 1), fill: eraseCell)
+        case 0x50:  // P — DCH
+            buffers[activeIndex].deleteChars(
+                row: cursorRow, col: cursorCol, count: arg(params, 0, 1), fill: eraseCell)
+        case 0x58:  // X — ECH
+            let n = arg(params, 0, 1)
+            buffers[activeIndex].eraseInRow(
+                cursorRow, from: cursorCol, through: cursorCol + n - 1, fill: eraseCell)
+        case 0x53:  // S — SU
+            scrollRegionUp(arg(params, 0, 1))
+        case 0x54:  // T — SD
+            buffers[activeIndex].scrollDown(
+                top: scrollTop, bottom: scrollBottom, count: arg(params, 0, 1), fill: eraseCell)
+        case 0x72:  // r — DECSTBM
+            setScrollRegion(top: arg(params, 0, 1), bottom: arg(params, 1, rows))
+        case 0x6D:  // m — SGR
+            applySGR(params)
+        case 0x6E:  // n — DSR
+            deviceStatusReport(arg(params, 0, 0))
+        case 0x63:  // c — primary DA
+            respond?("\u{1B}[?6c")
+        case 0x67:  // g — TBC (tab clear)
+            if arg(params, 0, 0) == 3 { tabStops.removeAll() } else { tabStops.remove(cursorCol) }
+        case 0x68:  // h — SM (ANSI modes)
+            setAnsiModes(params, enabled: true)
+        case 0x6C:  // l — RM
+            setAnsiModes(params, enabled: false)
+        case 0x73:  // s — save cursor (ANSI.SYS)
+            saveCursor()
+        case 0x75:  // u — restore cursor
+            restoreCursor()
+        default:
+            break
+        }
+    }
+
+    func oscDispatch(_ data: [UInt8]) {
+        guard let string = String(bytes: data, encoding: .utf8) else { return }
+        // Split "code;payload".
+        guard let sep = string.firstIndex(of: ";") else {
+            // Bare command (e.g. "104" reset palette) — no-op.
+            return
+        }
+        let code = String(string[string.startIndex..<sep])
+        let payload = String(string[string.index(after: sep)...])
+        switch code {
+        case "0", "1", "2":  // window / icon title
+            title = payload
+        default:
+            break  // palette / clipboard / hyperlink OSCs — ignored in v1
+        }
+    }
+
+    // MARK: - Cursor motion
+
+    private func clamp(_ value: Int, _ lo: Int, _ hi: Int) -> Int { min(max(value, lo), hi) }
+
+    private func cursorUp(_ n: Int) {
+        let limit = cursorRow >= scrollTop ? scrollTop : 0
+        cursorRow = max(limit, cursorRow - max(1, n))
+        pendingWrap = false
+    }
+
+    private func cursorDown(_ n: Int) {
+        let limit = cursorRow <= scrollBottom ? scrollBottom : rows - 1
+        cursorRow = min(limit, cursorRow + max(1, n))
+        pendingWrap = false
+    }
+
+    private func cursorForward(_ n: Int) {
+        cursorCol = min(cols - 1, cursorCol + max(1, n))
+        pendingWrap = false
+    }
+
+    private func cursorBack(_ n: Int) {
+        cursorCol = max(0, cursorCol - max(1, n))
+        pendingWrap = false
+    }
+
+    private func setCursor(row: Int, col: Int) {
+        cursorRow = clamp(row, 0, rows - 1)
+        cursorCol = clamp(col, 0, cols - 1)
+        pendingWrap = false
+    }
+
+    private func setCursorRowAbsolute(_ row: Int) {
+        if originMode {
+            cursorRow = clamp(scrollTop + row, scrollTop, scrollBottom)
+        } else {
+            cursorRow = clamp(row, 0, rows - 1)
+        }
+        pendingWrap = false
+    }
+
+    private func setCursorPosition(row: Int, col: Int) {
+        if originMode {
+            cursorRow = clamp(scrollTop + row, scrollTop, scrollBottom)
+        } else {
+            cursorRow = clamp(row, 0, rows - 1)
+        }
+        cursorCol = clamp(col, 0, cols - 1)
+        pendingWrap = false
+    }
+
+    private func lineFeed() {
+        if cursorRow == scrollBottom {
+            let removed = buffers[activeIndex].scrollUp(
+                top: scrollTop, bottom: scrollBottom, count: 1, fill: eraseCell)
+            if activeIndex == 0 && scrollTop == 0 {
+                appendScrollback(removed)
+            }
+        } else if cursorRow < rows - 1 {
+            cursorRow += 1
+        }
+    }
+
+    private func reverseIndex() {
+        if cursorRow == scrollTop {
+            buffers[activeIndex].scrollDown(
+                top: scrollTop, bottom: scrollBottom, count: 1, fill: eraseCell)
+        } else if cursorRow > 0 {
+            cursorRow -= 1
+        }
+    }
+
+    private func scrollRegionUp(_ n: Int) {
+        let removed = buffers[activeIndex].scrollUp(
+            top: scrollTop, bottom: scrollBottom, count: max(1, n), fill: eraseCell)
+        if activeIndex == 0 && scrollTop == 0 {
+            appendScrollback(removed)
+        }
+    }
+
+    // MARK: - Erase
+
+    private func eraseInDisplay(_ mode: Int) {
+        switch mode {
+        case 0:  // cursor to end
+            buffers[activeIndex].eraseInRow(cursorRow, from: cursorCol, through: cols - 1, fill: eraseCell)
+            if cursorRow + 1 <= rows - 1 {
+                buffers[activeIndex].eraseRows(from: cursorRow + 1, through: rows - 1, fill: eraseCell)
+            }
+        case 1:  // start to cursor
+            if cursorRow - 1 >= 0 {
+                buffers[activeIndex].eraseRows(from: 0, through: cursorRow - 1, fill: eraseCell)
+            }
+            buffers[activeIndex].eraseInRow(cursorRow, from: 0, through: cursorCol, fill: eraseCell)
+        case 3:  // whole screen + scrollback
+            buffers[activeIndex].eraseRows(from: 0, through: rows - 1, fill: eraseCell)
+            scrollback.removeAll(keepingCapacity: false)
+        default:  // 2 — whole screen
+            buffers[activeIndex].eraseRows(from: 0, through: rows - 1, fill: eraseCell)
+        }
+    }
+
+    private func eraseInLine(_ mode: Int) {
+        switch mode {
+        case 1:  // start to cursor
+            buffers[activeIndex].eraseInRow(cursorRow, from: 0, through: cursorCol, fill: eraseCell)
+        case 2:  // whole line
+            buffers[activeIndex].eraseInRow(cursorRow, from: 0, through: cols - 1, fill: eraseCell)
+        default:  // 0 — cursor to end
+            buffers[activeIndex].eraseInRow(cursorRow, from: cursorCol, through: cols - 1, fill: eraseCell)
+        }
+    }
+
+    // MARK: - Modes
+
+    private func setPrivateModes(_ params: [Int], enabled: Bool) {
+        for mode in params {
+            switch mode {
+            case 1:
+                applicationCursorKeys = enabled
+            case 7:
+                autowrap = enabled
+            case 25:
+                isCursorVisible = enabled
+            case 47, 1047:
+                setAlternateScreen(enabled, saveRestoreCursor: false, clearOnEnter: enabled)
+            case 1049:
+                setAlternateScreen(enabled, saveRestoreCursor: true, clearOnEnter: enabled)
+            case 2004:
+                bracketedPaste = enabled
+            default:
+                break
+            }
+        }
+    }
+
+    private func setAnsiModes(_ params: [Int], enabled: Bool) {
+        for mode in params {
+            switch mode {
+            case 4:
+                insertMode = enabled
+            case 20:
+                lineFeedNewLineMode = enabled
+            default:
+                break
+            }
+        }
+    }
+
+    private func setAlternateScreen(_ on: Bool, saveRestoreCursor: Bool, clearOnEnter: Bool) {
+        if on {
+            guard activeIndex == 0 else { return }
+            if saveRestoreCursor { saveCursor() }
+            activeIndex = 1
+            scrollTop = 0
+            scrollBottom = rows - 1
+            if clearOnEnter { buffers[1].clear() }
+            cursorRow = 0
+            cursorCol = 0
+            pendingWrap = false
+        } else {
+            guard activeIndex == 1 else { return }
+            buffers[1].clear()
+            activeIndex = 0
+            scrollTop = 0
+            scrollBottom = rows - 1
+            if saveRestoreCursor { restoreCursor() }
+            pendingWrap = false
+        }
+    }
+
+    private func softReset() {
+        pen = Pen()
+        autowrap = true
+        isCursorVisible = true
+        originMode = false
+        insertMode = false
+        lineFeedNewLineMode = false
+        scrollTop = 0
+        scrollBottom = rows - 1
+        savedCursor = nil
+        g0Graphics = false
+        g1Graphics = false
+        glSelectsG1 = false
+        cursorRow = 0
+        cursorCol = 0
+        pendingWrap = false
+    }
+
+    // MARK: - SGR
+
+    private func applySGR(_ rawParams: [Int]) {
+        let params = rawParams.isEmpty ? [0] : rawParams
+        var i = 0
+        while i < params.count {
+            let code = params[i]
+            switch code {
+            case 0:
+                pen = Pen()
+            case 1:
+                pen.attributes.insert(.bold)
+            case 2:
+                pen.attributes.insert(.dim)
+            case 3:
+                pen.attributes.insert(.italic)
+            case 4:
+                pen.attributes.insert(.underline)
+            case 5, 6:
+                pen.attributes.insert(.blink)
+            case 7:
+                pen.attributes.insert(.inverse)
+            case 8:
+                pen.attributes.insert(.hidden)
+            case 9:
+                pen.attributes.insert(.strikethrough)
+            case 22:
+                pen.attributes.subtract([.bold, .dim])
+            case 23:
+                pen.attributes.remove(.italic)
+            case 24:
+                pen.attributes.remove(.underline)
+            case 25:
+                pen.attributes.remove(.blink)
+            case 27:
+                pen.attributes.remove(.inverse)
+            case 28:
+                pen.attributes.remove(.hidden)
+            case 29:
+                pen.attributes.remove(.strikethrough)
+            case 30...37:
+                pen.foreground = .indexed(UInt8(code - 30))
+            case 38:
+                if let (color, consumed) = parseExtendedColor(params, from: i) {
+                    pen.foreground = color
+                    i += consumed
+                }
+            case 39:
+                pen.foreground = .default
+            case 40...47:
+                pen.background = .indexed(UInt8(code - 40))
+            case 48:
+                if let (color, consumed) = parseExtendedColor(params, from: i) {
+                    pen.background = color
+                    i += consumed
+                }
+            case 49:
+                pen.background = .default
+            case 90...97:
+                pen.foreground = .indexed(UInt8(code - 90 + 8))
+            case 100...107:
+                pen.background = .indexed(UInt8(code - 100 + 8))
+            default:
+                break
+            }
+            i += 1
+        }
+    }
+
+    /// Parses `38;5;n` / `38;2;r;g;b` (or `48;…`) starting at the `38`/`48` index.
+    /// Returns the color and how many extra params it consumed.
+    private func parseExtendedColor(_ params: [Int], from i: Int) -> (TerminalColor, Int)? {
+        guard i + 1 < params.count else { return nil }
+        switch params[i + 1] {
+        case 5:
+            guard i + 2 < params.count else { return nil }
+            return (.indexed(UInt8(clamping: params[i + 2])), 2)
+        case 2:
+            guard i + 4 < params.count else { return nil }
+            return (
+                .rgb(
+                    UInt8(clamping: params[i + 2]),
+                    UInt8(clamping: params[i + 3]),
+                    UInt8(clamping: params[i + 4])), 4
+            )
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - DSR / cursor save
+
+    private func deviceStatusReport(_ code: Int) {
+        switch code {
+        case 5:  // device status OK
+            respond?("\u{1B}[0n")
+        case 6:  // cursor position report
+            respond?("\u{1B}[\(cursorRow + 1);\(cursorCol + 1)R")
+        default:
+            break
+        }
+    }
+
+    private func saveCursor() {
+        savedCursor = SavedCursor(
+            row: cursorRow, col: cursorCol, pen: pen, originMode: originMode,
+            g0Graphics: g0Graphics, g1Graphics: g1Graphics, glSelectsG1: glSelectsG1)
+    }
+
+    private func restoreCursor() {
+        guard let saved = savedCursor else {
+            cursorRow = 0
+            cursorCol = 0
+            return
+        }
+        cursorRow = clamp(saved.row, 0, rows - 1)
+        cursorCol = clamp(saved.col, 0, cols - 1)
+        pen = saved.pen
+        originMode = saved.originMode
+        g0Graphics = saved.g0Graphics
+        g1Graphics = saved.g1Graphics
+        glSelectsG1 = saved.glSelectsG1
+        pendingWrap = false
+    }
+
+    private func setScrollRegion(top: Int, bottom: Int) {
+        let t = clamp(top - 1, 0, rows - 1)
+        let b = clamp(bottom - 1, 0, rows - 1)
+        if t < b {
+            scrollTop = t
+            scrollBottom = b
+        } else {
+            scrollTop = 0
+            scrollBottom = rows - 1
+        }
+        // DECSTBM homes the cursor.
+        cursorRow = originMode ? scrollTop : 0
+        cursorCol = 0
+        pendingWrap = false
+    }
+
+    // MARK: - Scrollback / tab stops
+
+    private func appendScrollback(_ lines: [[TerminalCell]]) {
+        guard !lines.isEmpty else { return }
+        scrollback.append(contentsOf: lines)
+        if scrollback.count > Self.maxScrollbackRows + Self.scrollbackTrimBatch {
+            scrollback.removeFirst(scrollback.count - Self.maxScrollbackRows)
+        }
+    }
+
+    private func resetTabStops() {
+        tabStops.removeAll(keepingCapacity: true)
+        var c = 8
+        while c < cols {
+            tabStops.insert(c)
+            c += 8
+        }
+    }
+
+    private func nextTabStop(after col: Int) -> Int {
+        var next = col + 1
+        while next < cols - 1 && !tabStops.contains(next) {
+            next += 1
+        }
+        return min(next, cols - 1)
+    }
+
+    // MARK: - Helpers
+
+    /// A blank cell carrying the current background (so a colored clear works).
+    private var eraseCell: TerminalCell {
+        TerminalCell(scalar: " ", foreground: .default, background: pen.background, attributes: [])
+    }
+
+    private func arg(_ params: [Int], _ index: Int, _ defaultValue: Int) -> Int {
+        guard index < params.count else { return defaultValue }
+        let value = params[index]
+        return value == 0 ? defaultValue : value
+    }
+
+    /// DEC special-graphics translation for the box-drawing range `0x5F...0x7E`.
+    private static func decGraphics(_ scalar: UnicodeScalar) -> UnicodeScalar {
+        switch scalar.value {
+        case 0x60: return "\u{25C6}"  // ` diamond
+        case 0x61: return "\u{2592}"  // a checkerboard
+        case 0x62: return "\u{2409}"  // b HT
+        case 0x63: return "\u{240C}"  // c FF
+        case 0x64: return "\u{240D}"  // d CR
+        case 0x65: return "\u{240A}"  // e LF
+        case 0x66: return "\u{00B0}"  // f degree
+        case 0x67: return "\u{00B1}"  // g plus/minus
+        case 0x68: return "\u{2424}"  // h NL
+        case 0x69: return "\u{240B}"  // i VT
+        case 0x6A: return "\u{2518}"  // j ┘
+        case 0x6B: return "\u{2510}"  // k ┐
+        case 0x6C: return "\u{250C}"  // l ┌
+        case 0x6D: return "\u{2514}"  // m └
+        case 0x6E: return "\u{253C}"  // n ┼
+        case 0x6F: return "\u{23BA}"  // o scan line 1
+        case 0x70: return "\u{23BB}"  // p scan line 3
+        case 0x71: return "\u{2500}"  // q ─
+        case 0x72: return "\u{23BC}"  // r scan line 7
+        case 0x73: return "\u{23BD}"  // s scan line 9
+        case 0x74: return "\u{251C}"  // t ├
+        case 0x75: return "\u{2524}"  // u ┤
+        case 0x76: return "\u{2534}"  // v ┴
+        case 0x77: return "\u{252C}"  // w ┬
+        case 0x78: return "\u{2502}"  // x │
+        case 0x79: return "\u{2264}"  // y ≤
+        case 0x7A: return "\u{2265}"  // z ≥
+        case 0x7B: return "\u{03C0}"  // { π
+        case 0x7C: return "\u{2260}"  // | ≠
+        case 0x7D: return "\u{00A3}"  // } £
+        case 0x7E: return "\u{00B7}"  // ~ ·
+        default: return scalar
+        }
+    }
+}

--- a/Kernova/Terminal/VTParser.swift
+++ b/Kernova/Terminal/VTParser.swift
@@ -80,7 +80,7 @@ struct VTParser {
     private var utf8Buffer: [UInt8] = []
     private var utf8Remaining = 0
 
-    private static let replacement = UnicodeScalar(0xFFFD)!
+    private static let replacement: UnicodeScalar = "\u{FFFD}"
 
     // MARK: Feed
 

--- a/Kernova/Terminal/VTParser.swift
+++ b/Kernova/Terminal/VTParser.swift
@@ -1,0 +1,363 @@
+import Foundation
+
+/// Receives the structured events a `VTParser` decodes from a raw byte stream.
+///
+/// The parser is a pure DFA that knows nothing about grids or rendering — it
+/// only classifies bytes and emits these callbacks. `TerminalEmulator` conforms
+/// to this protocol and applies the events to its cell buffers; tests conform a
+/// lightweight recorder to assert the exact dispatch sequence.
+///
+/// `@MainActor` because the production conformer (`TerminalEmulator`) mutates
+/// main-actor state; the parser invokes these synchronously from `feed`.
+@MainActor
+protocol TerminalPerformer: AnyObject {
+    /// A printable character (already UTF-8 decoded) should be written at the cursor.
+    func print(_ scalar: UnicodeScalar)
+    /// A C0 control byte (`< 0x20`) should be executed (LF, CR, BS, HT, BEL, …).
+    func execute(_ control: UInt8)
+    /// A complete CSI sequence: `ESC [ <prefix> <params> <intermediates> <final>`.
+    /// `prefix` is a private marker byte (`?`, `>`, `<`, `=`) when present.
+    func csiDispatch(prefix: UInt8?, params: [Int], intermediates: [UInt8], final: UInt8)
+    /// A complete two/three-byte escape sequence: `ESC <intermediates> <final>`.
+    func escDispatch(intermediates: [UInt8], final: UInt8)
+    /// A complete OSC string payload (the bytes between `ESC ]` and its `BEL`/`ST` terminator).
+    func oscDispatch(_ data: [UInt8])
+}
+
+/// An ECMA-48 / DEC escape-sequence parser modeled on Paul Williams' VT500
+/// state machine (https://vt100.net/emu/dec_ansi_parser).
+///
+/// Consumes raw guest bytes one at a time and emits `TerminalPerformer` events.
+/// Built to tolerate arbitrary/adversarial input: it never buffers the whole
+/// stream, bounds every accumulator, and always resyncs to a sane state.
+///
+/// UTF-8 is decoded incrementally in the ground state only (the escape grammar
+/// is pure 7-bit ASCII); partial multibyte sequences are carried across `feed`
+/// calls so a codepoint split over a pipe-read boundary is never dropped. C1
+/// controls (0x80–0x9F) are intentionally treated as UTF-8 bytes, not controls,
+/// since Linux serial consoles run in UTF-8 mode and use 7-bit escapes.
+struct VTParser {
+    // MARK: Robustness caps
+
+    /// Max stored CSI/DCS numeric parameters; further params are scanned but discarded.
+    static let maxParams = 16
+    /// Saturating ceiling for a single parameter value.
+    static let maxParamValue = 65535
+    /// Max intermediate bytes before a sequence is abandoned.
+    static let maxIntermediates = 2
+    /// Max bytes buffered for an OSC string before further bytes are discarded.
+    static let maxOSCLength = 4096
+
+    // MARK: State
+
+    private enum State {
+        case ground
+        case escape
+        case escapeIntermediate
+        case csiEntry
+        case csiParam
+        case csiIntermediate
+        case csiIgnore
+        case oscString
+        case dcsPassthrough  // covers DCS entry/param/intermediate/data — swallowed wholesale
+        case stringIgnore  // SOS / PM / APC — consumed until ST
+    }
+
+    private var state: State = .ground
+
+    // CSI / escape accumulators
+    private var params: [Int] = []
+    private var currentParam: Int?
+    private var prefix: UInt8?
+    private var intermediates: [UInt8] = []
+    private var paramsFull = false
+
+    // OSC accumulator
+    private var oscBuffer: [UInt8] = []
+    private var oscOverflowed = false
+
+    // Incremental UTF-8 decoder (ground state only)
+    private var utf8Buffer: [UInt8] = []
+    private var utf8Remaining = 0
+
+    private static let replacement = UnicodeScalar(0xFFFD)!
+
+    // MARK: Feed
+
+    /// Feed raw bytes from the pipe, dispatching decoded events to `performer`.
+    @MainActor
+    mutating func feed<P: TerminalPerformer>(_ data: Data, to performer: P) {
+        for byte in data {
+            advance(byte, performer)
+        }
+    }
+
+    @MainActor
+    private mutating func advance<P: TerminalPerformer>(_ byte: UInt8, _ performer: P) {
+        // --- UTF-8 continuation (ground state only) ---
+        if state == .ground, utf8Remaining > 0 {
+            if byte & 0xC0 == 0x80 {
+                utf8Buffer.append(byte)
+                utf8Remaining -= 1
+                if utf8Remaining == 0 { emitUTF8(performer) }
+                return
+            }
+            // Incomplete sequence interrupted — emit replacement, then reprocess `byte`.
+            performer.print(Self.replacement)
+            utf8Buffer.removeAll(keepingCapacity: true)
+            utf8Remaining = 0
+        }
+
+        // --- Universal aborts (any state) ---
+        switch byte {
+        case 0x18, 0x1A:  // CAN, SUB — abort any sequence back to ground
+            terminateStringIfNeeded(performer)
+            state = .ground
+            clear()
+            return
+        case 0x1B:  // ESC — terminates strings, starts a fresh escape
+            terminateStringIfNeeded(performer)
+            state = .escape
+            clear()
+            return
+        default:
+            break
+        }
+
+        // --- C0 controls (other than the aborts above) ---
+        if byte < 0x20 || byte == 0x7F {
+            switch state {
+            case .oscString:
+                if byte == 0x07 {  // BEL terminates OSC (xterm extension)
+                    performer.oscDispatch(oscBuffer)
+                    state = .ground
+                    clear()
+                }
+            // others ignored inside OSC
+            case .dcsPassthrough, .stringIgnore, .csiIgnore:
+                break  // ignore controls inside swallowed strings
+            default:
+                if byte != 0x7F { performer.execute(byte) }  // DEL ignored
+            }
+            return
+        }
+
+        // --- Printable / sequence bytes by state ---
+        switch state {
+        case .ground:
+            groundPrintable(byte, performer)
+
+        case .escape:
+            escapeByte(byte, performer)
+
+        case .escapeIntermediate:
+            if (0x20...0x2F).contains(byte) {
+                appendIntermediate(byte)
+            } else {  // 0x30...0x7E final
+                performer.escDispatch(intermediates: intermediates, final: byte)
+                state = .ground
+                clear()
+            }
+
+        case .csiEntry:
+            csiEntryByte(byte, performer)
+
+        case .csiParam:
+            csiParamByte(byte, performer)
+
+        case .csiIntermediate:
+            csiIntermediateByte(byte, performer)
+
+        case .csiIgnore:
+            if (0x40...0x7E).contains(byte) { state = .ground; clear() }
+        // else keep ignoring
+
+        case .oscString:
+            appendOSC(byte)
+
+        case .dcsPassthrough:
+            break  // data bytes swallowed; terminated by ESC/ST handled above
+
+        case .stringIgnore:
+            break  // swallowed; terminated by ESC/ST handled above
+        }
+    }
+
+    // MARK: Ground (UTF-8 assembly)
+
+    @MainActor
+    private mutating func groundPrintable<P: TerminalPerformer>(_ byte: UInt8, _ performer: P) {
+        if byte < 0x80 {
+            performer.print(UnicodeScalar(byte))
+        } else if byte & 0xE0 == 0xC0 {
+            utf8Buffer = [byte]
+            utf8Remaining = 1
+        } else if byte & 0xF0 == 0xE0 {
+            utf8Buffer = [byte]
+            utf8Remaining = 2
+        } else if byte & 0xF8 == 0xF0 {
+            utf8Buffer = [byte]
+            utf8Remaining = 3
+        } else {
+            // Stray continuation byte or invalid lead.
+            performer.print(Self.replacement)
+        }
+    }
+
+    @MainActor
+    private mutating func emitUTF8<P: TerminalPerformer>(_ performer: P) {
+        if let scalar = String(bytes: utf8Buffer, encoding: .utf8)?.unicodeScalars.first {
+            performer.print(scalar)
+        } else {
+            performer.print(Self.replacement)
+        }
+        utf8Buffer.removeAll(keepingCapacity: true)
+        utf8Remaining = 0
+    }
+
+    // MARK: Escape
+
+    @MainActor
+    private mutating func escapeByte<P: TerminalPerformer>(_ byte: UInt8, _ performer: P) {
+        switch byte {
+        case 0x5B:  // [
+            state = .csiEntry
+            clear()
+        case 0x5D:  // ]
+            state = .oscString
+            clear()
+        case 0x50:  // P — DCS
+            state = .dcsPassthrough
+            clear()
+        case 0x58, 0x5E, 0x5F:  // X (SOS), ^ (PM), _ (APC)
+            state = .stringIgnore
+            clear()
+        case 0x20...0x2F:  // intermediate
+            appendIntermediate(byte)
+            state = .escapeIntermediate
+        default:  // 0x30...0x7E final
+            performer.escDispatch(intermediates: intermediates, final: byte)
+            state = .ground
+            clear()
+        }
+    }
+
+    // MARK: CSI
+
+    @MainActor
+    private mutating func csiEntryByte<P: TerminalPerformer>(_ byte: UInt8, _ performer: P) {
+        switch byte {
+        case 0x30...0x39:  // digit
+            pushDigit(byte)
+            state = .csiParam
+        case 0x3A, 0x3B:  // : or ; — parameter separator
+            pushSeparator()
+            state = .csiParam
+        case 0x3C...0x3F:  // < = > ? — private prefix marker
+            prefix = byte
+            state = .csiParam
+        case 0x20...0x2F:  // intermediate
+            appendIntermediate(byte)
+            state = .csiIntermediate
+        default:  // 0x40...0x7E final
+            dispatchCSI(final: byte, performer)
+        }
+    }
+
+    @MainActor
+    private mutating func csiParamByte<P: TerminalPerformer>(_ byte: UInt8, _ performer: P) {
+        switch byte {
+        case 0x30...0x39:
+            pushDigit(byte)
+        case 0x3A, 0x3B:
+            pushSeparator()
+        case 0x3C...0x3F:  // private markers only valid at entry — abandon
+            state = .csiIgnore
+        case 0x20...0x2F:
+            appendIntermediate(byte)
+            state = .csiIntermediate
+        default:  // final
+            dispatchCSI(final: byte, performer)
+        }
+    }
+
+    @MainActor
+    private mutating func csiIntermediateByte<P: TerminalPerformer>(_ byte: UInt8, _ performer: P) {
+        switch byte {
+        case 0x20...0x2F:
+            appendIntermediate(byte)
+        case 0x30...0x3F:  // params/markers after intermediates are invalid
+            state = .csiIgnore
+        default:  // final
+            dispatchCSI(final: byte, performer)
+        }
+    }
+
+    @MainActor
+    private mutating func dispatchCSI<P: TerminalPerformer>(final: UInt8, _ performer: P) {
+        finishParams()
+        performer.csiDispatch(
+            prefix: prefix, params: params, intermediates: intermediates, final: final)
+        state = .ground
+        clear()
+    }
+
+    // MARK: Accumulator helpers
+
+    private mutating func pushDigit(_ byte: UInt8) {
+        guard !paramsFull else { return }
+        let digit = Int(byte - 0x30)
+        currentParam = min((currentParam ?? 0) * 10 + digit, Self.maxParamValue)
+    }
+
+    private mutating func pushSeparator() {
+        guard !paramsFull else { return }
+        if params.count >= Self.maxParams {
+            paramsFull = true
+            return
+        }
+        params.append(currentParam ?? 0)
+        currentParam = nil
+    }
+
+    private mutating func finishParams() {
+        if let value = currentParam, params.count < Self.maxParams {
+            params.append(value)
+        }
+        currentParam = nil
+    }
+
+    private mutating func appendIntermediate(_ byte: UInt8) {
+        if intermediates.count >= Self.maxIntermediates {
+            state = .csiIgnore
+            return
+        }
+        intermediates.append(byte)
+    }
+
+    private mutating func appendOSC(_ byte: UInt8) {
+        if oscBuffer.count >= Self.maxOSCLength {
+            oscOverflowed = true
+            return  // keep scanning for the terminator, but stop storing
+        }
+        oscBuffer.append(byte)
+    }
+
+    @MainActor
+    private mutating func terminateStringIfNeeded<P: TerminalPerformer>(_ performer: P) {
+        if state == .oscString {
+            performer.oscDispatch(oscBuffer)
+        }
+        // DCS / SOS / PM / APC are swallowed — nothing to dispatch.
+    }
+
+    private mutating func clear() {
+        params.removeAll(keepingCapacity: true)
+        currentParam = nil
+        prefix = nil
+        intermediates.removeAll(keepingCapacity: true)
+        paramsFull = false
+        oscBuffer.removeAll(keepingCapacity: true)
+        oscOverflowed = false
+    }
+}

--- a/Kernova/Views/Console/TerminalFindBar.swift
+++ b/Kernova/Views/Console/TerminalFindBar.swift
@@ -11,8 +11,10 @@ protocol TerminalFindBarDelegate: AnyObject {
 }
 
 /// A compact ⌘F search bar: a search field, a match-count label, previous/next
-/// steppers, and a close button. Stateless about matches — it just relays
-/// interaction to its delegate and displays the count it's told.
+/// steppers, and a close button.
+///
+/// Stateless about matches — it just relays interaction to its delegate and
+/// displays the count it's told.
 @MainActor
 final class TerminalFindBar: NSView, NSSearchFieldDelegate {
     weak var delegate: TerminalFindBarDelegate?

--- a/Kernova/Views/Console/TerminalFindBar.swift
+++ b/Kernova/Views/Console/TerminalFindBar.swift
@@ -86,8 +86,7 @@ final class TerminalFindBar: NSView, NSSearchFieldDelegate {
     }
 
     @objc private func searchFieldEntered() {
-        // Enter in the field advances to the next match.
-        delegate?.findBar(self, didChangeQuery: searchField.stringValue)
+        // Live search already ran via controlTextDidChange — Enter advances.
         delegate?.findBarDidRequestNext(self)
     }
 

--- a/Kernova/Views/Console/TerminalFindBar.swift
+++ b/Kernova/Views/Console/TerminalFindBar.swift
@@ -1,0 +1,111 @@
+import AppKit
+
+/// Reports find-bar interactions to its owner (the serial console VC), which
+/// owns the match search over the terminal's scrollback + screen.
+@MainActor
+protocol TerminalFindBarDelegate: AnyObject {
+    func findBar(_ bar: TerminalFindBar, didChangeQuery query: String)
+    func findBarDidRequestNext(_ bar: TerminalFindBar)
+    func findBarDidRequestPrevious(_ bar: TerminalFindBar)
+    func findBarDidClose(_ bar: TerminalFindBar)
+}
+
+/// A compact ⌘F search bar: a search field, a match-count label, previous/next
+/// steppers, and a close button. Stateless about matches — it just relays
+/// interaction to its delegate and displays the count it's told.
+@MainActor
+final class TerminalFindBar: NSView, NSSearchFieldDelegate {
+    weak var delegate: TerminalFindBarDelegate?
+
+    private let searchField = NSSearchField()
+    private let countLabel = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        build()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    var query: String { searchField.stringValue }
+
+    func focusSearchField() {
+        window?.makeFirstResponder(searchField)
+    }
+
+    func updateMatchCount(current: Int, total: Int) {
+        if total == 0 {
+            countLabel.stringValue = searchField.stringValue.isEmpty ? "" : "No matches"
+        } else {
+            countLabel.stringValue = "\(current) of \(total)"
+        }
+    }
+
+    private func build() {
+        searchField.delegate = self
+        searchField.sendsSearchStringImmediately = false
+        searchField.sendsWholeSearchString = false
+        searchField.target = self
+        searchField.action = #selector(searchFieldEntered)
+        searchField.placeholderString = "Find"
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        countLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        countLabel.textColor = .secondaryLabelColor
+
+        let prev = makeStepper(symbol: "chevron.up", action: #selector(previousTapped))
+        let next = makeStepper(symbol: "chevron.down", action: #selector(nextTapped))
+        let done = NSButton(title: "Done", target: self, action: #selector(closeTapped))
+        done.bezelStyle = .rounded
+
+        let stack = NSStackView(views: [searchField, countLabel, prev, next, done])
+        stack.orientation = .horizontal
+        stack.spacing = Spacing.small
+        stack.edgeInsets = NSEdgeInsets(top: 5, left: 10, bottom: 5, right: 10)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            searchField.widthAnchor.constraint(greaterThanOrEqualToConstant: 180),
+        ])
+    }
+
+    private func makeStepper(symbol: String, action: Selector) -> NSButton {
+        let image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)
+        let button = NSButton(image: image ?? NSImage(), target: self, action: action)
+        button.bezelStyle = .rounded
+        button.imageScaling = .scaleProportionallyDown
+        return button
+    }
+
+    @objc private func searchFieldEntered() {
+        // Enter in the field advances to the next match.
+        delegate?.findBar(self, didChangeQuery: searchField.stringValue)
+        delegate?.findBarDidRequestNext(self)
+    }
+
+    @objc private func previousTapped() { delegate?.findBarDidRequestPrevious(self) }
+    @objc private func nextTapped() { delegate?.findBarDidRequestNext(self) }
+    @objc private func closeTapped() { delegate?.findBarDidClose(self) }
+
+    // MARK: NSSearchFieldDelegate
+
+    func controlTextDidChange(_ obj: Notification) {
+        delegate?.findBar(self, didChangeQuery: searchField.stringValue)
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy selector: Selector) -> Bool {
+        if selector == #selector(cancelOperation(_:)) {
+            delegate?.findBarDidClose(self)
+            return true
+        }
+        return false
+    }
+}

--- a/Kernova/Views/Console/TerminalTheme.swift
+++ b/Kernova/Views/Console/TerminalTheme.swift
@@ -1,0 +1,75 @@
+import AppKit
+
+/// Maps abstract `TerminalColor` values to concrete `NSColor`s for the render
+/// layer, using the standard xterm 256-color palette.
+///
+/// RATIONALE: the ANSI/xterm palette values below are protocol-defined — they
+/// are *what* a terminal color code means, not app UI chrome — so SPEC.md's
+/// "use semantic `NSColor`s, no hardcoded RGB" rule does not apply here. The
+/// default foreground/background match the previous `SerialTextView` styling.
+@MainActor
+enum TerminalTheme {
+    static let defaultForeground = NSColor(white: 0.9, alpha: 1.0)
+    static let defaultBackground = NSColor(white: 0.1, alpha: 1.0)
+    /// Cursor block / outline color.
+    static let cursor = NSColor(white: 0.9, alpha: 1.0)
+    /// Selection highlight fill (matches SPEC.md's accent-at-low-opacity rule).
+    static let selection = NSColor.controlAccentColor.withAlphaComponent(0.35)
+    /// Find-match highlight fill.
+    static let findHighlight = NSColor.systemYellow.withAlphaComponent(0.45)
+
+    /// Resolves a cell color. `bold` brightens the low 8 ANSI foreground colors,
+    /// matching common terminal behavior.
+    static func color(for terminalColor: TerminalColor, foreground: Bool, bold: Bool) -> NSColor {
+        switch terminalColor {
+        case .default:
+            return foreground ? defaultForeground : defaultBackground
+        case .indexed(let raw):
+            var index = Int(raw)
+            if foreground && bold && index < 8 { index += 8 }
+            return palette[index]
+        case .rgb(let r, let g, let b):
+            return NSColor(
+                srgbRed: CGFloat(r) / 255, green: CGFloat(g) / 255, blue: CGFloat(b) / 255,
+                alpha: 1)
+        }
+    }
+
+    /// The 256-entry xterm palette: 16 ANSI, 216 color cube, 24 grayscale.
+    static let palette: [NSColor] = buildPalette()
+
+    private static func buildPalette() -> [NSColor] {
+        var colors: [NSColor] = []
+        colors.reserveCapacity(256)
+
+        // 0–15: standard + bright ANSI colors (classic xterm RGB triples).
+        let ansi: [(Int, Int, Int)] = [
+            (0, 0, 0), (205, 0, 0), (0, 205, 0), (205, 205, 0),
+            (0, 0, 238), (205, 0, 205), (0, 205, 205), (229, 229, 229),
+            (127, 127, 127), (255, 0, 0), (0, 255, 0), (255, 255, 0),
+            (92, 92, 255), (255, 0, 255), (0, 255, 255), (255, 255, 255),
+        ]
+        for (r, g, b) in ansi { colors.append(rgb(r, g, b)) }
+
+        // 16–231: 6×6×6 color cube.
+        let levels = [0, 95, 135, 175, 215, 255]
+        for r in 0..<6 {
+            for g in 0..<6 {
+                for b in 0..<6 {
+                    colors.append(rgb(levels[r], levels[g], levels[b]))
+                }
+            }
+        }
+
+        // 232–255: 24-step grayscale ramp.
+        for i in 0..<24 {
+            let v = 8 + i * 10
+            colors.append(rgb(v, v, v))
+        }
+        return colors
+    }
+
+    private static func rgb(_ r: Int, _ g: Int, _ b: Int) -> NSColor {
+        NSColor(srgbRed: CGFloat(r) / 255, green: CGFloat(g) / 255, blue: CGFloat(b) / 255, alpha: 1)
+    }
+}

--- a/Kernova/Views/Console/TerminalView.swift
+++ b/Kernova/Views/Console/TerminalView.swift
@@ -1,10 +1,10 @@
 import AppKit
 import os
 
-/// A custom-drawn AppKit view that renders a `TerminalEmulator`'s cell grid and
-/// forwards keyboard input to the guest.
+/// A custom-drawn AppKit view that renders the `TerminalEmulator` cell grid.
 ///
-/// Draws the visible grid directly (no `NSTextView`): per-row, runs of cells
+/// Forwards keyboard input to the guest, and draws the visible grid directly
+/// (no `NSTextView`): per-row, runs of cells
 /// sharing the same rendition are painted in one shot. Owns its own scrollback
 /// offset (scroll-wheel scrolls into history; output auto-follows only when
 /// pinned to the bottom). Supports rubber-band selection + ⌘C copy and a

--- a/Kernova/Views/Console/TerminalView.swift
+++ b/Kernova/Views/Console/TerminalView.swift
@@ -1,0 +1,383 @@
+import AppKit
+import os
+
+/// A custom-drawn AppKit view that renders a `TerminalEmulator`'s cell grid and
+/// forwards keyboard input to the guest.
+///
+/// Draws the visible grid directly (no `NSTextView`): per-row, runs of cells
+/// sharing the same rendition are painted in one shot. Owns its own scrollback
+/// offset (scroll-wheel scrolls into history; output auto-follows only when
+/// pinned to the bottom). Supports rubber-band selection + ⌘C copy and a
+/// find-match highlight driven by the owning view controller.
+///
+/// The emulator is owned by `VMInstance` and outlives this view, so the view
+/// attaches/detaches its `onRender` redraw hook as it enters/leaves a window.
+@MainActor
+final class TerminalView: NSView, NSMenuItemValidation {
+    private static let logger = Logger(subsystem: "com.kernova.app", category: "TerminalView")
+
+    private let emulator: TerminalEmulator
+
+    /// Called with characters typed by the user, to send to the guest's serial input.
+    var sendInput: ((String) -> Void)?
+
+    // MARK: Fonts & metrics
+
+    private let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+    private let boldFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .bold)
+    private let cellWidth: CGFloat
+    private let cellHeight: CGFloat
+
+    // MARK: Scrollback / selection / find
+
+    /// Lines scrolled up from the live bottom (0 = following live output).
+    private var scrollOffset = 0
+    private var lastScrollbackCount = 0
+
+    private struct GridPoint: Equatable {
+        var row: Int
+        var col: Int
+    }
+    private var selectionAnchor: GridPoint?
+    private var selectionHead: GridPoint?
+
+    private struct FindHighlight: Equatable {
+        var absoluteLine: Int
+        var colStart: Int
+        var colEnd: Int  // exclusive
+    }
+    private var findHighlight: FindHighlight?
+
+    // MARK: Init
+
+    init(emulator: TerminalEmulator) {
+        self.emulator = emulator
+        self.cellWidth = font.maximumAdvancement.width
+        self.cellHeight = ceil(font.ascender - font.descender + font.leading)
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.backgroundColor = TerminalTheme.defaultBackground.cgColor
+        setAccessibilityElement(true)
+        setAccessibilityRole(.textArea)
+        setAccessibilityLabel("Serial console output")
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: NSView overrides
+
+    override var isFlipped: Bool { true }
+    override var isOpaque: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil {
+            emulator.onRender = { [weak self] in self?.scheduleRedraw() }
+            lastScrollbackCount = emulator.scrollbackCount
+            setAccessibilityValue(emulator.visibleText())
+            needsDisplay = true
+        } else {
+            emulator.onRender = nil
+        }
+    }
+
+    override func layout() {
+        super.layout()
+        updateGridSize()
+    }
+
+    override func viewDidEndLiveResize() {
+        super.viewDidEndLiveResize()
+        updateGridSize()
+    }
+
+    private func updateGridSize() {
+        guard cellWidth > 0, cellHeight > 0, bounds.width > 0, bounds.height > 0 else { return }
+        let cols = max(1, Int(bounds.width / cellWidth))
+        let rows = max(1, Int(bounds.height / cellHeight))
+        emulator.resize(cols: cols, rows: rows)
+    }
+
+    /// Re-anchors the scrollback view as new output arrives, then redraws.
+    private func scheduleRedraw() {
+        let scrollback = emulator.scrollbackCount
+        if scrollOffset > 0 {
+            // Keep the user pinned to the same history while output pushes lines up.
+            let delta = scrollback - lastScrollbackCount
+            if delta > 0 { scrollOffset += delta }
+        }
+        scrollOffset = min(scrollOffset, scrollback)
+        lastScrollbackCount = scrollback
+        setAccessibilityValue(emulator.visibleText())
+        needsDisplay = true
+    }
+
+    // MARK: Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard cellWidth > 0, cellHeight > 0 else { return }
+        TerminalTheme.defaultBackground.setFill()
+        dirtyRect.fill()
+
+        let rows = emulator.displayRows(scrollOffset: scrollOffset)
+        let cols = emulator.cols
+        let firstAbsolute = emulator.scrollbackCount - scrollOffset
+
+        for r in 0..<rows.count {
+            let y = CGFloat(r) * cellHeight
+            guard y + cellHeight >= dirtyRect.minY, y <= dirtyRect.maxY else { continue }
+            drawRow(rows[r], displayRow: r, absoluteLine: firstAbsolute + r, y: y, cols: cols)
+        }
+
+        drawCursorIfNeeded(rows)
+    }
+
+    private struct RunKey: Equatable {
+        var foreground: TerminalColor
+        var background: TerminalColor
+        var attributes: CellAttributes
+        var selected: Bool
+        var found: Bool
+    }
+
+    private func drawRow(_ row: [TerminalCell], displayRow: Int, absoluteLine: Int, y: CGFloat, cols: Int) {
+        var c = 0
+        let count = min(cols, row.count)
+        while c < count {
+            let startCol = c
+            let key = runKey(row[c], displayRow: displayRow, absoluteLine: absoluteLine, col: c)
+            var scalars = String.UnicodeScalarView()
+            while c < count, runKey(row[c], displayRow: displayRow, absoluteLine: absoluteLine, col: c) == key {
+                scalars.append(row[c].scalar)
+                c += 1
+            }
+            let rect = NSRect(
+                x: CGFloat(startCol) * cellWidth, y: y,
+                width: CGFloat(c - startCol) * cellWidth, height: cellHeight)
+            drawRun(String(scalars), key: key, at: rect)
+        }
+    }
+
+    private func runKey(_ cell: TerminalCell, displayRow: Int, absoluteLine: Int, col: Int) -> RunKey {
+        RunKey(
+            foreground: cell.foreground, background: cell.background, attributes: cell.attributes,
+            selected: isSelected(row: displayRow, col: col),
+            found: isFound(absoluteLine: absoluteLine, col: col))
+    }
+
+    private func drawRun(_ text: String, key: RunKey, at rect: NSRect) {
+        let bold = key.attributes.contains(.bold)
+        var fg = TerminalTheme.color(for: key.foreground, foreground: true, bold: bold)
+        var bg = TerminalTheme.color(for: key.background, foreground: false, bold: false)
+        if key.attributes.contains(.inverse) { swap(&fg, &bg) }
+        if key.attributes.contains(.hidden) { fg = bg }
+        if key.attributes.contains(.dim) { fg = fg.withAlphaComponent(0.6) }
+
+        bg.setFill()
+        rect.fill()
+        if key.found {
+            TerminalTheme.findHighlight.setFill()
+            rect.fill()
+        }
+        if key.selected {
+            TerminalTheme.selection.setFill()
+            rect.fill()
+        }
+
+        var attributes: [NSAttributedString.Key: Any] = [
+            .font: bold ? boldFont : font,
+            .foregroundColor: fg,
+        ]
+        if key.attributes.contains(.underline) {
+            attributes[.underlineStyle] = NSUnderlineStyle.single.rawValue
+        }
+        if key.attributes.contains(.strikethrough) {
+            attributes[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+        }
+        NSAttributedString(string: text, attributes: attributes).draw(at: CGPoint(x: rect.minX, y: rect.minY))
+    }
+
+    private func drawCursorIfNeeded(_ rows: [[TerminalCell]]) {
+        guard emulator.isCursorVisible, scrollOffset == 0 else { return }
+        let r = emulator.cursorRow
+        let c = emulator.cursorCol
+        guard r >= 0, r < rows.count, c >= 0, c < emulator.cols else { return }
+        let rect = NSRect(x: CGFloat(c) * cellWidth, y: CGFloat(r) * cellHeight, width: cellWidth, height: cellHeight)
+
+        let focused = (window?.isKeyWindow ?? false) && (window?.firstResponder === self)
+        if focused {
+            TerminalTheme.cursor.setFill()
+            rect.fill()
+            // Redraw the glyph beneath the block in the background color for contrast.
+            let scalar = c < rows[r].count ? rows[r][c].scalar : " "
+            NSAttributedString(
+                string: String(scalar),
+                attributes: [.font: font, .foregroundColor: TerminalTheme.defaultBackground]
+            ).draw(at: CGPoint(x: rect.minX, y: rect.minY))
+        } else {
+            TerminalTheme.cursor.setStroke()
+            let path = NSBezierPath(rect: rect.insetBy(dx: 0.5, dy: 0.5))
+            path.lineWidth = 1
+            path.stroke()
+        }
+    }
+
+    // MARK: Selection
+
+    private func normalizedSelection() -> (start: GridPoint, end: GridPoint)? {
+        guard let a = selectionAnchor, let h = selectionHead else { return nil }
+        if a.row < h.row || (a.row == h.row && a.col <= h.col) { return (a, h) }
+        return (h, a)
+    }
+
+    private func isSelected(row: Int, col: Int) -> Bool {
+        guard let (start, end) = normalizedSelection() else { return false }
+        if row < start.row || row > end.row { return false }
+        if row == start.row && col < start.col { return false }
+        if row == end.row && col > end.col { return false }
+        return true
+    }
+
+    private func gridPoint(for event: NSEvent) -> GridPoint {
+        let p = convert(event.locationInWindow, from: nil)
+        let col = max(0, min(emulator.cols - 1, Int(p.x / cellWidth)))
+        let row = max(0, min(emulator.rows - 1, Int(p.y / cellHeight)))
+        return GridPoint(row: row, col: col)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeFirstResponder(self)
+        let point = gridPoint(for: event)
+        selectionAnchor = point
+        selectionHead = point
+        needsDisplay = true
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        selectionHead = gridPoint(for: event)
+        needsDisplay = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        selectionHead = gridPoint(for: event)
+        if selectionAnchor == selectionHead {
+            // A plain click clears any selection.
+            selectionAnchor = nil
+            selectionHead = nil
+        }
+        needsDisplay = true
+    }
+
+    private func selectedText() -> String? {
+        guard let (start, end) = normalizedSelection() else { return nil }
+        let rows = emulator.displayRows(scrollOffset: scrollOffset)
+        var lines: [String] = []
+        for r in start.row...end.row where r < rows.count {
+            let row = rows[r]
+            let lo = (r == start.row) ? start.col : 0
+            let hi = (r == end.row) ? end.col : emulator.cols - 1
+            var scalars = String.UnicodeScalarView()
+            for c in lo...min(hi, row.count - 1) { scalars.append(row[c].scalar) }
+            var line = String(scalars)
+            while line.hasSuffix(" ") { line.removeLast() }
+            lines.append(line)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: Find (driven by the view controller)
+
+    /// Returns the lines (scrollback + screen) to search over.
+    func searchableLines() -> [String] { emulator.historyLines() }
+
+    /// Highlights a match at the given absolute line/column span and scrolls it into view.
+    func highlightMatch(absoluteLine: Int, colStart: Int, colEnd: Int) {
+        findHighlight = FindHighlight(absoluteLine: absoluteLine, colStart: colStart, colEnd: colEnd)
+        let scrollback = emulator.scrollbackCount
+        scrollOffset = max(0, min(scrollback - absoluteLine, scrollback))
+        needsDisplay = true
+    }
+
+    func clearFindHighlight() {
+        findHighlight = nil
+        needsDisplay = true
+    }
+
+    private func isFound(absoluteLine: Int, col: Int) -> Bool {
+        guard let f = findHighlight else { return false }
+        return f.absoluteLine == absoluteLine && col >= f.colStart && col < f.colEnd
+    }
+
+    // MARK: Scrolling
+
+    override func scrollWheel(with event: NSEvent) {
+        let scrollback = emulator.scrollbackCount
+        guard scrollback > 0 else { return }
+        let lines = max(1, Int(abs(event.scrollingDeltaY) / cellHeight))
+        if event.scrollingDeltaY > 0 {
+            scrollOffset = min(scrollOffset + lines, scrollback)  // scroll up into history
+        } else {
+            scrollOffset = max(scrollOffset - lines, 0)
+        }
+        needsDisplay = true
+    }
+
+    // MARK: Keyboard input
+
+    override func keyDown(with event: NSEvent) {
+        guard let characters = event.characters, !characters.isEmpty else {
+            super.keyDown(with: event)
+            return
+        }
+        // Ignore arrow/function keys (Unicode private-use area) — input-side CSI
+        // encoding is intentionally out of scope (issue #249 follow-up).
+        if let first = characters.unicodeScalars.first, first.value >= 0xF700 {
+            return
+        }
+        // Typing jumps back to the live bottom so the echo is visible.
+        if scrollOffset != 0 {
+            scrollOffset = 0
+            needsDisplay = true
+        }
+        sendInput?(characters)
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        needsDisplay = true
+        return super.becomeFirstResponder()
+    }
+
+    override func resignFirstResponder() -> Bool {
+        needsDisplay = true
+        return super.resignFirstResponder()
+    }
+
+    // MARK: Menu actions
+
+    @objc func copy(_ sender: Any?) {
+        guard let text = selectedText() else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+
+    @objc override func selectAll(_ sender: Any?) {
+        let rows = emulator.displayRows(scrollOffset: scrollOffset)
+        guard !rows.isEmpty else { return }
+        selectionAnchor = GridPoint(row: 0, col: 0)
+        selectionHead = GridPoint(row: rows.count - 1, col: emulator.cols - 1)
+        needsDisplay = true
+    }
+
+    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        switch menuItem.action {
+        case #selector(copy(_:)):
+            return normalizedSelection() != nil
+        default:
+            return true
+        }
+    }
+}

--- a/Kernova/Views/Console/TerminalView.swift
+++ b/Kernova/Views/Console/TerminalView.swift
@@ -21,6 +21,9 @@ final class TerminalView: NSView, NSMenuItemValidation {
     /// Called with characters typed by the user, to send to the guest's serial input.
     var sendInput: ((String) -> Void)?
 
+    /// Called with the grid dimensions whenever they change (for the status bar).
+    var onGridSizeChange: ((Int, Int) -> Void)?
+
     // MARK: Fonts & metrics
 
     private let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
@@ -99,6 +102,7 @@ final class TerminalView: NSView, NSMenuItemValidation {
         let cols = max(1, Int(bounds.width / cellWidth))
         let rows = max(1, Int(bounds.height / cellHeight))
         emulator.resize(cols: cols, rows: rows)
+        onGridSizeChange?(emulator.cols, emulator.rows)
     }
 
     /// Re-anchors the scrollback view as new output arrives, then redraws.

--- a/KernovaTests/TerminalBufferTests.swift
+++ b/KernovaTests/TerminalBufferTests.swift
@@ -1,0 +1,101 @@
+import Testing
+
+@testable import Kernova
+
+@Suite("TerminalBuffer Tests")
+struct TerminalBufferTests {
+    private func filled(cols: Int, rows: Int) -> TerminalBuffer {
+        var buffer = TerminalBuffer(cols: cols, rows: rows)
+        for r in 0..<rows {
+            let marker = UnicodeScalar(UInt8(0x30 + (r % 10)))  // '0'..'9'
+            buffer.setCell(TerminalCell(scalar: marker), row: r, col: 0)
+        }
+        return buffer
+    }
+
+    @Test("scrollUp returns the lines pushed off the top and blanks the bottom")
+    func scrollUp() {
+        var buffer = filled(cols: 4, rows: 4)  // rows marked 0,1,2,3 in col 0
+        let removed = buffer.scrollUp(top: 0, bottom: 3, count: 1)
+        #expect(removed.count == 1)
+        #expect(removed[0][0].scalar == "0")
+        #expect(buffer.cell(row: 0, col: 0).scalar == "1")
+        #expect(buffer.cell(row: 3, col: 0).scalar == " ")  // new blank line
+    }
+
+    @Test("scrollUp respects a partial region")
+    func scrollUpRegion() {
+        var buffer = filled(cols: 4, rows: 4)
+        buffer.scrollUp(top: 0, bottom: 2, count: 1)  // region rows 0..2, row 3 untouched
+        #expect(buffer.cell(row: 0, col: 0).scalar == "1")
+        #expect(buffer.cell(row: 2, col: 0).scalar == " ")
+        #expect(buffer.cell(row: 3, col: 0).scalar == "3")  // outside region
+    }
+
+    @Test("scrollDown inserts blanks at the top of the region")
+    func scrollDown() {
+        var buffer = filled(cols: 4, rows: 4)
+        buffer.scrollDown(top: 0, bottom: 3, count: 1)
+        #expect(buffer.cell(row: 0, col: 0).scalar == " ")
+        #expect(buffer.cell(row: 1, col: 0).scalar == "0")
+    }
+
+    @Test("eraseInRow erases the requested column span only")
+    func eraseInRow() {
+        var buffer = TerminalBuffer(cols: 6, rows: 1)
+        for c in 0..<6 { buffer.setCell(TerminalCell(scalar: "X"), row: 0, col: c) }
+        buffer.eraseInRow(0, from: 2, through: 4)
+        #expect(buffer.cell(row: 0, col: 1).scalar == "X")
+        #expect(buffer.cell(row: 0, col: 2).scalar == " ")
+        #expect(buffer.cell(row: 0, col: 4).scalar == " ")
+        #expect(buffer.cell(row: 0, col: 5).scalar == "X")
+    }
+
+    @Test("insertLines pushes lines down within the region")
+    func insertLines() {
+        var buffer = filled(cols: 4, rows: 4)
+        buffer.insertLines(at: 1, count: 1, bottom: 3)
+        #expect(buffer.cell(row: 0, col: 0).scalar == "0")
+        #expect(buffer.cell(row: 1, col: 0).scalar == " ")  // inserted blank
+        #expect(buffer.cell(row: 2, col: 0).scalar == "1")  // pushed down
+    }
+
+    @Test("deleteLines pulls lines up and blanks the bottom")
+    func deleteLines() {
+        var buffer = filled(cols: 4, rows: 4)
+        buffer.deleteLines(at: 1, count: 1, bottom: 3)
+        #expect(buffer.cell(row: 1, col: 0).scalar == "2")  // pulled up
+        #expect(buffer.cell(row: 3, col: 0).scalar == " ")  // blanked
+    }
+
+    @Test("insertChars and deleteChars shift within the row")
+    func insertDeleteChars() {
+        var buffer = TerminalBuffer(cols: 5, rows: 1)
+        for (c, ch) in "ABCDE".unicodeScalars.enumerated() {
+            buffer.setCell(TerminalCell(scalar: ch), row: 0, col: c)
+        }
+        buffer.insertChars(row: 0, col: 1, count: 1)
+        #expect(buffer.cell(row: 0, col: 0).scalar == "A")
+        #expect(buffer.cell(row: 0, col: 1).scalar == " ")
+        #expect(buffer.cell(row: 0, col: 2).scalar == "B")
+
+        buffer.deleteChars(row: 0, col: 1, count: 1)
+        #expect(buffer.cell(row: 0, col: 1).scalar == "B")
+    }
+
+    @Test("resize grows and shrinks, preserving top-left content")
+    func resize() {
+        var buffer = filled(cols: 4, rows: 4)
+        buffer.resize(cols: 6, rows: 6)
+        #expect(buffer.cols == 6)
+        #expect(buffer.rowCount == 6)
+        #expect(buffer.cell(row: 0, col: 0).scalar == "0")  // preserved
+        #expect(buffer.cell(row: 0, col: 5).scalar == " ")  // padded
+        #expect(buffer.cell(row: 5, col: 0).scalar == " ")  // padded row
+
+        buffer.resize(cols: 2, rows: 2)
+        #expect(buffer.cols == 2)
+        #expect(buffer.rowCount == 2)
+        #expect(buffer.cell(row: 0, col: 0).scalar == "0")  // still there
+    }
+}

--- a/KernovaTests/TerminalEmulatorTests.swift
+++ b/KernovaTests/TerminalEmulatorTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("TerminalEmulator Tests")
+@MainActor
+struct TerminalEmulatorTests {
+    private func makeEmulator(cols: Int = 80, rows: Int = 24) -> TerminalEmulator {
+        TerminalEmulator(cols: cols, rows: rows)
+    }
+
+    private func cell(_ emulator: TerminalEmulator, _ row: Int, _ col: Int) -> TerminalCell {
+        emulator.displayRows(scrollOffset: 0)[row][col]
+    }
+
+    private func feed(_ emulator: TerminalEmulator, _ string: String) {
+        emulator.feed(Data(string.utf8))
+    }
+
+    // MARK: - SGR
+
+    @Test("SGR applies bold and indexed foreground to written cells")
+    func sgrApplies() {
+        let e = makeEmulator()
+        feed(e, "\u{1B}[1;31mX")
+        let c = cell(e, 0, 0)
+        #expect(c.scalar == "X")
+        #expect(c.attributes.contains(.bold))
+        #expect(c.foreground == .indexed(1))
+    }
+
+    @Test("SGR 0 resets the pen")
+    func sgrReset() {
+        let e = makeEmulator()
+        feed(e, "\u{1B}[1;31mA\u{1B}[0mB")
+        #expect(cell(e, 0, 0).attributes.contains(.bold))
+        #expect(cell(e, 0, 1).attributes.isEmpty)
+        #expect(cell(e, 0, 1).foreground == .default)
+    }
+
+    @Test("SGR 256-color foreground parses 38;5;n")
+    func sgr256() {
+        let e = makeEmulator()
+        feed(e, "\u{1B}[38;5;200mZ")
+        #expect(cell(e, 0, 0).foreground == .indexed(200))
+    }
+
+    // MARK: - Cursor
+
+    @Test("CUP to the far corner clamps to grid bounds")
+    func cupClamps() {
+        let e = makeEmulator()
+        feed(e, "\u{1B}[32766;32766H")
+        #expect(e.cursorRow == 23)
+        #expect(e.cursorCol == 79)
+        feed(e, "Z")
+        #expect(cell(e, 23, 79).scalar == "Z")
+    }
+
+    @Test("Autowrap defers to the next character, then wraps to the next line")
+    func autowrap() {
+        let e = makeEmulator()
+        feed(e, String(repeating: "A", count: 80))
+        #expect(e.cursorRow == 0)  // deferred wrap — not yet moved
+        #expect(cell(e, 0, 79).scalar == "A")
+        feed(e, "B")
+        #expect(cell(e, 1, 0).scalar == "B")
+    }
+
+    // MARK: - Erase
+
+    @Test("ED mode 2 clears the whole screen")
+    func eraseDisplay() {
+        let e = makeEmulator()
+        feed(e, "hello\u{1B}[2J")
+        #expect(cell(e, 0, 0).scalar == " ")
+    }
+
+    // MARK: - DSR / DA replies
+
+    @Test("DSR 6 reports the 1-based cursor position")
+    func dsrCursorReport() {
+        let e = makeEmulator()
+        var responses: [String] = []
+        e.respond = { responses.append($0) }
+        feed(e, "\u{1B}[5;10H\u{1B}[6n")
+        #expect(responses == ["\u{1B}[5;10R"])
+    }
+
+    @Test("DSR is answered from the default 80x24 size before any resize")
+    func dsrDefaultSize() {
+        let e = makeEmulator()
+        var responses: [String] = []
+        e.respond = { responses.append($0) }
+        feed(e, "\u{1B}[32766;32766H\u{1B}[6n")
+        #expect(responses == ["\u{1B}[24;80R"])
+    }
+
+    @Test("Primary device attributes reply identifies as VT102")
+    func primaryDA() {
+        let e = makeEmulator()
+        var responses: [String] = []
+        e.respond = { responses.append($0) }
+        feed(e, "\u{1B}[c")
+        #expect(responses == ["\u{1B}[?6c"])
+    }
+
+    // MARK: - DECSTR
+
+    @Test("DECSTR resets the pen but does not clear the screen")
+    func decstrSoftReset() {
+        let e = makeEmulator()
+        feed(e, "ABC\u{1B}[31m\u{1B}[!pQ")
+        #expect(cell(e, 0, 2).scalar == "C")  // screen not cleared
+        #expect(cell(e, 0, 0).scalar == "Q")  // cursor homed, Q written
+        #expect(cell(e, 0, 0).foreground == .default)  // pen reset
+    }
+
+    // MARK: - Modes
+
+    @Test("DEC private mode 25 toggles cursor visibility")
+    func cursorVisibility() {
+        let e = makeEmulator()
+        feed(e, "\u{1B}[?25l")
+        #expect(e.isCursorVisible == false)
+        feed(e, "\u{1B}[?25h")
+        #expect(e.isCursorVisible == true)
+    }
+
+    // MARK: - Alt-screen + scrollback freeze
+
+    @Test("Alternate screen does not grow the primary scrollback")
+    func altScreenFreezesScrollback() {
+        let e = makeEmulator()
+        feed(e, "\u{1B}[2J\u{1B}[H")
+        for i in 0..<40 { feed(e, "line\(i)\r\n") }
+        let frozenCount = e.scrollbackCount
+        #expect(frozenCount > 0)
+
+        feed(e, "\u{1B}[?1049h")  // enter alt screen
+        for i in 0..<20 { feed(e, "alt\(i)\r\n") }
+        #expect(e.scrollbackCount == 0)  // alt screen exposes no scrollback
+
+        feed(e, "\u{1B}[?1049l")  // exit alt screen
+        // The primary scrollback was frozen during alt — unchanged after returning.
+        #expect(e.scrollbackCount == frozenCount)
+    }
+
+    // MARK: - RIS
+
+    @Test("RIS clears the screen, scrollback, and homes the cursor")
+    func fullReset() {
+        let e = makeEmulator()
+        feed(e, "\u{1B}[2J\u{1B}[H")
+        for i in 0..<40 { feed(e, "line\(i)\r\n") }
+        feed(e, "\u{1B}c")
+        #expect(e.scrollbackCount == 0)
+        #expect(e.cursorRow == 0)
+        #expect(e.cursorCol == 0)
+        #expect(cell(e, 0, 0).scalar == " ")
+    }
+
+    // MARK: - Scrolling pushes to scrollback
+
+    @Test("Scrolling off the top of the primary screen accumulates scrollback")
+    func scrollbackAccumulates() {
+        let e = makeEmulator(cols: 10, rows: 3)
+        for i in 0..<10 { feed(e, "row\(i)\r\n") }
+        #expect(e.scrollbackCount > 0)
+        // Oldest visible-from-history line should be reachable via scrollOffset.
+        let top = e.displayRows(scrollOffset: e.scrollbackCount)
+        #expect(top.count == 3)
+    }
+}

--- a/KernovaTests/TerminalIssue249Tests.swift
+++ b/KernovaTests/TerminalIssue249Tests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+/// Regression test for issue #249: the Serial Console rendered raw ANSI/VT
+/// escape sequences as literal text. Feeds the exact garbled boot banner from
+/// the issue and asserts the emulator produces a clean grid with zero escape
+/// residue, and that the guest's cursor probes are answered.
+@Suite("Terminal Issue #249 Regression")
+@MainActor
+struct TerminalIssue249Tests {
+    /// The agetty/systemd banner from the issue: DECSTR, OSC palette reset, SGR
+    /// reset, autowrap, cursor positioning, two cursor-position probes, a
+    /// far-corner size probe, and a DCS termcap (XTGETTCAP) query — followed by
+    /// the actual login prompt.
+    private let banner =
+        "\u{1B}[!p"  // DECSTR soft reset
+        + "\u{1B}]104\u{1B}\\"  // OSC 104 reset palette, ST-terminated
+        + "\u{1B}[0m"  // SGR reset
+        + "\u{1B}[?7h"  // autowrap on
+        + "\u{1B}[1G"  // cursor to column 1
+        + "\u{1B}[0J"  // erase to end of display
+        + "\u{1B}[6n"  // DSR cursor-position report
+        + "\u{1B}[32766;32766H"  // move to far corner (size probe)
+        + "\u{1B}[6n"  // DSR again
+        + "\u{1B}P+q6E616D65\u{1B}\\"  // DCS XTGETTCAP query ("name"), ST-terminated
+        + "\r\npanda-vm-Platform login: "
+
+    @Test("The garbled banner renders cleanly with no escape residue")
+    func bannerRendersCleanly() {
+        let e = TerminalEmulator(cols: 80, rows: 24)
+        e.feed(Data(banner.utf8))
+
+        let visible = e.visibleText()
+        #expect(visible.contains("login:"))
+
+        // None of the control-sequence residue should appear as literal text.
+        for residue in ["\u{1B}", "[", "]104", "104", "6n", "+q", "!p", "?7h", "0J"] {
+            #expect(!visible.contains(residue), "rendered text leaked control residue: \(residue)")
+        }
+    }
+
+    @Test("Both cursor-position probes are answered to the guest")
+    func cursorProbesAnswered() {
+        let e = TerminalEmulator(cols: 80, rows: 24)
+        var responses: [String] = []
+        e.respond = { responses.append($0) }
+        e.feed(Data(banner.utf8))
+
+        // First [6n] after [1G: cursor at row 1, col 1. Second after the
+        // far-corner move: clamped to 24×80.
+        #expect(responses == ["\u{1B}[1;1R", "\u{1B}[24;80R"])
+    }
+
+    @Test("Full history (scrollback + screen) is also free of escape residue")
+    func fullTextClean() {
+        let e = TerminalEmulator(cols: 80, rows: 24)
+        e.feed(Data(banner.utf8))
+        let full = e.fullText()
+        #expect(full.contains("login:"))
+        #expect(!full.contains("\u{1B}"))
+        #expect(!full.contains("104"))
+    }
+}

--- a/KernovaTests/TerminalIssue249Tests.swift
+++ b/KernovaTests/TerminalIssue249Tests.swift
@@ -4,9 +4,11 @@ import Testing
 @testable import Kernova
 
 /// Regression test for issue #249: the Serial Console rendered raw ANSI/VT
-/// escape sequences as literal text. Feeds the exact garbled boot banner from
-/// the issue and asserts the emulator produces a clean grid with zero escape
-/// residue, and that the guest's cursor probes are answered.
+/// escape sequences as literal text.
+///
+/// Feeds the exact garbled boot banner from the issue and asserts the emulator
+/// produces a clean grid with zero escape residue, and that the guest's cursor
+/// probes are answered.
 @Suite("Terminal Issue #249 Regression")
 @MainActor
 struct TerminalIssue249Tests {

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -290,10 +290,27 @@ struct VMInstanceTests {
 
     // MARK: - Serial Console
 
-    @Test("serialOutputText starts empty")
-    func serialOutputTextStartsEmpty() {
+    @Test("terminal starts at the default size with no content")
+    func terminalStartsEmpty() {
         let instance = makeInstance()
-        #expect(instance.serialOutputText.isEmpty)
+        #expect(instance.terminal.cols == 80)
+        #expect(instance.terminal.rows == 24)
+        // A blank screen serializes to empty lines (only newline separators).
+        #expect(instance.terminal.visibleText().allSatisfy { $0 == "\n" })
+    }
+
+    @Test("terminal DSR replies route back to the serial input pipe")
+    func terminalDSRRoutesToInputPipe() {
+        let instance = makeInstance()
+        let pipe = Pipe()
+        instance.serialInputPipe = pipe
+
+        // A cursor-position report should be written to the guest's input pipe
+        // via the respond hook wired up in VMInstance.init.
+        instance.terminal.feed(Data("\u{1B}[6n".utf8))
+
+        let data = pipe.fileHandleForReading.availableData
+        #expect(String(data: data, encoding: .utf8) == "\u{1B}[1;1R")
     }
 
     @Test("sendSerialInput writes to input pipe")

--- a/KernovaTests/VTParserTests.swift
+++ b/KernovaTests/VTParserTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+/// A `TerminalPerformer` that records every dispatched event so tests can assert
+/// the exact decode sequence without a grid.
+@MainActor
+private final class RecordingPerformer: TerminalPerformer {
+    enum Event: Equatable {
+        case print(UnicodeScalar)
+        case execute(UInt8)
+        case csi(prefix: UInt8?, params: [Int], intermediates: [UInt8], final: UInt8)
+        case esc(intermediates: [UInt8], final: UInt8)
+        case osc([UInt8])
+    }
+
+    var events: [Event] = []
+
+    func print(_ scalar: UnicodeScalar) { events.append(.print(scalar)) }
+    func execute(_ control: UInt8) { events.append(.execute(control)) }
+    func csiDispatch(prefix: UInt8?, params: [Int], intermediates: [UInt8], final: UInt8) {
+        events.append(.csi(prefix: prefix, params: params, intermediates: intermediates, final: final))
+    }
+    func escDispatch(intermediates: [UInt8], final: UInt8) {
+        events.append(.esc(intermediates: intermediates, final: final))
+    }
+    func oscDispatch(_ data: [UInt8]) { events.append(.osc(data)) }
+
+    /// Concatenation of all printed scalars.
+    var printedText: String {
+        String(String.UnicodeScalarView(events.compactMap { if case .print(let s) = $0 { s } else { nil } }))
+    }
+
+    var csiEvents: [Event] {
+        events.filter { if case .csi = $0 { true } else { false } }
+    }
+}
+
+@Suite("VTParser Tests")
+@MainActor
+struct VTParserTests {
+    private func parse(_ string: String) -> RecordingPerformer {
+        let performer = RecordingPerformer()
+        var parser = VTParser()
+        parser.feed(Data(string.utf8), to: performer)
+        return performer
+    }
+
+    private func parse(_ bytes: [UInt8]) -> RecordingPerformer {
+        let performer = RecordingPerformer()
+        var parser = VTParser()
+        parser.feed(Data(bytes), to: performer)
+        return performer
+    }
+
+    // MARK: - Printables & controls
+
+    @Test("Plain ASCII prints through")
+    func plainASCII() {
+        #expect(parse("hello").printedText == "hello")
+    }
+
+    @Test("C0 controls are executed, not printed")
+    func c0Controls() {
+        let p = parse("a\r\nb")
+        #expect(p.events == [
+            .print("a"), .execute(0x0D), .execute(0x0A), .print("b"),
+        ])
+    }
+
+    // MARK: - CSI parsing
+
+    @Test("CSI with parameters dispatches with parsed ints")
+    func csiParams() {
+        let p = parse("\u{1B}[1;2H")
+        #expect(p.events == [.csi(prefix: nil, params: [1, 2], intermediates: [], final: 0x48)])
+    }
+
+    @Test("CSI private prefix is captured")
+    func csiPrivatePrefix() {
+        let p = parse("\u{1B}[?25h")
+        #expect(p.events == [.csi(prefix: 0x3F, params: [25], intermediates: [], final: 0x68)])
+    }
+
+    @Test("CSI intermediate byte is captured (DECSTR)")
+    func csiIntermediate() {
+        let p = parse("\u{1B}[!p")
+        #expect(p.events == [.csi(prefix: nil, params: [], intermediates: [0x21], final: 0x70)])
+    }
+
+    @Test("CSI parameter count is capped at 16")
+    func csiParamCap() {
+        let nums = (1...20).map(String.init).joined(separator: ";")
+        let p = parse("\u{1B}[\(nums)m")
+        guard case .csi(_, let params, _, _) = p.events.first else {
+            Issue.record("expected a CSI event")
+            return
+        }
+        #expect(params == Array(1...16))
+    }
+
+    @Test("CSI parameter value saturates at 65535")
+    func csiParamSaturates() {
+        let p = parse("\u{1B}[99999999H")
+        guard case .csi(_, let params, _, _) = p.events.first else {
+            Issue.record("expected a CSI event")
+            return
+        }
+        #expect(params == [65535])
+    }
+
+    @Test("Empty CSI parameters dispatch with no params")
+    func csiNoParams() {
+        let p = parse("\u{1B}[H")
+        #expect(p.events == [.csi(prefix: nil, params: [], intermediates: [], final: 0x48)])
+    }
+
+    // MARK: - OSC
+
+    @Test("OSC terminated by BEL dispatches its payload")
+    func oscBEL() {
+        let p = parse("\u{1B}]0;title\u{07}")
+        #expect(p.events == [.osc(Array("0;title".utf8))])
+    }
+
+    @Test("OSC terminated by ST dispatches its payload")
+    func oscST() {
+        let p = parse("\u{1B}]2;hi\u{1B}\\")
+        #expect(p.events.first == .osc(Array("2;hi".utf8)))
+    }
+
+    @Test("OSC payload is capped at maxOSCLength")
+    func oscOverflow() {
+        let p = parse("\u{1B}]" + String(repeating: "A", count: 5000) + "\u{07}")
+        guard case .osc(let data) = p.events.first else {
+            Issue.record("expected an OSC event")
+            return
+        }
+        #expect(data.count == VTParser.maxOSCLength)
+    }
+
+    // MARK: - DCS (swallowed)
+
+    @Test("DCS is swallowed; trailing text still prints")
+    func dcsSwallowed() {
+        let p = parse("\u{1B}P+q6E616D65\u{1B}\\X")
+        // No payload bytes leak as prints; only the trailing 'X' prints.
+        #expect(p.printedText == "X")
+        #expect(!p.events.contains(.print("6")))
+        #expect(!p.events.contains(.print("q")))
+    }
+
+    // MARK: - UTF-8
+
+    @Test("Multibyte UTF-8 split across feeds yields one scalar")
+    func utf8SplitAcrossFeeds() {
+        let performer = RecordingPerformer()
+        var parser = VTParser()
+        parser.feed(Data([0xC3]), to: performer)  // first byte of é (U+00E9)
+        #expect(performer.events.isEmpty)
+        parser.feed(Data([0xA9]), to: performer)  // continuation
+        #expect(performer.events == [.print("é")])
+    }
+
+    @Test("Invalid UTF-8 lead followed by ASCII yields replacement then the ASCII")
+    func invalidUTF8() {
+        let p = parse([0xC3, 0x41])  // bad: lead byte then non-continuation 'A'
+        #expect(p.events == [.print("\u{FFFD}"), .print("A")])
+    }
+
+    @Test("Stray continuation byte yields replacement")
+    func strayContinuation() {
+        let p = parse([0x80])
+        #expect(p.events == [.print("\u{FFFD}")])
+    }
+
+    // MARK: - Aborts
+
+    @Test("CAN aborts an in-progress CSI sequence")
+    func canAborts() {
+        let p = parse("\u{1B}[12\u{18}3")
+        #expect(p.csiEvents.isEmpty)
+        #expect(p.printedText == "3")
+    }
+
+    @Test("ESC mid-CSI starts a fresh escape sequence")
+    func escMidCSI() {
+        let p = parse("\u{1B}[12\u{1B}[5H")
+        // The first CSI is abandoned; only the second dispatches.
+        #expect(p.events == [.csi(prefix: nil, params: [5], intermediates: [], final: 0x48)])
+    }
+}

--- a/KernovaTests/VTParserTests.swift
+++ b/KernovaTests/VTParserTests.swift
@@ -64,9 +64,10 @@ struct VTParserTests {
     @Test("C0 controls are executed, not printed")
     func c0Controls() {
         let p = parse("a\r\nb")
-        #expect(p.events == [
-            .print("a"), .execute(0x0D), .execute(0x0A), .print("b"),
-        ])
+        #expect(
+            p.events == [
+                .print("a"), .execute(0x0D), .execute(0x0A), .print("b"),
+            ])
     }
 
     // MARK: - CSI parsing


### PR DESCRIPTION
## Summary
- The Serial Console rendered raw ANSI/VT escape sequences as literal text (agetty/systemd probes, colored output, and TUIs all showed their control bytes). This adds a hand-rolled VT100/xterm-subset terminal emulator (no third-party deps) that interprets the guest serial stream into a cell grid, rendered by a custom-drawn AppKit view.
- Guest output now reads cleanly; colors/bold/underline/inverse render; full-screen TUIs (htop/vim/less) work via alt-screen + scrollback; and the guest's `[6n`/`[c` probes get real DSR/DA replies so getty terminal detection succeeds.

Closes #249

## Changes
- **`Kernova/Terminal/`** (pure logic, AppKit-free): `TerminalCell` (glyph + 256-color/truecolor + SGR flags), `VTParser` (Paul Williams VT500 DFA + `TerminalPerformer`; incremental UTF-8; bounded params/OSC accumulators for untrusted input), `TerminalBuffer` (array-of-arrays grid ops), `TerminalEmulator` (`@MainActor` engine: CSI/ESC/OSC/DCS handlers, SGR, cursor, scroll regions, alt-screen, 5000-row scrollback, DEC line-drawing; DSR/DA replies via `respond`; redraw via `onRender`).
- **`Kernova/Views/Console/`**: `TerminalView` (custom-drawn `NSView` — run-batched cells, block/hollow cursor, internal scrollback offset + auto-follow, rubber-band selection + ⌘C copy, scroll-wheel history, key forwarding, find-match highlight, minimal NSAccessibility), `TerminalFindBar` (⌘F bar), `TerminalTheme` (xterm palette → `NSColor`, the one justified hardcoded-RGB site, RATIONALE-annotated).
- **`VMInstance`**: owns the emulator; routes DSR/DA replies to the guest via `sendSerialInput`; feeds raw bytes through a coalesced, 256 KB-budgeted main-actor drain (this also fixes a latent bug — the old per-chunk `String(data:encoding:.utf8)` silently dropped any chunk that split a multibyte codepoint across a pipe-read boundary); adds an EOF readability-handler nil-out; resets the emulator on session start/teardown; removes the now-unused `serialOutputText` 1 MB buffer (the on-disk `serial.log` still keeps full raw history).
- **`SerialConsoleContentViewController`**: hosts `TerminalView` instead of `SerialTextView`, adds the ⌘F find bar and a grid-size status indicator.
- Docs: ARCHITECTURE.md updated (directory map, component map/data flow, test coverage).

## Test plan
- [x] `make build` and full `make test` pass (three targets)
- [x] `make lint` (swift-format --strict) passes
- [x] New unit suites: `VTParserTests`, `TerminalBufferTests`, `TerminalEmulatorTests`, `TerminalIssue249Tests` (feeds the exact garbled banner from the issue → asserts zero escape residue + both cursor probes answered)
- [x] **Real-data verification**: fed the installed Ubuntu 26.04 VM's actual captured `serial.log` (7482 raw bytes, full of escape sequences) through the production emulator → renders to a clean banner ending at `panda-…-Platform login:` with zero residue (matches the issue's "Expected"). GUI launch under automation was blocked by a hidden system security dialog for the locally-built binary, so this real-byte end-to-end check stands in for clicking through the window.

## Notes
Out of scope (issue explicitly defers / follow-ups): input-side CSI encoding for arrow/function keys (the view keeps today's plain-character forwarding); full CJK double-width cells (v1 treats wide glyphs as single-cell); cursor blink, mouse reporting, Sixel, selection-level accessibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)