### PR TITLE
docs: Move CLAUDE.md to the repo root and rewire doc links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ make install-hooks       # One-time: enable .githooks/pre-push (runs `make lint`
 make clean               # Remove DerivedData/
 ```
 
-Run `make install-hooks` once after cloning to enable the pre-push `make lint` hook (see [Development setup](../README.md#development-setup) in the README for the mechanics; bypass an individual push with `git push --no-verify`).
+Run `make install-hooks` once after cloning to enable the pre-push `make lint` hook (see [Development setup](README.md#development-setup) in the README for the mechanics; bypass an individual push with `git push --no-verify`).
 
 `make test` is the canonical `xcodebuild` invocation:
 
@@ -35,7 +35,7 @@ The `-derivedDataPath DerivedData` flag ensures build output goes to a determini
 
 `CFBundleVersion` is `git rev-list --count HEAD` (the total commit count), substituted into the source `Info.plist` via `INFOPLIST_PREPROCESS`. The `Set Build Number from Git` build phase generates `KernovaBuildNumber.h` with `#define KERNOVA_BUILD_NUMBER N`, and `Kernova/App/Info.plist` references the symbol directly (`<string>KERNOVA_BUILD_NUMBER</string>`). Substitution happens inside `ProcessInfoPlistFile` so build-graph reordering can't clobber it. The `KernovaGuestAgent` target uses the same pattern with its own `AGENT_BUILD_NUMBER` (scoped to `git rev-list --count HEAD -- KernovaGuestAgent/`). When adding a new top-level target that needs a dynamic build number, replicate this pattern instead of patching the built `Info.plist` after the fact.
 
-Requires the toolchain listed under [Requirements](../README.md#requirements) in the README (Apple Silicon is needed for macOS guest support). The app uses the `com.apple.security.virtualization` entitlement.
+Requires the toolchain listed under [Requirements](README.md#requirements) in the README (Apple Silicon is needed for macOS guest support). The app uses the `com.apple.security.virtualization` entitlement.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Kernova build & test invocations.
 #
 # These targets wrap the canonical `xcodebuild` calls documented in
-# .claude/CLAUDE.md. Inside Xcode, just use the IDE (CMD-B / CMD-U); this
+# CLAUDE.md. Inside Xcode, just use the IDE (CMD-B / CMD-U); this
 # Makefile is for terminal, CI, and tooling use.
 
 PROJECT      := Kernova.xcodeproj

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The project has comprehensive test coverage using [Swift Testing](https://develo
 make test
 ```
 
-This runs all three test targets via the test plan; it wraps the canonical `xcodebuild` invocation documented in [CLAUDE.md](.claude/CLAUDE.md). See the test coverage section in [ARCHITECTURE.md](ARCHITECTURE.md) for details.
+This runs all three test targets via the test plan; it wraps the canonical `xcodebuild` invocation documented in [CLAUDE.md](CLAUDE.md). See the test coverage section in [ARCHITECTURE.md](ARCHITECTURE.md) for details.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Move the project-instructions file from `.claude/CLAUDE.md` to the repo root so it sits alongside `README.md`, `ARCHITECTURE.md`, and `SPEC.md` — the conventional, more discoverable spot. Claude Code auto-loads a root `CLAUDE.md` exactly as it did the `.claude/` one, so there is **no behavior change** for the agent.
- Supersedes this PR's original intent (which had been to *keep* the file in `.claude/` and fix its broken relative links). Moving it to root makes those links siblings again, which is simpler.

## Changes
- `git mv .claude/CLAUDE.md CLAUDE.md` (98% similarity — pure move + link tweaks)
- **CLAUDE.md** internal links: drop the now-incorrect `../` prefix on all five links — `SPEC.md`, `ARCHITECTURE.md` (×2), and the two anchored `README.md` links. They're siblings again at the root.
- **README.md**: `[CLAUDE.md](.claude/CLAUDE.md)` → `[CLAUDE.md](CLAUDE.md)`
- **Makefile**: header comment reference `.claude/CLAUDE.md` → `CLAUDE.md`

## Notes
- Docs/tooling-comment only; no code, build, or runtime behavior change.
- The net diff vs `main` is small because the `SPEC.md`/`ARCHITECTURE.md` links return to their original bare form once the file is back at root — only the two anchored `README.md` links, the README link to CLAUDE.md, and the Makefile comment actually change.

## Test plan
- [x] No remaining `.claude/CLAUDE.md` path references in tracked files (`git grep`)
- [x] No remaining `../` doc links inside `CLAUDE.md`
- [x] All link targets (`SPEC.md`, `ARCHITECTURE.md`, `README.md`, `CLAUDE.md`) resolve at the repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)