### PR TITLE
fix: Make timing-sensitive test waits event-driven; bump poll tick to 50 ms

### DIFF
--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -716,6 +716,16 @@ final class VMInstance {
         agentPostStartTask = nil
     }
 
+    #if DEBUG
+    /// The in-flight post-start watchdog task, or `nil` when none is armed.
+    ///
+    /// Test-only seam: watchdog tests `await` this task's completion instead of
+    /// polling `agentExpectedButMissing`, so they depend on the task actually
+    /// finishing rather than on a wall-clock deadline — removing the MainActor
+    /// timing flake that polling exhibited under CI contention.
+    var agentPostStartTaskForTesting: Task<Void, Never>? { agentPostStartTask }
+    #endif
+
     /// Reacts to a fresh, non-empty `agent_version` reported by the guest:
     /// cancel the post-start watchdog, clear the expected-missing flag, and
     /// route the new value through the view model's centralized

--- a/KernovaGuestAgentTests/TestHelpers.swift
+++ b/KernovaGuestAgentTests/TestHelpers.swift
@@ -35,14 +35,19 @@ func makeChannelPair() throws -> (VsockChannel, VsockChannel) {
 
 // MARK: - waitUntil
 
-/// Polls `predicate` every 10 ms until it returns `true` or `timeout` elapses.
+/// Polls `predicate` every 50 ms until it returns `true` or `timeout` elapses.
+///
+/// Prefer the event-driven `AsyncGate` below for new timing-sensitive waits —
+/// polling is retained for predicates with no underlying signal to await; the
+/// 50 ms tick (up from 10 ms) keeps idle pollers from adding avoidable
+/// executor churn under parallel CI load.
 func waitUntil(
     timeout: Duration = .seconds(5),
     _ predicate: @Sendable () -> Bool
 ) async throws {
     let deadline = ContinuousClock.now.advanced(by: timeout)
     while !predicate() && ContinuousClock.now < deadline {
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(for: .milliseconds(50))
     }
     guard predicate() else {
         throw TestFailure("Predicate did not become true within \(timeout)")
@@ -107,16 +112,24 @@ func awaitFirst<T: Sendable>(
 // MARK: - AtomicInt
 
 /// Lock-protected integer for use in non-async closures (e.g. socket providers).
+///
+/// Exposes a `changed` gate so tests can `await changed.wait { value >= n }`
+/// instead of polling — each `increment()` fires the gate.
 final class AtomicInt: @unchecked Sendable {
     private let lock = NSLock()
     private var storedValue: Int = 0
 
+    /// Fires on every `increment()`; await it instead of polling `value`.
+    let changed = AsyncGate()
+
     @discardableResult
     func increment() -> Int {
-        lock.withLock {
+        let newValue = lock.withLock { () -> Int in
             storedValue += 1
             return storedValue
         }
+        changed.notify()
+        return newValue
     }
 
     var value: Int {
@@ -158,4 +171,99 @@ func makeLogFrame(message: String) -> Frame {
         $0.message = message
     }
     return frame
+}
+
+// MARK: - AsyncGate
+
+/// Resumes its continuation at most once, regardless of how many racing paths
+/// (a `notify()` and the timeout backstop) try to fire it. `CheckedContinuation`
+/// traps on a second resume, so this guard makes the race safe.
+private final class ResumeOnce: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+    func fire(_ body: () -> Void) {
+        lock.lock()
+        let already = fired
+        fired = true
+        lock.unlock()
+        if !already { body() }
+    }
+}
+
+/// Event-driven replacement for `waitUntil` polling.
+///
+/// A producer calls `notify()` after each observable state change; the consumer
+/// awaits `wait(until:)`, which suspends until the predicate holds — re-checked
+/// on every `notify()` — or throws `TestFailure` after `timeout`.
+///
+/// Unlike the poll loop, an idle waiter adds **zero** wake-ups to the shared
+/// (and, on CI, contended) executor, and the `timeout` is a backstop the happy
+/// path never reaches rather than the success deadline — so a slow runner no
+/// longer fails the wait, only a genuinely stuck condition does. This is the
+/// fix for the timing-sensitive flakes documented in the flaky-CI
+/// investigation; keep it aligned with the KernovaTests bundle's copy.
+///
+/// `wait` is `nonisolated` with a `@Sendable` predicate to match this bundle's
+/// `waitUntil` (its suites are not `@MainActor`); predicates read `Sendable`
+/// boxes (`AtomicInt`, `PolicyBox`).
+final class AsyncGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var waiters: [UUID: () -> Void] = [:]
+
+    /// Wake every current waiter; call right after mutating observed state.
+    func notify() {
+        lock.lock()
+        let resumes = Array(waiters.values)
+        waiters.removeAll()
+        lock.unlock()
+        resumes.forEach { $0() }
+    }
+
+    /// Suspend until `predicate()` holds (re-checked on each `notify()`), or
+    /// throw `TestFailure` after `timeout`.
+    func wait(
+        timeout: Duration = .seconds(10),
+        until predicate: @Sendable () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while !predicate() {
+            if ContinuousClock.now >= deadline {
+                throw TestFailure("Condition not met within \(timeout)")
+            }
+            await armOnce(deadline: deadline, predicate: predicate)
+        }
+    }
+
+    /// Suspends until the next `notify()`, an immediate hit (the predicate
+    /// already holds at arm time, closing the arm-vs-notify race), or the
+    /// `deadline` backstop — whichever comes first.
+    private func armOnce(
+        deadline: ContinuousClock.Instant,
+        predicate: @Sendable () -> Bool
+    ) async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            let id = UUID()
+            let once = ResumeOnce()
+            lock.lock()
+            waiters[id] = { once.fire { cont.resume() } }
+            lock.unlock()
+            // Close the arm-vs-notify race: if the state already satisfies the
+            // predicate (a notify may have landed before we registered), resume
+            // now so the outer loop re-checks promptly instead of blocking.
+            if predicate() {
+                lock.lock()
+                waiters.removeValue(forKey: id)
+                lock.unlock()
+                once.fire { cont.resume() }
+                return
+            }
+            // Backstop: resume at the deadline even if no notify arrives, so a
+            // genuinely stuck condition fails the wait instead of hanging.
+            Task {
+                try? await Task.sleep(until: deadline, clock: ContinuousClock())
+                self.lock.withLock { _ = self.waiters.removeValue(forKey: id) }
+                once.fire { cont.resume() }
+            }
+        }
+    }
 }

--- a/KernovaGuestAgentTests/VsockGuestClientTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClientTests.swift
@@ -414,7 +414,7 @@ struct ClassifySocketErrnoTests {
         // Wait for the provider to be entered, then pause while it's mid-sleep.
         // The lock check inside connectAndServe must observe paused=true when
         // the provider returns, and abort the publish.
-        try await waitUntil { providerEntered.value >= 1 }
+        try await providerEntered.changed.wait { providerEntered.value >= 1 }
         client.pause()
 
         // Wait past the provider's sleep so connectAndServe has returned.

--- a/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
@@ -244,7 +244,12 @@ struct VsockGuestControlAgentTests {
     private final class PolicyBox: @unchecked Sendable {
         private let lock = NSLock()
         private var storedValue: Kernova_V1_PolicyUpdate?
-        func set(_ p: Kernova_V1_PolicyUpdate) { lock.withLock { storedValue = p } }
+        /// Fires on every `set`; await it instead of polling `value`.
+        let changed = AsyncGate()
+        func set(_ p: Kernova_V1_PolicyUpdate) {
+            lock.withLock { storedValue = p }
+            changed.notify()
+        }
         var value: Kernova_V1_PolicyUpdate? { lock.withLock { storedValue } }
     }
 
@@ -277,7 +282,7 @@ struct VsockGuestControlAgentTests {
         }
         try host.send(frame)
 
-        try await waitUntil { received.value != nil }
+        try await received.changed.wait { received.value != nil }
         let policy = try #require(received.value)
         #expect(policy.logForwardingEnabled == true)
         #expect(policy.clipboardSharingEnabled == false)
@@ -311,7 +316,7 @@ struct VsockGuestControlAgentTests {
             try host.send(frame)
         }
 
-        try await waitUntil { counts.value >= 3 }
+        try await counts.changed.wait { counts.value >= 3 }
     }
 
     @Test("stop() halts the connection without throwing")

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -33,10 +33,13 @@ func makeRawSocketPair() throws -> (Int32, Int32) {
 
 // MARK: - waitUntil
 
-/// Polls `predicate` every 10 ms until it returns `true` or `timeout` elapses.
+/// Polls `predicate` every 50 ms until it returns `true` or `timeout` elapses.
 ///
 /// Default deadline is generous (5 s) to absorb MainActor scheduling jitter on
-/// CI runners. See feedback memory `feedback_ci_test_timings`.
+/// CI runners. See feedback memory `feedback_ci_test_timings`. Prefer the
+/// event-driven `AsyncGate` below for new timing-sensitive waits — polling is
+/// retained for predicates with no underlying signal to await; the 50 ms tick
+/// (up from 10 ms) keeps idle pollers from adding avoidable MainActor churn.
 ///
 /// `@MainActor`-isolated because every test in `KernovaTests` is MainActor and
 /// the predicates routinely close over MainActor-isolated state (services,
@@ -49,7 +52,7 @@ func waitUntil(
 ) async throws {
     let deadline = ContinuousClock.now.advanced(by: timeout)
     while !predicate() && ContinuousClock.now < deadline {
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(for: .milliseconds(50))
     }
     guard predicate() else {
         throw TestFailure("Predicate did not become true within \(timeout)")
@@ -92,5 +95,99 @@ func nextFrame(
         return frame
     } catch is CancellationError {
         throw TestFailure("Timed out waiting for a frame after \(timeout)")
+    }
+}
+
+// MARK: - AsyncGate
+
+/// Resumes its continuation at most once, regardless of how many racing paths
+/// (a `notify()` and the timeout backstop) try to fire it. `CheckedContinuation`
+/// traps on a second resume, so this guard makes the race safe.
+private final class ResumeOnce: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+    func fire(_ body: () -> Void) {
+        lock.lock()
+        let already = fired
+        fired = true
+        lock.unlock()
+        if !already { body() }
+    }
+}
+
+/// Event-driven replacement for `waitUntil` polling.
+///
+/// A producer calls `notify()` after each observable state change; the consumer
+/// awaits `wait(until:)`, which suspends until the predicate holds — re-checked
+/// on every `notify()` — or throws `TestFailure` after `timeout`.
+///
+/// Unlike the poll loop, an idle waiter adds **zero** wake-ups to the shared
+/// (and, on CI, contended) MainActor, and the `timeout` is a backstop the happy
+/// path never reaches rather than the success deadline — so a slow runner no
+/// longer fails the wait, only a genuinely stuck condition does. This is the
+/// fix for the timing-sensitive flakes documented in the flaky-CI
+/// investigation; keep it aligned with the GuestAgent bundle's copy.
+final class AsyncGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var waiters: [UUID: () -> Void] = [:]
+
+    /// Wake every current waiter; call right after mutating observed state.
+    func notify() {
+        lock.lock()
+        let resumes = Array(waiters.values)
+        waiters.removeAll()
+        lock.unlock()
+        resumes.forEach { $0() }
+    }
+
+    /// Suspend until `predicate()` holds (re-checked on each `notify()`), or
+    /// throw `TestFailure` after `timeout`. `@MainActor` so predicates may read
+    /// MainActor-isolated test state, matching this bundle's `waitUntil`.
+    @MainActor
+    func wait(
+        timeout: Duration = .seconds(10),
+        until predicate: () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while !predicate() {
+            if ContinuousClock.now >= deadline {
+                throw TestFailure("Condition not met within \(timeout)")
+            }
+            await armOnce(deadline: deadline, predicate: predicate)
+        }
+    }
+
+    /// Suspends until the next `notify()`, an immediate hit (the predicate
+    /// already holds at arm time, closing the arm-vs-notify race), or the
+    /// `deadline` backstop — whichever comes first.
+    @MainActor
+    private func armOnce(
+        deadline: ContinuousClock.Instant,
+        predicate: () -> Bool
+    ) async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            let id = UUID()
+            let once = ResumeOnce()
+            lock.lock()
+            waiters[id] = { once.fire { cont.resume() } }
+            lock.unlock()
+            // Close the arm-vs-notify race: if the state already satisfies the
+            // predicate (a notify may have landed before we registered), resume
+            // now so the outer loop re-checks promptly instead of blocking.
+            if predicate() {
+                lock.lock()
+                waiters.removeValue(forKey: id)
+                lock.unlock()
+                once.fire { cont.resume() }
+                return
+            }
+            // Backstop: resume at the deadline even if no notify arrives, so a
+            // genuinely stuck condition fails the wait instead of hanging.
+            Task {
+                try? await Task.sleep(until: deadline, clock: ContinuousClock())
+                self.lock.withLock { _ = self.waiters.removeValue(forKey: id) }
+                once.fire { cont.resume() }
+            }
+        }
     }
 }

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -549,11 +549,10 @@ struct VMInstanceTests {
         let instance = makeMacOSInstanceWithAgentInstalled()
         instance.startAgentPostStartWatchdog(grace: Self.testWatchdogGrace)
 
-        // 5 s default deadline = 25× the grace; comfortable margin for CI
-        // MainActor jitter without hiding genuine bugs.
-        try await waitUntil {
-            instance.agentExpectedButMissing
-        }
+        // Await the watchdog task itself rather than polling the flag: the task
+        // completes exactly when the grace elapses and flips the flag, so there
+        // is no wall-clock deadline to lose under CI MainActor contention.
+        await instance.agentPostStartTaskForTesting?.value
         #expect(instance.agentExpectedButMissing == true)
         #expect(instance.agentStatus == .expectedMissing(expected: "0.9.2"))
     }
@@ -660,9 +659,8 @@ struct VMInstanceTests {
 
         instance.startAgentPostStartWatchdog(grace: Self.testWatchdogGrace)
 
-        try await waitUntil {
-            instance.agentExpectedButMissing
-        }
+        await instance.agentPostStartTaskForTesting?.value
+        #expect(instance.agentExpectedButMissing == true)
         #expect(instance.configuration.agentInstallNudgeDismissed == false)
         #expect(persistCallCount == 1)
     }
@@ -679,9 +677,8 @@ struct VMInstanceTests {
 
         instance.startAgentPostStartWatchdog(grace: Self.testWatchdogGrace)
 
-        try await waitUntil {
-            instance.agentExpectedButMissing
-        }
+        await instance.agentPostStartTaskForTesting?.value
+        #expect(instance.agentExpectedButMissing == true)
         #expect(persistCallCount == 0)
     }
 
@@ -698,9 +695,8 @@ struct VMInstanceTests {
         // Re-arming after teardown should now succeed — the prior task was
         // cancelled, so the idempotency guard does not block this.
         instance.startAgentPostStartWatchdog(grace: Self.testWatchdogGrace)
-        try await waitUntil {
-            instance.agentExpectedButMissing
-        }
+        await instance.agentPostStartTaskForTesting?.value
+        #expect(instance.agentExpectedButMissing == true)
     }
 
     @Test("agentStatus surfaces .expectedMissing only when both the flag and persisted version are set")
@@ -783,8 +779,7 @@ struct VMInstanceTests {
         // Re-arming after the cancel must succeed (proves the prior task
         // was cancelled — the idempotency guard does not block this).
         instance.startAgentPostStartWatchdog(grace: Self.testWatchdogGrace)
-        try await waitUntil {
-            instance.agentExpectedButMissing
-        }
+        await instance.agentPostStartTaskForTesting?.value
+        #expect(instance.agentExpectedButMissing == true)
     }
 }

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -32,11 +32,15 @@ struct VsockClipboardServiceTests {
         var frames: [Frame] = []
         private var consumeTask: Task<Void, Never>?
 
+        /// Fires on every recorded frame; await it instead of polling `frames`.
+        let recorded = AsyncGate()
+
         init(channel: VsockChannel) {
             consumeTask = Task { @MainActor [weak self] in
                 do {
                     for try await frame in channel.incoming {
                         self?.frames.append(frame)
+                        self?.recorded.notify()
                     }
                 } catch {
                     // Stream errored — recording stops. Tests that care
@@ -49,14 +53,16 @@ struct VsockClipboardServiceTests {
         deinit { consumeTask?.cancel() }
     }
 
-    /// Spins until `recorder.frames.count == expected`, or fails the test if
-    /// the deadline elapses.
+    /// Awaits the recorder's gate (fired per frame) until `frames.count ==
+    /// expected`.
+    ///
+    /// The `timeout` is a stuck-stream backstop, not the success deadline.
     private func waitForFrameCount(
         _ recorder: FrameRecorder,
         equals expected: Int,
-        timeout: Duration = .seconds(5)
+        timeout: Duration = .seconds(10)
     ) async throws {
-        try await waitUntil(timeout: timeout) {
+        try await recorder.recorded.wait(timeout: timeout) {
             recorder.frames.count == expected
         }
     }

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -613,7 +613,7 @@ struct VsockControlServiceTests {
         // Service fires the closure verbatim each time. Suppressing duplicate
         // writes is `VMInstance`'s responsibility (it compares against the
         // persisted value before invoking onUpdateConfiguration).
-        try await waitUntil { observed.values.count == 2 }
+        try await observed.changed.wait { observed.values.count == 2 }
         #expect(observed.values == ["0.9.2", "0.9.2"])
     }
 
@@ -655,7 +655,11 @@ struct VsockControlServiceTests {
 private final class ObservedRecorder {
     private(set) var values: [String] = []
 
+    /// Fires on every `append`; await it instead of polling `values.count`.
+    let changed = AsyncGate()
+
     func append(_ value: String) {
         values.append(value)
+        changed.notify()
     }
 }

--- a/KernovaTests/VsockGuestLogServiceTests.swift
+++ b/KernovaTests/VsockGuestLogServiceTests.swift
@@ -14,17 +14,17 @@ struct VsockGuestLogServiceTests {
         return (VsockChannel(fileDescriptor: a), VsockChannel(fileDescriptor: b))
     }
 
-    // Generous default — multi-frame tests on slower CI runners were
-    // landing right around the prior 1-second deadline. Local runs
-    // typically finish well under a second; this is purely a ceiling.
+    // Event-driven: awaits the emitter's gate (fired on each `emit`) until at
+    // least `count` records have arrived. The `timeout` is a backstop for a
+    // genuinely stuck stream, not the success deadline — so a slow CI runner
+    // no longer trips it.
     private func waitForRecords(
         _ emitter: RecordingEmitter,
         count: Int,
-        timeout: Duration = .seconds(5)
+        timeout: Duration = .seconds(10)
     ) async throws {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while emitter.snapshot().count < count && ContinuousClock.now < deadline {
-            try await Task.sleep(for: .milliseconds(10))
+        try await emitter.recorded.wait(timeout: timeout) {
+            emitter.snapshot().count >= count
         }
     }
 
@@ -180,9 +180,14 @@ private final class RecordingEmitter: GuestLogEmitter, @unchecked Sendable {
     private let lock = NSLock()
     private var records: [Kernova_V1_LogRecord] = []
 
+    /// Fires on every `emit`; await it instead of polling `snapshot().count`.
+    let recorded = AsyncGate()
+
     func emit(_ record: Kernova_V1_LogRecord) {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
         records.append(record)
+        lock.unlock()
+        recorded.notify()
     }
 
     func snapshot() -> [Kernova_V1_LogRecord] {


### PR DESCRIPTION
## Summary
- Fixes the flaky timing tests that turned `main` **red** after PR #285's merge — 8 failing tests (`VMInstanceTests` watchdog ×5, `VsockGuestLogServiceTests` ×3) plus 8 more in the same fragile class — by **awaiting real signals** instead of polling a flag/count against a wall-clock deadline.
- The failures were never #285's code: its squash-merge tree was byte-identical to the PR branch that passed CI. They were `Task.sleep`-timed poll loops blowing their 5 s budget under MainActor contention on a slow runner (every failing test waited the *full* deadline, then failed). The 5 s budget had already been bumped from 2 s once and regressed — a tuning treadmill the event-driven waits end.

## Changes
- **`AsyncGate`** (new, in both bundles' `TestHelpers`): an event-driven wait primitive — producers `notify()` on each state change, consumers `await wait(until:)`. Leak-safe via a single-resume guard; the `timeout` is a **backstop the happy path never reaches** rather than the success deadline, so a slow runner no longer fails the wait — only a genuinely stuck condition does.
- **Watchdog** (`VMInstanceTests` ×5): `await` the production `agentPostStartTask` via a new `#if DEBUG agentPostStartTaskForTesting` seam (matches the documented test-seam convention) instead of polling `agentExpectedButMissing`.
- **Test doubles** `RecordingEmitter`, `FrameRecorder`, `ObservedRecorder`, `PolicyBox`, `AtomicInt` now fire an `AsyncGate` on each mutation; their waits (`VsockGuestLogServiceTests` ×5, `VsockClipboardServiceTests` ×2, `VsockControlServiceTests` / `VsockGuestControlAgentTests` / `VsockGuestClientTests` ×4) await it.
- **Poll interval 10 ms → 50 ms** for the remaining `waitUntil` sites in both bundles, to cut idle-poller MainActor churn under parallel load.

The only production-code change is the `#if DEBUG` watchdog-task accessor; everything else is test-side.

## Test plan
- [x] `xcodebuild build-for-testing` succeeds — no concurrency/isolation errors
- [x] Full suite passes locally (1019 tests, 0 failures)
- [x] Converted suites pass 6× under `-test-iterations -run-tests-until-failure` (no leaks/crashes)
- [x] `make lint` clean

## Notes
- Local hardware can't reproduce the CI contention, so the local runs prove **correctness** of the conversions; the contention-robustness rests on the design (timeout demoted to a backstop; idle waiters add zero executor churn).
- Scoped to the 16 cleanly-convertible waits. The ~40 other `waitUntil` sites (connection/channel/pasteboard waits) would each need a production event seam and aren't failing — left as polling, now on the calmer 50 ms tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
