### PR TITLE
fix: Silence two test-target compile warnings

### DIFF
--- a/KernovaTests/StorageDiskReorderSheetContentViewControllerTests.swift
+++ b/KernovaTests/StorageDiskReorderSheetContentViewControllerTests.swift
@@ -246,11 +246,8 @@ struct StorageDiskReorderSheetContentViewControllerTests {
 ///
 /// AppKit's protocol surface is large, but `acceptDrop` /
 /// `validateDrop` in our data source only touch `draggingPasteboard`;
-/// every other member returns a neutral default. `@preconcurrency`
-/// silences the actor-isolation mismatch between this main-actor-safe
-/// stub (constructed and used from `@MainActor` test methods) and
-/// `NSDraggingInfo`'s nonisolated protocol requirements.
-private final class StubDraggingInfo: NSObject, @preconcurrency NSDraggingInfo {
+/// every other member returns a neutral default.
+private final class StubDraggingInfo: NSObject, NSDraggingInfo {
     let pasteboard: NSPasteboard
     init(pasteboard: NSPasteboard) {
         self.pasteboard = pasteboard

--- a/KernovaTests/VMCreationWizardViewControllerTests.swift
+++ b/KernovaTests/VMCreationWizardViewControllerTests.swift
@@ -106,7 +106,8 @@ struct VMCreationWizardViewControllerTests {
         vm.currentStep = .review
         vm.vmName = "Retry VM"
         let wizard = VMCreationWizardViewController(creationVM: vm)
-        wizard.delegate = MockDelegate()
+        let delegate = MockDelegate()
+        wizard.delegate = delegate
         wizard.loadViewIfNeeded()
 
         // Clicking Create disables Cancel/Back/Create to block a duplicate.


### PR DESCRIPTION
## Summary
- Clear the only two genuine compiler warnings in the test build. Swift's batch-mode compilation duplicated them into ~25 lines in the CI **Build & Test → Build for testing** log, but they trace to just two source sites. Fixing them keeps the compile step clean so real warnings stay visible.

## Changes
- **`VMCreationWizardViewControllerTests.swift:109`** — hoist the wizard's `MockDelegate()` into a local `let` so it outlives the assignment. `delegate` is `weak`; the inline `wizard.delegate = MockDelegate()` was deallocated immediately, leaving `delegate` nil for the entire test. Now matches the live-delegate pattern every other test in the suite already uses. *(emitted 21× in the log)*
- **`StorageDiskReorderSheetContentViewControllerTests.swift:253`** — drop the now-ineffective `@preconcurrency` from the `StubDraggingInfo: NSDraggingInfo` conformance plus the stale doc paragraph that justified it. The current SDK imports `NSDraggingInfo` as main-actor-isolated, so there is no isolation boundary left to bridge. *(emitted 2× in the log)*

## Test plan
- [x] `xcodebuild build-for-testing` → **TEST BUILD SUCCEEDED**; no `deallocated` and no `@preconcurrency … has no effect` warnings remain (only unrelated pre-existing `appintentsmetadataprocessor` noise)
- [x] Removing `@preconcurrency` does **not** reintroduce an actor-isolation error
- [x] `VMCreationWizardViewControllerTests` + `StorageDiskReorderSheetContentViewControllerTests` pass (incl. `failedCreateReenablesNavigation` and `acceptDropRoundTrip`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)