### PR TITLE
docs: Reorganize project guidance into a lean CLAUDE.md + docs/ guides

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,138 +2,149 @@
 
 ## Overview
 
-Kernova is a macOS application for creating and managing virtual machines via Apple's Virtualization.framework, supporting both macOS and Linux guests. It is built as a pure-AppKit app (the app target no longer imports SwiftUI), targeting macOS 26 (Tahoe) with Swift 6 strict concurrency. There are no external package dependencies — the app uses only Apple system frameworks.
+Kernova is a macOS application for creating and managing virtual machines via Apple's Virtualization.framework, supporting both macOS and Linux guests. It is built as a pure-AppKit app (the app target no longer imports SwiftUI), targeting macOS 26 (Tahoe) with Swift 6 strict concurrency. The app target uses only Apple system frameworks; the lone package dependency is Apple-published `swift-protobuf`, consumed by the local `KernovaProtocol` package (see [Dependencies](#dependencies)).
 
 ## Directory Structure
+
+Each entry carries a one-line role; behavioral detail lives in the [Component Map](#component-map) below.
 
 ```
 Kernova/
 ├── App/                                # App lifecycle and window management
-│   ├── AppDelegate.swift               # NSApplicationDelegate — startup, window tracking, menu, suspend-on-quit
-│   ├── MainWindowController.swift      # NSSplitViewController + NSToolbar with native items
-│   ├── VMDisplayWindowController.swift  # Per-VM display window (pop-out or fullscreen), auto-closes on VM stop
-│   ├── DetailContainerViewController.swift # Layers AppKit VM display over the AppKit detail content (empty-state view ⇆ `VMDetailRouterViewController`); respects per-instance detailPaneMode; owns `DetailAlertsPresenter`; conforms to `VMLibraryPresenting` (the view model's presentation delegate), forwarding lifecycle alerts to `DetailAlertsPresenter` and presenting the creation-wizard sheet via `SheetPresenter`
+│   ├── AppDelegate.swift               # NSApplicationDelegate — startup, window tracking, menus, suspend-on-quit, TCC relaunch
+│   ├── MainWindowController.swift      # Main window: NSSplitViewController + native NSToolbar
+│   ├── VMDisplayWindowController.swift # Per-VM display window (pop-out or fullscreen), auto-closes on VM stop
+│   ├── DetailContainerViewController.swift # Detail-pane host — layers the VM display over detail content; owns DetailAlertsPresenter; implements VMLibraryPresenting
 │   ├── VMToolbarManager.swift          # Shared toolbar logic for lifecycle, suspend, display, and settings-toggle items
-│   ├── ClipboardWindowController.swift   # Per-VM clipboard sharing window, auto-closes on VM stop
-│   ├── ClipboardContentViewController.swift # Pure AppKit clipboard text editor + status bar
-│   └── Info.plist                        # App configuration and metadata
+│   ├── ClipboardWindowController.swift # Per-VM clipboard sharing window, auto-closes on VM stop
+│   ├── ClipboardContentViewController.swift # Pure-AppKit clipboard text editor + status bar
+│   └── Info.plist                      # App configuration and metadata
 ├── Models/                             # Data types — all value types or @MainActor-isolated
 │   ├── VMConfiguration.swift           # Codable/Sendable struct persisted as config.json per VM bundle
 │   ├── VMInstance.swift                # @Observable runtime wrapper: VMConfiguration + VZVirtualMachine + VMStatus
-│   ├── VMBundleLayout.swift            # Sendable struct centralizing file paths within a .kernova bundle; `diskURL(forRelativePath:isInternal:)` is the single internal-vs-external path-to-URL rule; `diskSizes(forRelativePath:isInternal:)` returns on-disk footprint (`totalFileAllocatedSize`) **and** virtual capacity in one coalesced read — capacity from an ASIF's `shdw` header (offset 0x30, big-endian 512-sectors; magic-validated, bounds-checked, **checked** ×512 so a corrupt count degrades rather than wraps), or the logical file size for a non-ASIF (raw `.img`/`.iso`/`.dmg`); `diskOnDiskBytes`/`diskCapacityBytes` remain as thin accessors. All read live, no caching
-│   ├── StorageDisk.swift               # StorageDisk (+ `uniqueLabel(base:existingLabels:)`) + StorageDiskKind (.virtio / .usbMassStorage) + RemovableMediaItem
+│   ├── VMBundleLayout.swift            # Sendable struct centralizing bundle file paths + live disk sizing
+│   ├── StorageDisk.swift               # StorageDisk + StorageDiskKind (.virtio/.usbMassStorage) + RemovableMediaItem
+│   ├── USBDeviceInfo.swift             # Runtime metadata for an attached USB mass-storage device
+│   ├── MacOSInstallContext.swift       # Persisted macOS IPSW install intent: source, paths, fresh-download flag
+│   ├── MacOSInstallState.swift         # Tracks two-phase macOS installation progress (download + install)
 │   ├── VMStatus.swift                  # Enum: stopped, starting, running, paused, saving, restoring, installing, error
 │   ├── VMBootMode.swift                # Enum: macOS, efi, linuxKernel
 │   ├── VMGuestOS.swift                 # Enum: macOS, linux
-│   ├── MacOSInstallState.swift         # Tracks two-phase macOS installation progress (download + install)
-│   └── KernovaUTType.swift             # UTType declaration for .kernova bundle
+│   └── KernovaUTType.swift             # UTType declaration for the .kernova bundle
 ├── Services/                           # Business logic — stateless or @MainActor
 │   ├── ConfigurationBuilder.swift      # VMConfiguration → VZVirtualMachineConfiguration (3 boot paths)
 │   ├── VirtualizationService.swift     # VM lifecycle: start/stop/pause/resume/save/restore (@MainActor)
 │   ├── VMStorageService.swift          # CRUD for VM bundles + cloning (Sendable struct)
 │   ├── DiskImageService.swift          # Creates ASIF disk images from bundled templates (Sendable struct)
 │   ├── MacOSInstallService.swift       # Drives macOS guest install via VZMacOSInstaller (@MainActor)
-│   ├── IPSWService.swift               # Fetches/downloads macOS restore images via streamed Range/If-Range into a .kernovadownload bundle (Sendable final class)
+│   ├── IPSWService.swift               # Fetches/downloads macOS restore images with streamed, resumable HTTP (Sendable final class)
+│   ├── USBDeviceService.swift          # Runtime USB mass-storage attach/detach against the live VM's XHCI controller
 │   ├── SystemSleepWatcher.swift        # Observes system sleep/wake, triggers VM pause/resume
-│   ├── SpiceAgentProtocol.swift       # SPICE agent wire format: VDI chunks, message headers, clipboard types
-│   ├── AgentStatus.swift              # Sidebar/clipboard-window install/version/liveness enum (.waiting, .current, .outdated, .unresponsive, .expectedMissing)
-│   ├── ClipboardServicing.swift       # Protocol shared by Spice + Vsock clipboard implementations
-│   ├── SpiceClipboardService.swift    # Linux clipboard: pipe I/O, SPICE protocol state machine (@MainActor)
-│   ├── VsockClipboardService.swift    # macOS clipboard: vsock-based offer/request/data state machine (@MainActor)
-│   ├── VsockControlService.swift      # macOS always-on control channel: Hello + bidirectional heartbeat, owns AgentStatus (@MainActor, @Observable)
-│   ├── KernovaGuestAgentInfo.swift    # Bundled guest agent version + installer DMG URL accessors
-│   ├── AttachmentFileMonitor.swift    # Reactive existence tracker for external attachments — DispatchSource on each parent dir + NSWorkspace mount notifications (@MainActor, @Observable)
-│   ├── SerialSocketRelay.swift        # Host-side AF_UNIX listener exposing the serial port to an external terminal; raw-byte tee/input (@unchecked Sendable, NSLock + DispatchSourceRead, re-startable for hot-toggle)
+│   ├── AttachmentFileMonitor.swift     # Reactive existence tracker for external attachments (@MainActor, @Observable)
+│   ├── SerialSocketRelay.swift         # Host-side AF_UNIX listener exposing the serial port to an external terminal
+│   ├── SpiceAgentProtocol.swift        # SPICE agent wire format: VDI chunks, message headers, clipboard types
+│   ├── SpiceClipboardService.swift     # Linux clipboard: pipe I/O, SPICE protocol state machine (@MainActor)
+│   ├── ClipboardServicing.swift        # Protocol shared by the SPICE + vsock clipboard implementations
+│   ├── VsockClipboardService.swift     # macOS clipboard: vsock offer/request/data state machine (@MainActor)
+│   ├── VsockControlService.swift       # macOS always-on control channel: Hello + heartbeat liveness, owns AgentStatus (@MainActor, @Observable)
+│   ├── VsockGuestLogService.swift      # Consumes guest LogRecord frames, forwards to os.Logger (@MainActor)
+│   ├── VsockListenerHost.swift         # @MainActor wrapper binding a VZVirtioSocketListener to one vsock port
+│   ├── VsockPorts.swift                # Central registry of host-side vsock port assignments
+│   ├── AgentStatus.swift               # Guest-agent install/version/liveness enum driving sidebar + clipboard-window affordances
+│   ├── KernovaGuestAgentInfo.swift     # Bundled guest agent version + installer DMG URL accessors
 │   └── Protocols/                      # Service protocol abstractions for DI and testing
 │       ├── VirtualizationProviding.swift
 │       ├── VMStorageProviding.swift
 │       ├── DiskImageProviding.swift
 │       ├── MacOSInstallProviding.swift
-│       └── IPSWProviding.swift
+│       ├── IPSWProviding.swift
+│       └── USBDeviceProviding.swift
 ├── ViewModels/                         # Observable view models and coordinators
-│   ├── VMLibraryViewModel.swift        # Central view model — owns [VMInstance], delegates to coordinator; surfaces alerts/sheets/wizard imperatively via the `VMLibraryPresenting` delegate
-│   ├── VMLibraryPresenting.swift       # Presentation delegate protocol the view model calls (implemented by `DetailContainerViewController`)
-│   ├── VMLifecycleCoordinator.swift    # Owns services, orchestrates multi-step operations (@MainActor)
+│   ├── VMLibraryViewModel.swift        # Central view model — owns [VMInstance]; presents via the VMLibraryPresenting delegate
+│   ├── VMLibraryPresenting.swift       # Presentation delegate protocol (implemented by DetailContainerViewController)
+│   ├── VMLifecycleCoordinator.swift    # Owns services, orchestrates multi-step ops, serializes per-VM operations (@MainActor)
 │   ├── VMCreationViewModel.swift       # Drives the multi-step VM creation wizard
 │   └── VMDirectoryWatcher.swift        # DispatchSource monitor for external filesystem changes
 ├── Views/                              # Pure-AppKit NSViewControllers / NSViews
-│   ├── VMInstance+Display.swift        # Display-layer extension: cold-paused vs live-paused distinction; `statusDisplayNSColor` status-dot color
+│   ├── VMInstance+Display.swift        # Display-layer extension: status display names/colors, cold- vs live-paused distinction
 │   ├── Sidebar/
-│   │   ├── SidebarViewController.swift  # Pure-AppKit source-list `NSOutlineView`: VM list under a collapsible "Virtual Machines" group; selection↔`selectedID`, double-click-to-start, status-dependent context menu, inline rename, drag-reorder + Finder-bundle import
-│   │   ├── SidebarVMRowCellView.swift   # Leaf-row `NSTableCellView`: state-tinted OS icon (swapped in place for a spinner while busy), VM name, optional agent accessory; owns a per-instance `ObservationLoop` for live updates; hosts the inline-rename field editor
-│   │   ├── SidebarGroupHeaderCellView.swift # Group-row `NSTableCellView` rendering a section title
-│   │   ├── SidebarSection.swift         # Outline section model (single `.virtualMachines` today; structured so a second group is a localized addition)
-│   │   ├── SidebarAgentStatusButtonView.swift # Pure AppKit (`NSView`) wrapper: stacked `NSButton` (SF Symbol for static states) + `NSProgressIndicator` (.mini spinning for `.connecting`); owns a `PopoverPresenter` + content VC; refreshes popover in place when status changes mid-popover (e.g. `.waiting` → `.current`); anchors `.maxX` so the popover flows into the detail-pane area rather than out the sidebar's right edge
-│   │   └── AgentStatusPopoverContentViewController.swift # Concrete `NSViewController` for the agent-status popover: per-status title + wrapping body + action row with optional "Don't show again" link (surfaced only for `.waiting`) and per-status action button ("Install Guest Agent…" / "Update Guest Agent…" / "Reinstall Guest Agent…" / "Done"). Delegate protocol with `didTapAction` + `didTapDismiss`. Static helpers expose `title(for:)`, `bodyText(for:vmName:)`, `actionButtonTitle(for:)`, `requiresMountAction(for:)`. `update(status:vmName:hasDismissAction:)` swaps labels in place.
+│   │   ├── SidebarViewController.swift # Source-list NSOutlineView: selection, double-click-to-start, context menu, inline rename, drag-reorder + bundle import
+│   │   ├── SidebarVMRowCellView.swift  # Leaf-row cell: state-tinted OS icon / busy spinner, name, agent accessory, inline-rename editor
+│   │   ├── SidebarGroupHeaderCellView.swift # Group-row cell rendering a section title
+│   │   ├── SidebarSection.swift        # Outline section model (single .virtualMachines today; a second group is a localized addition)
+│   │   ├── SidebarAgentStatusButtonView.swift # Agent-status accessory: SF-Symbol button or spinner + status-popover anchor
+│   │   └── AgentStatusPopoverContentViewController.swift # Agent-status popover: per-status copy + install/update/reinstall actions
 │   ├── Detail/
-│   │   ├── VMDetailRouterViewController.swift # Per-VM detail router — resolves a `DetailRoute` from instance status and swaps its reused child (settings / status placeholder / install progress / display placeholder); stacks `InitialBootBannerView` above settings for the initial-boot route. Rebuilds per-instance state on VM switch (`reconfigure(instance:)`)
-│   │   ├── DetailRoute.swift           # Pure routing enum + `DetailRoute.resolve(preparingLabel:status:hasInstallState:detailPaneMode:)` mapping (unit-tested), replacing the former SwiftUI `VMDetailView` switch
-│   │   ├── VMSettingsViewController.swift # VM configuration editor (9 grouped-form sections) in pure AppKit; observation-driven idempotent `apply()`; lockable sections disabled while running with their headers/info still live; writes route through `VMLibraryViewModel.updateConfiguration`; reuses the AppKit popovers/sheets/alerts below. Per-row storage/removable delete shows a context-aware confirmation decided by the pure `attachmentDeletePrompt(...)` helper, matching the VM-delete sheet's rules (internal disk → Move-to-Trash-or-Cancel; private external → trash or detach; shared external → detach-only naming the other VMs; Guest Agent installer → detach-only, file never trashed). Rebuilds the form on VM switch
-│   │   ├── DetailStatusPlaceholderViewController.swift # Centered spinner + status label for transient states (starting/suspending/restoring) and clone/import preparing
-│   │   ├── InitialBootBannerView.swift # Orange "Initial Boot" banner with install-context-aware subtitle, stacked above the settings form for not-yet-booted macOS VMs
-│   │   ├── DetailEmptyStateView.swift  # Centered "No Virtual Machine Selected" empty state with a New Virtual Machine button (calls the container's `presentCreationWizard()`)
-│   │   ├── MacOSInstallProgressViewController.swift # Two-step (download → install) progress UI in pure AppKit — numbered step circles + connector, linear progress bar, monospaced detail text; observes `instance.installState`; Cancel confirms via `presentSheetAlert`
-│   │   ├── MicPermissionPresentation.swift # Pure helpers (unit-tested): `micPermissionPresentation(_:micEnabled:)` status→warning mapping, `externalAttachmentPaths(for:)`, `isGuestAgentSectionVisible(guestOS:)`
-│   │   ├── DiskSizePopoverCoordinator.swift # Pure-AppKit coordinator owning a `PopoverPresenter`; shows `DiskSizePopoverContentViewController` and forwards the confirmed size to an `onConfirm` closure (the settings VC wires in-bundle disk creation vs. the removable-media save panel). Replaces the former SwiftUI Create* anchors
-│   │   ├── StorageDiskReorderSheetContentViewController.swift # AppKit `NSViewController` for the Boot Order sheet — headline + `InfoButtonView` header, view-based `NSTableView` (alternating rows, hidden headers) inside `NSScrollView`, Done button. Drag-anywhere reorder via the native `NSTableView` drag-and-drop machinery (`pasteboardWriterForRow:`, `validateDrop:`, `acceptDrop:`); the pure index-math primitive is exposed as `performReorder(sourceRow:proposedRow:)` so tests can exercise it without mocking `NSDraggingInfo`. Re-arms a `withObservationTracking` subscription on `fileMonitor.existsByPath` so missing-file affordances update live without dismiss/re-present. Presented by the settings VC via `SheetPresenter`
-│   │   ├── AttachmentRowView.swift      # `NSView` for one attachment row — a storage disk **or** a removable medium: leading icon + title + subtitle + Read Only switch + an **optional trailing inline Eject button** (removable-media rows only — a one-click detach with no confirmation, file untouched, since hot-pluggable media is swapped often; storage-disk rows pass `ejectButton: nil` and detach via the right-click menu). The file-trashing **Remove (with confirmation) always lives in the right-click menu** on every attachment row, plus inline title rename (double-click; mirrors `SidebarVMRowCellView`'s field-editor state machine, and commits on any click outside the field via a local mouse-down monitor), the per-row right-click menu via `menu(for:)` → controller-supplied closure, and `update(...)` to patch title/icon/Read-Only/enabled state **in place** (so a non-structural refresh, e.g. a rename, doesn't tear the row down and re-fade its size). Carries `itemID` + `infoAnchor` (the icon, so Get Info points at it) + `subtitleField` (so the controller re-populates the live size off-main); the controller wires rename began/committed/cancelled closures. Used by both the Storage Disks and Removable Media lists
-│   │   ├── StorageDiskSubtitle.swift   # `nonisolated diskSubtitle(for:bundleLayout:)` (reads `diskOnDiskBytes` + `diskCapacityBytes` **live**, so it can run on a detached task — no main-thread file I/O) + `@MainActor populateDiskSubtitle(…:isMissing:animated:)` (with `for disk: StorageDisk` / `for item: RemovableMediaItem` convenience overloads) which reads off-main and fills the label in (tagging the field's `identifier` with the disk id so a recycled Boot Order cell ignores a stale result and a same-disk refresh updates in place; a re-bind cancels the prior in-flight read via a generation-tagged map; `animated: false` skips the fade so the Boot Order sheet's drag-drop `reloadData()` doesn't flicker). The "In-bundle disk image" placeholder is **deferred** behind a ~100ms grace and cancelled when the read lands, so the sub-ms common case never flickers it — only a genuinely slow read surfaces it + `diskIconSystemName(for:)`. Every disk — in-bundle or external, ASIF or raw `.img`/`.iso`/`.dmg` — shows `<on disk> / <allocated>` uniformly (the main disk included), reflecting current state (e.g. an external resize); falls back to on-disk-only when capacity isn't readable, then to the file's path when neither figure reads. An external disk seeds its path as the holding value while the read runs (so it never flickers and needs no placeholder); a **missing** external file short-circuits to the red "Missing —" state. Used by both the settings list and the Boot Order sheet
-│   │   ├── AttachmentInfoPopoverContentViewController.swift # Concrete `NSViewController` for an attachment row's "Get Info" popover (storage disks and removable media alike) — headline (label) + two-column `NSGridView` of facts (file, on-disk, allocated, read-only, bus, created) + monospaced selectable full path, built in `loadView()` from `CalloutStyle`; value-snapshot init (no live `VMInstance`)
-│   │   ├── AttachmentSubtitleLabel.swift # `makeAttachmentSubtitleLabel(path:isMissing:)` returns an `NSTextField` styled as caption, prefixed with bold "Missing — " in `systemRed` when the file's gone. Used by the settings list and the Boot Order sheet's row cells.
-│   │   ├── AttachmentIconButton.swift  # Pure AppKit (`NSView`) leading-icon control: SF Symbol when present, red-triangle button + `NSPopover` (via `PopoverPresenter`) showing a `MissingAttachmentPopoverContentViewController` when the backing file is missing. Optional `onActivate` makes the present-state icon clickable (storage rows wire it to Get Info, anchored to the icon); inert by default
-│   │   ├── CalloutStyle.swift          # AppKit callout-popover design tokens (width, padding, spacing, fonts, body color) + `makeCalloutHeadline` / `makeCalloutBody` / `makeCalloutCode` atom factories; visual consistency without a shared container class
-│   │   ├── MissingAttachmentPopoverContentViewController.swift # Concrete `NSViewController` for the missing-file popover — builds header + body labels + monospaced byCharWrapping path label in `loadView()` using `CalloutStyle`
-│   │   ├── DiskSizePopoverContentViewController.swift # Generic concrete `NSViewController` for "pick a disk size and confirm/cancel" popovers — headline + size `NSPopUpButton` + caption body + Cancel/Create buttons; `headline`/`caption` strings supplied via init so both Storage Disk and Removable Media reuse this controller; delegation protocol decouples from `VMLibraryViewModel`
-│   │   ├── InfoPopoverContentViewController.swift # Concrete `NSViewController` for the generic "info" popover (the small `info.circle` next to section titles and per-control labels); takes `[InfoPopoverParagraph]` where each paragraph is `.body(String)` or `.code(String)` — `.code` uses `makeCalloutCode` for monospaced selectable snippets (e.g. the virtiofs `mount` command)
-│   │   ├── InfoButtonView.swift        # Pure-AppKit `NSView` wrapping the `info.circle` `NSButton`; a private coordinator holds a `PopoverPresenter` and shows `InfoPopoverContentViewController` on click. Call sites use `configure(label:paragraphs:)`
-│   │   ├── MicrophonePermissionPopoverContentViewController.swift # Concrete `NSViewController` for the mic-permission warning bar's info popover: headline + body + `NSBox` separator + `.subheadline`-weight sub-headline + 3 numbered steps as `NSAttributedString` with bold runs for the app/setting names + secondary-color tail caption. Unique structure (divider + sub-headline + bold step phrases) lives in its own concrete subclass rather than bloating `InfoPopoverParagraph`.
-│   │   └── DeleteVMSheetContentViewController.swift # AppKit `NSViewController` for the unified Delete-VM confirmation sheet (red trash icon header + body paragraph + scrollable two-section list + Cancel / Move-to-Trash buttons). Section 1 "Removed with the VM" lists the VM's in-bundle disks read-only; section 2 "Files outside this VM" lists external disks/media with a per-row checkbox each (exclusively-owned default to on; shared *or* missing-file rows are locked off and never collected on confirm — shared show a "Kept — still used by …" note, missing show the red "Missing —" path style (`makeAttachmentSubtitleLabel`) plus an "Already gone — nothing to remove" note; when both, the shared note wins). Per-file `isMissing` is resolved off-main by `VMLibraryViewModel.externalAttachmentsResolvingExistence(for:)` before the presenter assembles the sheet (the synchronous `externalAttachments(for:)` leaves it `false` so the trash fan-out stays free of main-thread filesystem syscalls). Delegate protocol fires `didCancel` and `didConfirmTrashingExternalIDs(Set<UUID>)`. Presented by `DetailAlertsPresenter` via `SheetPresenter` for every delete. Move-to-Trash is intentionally the default action (Return) AND destructive (red tint).
+│   │   ├── VMDetailRouterViewController.swift # Resolves a DetailRoute from VM status and swaps its reused child VCs
+│   │   ├── DetailRoute.swift           # Pure routing enum + DetailRoute.resolve(...) mapping (unit-tested)
+│   │   ├── VMSettingsViewController.swift # VM configuration editor — 9 grouped-form sections
+│   │   ├── DetailStatusPlaceholderViewController.swift # Centered spinner + label for transient states and clone/import preparing
+│   │   ├── InitialBootBannerView.swift # Orange "Initial Boot" banner stacked above settings for not-yet-booted macOS VMs
+│   │   ├── DetailEmptyStateView.swift  # "No Virtual Machine Selected" empty state with a New VM button
+│   │   ├── MacOSInstallProgressViewController.swift # Two-step (download → install) progress UI
+│   │   ├── MicPermissionPresentation.swift # Pure helpers: mic-permission warning mapping, external attachment paths (unit-tested)
+│   │   ├── DiskSizePopoverCoordinator.swift # Owns the disk-size PopoverPresenter; forwards the confirmed size to onConfirm
+│   │   ├── DiskSizePopoverContentViewController.swift # Generic "pick a disk size and confirm/cancel" popover content
+│   │   ├── StorageDiskReorderSheetContentViewController.swift # Boot Order sheet: drag-reorderable disk table
+│   │   ├── AttachmentRowView.swift     # One attachment row (storage disk or removable medium)
+│   │   ├── StorageDiskSubtitle.swift   # Off-main live disk-size subtitle reads + label fill-in
+│   │   ├── AttachmentSubtitleLabel.swift # Caption label factory with red "Missing — " prefix for absent files
+│   │   ├── AttachmentIconButton.swift  # Leading-icon control: SF Symbol, or red triangle + missing-file popover
+│   │   ├── AttachmentInfoPopoverContentViewController.swift # "Get Info" popover for attachment rows (value-snapshot init)
+│   │   ├── MissingAttachmentPopoverContentViewController.swift # Missing-file popover: header + body + wrapped path
+│   │   ├── CalloutStyle.swift          # Callout-popover design tokens + atom factories (headline/body/code)
+│   │   ├── InfoButtonView.swift        # info.circle button wrapper showing InfoPopoverContentViewController on click
+│   │   ├── InfoPopoverContentViewController.swift # Generic info popover taking [.body|.code] paragraphs
+│   │   ├── MicrophonePermissionPopoverContentViewController.swift # Mic-permission warning popover with numbered bold-run steps
+│   │   └── DeleteVMSheetContentViewController.swift # Unified Delete-VM confirmation sheet
 │   ├── Shared/
-│   │   └── GroupedFormStyle.swift      # Grouped-form design atoms shared by the creation wizard and the settings pane — `makeGroupedFormCard` / `makeGroupedFormCardRow` / `makeGroupedFormSectionHeader` / `makeGroupedFormCaption` / `makeGroupedFormValueLabel` / `makeGroupedFormBanner` / `makeGroupedFormHairline` / `makeGroupedFormBox` + `makeGroupedFormScrollView` (top-anchored, centered, overlay-scroller). Extracted from `WizardStyle`; visual consistency without a shared base class
+│   │   ├── GroupedFormStyle.swift      # Grouped-form design atoms shared by the wizard and settings pane
+│   │   └── DiskSizeMenuTitle.swift     # Tab-stop-aligned disk-size menu titles (right-aligned number, left-aligned unit)
 │   ├── Console/
-│   │   ├── VMDisplayPlaceholderContentViewController.swift # Concrete `NSViewController` for the detail-pane placeholder shown when the VM display is unavailable inline — centered empty-state (SF Symbol + title + description + optional action button) for the non-inline display states (Fullscreen / Popped Out / Suspended / No Display), inert black fill behind it for the `.live` case (covered by `VMDisplayBackingView`). Observes `VMInstance.displayMode`, `isColdPaused`, and `virtualMachine` via `observeRecurring`. Action buttons dispatch through `NSApp.sendAction(_:to:from:)` to `AppDelegate.toggleFullscreen(_:)` / `togglePopOut(_:)`. The reusable `DisplayPlaceholderEmptyStateView` lives privately in the same file (one consumer today; no premature extraction). Used directly by `VMDetailRouterViewController`
-│   │   └── VMDisplayBackingView.swift  # Pure AppKit VM display with pause/transition overlays
+│   │   ├── VMDisplayPlaceholderContentViewController.swift # Detail-pane placeholder for non-inline display states
+│   │   └── VMDisplayBackingView.swift  # Pure-AppKit VM display with pause/transition overlays
 │   └── Creation/                       # Pure AppKit — every wizard step is an NSViewController
-│       ├── VMCreationWizardViewController.swift # Shell: step indicator + swappable child step VCs + nav bar; observes VMCreationViewModel; reports Cancel/Create via VMCreationWizardViewControllerDelegate
-│       ├── OSSelectionContentViewController.swift   # Step 1: Choose macOS or Linux (selectable cards)
+│       ├── VMCreationWizardViewController.swift # Shell: step indicator + swappable child step VCs + nav bar
+│       ├── OSSelectionContentViewController.swift   # Step 1: choose macOS or Linux
 │       ├── IPSWSelectionContentViewController.swift # Step 2 (macOS): IPSW source, path badge, overwrite/resume banners
 │       ├── BootConfigContentViewController.swift    # Step 2 (Linux): EFI/kernel segmented control + file pickers
-│       ├── ResourceConfigContentViewController.swift # Step 3: name, CPU/memory steppers, disk popup, networking (NSGridView form)
+│       ├── ResourceConfigContentViewController.swift # Step 3: name, CPU/memory steppers, disk popup, networking
 │       ├── ReviewContentViewController.swift   # Step 4: read-only summary + start-after-create switch
-│       ├── WizardStyle.swift           # Scoped design tokens + make* atom factories (title/subtitle/form rows, section headers, banner, path badge, scroll-view helper)
-│       ├── WizardSelectableCardView.swift # Clickable card with accent selection chrome (OS + IPSW-source cards)
-│       ├── WizardStepIndicatorView.swift  # Dotted step-progress bar
-│       └── WizardTintedBox.swift       # Rounded tinted container for the path badge + warning banners
+│       ├── WizardStepIndicatorView.swift # Dotted step-progress bar
+│       └── WizardStyle.swift           # Scoped design tokens + make* atom factories for the wizard
 ├── Utilities/
 │   ├── DataFormatters.swift            # Human-readable formatting for bytes, CPU counts, etc.
-│   ├── UniqueName.swift                # `UniqueName.firstAvailable(prefix:existing:)` — shared collision-free name generation backing both `StorageDisk.uniqueLabel` (bare numeric suffix) and `VMConfiguration.generateCloneName` (" Copy" infix)
+│   ├── UniqueName.swift                # Collision-free name generation (disk labels, clone names)
+│   ├── PathValidation.swift            # Shared path validation: resolve symlinks, check existence/type/permissions
+│   ├── InlineRenameSizing.swift        # Text-hugging sizing for inline-rename field editors
 │   ├── NSImageExtensions.swift         # Nil-safe SF Symbol image loading
 │   ├── NSViewExtensions.swift          # Full-size subview constraint helper
-│   ├── DesignTokens.swift              # Centralized `Spacing` scale, `StatusColor` palette, and shared `Typography` font token
-│   ├── ObservationLoop.swift           # observeRecurring(track:apply:) helper wrapping withObservationTracking
-│   ├── PopoverPresenter.swift          # `NSPopover` lifecycle wrapper — one instance per anchor, refreshes content in place if shown again, fires `onClose` after dismissal
-│   ├── SheetPresenter.swift            # Custom-content sheet lifecycle wrapper — wraps an `NSViewController` in an `NSWindow` and attaches it as a sheet via `parent.beginSheet(_:completionHandler:)`. Use for richer sheets than `NSAlert` can express (e.g. `DeleteVMSheetContentViewController`, `StorageDiskReorderSheetContentViewController`).
-│   ├── SheetAlert.swift                # AppKit `NSAlert` presenter — `AlertConfiguration` (title + message + ordered `[AlertButton]`) + role enum (`.default` / `.cancel` / `.destructive` / `.standard`) maps to key-equivalents and `hasDestructiveAction`. `presentSheetAlert(_:in:completion:)` shows the alert as a window-modal sheet on the supplied `NSWindow`.
-│   └── DetailAlertsPresenter.swift     # Imperative presenter for the detail-pane lifecycle alerts + delete sheet (delete sheet, cancel-preparing, force-stop, stop-paused, error, installer-mounted). `DetailContainerViewController` forwards `VMLibraryPresenting` calls here; it serializes presentations (one at a time, queueing the rest) and shows each via `presentSheetAlert` / `SheetPresenter(DeleteVMSheetContentViewController)`. Owned by `DetailContainerViewController` so alerts survive while the VM display is showing
+│   ├── NSOpenPanelExtensions.swift     # Pre-configured NSOpenPanel factory for browsing disk images
+│   ├── DesignTokens.swift              # Spacing scale, StatusColor palette, shared Typography token
+│   ├── ObservationLoop.swift           # observeRecurring(track:apply:) wrapper around withObservationTracking
+│   ├── PopoverPresenter.swift          # NSPopover lifecycle wrapper (one per anchor, refresh-in-place, onClose)
+│   ├── SheetPresenter.swift            # Custom-content sheet lifecycle wrapper around beginSheet
+│   ├── SheetAlert.swift                # NSAlert presenter: AlertConfiguration + button roles → key-equivalents
+│   └── DetailAlertsPresenter.swift     # Serialized presenter for detail-pane lifecycle alerts + delete sheet
 └── Resources/
     ├── Assets.xcassets/                # App icons and image assets
     └── Kernova.entitlements            # com.apple.security.virtualization entitlement
 
-DiskTemplates/                             # Bundled ASIF disk image templates (19 lzfse-compressed files)
-                                           # Decompressed at VM creation time by DiskImageService
+DiskTemplates/                          # Bundled ASIF disk image templates (lzfse-compressed),
+                                        # decompressed at VM creation time by DiskImageService
 
 KernovaRelaunchHelper/
 └── main.swift                          # Lightweight CLI watchdog for TCC-forced restarts
 
 KernovaGuestAgent/                      # Guest-side vsock agent for macOS VMs + DMG packaging resources
 ├── main.swift                          # Entry point: signal handling, starts control + log + clipboard agents
-├── VsockGuestClient.swift              # Generic connect/retry/serve loop — shared by control, log, and clipboard
-├── VsockGuestControlAgent.swift        # Always-on control agent on port 49154 (Hello + bidirectional heartbeat)
-├── VsockHostConnection.swift           # Log-forwarding agent on port 49153 (uses VsockGuestClient)
-├── VsockGuestClipboardAgent.swift      # Clipboard sync agent on port 49152 (uses VsockGuestClient)
+├── VsockGuestClient.swift              # Generic connect/retry/serve loop shared by all three agents
+├── VsockGuestControlAgent.swift        # Always-on control agent: Hello + heartbeat + PolicyUpdate handling
+├── VsockHostConnection.swift           # Log-forwarding agent (ring buffer + flush over vsock)
+├── VsockGuestClipboardAgent.swift      # Clipboard sync agent (pasteboard polling + offer/request/data)
 ├── VsockPorts.swift                    # Guest-side port registry (mirrors Kernova/Services/VsockPorts.swift)
 ├── VsockLogBridge.swift                # Static handle so KernovaLogger can hand records to VsockHostConnection
-├── KernovaLogger.swift                 # Drop-in os.Logger wrapper that mirrors records to host
+├── KernovaLogger.swift                 # Drop-in os.Logger wrapper that mirrors records to the host
 ├── KernovaLogMessage.swift             # Custom interpolation supporting OSLogPrivacy-shaped privacy attrs
 ├── Info.plist                          # Explicit Info.plist with preprocessor macro for CFBundleVersion
 ├── install.command                     # Guest-side installer: copies binary, registers LaunchAgent
@@ -143,7 +154,7 @@ KernovaGuestAgent/                      # Guest-side vsock agent for macOS VMs +
 KernovaProtocol/                        # SPM package: extensible vsock wire protocol shared host <-> guest
 ├── Package.swift                       # Swift 6 package, depends on apple/swift-protobuf
 ├── Proto/
-│   └── kernova.proto                   # Frame envelope + Hello + Error + Heartbeat (clipboard/log payloads added later)
+│   └── kernova.proto                   # Frame envelope + Hello/Error/Heartbeat + policy, clipboard, and log payloads
 ├── Sources/KernovaProtocol/
 │   ├── Generated/
 │   │   └── kernova.pb.swift            # Generated by Tools/regen-proto.sh — do not edit
@@ -157,72 +168,88 @@ Tools/
 └── regen-proto.sh                      # Regenerates kernova.pb.swift via protoc + protoc-gen-swift
 
 KernovaTests/
-├── Mocks/                              # Mock service implementations (9 files)
+├── Mocks/                              # Protocol-conforming mocks with call counting + error injection
 │   ├── MockVirtualizationService.swift
-│   ├── SuspendingMockVirtualizationService.swift
+│   ├── SuspendingMockVirtualizationService.swift # Suspends mid-operation to test per-VM serialization
 │   ├── MockVMStorageService.swift
 │   ├── MockDiskImageService.swift
 │   ├── MockMacOSInstallService.swift
 │   ├── MockIPSWService.swift
 │   ├── MockUSBDeviceService.swift
-│   ├── SuspendingMockUSBDeviceService.swift
-│   └── MockVMLibraryPresenting.swift   # Records VMLibraryViewModel presentation requests for test assertions
-├── VMConfigurationTests.swift          # 45 tests for VMConfiguration
-├── VMToolbarManagerTests.swift          # Toolbar manager item creation and state update tests
-├── VMConfigurationCloneTests.swift     # Clone-specific configuration tests
-├── VMLibraryViewModelTests.swift       # 39 tests for the central view model
-├── VMCreationViewModelTests.swift      # 49 tests for the creation wizard
-├── VMLifecycleCoordinatorTests.swift   # Coordinator orchestration tests
-├── VMInstanceTests.swift               # Runtime instance behavior tests
-├── ConfigurationBuilderTests.swift     # VZ configuration translation tests
-├── VirtualizationServiceTests.swift    # VM lifecycle operation tests
-├── VMStorageServiceTests.swift         # Storage CRUD tests
-├── VMBundleLayoutTests.swift           # Bundle path calculation tests
-├── VMStatusTests.swift                 # Status enum behavior tests
-├── SerialSocketRelayTests.swift        # AF_UNIX serial relay: output tee, client input, supersede, reconnect, unlink, length guard, idempotency
-├── VMBootModeTests.swift               # Boot mode enum tests
-├── VMGuestOSTests.swift                # Guest OS enum tests
-├── MacOSInstallStateTests.swift        # Install state tracking tests
-├── SpiceAgentProtocolTests.swift       # SPICE wire format serialization/deserialization tests
-├── DataFormattersTests.swift           # Formatting utility tests
-├── NSImageExtensionsTests.swift        # SF Symbol loading utility tests
-├── PopoverPresenterTests.swift         # Lifecycle (initial state, idempotent close, onClose-on-delegate)
+│   ├── SuspendingMockUSBDeviceService.swift # Suspends mid-operation to test the installer-mount mutex
+│   └── MockVMLibraryPresenting.swift   # Records presentation requests for test assertions
+├── TestHelpers.swift                   # Shared factories (makeInstance, …), waitUntil, event-driven AsyncGate
+├── AgentStatusTests.swift              # AgentStatus synthesis pure-function tests
+├── AttachmentFileMonitorTests.swift    # Attachment file existence monitoring and probing
+├── BootConfigContentViewControllerTests.swift # Boot-mode selection UI + kernel command line
 ├── CalloutStyleTests.swift             # Token math + headline/body factory configuration
-├── MissingAttachmentPopoverContentViewControllerTests.swift # Layout loads, fitting size, header + path label configuration
-├── StorageDiskSubtitleTests.swift      # `diskSubtitle(for:bundleLayout:)` reading live from real on-disk files: ASIF → on-disk/allocated, non-ASIF → on-disk/logical-size-as-allocated, in-bundle missing file → generic label, external raw → on-disk/allocated, external unreadable → path fallback, main disk measured identically
-├── DiskSizePopoverContentViewControllerTests.swift # Popup population, default selection, headline/caption injection, Cancel/Create delegate firing
-├── InfoPopoverContentViewControllerTests.swift # Paragraph rendering, fitting size, monospaced+selectable code paragraphs
-├── MicrophonePermissionPopoverContentViewControllerTests.swift # Layout loads, headline+sub-headline present, divider present, bold step font runs, non-selectable bodies
-├── AgentStatusPopoverContentViewControllerTests.swift # update() swaps title/body/action-button per status, dismiss-button visibility, delegate firing for action and dismiss, `requiresMountAction(for:)` classifier
-├── SheetAlertTests.swift                # Role-to-NSButton-config mapping (keyEquivalent + hasDestructiveAction per role), response-index → button-action dispatch, AlertConfiguration shape
-├── SheetPresenterTests.swift            # Lifecycle (initial state, idempotent close, onClose-on-delegate); show() is not unit-tested (needs key window + run loop)
-├── DeleteVMSheetContentViewControllerTests.swift # Header shows VM name; in-bundle disks render read-only under their section; one row per external; exclusively-owned externals start checked; shared externals are locked off with a "Kept" note; missing-file externals are locked off (not selectable) with a red "Missing —" path and an "Already gone" note (shared note wins when both, present rows stay checked); Move-to-Trash returns the checked externals' ids; Cancel fires delegate; Move-to-Trash is the default+destructive button; Cancel is keyed to Escape
-└── StorageDiskReorderSheetContentViewControllerTests.swift # Header shows "Boot Order" + `InfoButtonView`; one row per disk; `performReorder(sourceRow:proposedRow:)` index math (downward/upward shifts, no-op on same index, out-of-range source); Done fires delegate; Return key bound to Done
+├── ConfigurationBuilderTests.swift     # VZ translation: boot paths, devices, path validation, storage topology
+├── DataFormattersTests.swift           # Formatting utilities
+├── DeleteVMSheetContentViewControllerTests.swift # Delete-sheet sections, checkbox locking rules, delegate flows
+├── DetailRouteTests.swift              # Detail route resolution: install, settings, preparing states
+├── DiskSizePopoverContentViewControllerTests.swift # Popup population, defaults, delegate firing
+├── IPSWBundleTests.swift               # .kernovadownload bundle resume-URL + fresh-download layout
+├── IPSWSelectionContentViewControllerTests.swift # IPSW source selection, destination, overwrite warning UI
+├── IPSWServiceDownloadTests.swift      # Full HTTP download flow against a stub: fresh, resume, file-changed, 416
+├── InfoPopoverContentViewControllerTests.swift # Paragraph rendering, fitting size, code paragraphs
+├── MacOSInstallContextTests.swift      # Codec round-trip + backward-compat for the persisted install context
+├── MacOSInstallStateTests.swift        # Install phase tracking
+├── MicPermissionPresentationTests.swift # Mic-permission status → presentation mapping
+├── MicrophonePermissionPopoverContentViewControllerTests.swift # Layout, bold step runs, non-selectable bodies
+├── MissingAttachmentPopoverContentViewControllerTests.swift # Layout, fitting size, header + path label
+├── NSImageExtensionsTests.swift        # SF Symbol loading utility
+├── ObservationLoopTests.swift          # Observation re-registration + cancel-token behavior
+├── OSSelectionContentViewControllerTests.swift # OS card selection + model binding
+├── PathValidationTests.swift           # Resolve/symlink/existence/type/permission checks
+├── PopoverPresenterTests.swift         # Lifecycle: initial state, idempotent close, onClose-on-delegate
+├── ResourceConfigContentViewControllerTests.swift # Name/CPU/memory stepper bounds + disk popup
+├── ReviewContentViewControllerTests.swift # Review-step display incl. macOS IPSW handling
+├── SerialSocketRelayTests.swift        # AF_UNIX relay: tee, client input, supersede, reconnect, unlink, guards
+├── SheetAlertTests.swift               # Role → NSButton config mapping + response dispatch
+├── SheetPresenterTests.swift           # Lifecycle (show() untested — needs key window + run loop)
+├── SidebarViewControllerTests.swift    # Status-dot color, agent-indicator gating, drag-reorder, context menu
+├── SpiceAgentProtocolTests.swift       # SPICE wire format serialization + incremental parsing
+├── SpiceClipboardServiceTests.swift    # SPICE clipboard message parsing + capabilities
+├── StorageDiskReorderSheetContentViewControllerTests.swift # Boot Order rows, performReorder index math, delegate
+├── StorageDiskSubtitleTests.swift      # Live disk-size subtitle reads from real on-disk files (ASIF, raw, missing)
+├── USBDeviceServiceTests.swift         # USB device info model + attach/detach recording
+├── VMBootModeTests.swift               # Boot mode enum
+├── VMBundleLayoutTests.swift           # Bundle path derivation + ASIF capacity parsing (shdw header, overflow guards)
+├── VMConfigurationTests.swift          # Encoding/decoding, defaults, migrations, storage lists, live-editable fields
+├── VMConfigurationCloneTests.swift     # Clone-specific behavior (ID regeneration, clone-name generation)
+├── VMCreationViewModelTests.swift      # All wizard steps, validation, OS-specific paths
+├── VMCreationWizardViewControllerTests.swift # Wizard chrome, navigation, Next/Back/Create button states
+├── VMGuestOSTests.swift                # Guest OS enum
+├── VMInstanceTests.swift               # Status transitions, bundle layout, preparing state, agent watchdog
+├── VMLibraryViewModelTests.swift       # List ops, selection, phantom rows, reconcile, delete fan-out, updateConfiguration
+├── VMLifecycleCoordinatorTests.swift   # Orchestration, error handling, per-VM serialization, stop bypass
+├── VMSettingsViewControllerTests.swift # Delete-confirmation prompts + control bindings
+├── VMStatusTests.swift                 # Status enum behavior incl. canForceStop
+├── VMStorageServiceTests.swift         # Storage CRUD + cloning
+├── VMToolbarManagerTests.swift         # Toolbar item creation, state updates, label toggling
+├── VirtualizationServiceTests.swift    # VM lifecycle operations via mock VZ objects
+├── VsockClipboardServiceTests.swift    # Offer dedup, generations, stale-drop, inbound population
+├── VsockControlServiceTests.swift      # Hello/heartbeat/liveness/policy + version comparison
+└── VsockGuestLogServiceTests.swift     # Channel setup, log-frame parsing, record emission
 
-KernovaGuestAgentTests/                 # Unit tests for the guest agent (standalone xctest bundle — no TEST_HOST)
-│                                       # Compiles KernovaGuestAgent source files directly (except main.swift)
-│                                       # so internal members are accessible without @testable import.
-│                                       # See Helper Targets section for the source-compilation rationale.
-├── TestHelpers.swift                   # Shared helpers: makeRawSocketPair, makeChannelPair, waitUntil,
-│                                       # nextFrame, awaitFirst, AtomicInt, frame factories (makeLogFrame etc.)
+KernovaGuestAgentTests/                 # Unit tests for the guest agent (standalone xctest bundle — no TEST_HOST;
+│                                       # compiles the agent sources directly — see Helper Targets)
+├── TestHelpers.swift                   # Socket-pair factories, waitUntil, AsyncGate, nextFrame, frame factories
 ├── KernovaLogMessageTests.swift        # Privacy-redaction matrix for KernovaLogMessage interpolations
-├── VsockHostConnectionTests.swift      # Log ring-buffer cap, partial-flush re-enqueue, forwardLog live-channel paths
-├── VsockGuestClientTests.swift         # Connect/retry/stop lifecycle; socket-factory injection
-├── VsockGuestClipboardAgentTests.swift # Echo suppression, reconnect reset, offer/request/data flow
-└── VsockGuestControlAgentTests.swift   # Hello on connect, heartbeat cadence, reconnect after host close
+├── VsockHostConnectionTests.swift      # Log ring-buffer cap, partial-flush re-enqueue, live-channel forwarding
+├── VsockGuestClientTests.swift         # Connect/retry/stop lifecycle, socket-factory injection, pause/resume
+├── VsockGuestClipboardAgentTests.swift # Echo suppression, reconnect reset, offer/request/data flow, setEnabled
+└── VsockGuestControlAgentTests.swift   # Hello on connect, heartbeat cadence, reconnect, PolicyUpdate → onPolicy
 ```
-
-**Total: 77 source files + 2 helpers, 43 test files (35 suites + 8 mocks + 1 test-helpers).**
-
-*Note: `ContentView.swift` was removed when `NavigationSplitView` was replaced by `NSSplitViewController` in `MainWindowController`. Its responsibilities were split between `MainWindowController` (toolbar, split view) and `MainDetailView` (detail switching, sheets, alerts).*
 
 ## Component Map
 
 ### App Layer
 
-**Files:** `AppDelegate.swift`, `MainWindowController.swift`, `DetailContainerViewController.swift`, `VMDisplayWindowController.swift`, `VMToolbarManager.swift`, `ClipboardWindowController.swift`
+**Files:** `AppDelegate.swift`, `MainWindowController.swift`, `DetailContainerViewController.swift`, `VMDisplayWindowController.swift`, `VMToolbarManager.swift`, `ClipboardWindowController.swift`, `ClipboardContentViewController.swift`
 
 `AppDelegate` is the entry point. It creates the `VMLibraryViewModel` and `VMLifecycleCoordinator`, opens the main window, and manages the lifecycle of all windows. It tracks window controllers in dictionaries keyed by VM UUID, enabling one-to-many relationships (a VM can have a main view, a fullscreen window, and a clipboard window open simultaneously). `AppDelegate` also handles:
+
 - The application menu (including VM-specific actions, Force Stop with `canForceStop` validation, and Window > Show Library with Cmd+0)
 - Suspend-on-quit behavior (suspending VMs before termination)
 - Conditional termination: `applicationShouldTerminateAfterLastWindowClosed` returns `false` when VMs are active or fullscreen windows exist, preventing premature exit on fullscreen-to-inline transitions
@@ -232,9 +259,11 @@ KernovaGuestAgentTests/                 # Unit tests for the guest agent (standa
 
 `MainWindowController` creates an `NSWindow` with an `NSSplitViewController` as the content view controller. The split view has two panes: a sidebar (`NSSplitViewItem(sidebarWithViewController:)` wrapping the pure-AppKit `SidebarViewController` — a source-list `NSOutlineView`) and a detail pane (`DetailContainerViewController`, which hosts the AppKit empty-state ⇆ `VMDetailRouterViewController`). An `NSToolbar` with native `NSToolbarItem`s provides lifecycle controls (Start/Resume, Pause, Stop), Suspend, Fullscreen, New VM, and a Show/Hide Settings toggle that lets the user view the (read-only) settings form while a VM is running. Shared toolbar items (lifecycle, suspend, display, settings toggle) are managed by `VMToolbarManager`; the New VM button and sidebar items remain controller-specific. The settings toggle only appears in the main window — the pop-out display window passes `settingsToggleID: nil`. Toolbar state is observed via `withObservationTracking` and items are validated through `NSToolbarItemValidation`. The `.fullSizeContentView` style mask and `.sidebarTrackingSeparator` preserve the full-height sidebar appearance matching Mail/Finder. The split view controller is a `SnapToFitSplitViewController` subclass that overrides `constrainSplitPosition` to magnetically snap the sidebar divider to the width that fully shows the longest VM name (computed by `SidebarViewController.widthToFitLongestRow()` from `SidebarVMRowCellView.contentWidth(forName:showsAgentAccessory:)`), clamped to the sidebar's `minimumThickness`/`maximumThickness` — the way Finder snaps its sidebar to the longest item.
 
+`DetailContainerViewController` layers the AppKit VM display (`VMDisplayBackingView`) over the AppKit detail content (empty-state view ⇆ `VMDetailRouterViewController`), respecting each instance's `detailPaneMode`. It owns `DetailAlertsPresenter` and conforms to `VMLibraryPresenting` (the view model's presentation delegate), forwarding lifecycle alerts to the presenter and presenting the creation-wizard sheet via `SheetPresenter`.
+
 ### Models
 
-**Files:** `VMConfiguration.swift`, `VMInstance.swift`, `VMBundleLayout.swift`, `VMStatus.swift`, `VMBootMode.swift`, `VMGuestOS.swift`, `MacOSInstallState.swift`, `KernovaUTType.swift`
+**Files:** `VMConfiguration.swift`, `VMInstance.swift`, `VMBundleLayout.swift`, `StorageDisk.swift`, `USBDeviceInfo.swift`, `MacOSInstallContext.swift`, `MacOSInstallState.swift`, `VMStatus.swift`, `VMBootMode.swift`, `VMGuestOS.swift`, `KernovaUTType.swift`
 
 The model layer has two key types:
 
@@ -242,21 +271,24 @@ The model layer has two key types:
 
 - **`VMInstance`** is the runtime representation. It's an `@Observable` `@MainActor` class that wraps a `VMConfiguration`, an optional `VZVirtualMachine`, and a `VMStatus`. It references the VM's bundle path and provides computed properties for disk image, aux storage, and save file locations via `VMBundleLayout`. A view-layer extension (`VMInstance+Display.swift`) provides display properties (`statusDisplayName`, `statusDisplayColor`, `statusToolTip`) that distinguish preparing VMs (shown as "Cloning…"/"Importing…" in orange with a spinner), cold-paused VMs (state saved to disk, shown as "Suspended" in orange), and live-paused VMs (in memory, shown as "Paused" in yellow). The `PreparingOperation` enum (`.cloning`, `.importing`) provides display labels, cancel labels, and alert titles for preparing states. The `PreparingState` struct bundles the operation and its cancellable task into a single optional (`preparingState`) — when non-nil the instance is preparing, and `isPreparing` is a computed convenience. A per-instance `detailPaneMode` (enum `DetailPaneMode { case display, settings }`, defaulting to `.display`) lets the user toggle, while the VM is running, between the live display and a read-only view of the settings form; the mode is ignored when the VM is stopped (settings are always shown then). For macOS guests, `VMInstance` also owns a one-shot post-start watchdog: `startAgentPostStartWatchdog(grace:)` (kicked from `VirtualizationService.start` once status reaches `.running`) waits for the grace period (default 120 s) and flips `agentExpectedButMissing = true` if no guest agent `Hello` arrived in that window; the flag is cleared by `recordObservedAgentVersion(_:)` (called via the `VsockControlService` `onAgentVersionObserved` callback) and by `tearDownSession`. `VMInstance.agentStatus` synthesizes the `.expectedMissing(expected:)` case from `agentExpectedButMissing` + `configuration.lastSeenAgentVersion` so the rest of the UI sees the case alongside live `VsockControlService`-sourced states. Configuration mutations driven by guest activity (e.g. persisting a new `lastSeenAgentVersion`) flow through the `onUpdateConfiguration` closure, which `VMLibraryViewModel` wires to its centralized `updateConfiguration(of:mutate:)` dispatcher at every instance-construction site — so guest-driven and user-driven mutations share one persist + apply-live-policy path. The runtime list of currently-attached USB mass storage devices (whether sourced from `removableMedia` at cold start or from later XHCI hot-attaches) lives on `VMInstance.liveRemovableMedia: [USBDeviceInfo]`, which the reconcile flow keeps in sync with the actual VZ device list.
 
-`VMBundleLayout` is a `Sendable` struct that takes a bundle root path and provides all derived file paths (disk image, aux storage, save file, serial log, etc.), keeping path logic centralized.
+`VMBundleLayout` is a `Sendable` struct that takes a bundle root path and provides all derived file paths (disk image, aux storage, save file, serial log, etc.), keeping path logic centralized. `diskURL(forRelativePath:isInternal:)` is the single internal-vs-external path-to-URL rule. It also owns **live disk sizing**: `diskSizes(forRelativePath:isInternal:)` returns the on-disk footprint (`totalFileAllocatedSize`) *and* the virtual capacity in one coalesced read — capacity parsed from an ASIF's `shdw` header (offset 0x30, big-endian 512-byte sector count; magic-validated, bounds-checked, and **checked**-multiplied ×512 so a corrupt count degrades to nil rather than wrapping), or the logical file size for a non-ASIF (raw `.img`/`.iso`/`.dmg`). `diskOnDiskBytes`/`diskCapacityBytes` remain as thin accessors over the same read. All reads are live, never cached — a size can change out-of-band (e.g. a CLI resize), so any stored copy would go stale.
+
+`StorageDisk` (with `StorageDiskKind`: `.virtio` / `.usbMassStorage`) and `RemovableMediaItem` model the two attachment lists — see [Storage topology](#storage-topology-mirrors-vz) below. `StorageDisk.uniqueLabel(base:existingLabels:)` generates collision-free default labels. `USBDeviceInfo` is the runtime metadata for an attached USB mass-storage device (id, path, read-only flag, attach date). `MacOSInstallContext` persists the macOS IPSW install intent (source, paths, fresh-download flag).
 
 The remaining models are enums: `VMStatus` (stopped/starting/running/paused/saving/restoring/installing/error), `VMBootMode` (macOS/efi/linuxKernel), `VMGuestOS` (macOS/linux), and `MacOSInstallState` (tracking download and install phases with progress). `VMStatus` provides computed properties for state checks (`canStart`, `canStop`, `canForceStop`, `canPause`, `canResume`, `canSave`, `canEditSettings`, `canRename`, `isTransitioning`, `isActive`). `canForceStop` covers all states where a `VZVirtualMachine` may exist and need forceful termination (running, paused, starting, saving, restoring).
 
 ### Services
 
-**Files:** `ConfigurationBuilder.swift`, `VirtualizationService.swift`, `VMStorageService.swift`, `DiskImageService.swift`, `MacOSInstallService.swift`, `IPSWService.swift`, `SpiceAgentProtocol.swift`, `AgentStatus.swift`, `ClipboardServicing.swift`, `SpiceClipboardService.swift`, `VsockClipboardService.swift`, `VsockControlService.swift`, `VsockListenerHost.swift`, `VsockGuestLogService.swift`, `VsockPorts.swift`
+**Files:** `ConfigurationBuilder.swift`, `VirtualizationService.swift`, `VMStorageService.swift`, `DiskImageService.swift`, `MacOSInstallService.swift`, `IPSWService.swift`, `USBDeviceService.swift`, `SystemSleepWatcher.swift`, `AttachmentFileMonitor.swift`, `SerialSocketRelay.swift`, `SpiceAgentProtocol.swift`, `AgentStatus.swift`, `ClipboardServicing.swift`, `SpiceClipboardService.swift`, `VsockClipboardService.swift`, `VsockControlService.swift`, `VsockListenerHost.swift`, `VsockGuestLogService.swift`, `VsockPorts.swift`, `KernovaGuestAgentInfo.swift`
 
-**Protocols:** `VirtualizationProviding`, `VMStorageProviding`, `DiskImageProviding`, `MacOSInstallProviding`, `IPSWProviding`
+**Protocols:** `VirtualizationProviding`, `VMStorageProviding`, `DiskImageProviding`, `MacOSInstallProviding`, `IPSWProviding`, `USBDeviceProviding`
 
 Services are split by concurrency requirements:
 
 - **`@MainActor` services** (interact with `VZVirtualMachine`):
   - `VirtualizationService` — start, stop, pause, resume, save state, restore state. `start(_:)` has two branches: restore from a save file, or cold-boot (build a fresh `VZVirtualMachineConfiguration` and attach a new VM). The post-install auto-boot path also runs through cold-boot — see `MacOSInstallService` below for the synchronisation that makes that safe.
   - `MacOSInstallService` — loads restore image, creates platform files (aux storage, hardware model, machine identifier), runs `VZMacOSInstaller` with KVO progress tracking. After `installer.install()` resolves, it explicitly **waits for `vm.state` to reach `.stopped`** before returning. VZ's `install` completion handler fires while the post-install guest shutdown is still propagating through the framework's state machine — without the wait, the caller's auto-boot would cold-rebuild a `VZMacAuxiliaryStorage(contentsOf:)` while the install-side instance still held the file lock, producing the "Failed to lock auxiliary storage" error. Waiting also gives our `VZVirtualMachineDelegate.guestDidStop` a chance to fire, which releases our refs via `resetToStopped`; if the delegate doesn't fire within the timeout the install service tears down explicitly as belt-and-braces.
+  - `USBDeviceService` — runtime attach/detach of USB mass-storage devices against the live VM's XHCI controller, behind `USBDeviceProviding` for mocking; used by the removable-media reconcile and the Guest Agent installer mount.
 
 - **`Sendable` struct services** (no mutable state, safe to call from anywhere):
   - `VMStorageService` — creates/deletes/lists VM bundle directories at `~/Library/Application Support/Kernova/VMs/` and handles cloning (deep copy with new UUID)
@@ -265,9 +297,13 @@ Services are split by concurrency requirements:
 
 - **`SystemSleepWatcher`** — `@MainActor` observer class that monitors `NSWorkspace.willSleepNotification` and `NSWorkspace.didWakeNotification`. Follows the same pattern as `VMDirectoryWatcher`: callback-driven, `nonisolated(unsafe)` for observer tokens, `start()`/`deinit` lifecycle. Owned by `VMLibraryViewModel`, which uses it to auto-pause running VMs before sleep and resume them on wake.
 
-- **`ConfigurationBuilder`** — Translates a `VMConfiguration` into a `VZVirtualMachineConfiguration`. Handles three boot paths: `VZMacOSBootLoader` (macOS), `VZEFIBootLoader` (EFI/UEFI), and `VZLinuxBootLoader` (direct kernel boot). Configures CPU, memory, storage, network, display, keyboard, trackpad, and audio devices. When `clipboardSharingEnabled` is set on a Linux guest, configures a `VZVirtioConsoleDeviceConfiguration` with a SPICE-named port using raw `VZFileHandleSerialPortAttachment` pipes (not `VZSpiceAgentPortAttachment`); macOS guests instead carry clipboard over the vsock device. For macOS guests it always appends a `VZVirtioSocketDeviceConfiguration` so the host can install vsock listeners (log + clipboard) against the live device once the VM is created. Resolves symlinks on user-supplied paths (shared directories, kernel/initrd, ISO images) and validates them before passing to VZ. File paths (kernel, initrd, ISO) are checked for existence and rejected if they point to directories. Shared directory validation checks existence, is-directory, readability, and writability (for read-write shares) against the resolved path.
+- **`AttachmentFileMonitor`** — `@MainActor` `@Observable` reactive existence tracker for external attachments: one `DispatchSource` per watched parent directory plus `NSWorkspace` mount notifications, surfacing an observable `existsByPath` map that drives the missing-file affordances in the settings list, Boot Order sheet, and delete sheet.
 
-- **`SpiceAgentProtocol`** — Pure data types and parsing for the SPICE agent wire format. Defines VDI chunk headers, VDAgent message headers, clipboard message types, and capability bitmasks. Includes `SpiceMessageBuilder` (builds wire-ready messages with a `port` parameter defaulting to `serverPort` for host-side use) and `SpiceAgentParser` (incremental parser handling fragmented data across multiple pipe reads). Fully `Sendable`, no I/O. Used only by the host-side `SpiceClipboardService` (Linux clipboard transport) — macOS guests now use vsock instead, so the file is no longer multi-target.
+- **`SerialSocketRelay`** — `@unchecked Sendable` (NSLock + `DispatchSourceRead`) host-side AF_UNIX listener that exposes the guest serial port to an external terminal: best-effort tee of guest output, sole host-side writer of serial input; re-startable for hot-toggle. See the [serial console data flow](#serial-console-data-flow) under Views.
+
+- **`ConfigurationBuilder`** — Translates a `VMConfiguration` into a `VZVirtualMachineConfiguration`. Handles three boot paths: `VZMacOSBootLoader` (macOS), `VZEFIBootLoader` (EFI/UEFI), and `VZLinuxBootLoader` (direct kernel boot). Configures CPU, memory, storage, network, display, keyboard, trackpad, and audio devices. When `clipboardSharingEnabled` is set on a Linux guest, configures a `VZVirtioConsoleDeviceConfiguration` with a SPICE-named port using raw `VZFileHandleSerialPortAttachment` pipes (not `VZSpiceAgentPortAttachment`); macOS guests instead carry clipboard over the vsock device. For macOS guests it always appends a `VZVirtioSocketDeviceConfiguration` so the host can install vsock listeners (log + clipboard) against the live device once the VM is created. Resolves symlinks on user-supplied paths (shared directories, kernel/initrd, ISO images) and validates them before passing to VZ — via the shared `PathValidation` helpers. File paths (kernel, initrd, ISO) are checked for existence and rejected if they point to directories. Shared directory validation checks existence, is-directory, readability, and writability (for read-write shares) against the resolved path.
+
+- **`SpiceAgentProtocol`** — Pure data types and parsing for the SPICE agent wire format. Defines VDI chunk headers, VDAgent message headers, clipboard message types, and capability bitmasks. Includes `SpiceMessageBuilder` (builds wire-ready messages with a `port` parameter defaulting to `serverPort` for host-side use) and `SpiceAgentParser` (incremental parser handling fragmented data across multiple pipe reads). Fully `Sendable`, no I/O. Used only by the host-side `SpiceClipboardService` (Linux clipboard transport) — macOS guests use vsock instead, so the file is no longer multi-target.
 
 - **`AgentStatus`** — Enum (`.waiting | .current(version) | .outdated(installed, bundled) | .unresponsive(version) | .expectedMissing(expected)`) that drives install/update/unresponsive/reinstall affordances in the sidebar and clipboard window. Sourced from `VsockControlService` for macOS guests (independent of clipboard sharing — first four cases) and from `SpiceClipboardService` for Linux guests (`.waiting` / `.current` only). The UI reads it via `VMInstance.agentStatus`, which dispatches by `configuration.guestOS` and synthesizes `.expectedMissing(expected:)` from the post-start watchdog flag plus `configuration.lastSeenAgentVersion` — `VsockControlService` itself does not (and cannot) produce that case because it has no access to persisted host state.
 
@@ -289,21 +325,29 @@ Services are split by concurrency requirements:
 
 - **`VsockPorts`** — Central registry of port assignments (`KernovaVsockPort.control = 49154`, `KernovaVsockPort.clipboard = 49152`, `KernovaVsockPort.log = 49153`) so each service gets its own listener on a distinct port instead of in-band multiplexing. The control listener is always installed for macOS guests with a `VZVirtioSocketDevice`; the log listener is gated on `configuration.agentLogForwardingEnabled`; the clipboard listener is gated on `configuration.clipboardSharingEnabled`. Both gates are also re-evaluated at runtime via `VMInstance.applyLivePolicy(oldConfig:newConfig:)` — flipping the toggle while a macOS VM is running installs or tears down the listener and pushes a fresh `PolicyUpdate` to the guest agent. Linux clipboard sharing is restart-only (the SPICE port must be declared at config-build time).
 
-**Storage topology mirrors VZ.** `VMConfiguration` carries two ordered lists that map directly onto VZ's two storage surfaces. `storageDisks: [StorageDisk]?` maps onto `vzConfig.storageDevices`; position [0] boots first on EFI guests. Each entry's `kind` (`.virtio` or `.usbMassStorage`) is inferred from the file extension at add-time via `StorageDisk.defaultKind(forPath:)` — `.iso`/`.dmg` default to USB mass storage so installer media doesn't shift the main disk's `/dev/vda` letter when reordered for boot, everything else defaults to virtio. `removableMedia: [RemovableMediaItem]?` maps onto `usbControllers[0].usbDevices` — hot-pluggable, no boot semantics. The same bundled-disk entry (`Disk.asif`, internal, virtio) appears in `storageDisks` as a regular row; nothing in the data model singles it out as "the main disk." Each `StorageDisk` carries a user-editable `label` (renamed inline or via the row context menu through `VMLibraryViewModel.renameStorageDisk`; cosmetic — the backing file keeps its stable UUID name and the guest is unaffected); new disks get a collision-free default label via `StorageDisk.uniqueLabel`. The model stores **no** physical sizing — on-disk footprint, virtual capacity, and creation date are read live from the file at display time (uniformly for the main disk and additional disks), since a size can change out-of-band (e.g. a CLI resize) and any stored copy would go stale. The subtitle reads run **off the main thread** via `populateDiskSubtitle` (placeholder → detached read → fill-in; reads are cancelled when a field is re-bound); Get Info also reads off-main (a detached size + creation-date read, then presents). Both attachment lists share one `VMSettingsViewController` implementation — `refreshAttachmentList`/`makeAttachmentRow` (rebuild vs. in-place), one `buildAttachmentContextMenu` with eight `@objc` handlers dispatched on an `AttachmentRef(kind, id)` `representedObject` (Eject is removable-only, so its handler is a no-op for storage refs), `presentAttachmentInfoPopover`, and `commitAttachmentRename` — parameterized by `AttachmentKind` rather than duplicated per list. **Removable media (`RemovableMediaItem`) is at full parity with storage disks**: same editable `label` (inline rename or context menu, via `VMLibraryViewModel.renameRemovableMedia` — safe to rename while running, since a label-only edit leaves `path`/`readOnly` untouched and the reconcile only detaches/reattaches on those, so the medium stays mounted), the same `AttachmentRowView` UI **plus an inline trailing Eject button that storage rows omit** (a one-click detach — no confirmation, file untouched, via `removeRemovableMedia(_:from:trashFile: false)` — hot-pluggable media is swapped often, so it earns a dedicated control; the eject glyph is shared with the Shared Directories row button), the right-click menu (Rename / Get Info / Show in Finder / Copy Path / Copy File Name / Read Only / **Eject** / Remove — Eject, the no-confirmation detach, is removable-only, the one menu item storage rows lack), the same `AttachmentInfoPopoverContentViewController`, and the same live on-disk/allocated sizing (always external — a raw `.iso`/`.dmg` reports its logical size as the capacity).
+#### Storage topology mirrors VZ
 
-**Live-editable fields and their dispatch.** `VMConfiguration.liveEditableFieldsChanged(old:new:)` is the single source of truth for "did anything change that should take effect while the VM is running?" It combines `hotToggleFields` (a typed `[KeyPath<VMConfiguration, Bool>]`) with `removableMediaChanged(old:new:)`, which array-compares the `removableMedia` lists. `storageDisks` changes are deliberately NOT live-editable — they go to `vzConfig.storageDevices`, which VZ requires fixed at start time, so the settings UI keeps that section locked while the VM is running. `VMSettingsViewController` mutates via the centralized `VMLibraryViewModel.updateConfiguration(of:mutate:)` dispatcher (persist + `applyLivePolicy`). Every control's target/action handler routes its write through this dispatcher; no settings control writes to `instance.configuration` directly.
+`VMConfiguration` carries two ordered lists that map directly onto VZ's two storage surfaces. `storageDisks: [StorageDisk]?` maps onto `vzConfig.storageDevices`; position [0] boots first on EFI guests. Each entry's `kind` (`.virtio` or `.usbMassStorage`) is inferred from the file extension at add-time via `StorageDisk.defaultKind(forPath:)` — `.iso`/`.dmg` default to USB mass storage so installer media doesn't shift the main disk's `/dev/vda` letter when reordered for boot, everything else defaults to virtio. `removableMedia: [RemovableMediaItem]?` maps onto `usbControllers[0].usbDevices` — hot-pluggable, no boot semantics. The same bundled-disk entry (`Disk.asif`, internal, virtio) appears in `storageDisks` as a regular row; nothing in the data model singles it out as "the main disk." Each `StorageDisk` carries a user-editable `label` (renamed inline or via the row context menu through `VMLibraryViewModel.renameStorageDisk`; cosmetic — the backing file keeps its stable UUID name and the guest is unaffected); new disks get a collision-free default label via `StorageDisk.uniqueLabel`. The model stores **no** physical sizing — on-disk footprint, virtual capacity, and creation date are read live from the file at display time (uniformly for the main disk and additional disks), since a size can change out-of-band (e.g. a CLI resize) and any stored copy would go stale. The subtitle reads run **off the main thread** via `populateDiskSubtitle` (placeholder → detached read → fill-in; reads are cancelled when a field is re-bound); Get Info also reads off-main (a detached size + creation-date read, then presents). Both attachment lists share one `VMSettingsViewController` implementation — `refreshAttachmentList`/`makeAttachmentRow` (rebuild vs. in-place), one `buildAttachmentContextMenu` with eight `@objc` handlers dispatched on an `AttachmentRef(kind, id)` `representedObject` (Eject is removable-only, so its handler is a no-op for storage refs), `presentAttachmentInfoPopover`, and `commitAttachmentRename` — parameterized by `AttachmentKind` rather than duplicated per list. **Removable media (`RemovableMediaItem`) is at full parity with storage disks**: same editable `label` (inline rename or context menu, via `VMLibraryViewModel.renameRemovableMedia` — safe to rename while running, since a label-only edit leaves `path`/`readOnly` untouched and the reconcile only detaches/reattaches on those, so the medium stays mounted), the same `AttachmentRowView` UI **plus an inline trailing Eject button that storage rows omit** (a one-click detach — no confirmation, file untouched, via `removeRemovableMedia(_:from:trashFile: false)` — hot-pluggable media is swapped often, so it earns a dedicated control; the eject glyph is shared with the Shared Directories row button), the right-click menu (Rename / Get Info / Show in Finder / Copy Path / Copy File Name / Read Only / **Eject** / Remove — Eject, the no-confirmation detach, is removable-only, the one menu item storage rows lack), the same `AttachmentInfoPopoverContentViewController`, and the same live on-disk/allocated sizing (always external — a raw `.iso`/`.dmg` reports its logical size as the capacity).
 
-**Removable-media reconcile.** `VMLibraryViewModel.applyLivePolicy(for:old:new:)` forks: vsock listener changes go through `VMInstance.applyLivePolicy`; `removableMedia` changes are dropped into `pendingRemovableMediaTarget` and a coalesce-and-drain task (`runRemovableMediaReconciliation`) calls `applyLiveRemovableMediaChange(for:target:)` until the pending dictionary empties. The reconciler computes a per-id diff against `instance.liveRemovableMedia` (add / remove / mutate-in-place / reorder-noop), detaches first to avoid duplicate-UUID conflicts on swaps, then attaches. `deviceNotFound` (guest-side ejection) and `noVirtualMachine` (VM torn down) are handled distinctly; on any other framework error the reconciler calls `reconcileConfigToLiveState(for:lookup:)` to rebuild `config.removableMedia` from `instance.liveRemovableMedia` — so the UI snaps to what's actually attached instead of describing a state VZ refused. The rollback bypasses `updateConfiguration` (direct write + `saveConfiguration`) to avoid re-entering the reconcile pipeline.
+#### Live-editable fields and their dispatch
 
-**Save-state device UUID persistence.** `VZUSBDeviceConfiguration.uuid` is matched against the saved-state file's recorded device list during `restoreMachineStateFrom(url:)` — fresh UUIDs each launch would break restore. `RemovableMediaItem.id` becomes `VZUSBMassStorageDeviceConfiguration.uuid` and is persisted with the entry in `config.json`. For virtio entries in `storageDisks`, the entry's `id` is also used as the `VZVirtioBlockDeviceConfiguration.blockDeviceIdentifier` (truncated to 20 ASCII chars), giving Linux guests a stable `/dev/disk/by-id/virtio-<identifier>` symlink — with the exception of the bundle's primary disk (`Disk.asif`, identified by `ConfigurationBuilder.isMainBundleDisk(_:layout:)`), which intentionally has no `blockDeviceIdentifier` set so the pre-refactor `/etc/fstab` behavior is preserved. The synthesized default main disk (used when `storageDisks` is nil/empty) derives its UUID deterministically from `SHA256(bundleURL.path)` via `ConfigurationBuilder.stableMainDiskID(forBundleAt:)`, so entry-by-id lookups (notably `removeStorageDisk` and the settings list's read-only/delete row actions) are stable before the user has materialized the list. `clonedForNewInstance` regenerates every `StorageDisk.id` and `RemovableMediaItem.id` so two bundles don't share device identity.
+`VMConfiguration.liveEditableFieldsChanged(old:new:)` is the single source of truth for "did anything change that should take effect while the VM is running?" It combines `hotToggleFields` (a typed `[KeyPath<VMConfiguration, Bool>]`) with `removableMediaChanged(old:new:)`, which array-compares the `removableMedia` lists. `storageDisks` changes are deliberately NOT live-editable — they go to `vzConfig.storageDevices`, which VZ requires fixed at start time, so the settings UI keeps that section locked while the VM is running. `VMSettingsViewController` mutates via the centralized `VMLibraryViewModel.updateConfiguration(of:mutate:)` dispatcher (persist + `applyLivePolicy`). Every control's target/action handler routes its write through this dispatcher; no settings control writes to `instance.configuration` directly.
+
+#### Removable-media reconcile
+
+`VMLibraryViewModel.applyLivePolicy(for:old:new:)` forks: vsock listener changes go through `VMInstance.applyLivePolicy`; `removableMedia` changes are dropped into `pendingRemovableMediaTarget` and a coalesce-and-drain task (`runRemovableMediaReconciliation`) calls `applyLiveRemovableMediaChange(for:target:)` until the pending dictionary empties. The reconciler computes a per-id diff against `instance.liveRemovableMedia` (add / remove / mutate-in-place / reorder-noop), detaches first to avoid duplicate-UUID conflicts on swaps, then attaches. `deviceNotFound` (guest-side ejection) and `noVirtualMachine` (VM torn down) are handled distinctly; on any other framework error the reconciler calls `reconcileConfigToLiveState(for:lookup:)` to rebuild `config.removableMedia` from `instance.liveRemovableMedia` — so the UI snaps to what's actually attached instead of describing a state VZ refused. The rollback bypasses `updateConfiguration` (direct write + `saveConfiguration`) to avoid re-entering the reconcile pipeline.
+
+#### Save-state device UUID persistence
+
+`VZUSBDeviceConfiguration.uuid` is matched against the saved-state file's recorded device list during `restoreMachineStateFrom(url:)` — fresh UUIDs each launch would break restore. `RemovableMediaItem.id` becomes `VZUSBMassStorageDeviceConfiguration.uuid` and is persisted with the entry in `config.json`. For virtio entries in `storageDisks`, the entry's `id` is also used as the `VZVirtioBlockDeviceConfiguration.blockDeviceIdentifier` (truncated to 20 ASCII chars), giving Linux guests a stable `/dev/disk/by-id/virtio-<identifier>` symlink — with the exception of the bundle's primary disk (`Disk.asif`, identified by `ConfigurationBuilder.isMainBundleDisk(_:layout:)`), which intentionally has no `blockDeviceIdentifier` set so the pre-refactor `/etc/fstab` behavior is preserved. The synthesized default main disk (used when `storageDisks` is nil/empty) derives its UUID deterministically from `SHA256(bundleURL.path)` via `ConfigurationBuilder.stableMainDiskID(forBundleAt:)`, so entry-by-id lookups (notably `removeStorageDisk` and the settings list's read-only/delete row actions) are stable before the user has materialized the list. `clonedForNewInstance` regenerates every `StorageDisk.id` and `RemovableMediaItem.id` so two bundles don't share device identity.
 
 All service implementations conform to protocols defined in `Services/Protocols/`. This enables full dependency injection — tests use mock implementations that track call counts and support error injection.
 
 ### ViewModels
 
-**Files:** `VMLibraryViewModel.swift`, `VMLifecycleCoordinator.swift`, `VMCreationViewModel.swift`, `VMDirectoryWatcher.swift`
+**Files:** `VMLibraryViewModel.swift`, `VMLibraryPresenting.swift`, `VMLifecycleCoordinator.swift`, `VMCreationViewModel.swift`, `VMDirectoryWatcher.swift`
 
-- **`VMLibraryViewModel`** is the central `@Observable` view model. It owns the array of `VMInstance`s and handles list-level operations: add, remove, rename, reorder, selection tracking. VM order is user-customizable via drag-and-drop in the sidebar, persisted as a UUID array in `UserDefaults` (key `"vmOrder"`). VMs not in the custom order (newly created/discovered) sort after ordered VMs by `createdAt`. For lifecycle operations (start, stop, install), it delegates to `VMLifecycleCoordinator`. Clone and import operations use a "phantom row" pattern: a `VMInstance` with `isPreparing = true` appears immediately in the sidebar with a spinner while the file copy runs asynchronously via `Task.detached`. The `hasPreparing` computed property enforces serialization — only one clone/import at a time. Cancellation removes the phantom row, cancels the task, and cleans up partial files on disk. Force-stop is surfaced via `confirmForceStop()` which presents a confirmation dialog. **All `VMConfiguration` mutations route through `updateConfiguration(of:mutate:)`** — a single dispatcher that takes an `inout` closure, no-ops when the closure produces an equal value, persists via `saveConfiguration`, and calls `applyLivePolicy(for:old:new:)`. This is the only place persist + live-policy fire together; settings-UI bindings (`configBinding`, `storageDiskBinding`, `removableMediaBinding`), install/uninstall flows, rename, display-window callbacks, and guest-driven `VMInstance.onUpdateConfiguration` writes all funnel through it.
+- **`VMLibraryViewModel`** is the central `@Observable` view model. It owns the array of `VMInstance`s and handles list-level operations: add, remove, rename, reorder, selection tracking. VM order is user-customizable via drag-and-drop in the sidebar, persisted as a UUID array in `UserDefaults` (key `"vmOrder"`). VMs not in the custom order (newly created/discovered) sort after ordered VMs by `createdAt`. For lifecycle operations (start, stop, install), it delegates to `VMLifecycleCoordinator`. Clone and import operations use a "phantom row" pattern: a `VMInstance` with `isPreparing = true` appears immediately in the sidebar with a spinner while the file copy runs asynchronously via `Task.detached`. The `hasPreparing` computed property enforces serialization — only one clone/import at a time. Cancellation removes the phantom row, cancels the task, and cleans up partial files on disk. Force-stop is surfaced via `confirmForceStop()` which presents a confirmation dialog. **All `VMConfiguration` mutations route through `updateConfiguration(of:mutate:)`** — a single dispatcher that takes an `inout` closure, no-ops when the closure produces an equal value, persists via `saveConfiguration`, and calls `applyLivePolicy(for:old:new:)`. This is the only place persist + live-policy fire together; settings-UI bindings (`configBinding`, `storageDiskBinding`, `removableMediaBinding`), install/uninstall flows, rename, display-window callbacks, and guest-driven `VMInstance.onUpdateConfiguration` writes all funnel through it. It surfaces alerts, sheets, and the wizard imperatively via the `VMLibraryPresenting` delegate (implemented by `DetailContainerViewController`).
 
 - **`VMLifecycleCoordinator`** is an `@MainActor` coordinator that owns the lifecycle services (`VirtualizationService`, `MacOSInstallService`, `IPSWService`). It orchestrates multi-step operations like macOS installation (which involves IPSW download → platform file creation → VM configuration → installation). This separation keeps `VMLibraryViewModel` focused on list management. The coordinator enforces **per-VM operation serialization** — at most one lifecycle operation can be in flight for a given VM at any time; concurrent requests are rejected with `VMLifecycleCoordinator.LifecycleError.operationInProgress`. `stop` and `forceStop` bypass serialization entirely (clearing the active-operation token before calling the service) so users can always cancel hung operations.
 
@@ -315,9 +359,46 @@ All service implementations conform to protocols defined in `Services/Protocols/
 
 ### Views
 
-**Files:** the entire app target is pure AppKit — `NSViewController`/`NSView` subclasses plus free `make*` atom-factory functions, with no `import SwiftUI` anywhere. The detail pane (settings, router, install progress, placeholders, empty state) was the last SwiftUI surface and is now AppKit: `VMDetailRouterViewController` routes by status (via the unit-tested `DetailRoute.resolve`) to `VMSettingsViewController`, `DetailStatusPlaceholderViewController`, `MacOSInstallProgressViewController`, or the display placeholder. **Every popover, sheet, and alert is end-to-end AppKit**: missing-attachment (`AttachmentIconButton` → `MissingAttachmentPopoverContentViewController`), attachment Get Info (`AttachmentRowView` context menu → `AttachmentInfoPopoverContentViewController`, shared by storage disks and removable media), Storage Disk / Removable Media Create (`DiskSizePopoverCoordinator` → `DiskSizePopoverContentViewController`), the generic info-popover surface (`InfoButtonView` → `InfoPopoverContentViewController`), the mic-permission warning popover (`MicrophonePermissionPopoverContentViewController`), the Boot Order and Delete-VM sheets (via `SheetPresenter`), the lifecycle confirmation alerts (`DetailAlertsPresenter` → `presentSheetAlert`), and the sidebar agent-status popover (`SidebarVMRowCellView` → `SidebarAgentStatusButtonView` → `AgentStatusPopoverContentViewController`). Each uses a real `NSPopover`/`NSAlert`/sheet; controllers build their full layouts in `loadView()` using shared token sets (`CalloutStyle` for popovers, `GroupedFormStyle` for grouped forms shared with the wizard) + atom factory functions. **All popover anchors target a wrapper `NSView`** (never an inner control) so `NSPopover.preferredEdge` semantics are interpreted in an unflipped coordinate system. **No shared callout/form container or base class** — visual consistency comes from shared tokens, not inheritance. **Genuinely shareable controllers are reused via init parameterization** (`DiskSizePopoverContentViewController` serves both Create flows via `headline`/`caption`; `InfoPopoverContentViewController` takes `[InfoPopoverParagraph]` distinguishing `.body` from `.code`). AppKit content controllers decouple from `VMLibraryViewModel` via delegate protocols; their hosts (settings VC, alerts presenter) implement the delegates and forward user choices to the view model. Conversely, the view model surfaces alerts, sheets, and the wizard by calling its `VMLibraryPresenting` delegate (`DetailContainerViewController`) imperatively — not by toggling observed `show*` flags. Errors raised before the delegate attaches (e.g. the initial `loadVMs()` in `init`) are buffered on the view model and flushed when it is set.
+The entire app target is pure AppKit — `NSViewController`/`NSView` subclasses plus free `make*` atom-factory functions, with no `import SwiftUI` anywhere. Views observe `VMLibraryViewModel` and individual `VMInstance`s via the Observation framework (`observeRecurring`).
 
-Views observe `VMLibraryViewModel` and individual `VMInstance`s via the Observation framework (`observeRecurring`). The view hierarchy (AppKit throughout):
+#### Sidebar
+
+`SidebarViewController` is a source-list `NSOutlineView`: VMs under a collapsible "Virtual Machines" group (`SidebarSection` is structured so a second group would be a localized addition), selection synced with `selectedID`, double-click-to-start, a status-dependent context menu, inline rename, and drag-reorder plus Finder-bundle import. `SidebarVMRowCellView` renders each VM row: a state-tinted OS icon (swapped in place for a spinner while busy), the VM name, and an optional agent accessory; it owns a per-instance `ObservationLoop` for live updates and hosts the inline-rename field editor. `SidebarAgentStatusButtonView` is the agent accessory — a stacked `NSButton` (SF Symbol for static states) and `.mini` spinning `NSProgressIndicator` (for `.connecting`); it owns a `PopoverPresenter` + `AgentStatusPopoverContentViewController`, refreshes the popover in place when status changes mid-popover (e.g. `.waiting` → `.current`), and anchors `.maxX` so the popover flows into the detail-pane area rather than out the sidebar's right edge. The popover content shows a per-status title, wrapping body, and an action row — an optional "Don't show again" link (surfaced only for `.waiting`) plus a per-status action button ("Install Guest Agent…" / "Update Guest Agent…" / "Reinstall Guest Agent…" / "Done") — through a delegate protocol (`didTapAction` + `didTapDismiss`); static helpers expose `title(for:)`, `bodyText(for:vmName:)`, `actionButtonTitle(for:)`, and `requiresMountAction(for:)`, and `update(status:vmName:hasDismissAction:)` swaps labels in place.
+
+#### Detail routing
+
+`VMDetailRouterViewController` resolves a `DetailRoute` from instance status — via the pure, unit-tested `DetailRoute.resolve(preparingLabel:status:hasInstallState:detailPaneMode:)` — and swaps its reused children: `VMSettingsViewController`, `DetailStatusPlaceholderViewController` (centered spinner + label for transient states and clone/import preparing), `MacOSInstallProgressViewController`, or the display placeholder. For the initial-boot route it stacks `InitialBootBannerView` (orange banner with an install-context-aware subtitle) above the settings form. It rebuilds per-instance state on VM switch via `reconfigure(instance:)`. `MacOSInstallProgressViewController` renders the two-step (download → install) progress — numbered step circles + connector, linear progress bar, monospaced detail text — observing `instance.installState`; Cancel confirms via `presentSheetAlert`. `DetailEmptyStateView` is the centered "No Virtual Machine Selected" state with a New Virtual Machine button (calls the container's `presentCreationWizard()`).
+
+#### Settings
+
+`VMSettingsViewController` is the VM configuration editor: nine grouped-form sections built with the `GroupedFormStyle` factories, observation-driven idempotent `apply()`, and lockable sections disabled while the VM runs (their headers/info stay live). All writes route through `VMLibraryViewModel.updateConfiguration`. Per-row storage/removable delete shows a context-aware confirmation decided by the pure `attachmentDeletePrompt(...)` helper, matching the VM-delete sheet's rules (internal disk → Move-to-Trash-or-Cancel; private external → trash or detach; shared external → detach-only naming the other VMs; Guest Agent installer → detach-only, file never trashed). The form rebuilds on VM switch. `MicPermissionPresentation` holds the pure, unit-tested helpers behind the mic-permission warning bar (`micPermissionPresentation(_:micEnabled:)`, `externalAttachmentPaths(for:)`, `isGuestAgentSectionVisible(guestOS:)`).
+
+#### Attachment rows and live sizing
+
+`AttachmentRowView` renders one attachment row — a storage disk **or** a removable medium: leading icon + title + subtitle + Read Only switch + an optional trailing inline Eject button (removable-media rows only — a one-click detach with no confirmation, file untouched, since hot-pluggable media is swapped often; storage-disk rows pass `ejectButton: nil` and detach via the right-click menu; the file-trashing Remove, with confirmation, always lives in the right-click menu on every row). Rows support inline title rename (double-click; mirrors `SidebarVMRowCellView`'s field-editor state machine and commits on any click outside the field via a local mouse-down monitor), a per-row right-click menu via `menu(for:)` → controller-supplied closure, and `update(...)` to patch title/icon/Read-Only/enabled state **in place** — so a non-structural refresh (e.g. a rename) doesn't tear the row down and re-fade its size. Each row carries `itemID` + `infoAnchor` (the icon, so Get Info points at it) + `subtitleField` (so the controller re-populates the live size off-main). `AttachmentIconButton` is the leading-icon control: SF Symbol when the file is present, red-triangle button + missing-file popover (`MissingAttachmentPopoverContentViewController`, via `PopoverPresenter`) when it's gone; an optional `onActivate` makes the present-state icon clickable (storage rows wire it to Get Info), inert by default.
+
+The subtitle pipeline lives in `StorageDiskSubtitle.swift`: `nonisolated diskSubtitle(for:bundleLayout:)` reads `diskOnDiskBytes` + `diskCapacityBytes` **live** (no main-thread file I/O — it runs on a detached task), and `@MainActor populateDiskSubtitle(…:isMissing:animated:)` (with `StorageDisk` / `RemovableMediaItem` convenience overloads) fills the label in: the field's `identifier` is tagged with the disk id so a recycled Boot Order cell ignores a stale result and a same-disk refresh updates in place; a re-bind cancels the prior in-flight read via a generation-tagged map; `animated: false` skips the fade so the Boot Order sheet's drag-drop `reloadData()` doesn't flicker. The "In-bundle disk image" placeholder is **deferred** behind a ~100 ms grace and cancelled when the read lands, so the sub-ms common case never flickers it — only a genuinely slow read surfaces it. Every disk — in-bundle or external, ASIF or raw `.img`/`.iso`/`.dmg` — shows `<on disk> / <allocated>` uniformly (the main disk included), reflecting current state (e.g. an external resize); it falls back to on-disk-only when capacity isn't readable, then to the file's path when neither figure reads. An external disk seeds its path as the holding value while the read runs (so it never flickers and needs no placeholder); a **missing** external file short-circuits to the red "Missing —" state (`AttachmentSubtitleLabel`'s bold `systemRed` prefix). `diskIconSystemName(for:)` supplies the per-kind icon. Used by both the settings list and the Boot Order sheet.
+
+#### Popovers, sheets, and alerts
+
+Every popover, sheet, and alert is end-to-end AppKit — a real `NSPopover`/`NSAlert`/sheet, with controllers building their full layouts in `loadView()` from shared token sets (`CalloutStyle` for callout popovers, `GroupedFormStyle` for grouped forms shared with the wizard) plus atom factory functions. **All popover anchors target a wrapper `NSView`** (never an inner control) so `NSPopover.preferredEdge` semantics are interpreted in an unflipped coordinate system. **No shared callout/form container or base class** — visual consistency comes from shared tokens, not inheritance. **Genuinely shareable controllers are reused via init parameterization**: `DiskSizePopoverContentViewController` (headline + size `NSPopUpButton` + caption + Cancel/Create) serves both the Storage Disk and Removable Media Create flows via injected `headline`/`caption`; its `DiskSizePopoverCoordinator` owns the `PopoverPresenter` and forwards the confirmed size to an `onConfirm` closure (the settings VC wires in-bundle disk creation vs. the removable-media save panel). `InfoPopoverContentViewController` backs the generic `info.circle` surface (`InfoButtonView`), taking `[InfoPopoverParagraph]` where each paragraph is `.body(String)` or `.code(String)` — `.code` uses `makeCalloutCode` for monospaced selectable snippets (e.g. the virtiofs `mount` command). `MicrophonePermissionPopoverContentViewController` keeps its unique structure (divider + sub-headline + numbered steps with bold runs + tail caption) in its own concrete subclass rather than bloating `InfoPopoverParagraph`. `AttachmentInfoPopoverContentViewController` is the attachment Get Info popover — headline + two-column `NSGridView` of facts (file, on-disk, allocated, read-only, bus, created) + monospaced selectable full path — initialized from a value snapshot (no live `VMInstance`).
+
+AppKit content controllers decouple from `VMLibraryViewModel` via delegate protocols; their hosts (settings VC, alerts presenter) implement the delegates and forward user choices to the view model. Conversely, the view model surfaces alerts, sheets, and the wizard by calling its `VMLibraryPresenting` delegate (`DetailContainerViewController`) imperatively — not by toggling observed `show*` flags. Errors raised before the delegate attaches (e.g. the initial `loadVMs()` in `init`) are buffered on the view model and flushed when it is set.
+
+Two sheets are rich enough for `SheetPresenter` rather than `NSAlert`:
+
+- **Delete-VM sheet** (`DeleteVMSheetContentViewController`) — red trash icon header + body paragraph + scrollable two-section list + Cancel / Move-to-Trash buttons. Section 1 "Removed with the VM" lists the VM's in-bundle disks read-only; section 2 "Files outside this VM" lists external disks/media with a per-row checkbox (exclusively-owned default to on; shared *or* missing-file rows are locked off and never collected on confirm — shared show a "Kept — still used by …" note, missing show the red "Missing —" path style plus an "Already gone — nothing to remove" note; when both, the shared note wins). Per-file `isMissing` is resolved off-main by `VMLibraryViewModel.externalAttachmentsResolvingExistence(for:)` before the presenter assembles the sheet (the synchronous `externalAttachments(for:)` leaves it `false`, keeping the trash fan-out free of main-thread filesystem syscalls). The delegate fires `didCancel` / `didConfirmTrashingExternalIDs(Set<UUID>)`. Presented by `DetailAlertsPresenter` for every delete. Move-to-Trash is intentionally the default action (Return) AND destructive (red tint).
+- **Boot Order sheet** (`StorageDiskReorderSheetContentViewController`) — headline + `InfoButtonView` header, a view-based `NSTableView` (alternating rows, hidden headers) inside an `NSScrollView`, Done button. Drag-anywhere reorder via the native `NSTableView` drag-and-drop machinery (`pasteboardWriterForRow:`, `validateDrop:`, `acceptDrop:`); the pure index-math primitive is exposed as `performReorder(sourceRow:proposedRow:)` so tests exercise it without mocking `NSDraggingInfo`. It re-arms a `withObservationTracking` subscription on `fileMonitor.existsByPath` so missing-file affordances update live without dismiss/re-present. Presented by the settings VC via `SheetPresenter`.
+
+#### Display
+
+`VMDisplayBackingView` is the pure-AppKit VM display — it hosts `VZVirtualMachineView` with pause/transition overlays. In the detail pane, `DetailContainerViewController` layers it on top of the detail content; in pop-out/fullscreen windows, `VMDisplayWindowController` uses it directly as the window's content view. `VMDisplayPlaceholderContentViewController` is the detail-pane placeholder when the display is unavailable inline — a centered empty state (SF Symbol + title + description + optional action button) for the non-inline states (Fullscreen / Popped Out / Suspended / No Display), with an inert black fill behind it for the `.live` case (covered by `VMDisplayBackingView`). It observes `VMInstance.displayMode`, `isColdPaused`, and `virtualMachine` via `observeRecurring`; action buttons dispatch through `NSApp.sendAction(_:to:from:)` to `AppDelegate.toggleFullscreen(_:)` / `togglePopOut(_:)`. The reusable `DisplayPlaceholderEmptyStateView` lives privately in the same file (one consumer today; no premature extraction).
+
+#### Creation wizard
+
+`VMCreationWizardViewController` is the shell — step indicator (`WizardStepIndicatorView`) + swappable child step VCs + nav bar — observing `VMCreationViewModel` and reporting Cancel/Create via `VMCreationWizardViewControllerDelegate`. The steps are concrete `NSViewController`s: `OSSelectionContentViewController` (step 1), `IPSWSelectionContentViewController` / `BootConfigContentViewController` (step 2, chosen by OS), `ResourceConfigContentViewController` (step 3, `NSGridView` form), and `ReviewContentViewController` (step 4). `WizardStyle` provides the scoped design tokens + `make*` atom factories (title/subtitle/form rows, section headers, banner, path badge, scroll-view helper); the wizard shares the grouped-form atoms in `GroupedFormStyle` with the settings pane.
+
+#### View hierarchy
 
 ```
 NSSplitViewController (MainWindowController)
@@ -338,20 +419,9 @@ VMCreationWizardViewController (pure-AppKit modal sheet; presented by DetailCont
 └── ReviewContentViewController
 ```
 
-**Serial console data flow:** the guest serial output pipe has a single reader —
-`VMInstance.startSerialReading`'s `readabilityHandler` (background GCD queue) — which
-fans out to (a) `serial.log` (authoritative, always on) and (b) `SerialSocketRelay.forwardOutput`
-(best-effort tee, only when `serialSocketRelayEnabled`). An external terminal attaches to the
-relay's AF_UNIX socket; bytes it sends are written straight to the serial input pipe, making the
-relay the sole host-side writer of serial input. There is no in-app terminal emulator and no serial
-window — emulation is delegated to the user's terminal. The connect instructions and the (per-VM
-deterministic) socket path are surfaced via the info button on the **Serial Console** section of
-`VMSettingsViewController` (the path is `VMInstance.serialSocketPath(for:)`, computed the same way
-the relay binds it). The relay socket lives under `NSTemporaryDirectory()` (short path; the bundle
-dir overflows `sockaddr_un.sun_path`) and is App-Sandbox/Mac-App-Store-compatible (no entitlement).
-The per-VM `serialSocketRelayEnabled` flag is hot-toggleable via `applyLivePolicy` →
-`applyLiveSerialRelayPolicy`, handled before the vsock-socket-device guard since the relay is
-host-only.
+#### Serial console data flow
+
+The guest serial output pipe has a single reader — `VMInstance.startSerialReading`'s `readabilityHandler` (background GCD queue) — which fans out to (a) `serial.log` (authoritative, always on) and (b) `SerialSocketRelay.forwardOutput` (best-effort tee, only when `serialSocketRelayEnabled`). An external terminal attaches to the relay's AF_UNIX socket; bytes it sends are written straight to the serial input pipe, making the relay the sole host-side writer of serial input. There is no in-app terminal emulator and no serial window — emulation is delegated to the user's terminal. The connect instructions and the (per-VM deterministic) socket path are surfaced via the info button on the **Serial Console** section of `VMSettingsViewController` (the path is `VMInstance.serialSocketPath(for:)`, computed the same way the relay binds it). The relay socket lives under `NSTemporaryDirectory()` (short path; the bundle dir overflows `sockaddr_un.sun_path`) and is App-Sandbox/Mac-App-Store-compatible (no entitlement). The per-VM `serialSocketRelayEnabled` flag is hot-toggleable via `applyLivePolicy` → `applyLiveSerialRelayPolicy`, handled before the vsock-socket-device guard since the relay is host-only.
 
 ### Data Flow
 
@@ -383,11 +453,21 @@ SystemSleepWatcher ──sleep/wake──→ VMLibraryViewModel ──pause/resu
 
 ### Utilities
 
-**Files:** `DataFormatters.swift`, `NSImageExtensions.swift`, `NSViewExtensions.swift`, `ObservationLoop.swift`
+**Files:** `DataFormatters.swift`, `UniqueName.swift`, `PathValidation.swift`, `InlineRenameSizing.swift`, `NSImageExtensions.swift`, `NSViewExtensions.swift`, `NSOpenPanelExtensions.swift`, `DesignTokens.swift`, `ObservationLoop.swift`, `PopoverPresenter.swift`, `SheetPresenter.swift`, `SheetAlert.swift`, `DetailAlertsPresenter.swift`
 
 - `DataFormatters` — human-readable formatting for bytes (e.g., "107.4 GB"), CPU counts, etc.
+- `UniqueName` — `UniqueName.firstAvailable(prefix:existing:)`, the shared collision-free name generation backing both `StorageDisk.uniqueLabel` (bare numeric suffix) and `VMConfiguration.generateCloneName` (" Copy" infix)
+- `PathValidation` — shared path-validation helpers (resolve symlinks, check existence/type/permissions), used by `ConfigurationBuilder` and `USBDeviceService`
+- `InlineRenameSizing` — text-hugging sizing for the inline-rename field editors (sidebar rows, attachment rows)
 - `NSImageExtensions` — `NSImage.systemSymbol(_:accessibilityDescription:)` for nil-safe SF Symbol loading with error logging
-- `ObservationLoop` — `observeRecurring(track:apply:) -> ObservationLoop` helper that encapsulates the `withObservationTracking` + `Task { @MainActor }` + recursive re-register dance. Returns a cancel token stored by the caller; the loop stops when the token is deallocated or `cancel()` is called. Used by all 6 observation sites (`MainWindowController`, `VMDisplayWindowController`, `ClipboardWindowController`, `DetailContainerViewController`, `ClipboardContentViewController`, `AppDelegate.observeForTermination`) so each site only declares *what* to track and *what* to do — not how to sustain the loop.
+- `NSViewExtensions` — full-size subview constraint helper
+- `NSOpenPanelExtensions` — pre-configured `NSOpenPanel` factory for browsing disk images
+- `DesignTokens` — centralized `Spacing` scale, `StatusColor` palette, and shared `Typography` font token
+- `ObservationLoop` — `observeRecurring(track:apply:) -> ObservationLoop` helper that encapsulates the `withObservationTracking` + `Task { @MainActor }` + recursive re-register dance. Returns a cancel token stored by the caller; the loop stops when the token is deallocated or `cancel()` is called. Used by every observation site (window controllers, detail/sidebar/wizard VCs, `AppDelegate.observeForTermination`) so each site only declares *what* to track and *what* to do — not how to sustain the loop
+- `PopoverPresenter` — `NSPopover` lifecycle wrapper: one instance per anchor, refreshes content in place if shown again, fires `onClose` after dismissal
+- `SheetPresenter` — custom-content sheet lifecycle wrapper: wraps an `NSViewController` in an `NSWindow` and attaches it as a sheet via `parent.beginSheet(_:completionHandler:)`. Use for richer sheets than `NSAlert` can express (the Delete-VM and Boot Order sheets)
+- `SheetAlert` — AppKit `NSAlert` presenter: `AlertConfiguration` (title + message + ordered `[AlertButton]`) with a role enum (`.default` / `.cancel` / `.destructive` / `.standard`) mapping to key-equivalents and `hasDestructiveAction`; `presentSheetAlert(_:in:completion:)` shows the alert as a window-modal sheet
+- `DetailAlertsPresenter` — imperative presenter for the detail-pane lifecycle alerts + delete sheet (delete sheet, cancel-preparing, force-stop, stop-paused, error, installer-mounted). `DetailContainerViewController` forwards `VMLibraryPresenting` calls here; it serializes presentations (one at a time, queueing the rest) and shows each via `presentSheetAlert` / `SheetPresenter(DeleteVMSheetContentViewController)`. Owned by `DetailContainerViewController` so alerts survive while the VM display is showing
 
 ## Key Design Decisions
 
@@ -457,7 +537,7 @@ Three standalone targets are built alongside the main app — two CLI tools and 
 
 - **KernovaGuestAgent** — Not embedded directly. Runs inside macOS VMs and maintains three long-lived vsock connections to the host: an always-on control channel (`VsockGuestControlAgent` on port 49154 carrying the version handshake, bidirectional heartbeat, and the inbound `PolicyUpdate` push), log forwarding (`VsockHostConnection` on port 49153), and bidirectional clipboard sync (`VsockGuestClipboardAgent` on port 49152). All three connections are independent — a disconnect on one doesn't take the others down — and all share a `VsockGuestClient` helper that owns the connect/retry/serve loop. The log + clipboard agents start in a default-disabled state (paused at the `VsockGuestClient` level so no connect attempts run); they're enabled when the control agent receives the host's first `PolicyUpdate` and routes it via an `onPolicy` closure to `vsockConnection.setEnabled(_:)` and `clipboardAgent.setEnabled(_:)`. Disabling either capability discards buffered records and pauses the reconnect loop, so the guest stops generating traffic rather than relying on the host to ignore it. The clipboard agent polls `NSPasteboard.general` at 500 ms and announces changes to the host via `ClipboardOffer` frames; on inbound offers it requests the bytes and writes them to the local pasteboard. The agent depends on the local `KernovaProtocol` SPM package for the wire types and channel implementation. Packaged into a disk image at build time by the "Package Guest Agent DMG" Run Script build phase. The disk image (containing the binary, `install.command`, `uninstall.command`, and a LaunchAgent plist) is placed in `Contents/Resources/KernovaGuestAgent.dmg`. At runtime, the "Install Guest Agent..." menu item in the Virtual Machine menu attaches it to a guest VM as USB mass storage. The guest user runs `install.command` to install the agent as a LaunchAgent in user-space (`~/Library/Application Support/Kernova/`). The vsock reconnect loop uses a flat 5s retry interval; `SO_RCVTIMEO` / `SO_SNDTIMEO` are set to 30 s as a safety net against wedged read/write calls. The build number is injected via `INFOPLIST_PREPROCESS`: a pre-Sources build phase ("Set Build Number from Git") writes `#define AGENT_BUILD_NUMBER` (set to the git commit count scoped to `KernovaGuestAgent/`) to a header in `DERIVED_FILE_DIR`, and the explicit `Info.plist` references that macro for `CFBundleVersion`. The preprocessed plist is embedded in the binary via `CREATE_INFOPLIST_SECTION_IN_BINARY`.
 
-- **KernovaGuestAgentTests** — Standalone unit-test bundle (no `TEST_HOST` / `BUNDLE_LOADER`) that covers the agent-side classes. Because `KernovaGuestAgent` is an executable tool target (not a framework), its symbols are not linkable — the test bundle instead compiles the agent's Swift source files directly (all except `main.swift`, `Info.plist`, and the shell scripts, excluded via `PBXFileSystemSynchronizedBuildFileExceptionSet`). This direct compilation makes all `internal` members accessible without `@testable import`, which is unavailable for tool targets. Three agent classes required light testability seams: `VsockGuestClient` gained a `socketProvider` closure injection point and a parameterized `retryInterval` (default unchanged at 5 s); `VsockGuestClipboardAgent` gained a `Pasteboard` protocol (with `NSPasteboard` conformance) and injected `client`/`pasteboard` init parameters; `VsockHostConnection` lifted `pendingLogs`, `lock`, `bufferFrame`, `flushPendingLogs`, and `logBufferLimit` from `private` to internal. Shared test helpers live in `TestHelpers.swift` (socket-pair factories, `waitUntil`, `nextFrame`, `awaitFirst`, `AtomicInt`, frame factories). Non-parallelizable in the scheme because each test worker loads the agent sources which include global state (`VsockLogBridge.connection`); tests share one runner process.
+- **KernovaGuestAgentTests** — Standalone unit-test bundle (no `TEST_HOST` / `BUNDLE_LOADER`) that covers the agent-side classes. Because `KernovaGuestAgent` is an executable tool target (not a framework), its symbols are not linkable — the test bundle instead compiles the agent's Swift source files directly (all except `main.swift`, `Info.plist`, and the shell scripts, excluded via `PBXFileSystemSynchronizedBuildFileExceptionSet`). This direct compilation makes all `internal` members accessible without `@testable import`, which is unavailable for tool targets. Three agent classes required light testability seams: `VsockGuestClient` gained a `socketProvider` closure injection point and a parameterized `retryInterval` (default unchanged at 5 s); `VsockGuestClipboardAgent` gained a `Pasteboard` protocol (with `NSPasteboard` conformance) and injected `client`/`pasteboard` init parameters; `VsockHostConnection` lifted `pendingLogs`, `lock`, `bufferFrame`, `flushPendingLogs`, and `logBufferLimit` from `private` to internal. Shared test helpers live in `TestHelpers.swift` (socket-pair factories, `waitUntil`, `AsyncGate`, `nextFrame`, `awaitFirst`, `AtomicInt`, frame factories). Non-parallelizable in the scheme because each test worker loads the agent sources which include global state (`VsockLogBridge.connection`); tests share one runner process.
 
 ## Dependencies
 
@@ -473,60 +553,6 @@ Three standalone targets are built alongside the main app — two CLI tools and 
 
 No third-party (non-Apple) package dependencies. No CocoaPods or Carthage.
 
-## Test Coverage
+## Testing
 
-### Well Covered
-
-| Component | Tests | Notes |
-|-----------|-------|-------|
-| `VMConfiguration` | 49+ tests + clone suite | Encoding/decoding, defaults, validation, `lastSeenAgentVersion` migration, `storageDisks` / `removableMedia` round-trip + nil-decode, `StorageDisk.uniqueLabel` (no-collision / numeric-suffix / case-sensitivity), `liveEditableFieldsChanged` covering hot-toggle booleans + `removableMediaChanged` list-diff, clone regenerates all `StorageDisk.id` / `RemovableMediaItem.id` while preserving paths/labels |
-| `VMLibraryViewModel` | 90+ tests | Add/remove/rename/reorder VMs, selection, auto-select on load, selection preservation on reload, delegation to coordinator, sleep/wake, clone/import phantom rows, cancel preparing, force-stop confirmation, stop escalation timing, custom order persistence, guest agent installer mount/unmount (via the `removableMedia` config path), centralized `updateConfiguration` dispatcher, removable-media list-diff reconcile (add / remove / mutate / reorder-noop / rapid-fire coalesce / `deviceNotFound` continues / `noVirtualMachine` silent bail / transient-error fail-fast), rollback-to-live-state on unexpected detach / attach / swap failure, `removeStorageDisk` trash-vs-remove paths (incl. shared-file and Guest-Agent trash guards that detach-only), `createStorageDisk` async append (returns its Task; assigns a collision-free default label), `renameStorageDisk` / `renameRemovableMedia` persist + whitespace-trim + empty-guard (no save) + unknown-id no-op (removable also asserts a label-only edit leaves `path`/`readOnly` untouched so it stays mounted live), synthetic main disk removal works against the stable derived UUID, delete-VM external-attachment enumeration (sharing detection across VMs via `sharingVMNames`, Guest Agent DMG excluded; per-file `isMissing` resolved off-main by `externalAttachmentsResolvingExistence`), `bundledDisks` internal-disk listing, `isMainDisk` / `isGuestAgentInstaller` predicates, and the `deleteConfirmed(trashingExternalIDs:)` per-item trash-fan-out (selected-only, shared hard-blocked, Guest Agent never trashed) |
-| `VMCreationViewModel` | 49 tests | All wizard steps, validation, OS-specific paths, post-creation auto-start preference |
-| `VMLifecycleCoordinator` | Yes | Multi-step orchestration, error handling, service delegation, token-based operation serialization, stop/forceStop bypass, stale-token race condition coverage |
-| `VMInstance` | Yes | Status transitions, configuration updates, bundle layout, preparing state display properties, post-start agent watchdog (firing/cancellation/no-op guards/idempotency), `recordObservedAgentVersion` persistence + dedup |
-| `VMBundleLayout` (disk sizing) | `VMBundleLayoutTests` | `diskOnDiskBytes` nil/size/sparse; `diskCapacityBytes` parses a crafted `shdw` header (sector count → bytes), returns the logical size for a non-ASIF (in-bundle + external absolute path), nil for a missing file, nil — *not* the file size — for a malformed (out-of-bounds) ASIF, and nil for a sector count that **overflows** when ×512 (wrap-to-sanity-window rejected); `diskSizes` returns both figures in one read |
-| `diskSubtitle(for:bundleLayout:)` | `StorageDiskSubtitleTests` | Reads live from real files: ASIF disk → on-disk/allocated; non-ASIF → on-disk/logical-size-as-allocated; in-bundle missing file → "In-bundle disk image"; external raw → on-disk/allocated; external unreadable → path fallback; main disk measured identically to additional disks |
-| `ConfigurationBuilder` | Yes | All three boot paths, device configuration, path validation (symlinks resolved for external storage disks → VZ gets the followed URL, missing kernel/initrd/ISO/storage-disk, directory rejection, non-writable rejection, internal-path-traversal containment), storage-topology dispatch (`storageDisks` → ordered `storageDevices` with kind-based virtio/USB; `removableMedia` → XHCI; `coldRemovableMedia` `USBDeviceInfo`s match persisted UUIDs), synthesized main-disk UUID is stable across calls and distinct across bundles |
-| `VirtualizationService` | Yes | Start/stop/pause/resume via mock VZ objects |
-| `VMStorageService` | Yes | CRUD operations, cloning |
-| `VMBundleLayout` | Yes | Path derivation from bundle root |
-| `VMStatus` | Yes | Enum behavior, transitions, `canForceStop` |
-| `VMBootMode` | Yes | Enum cases and properties |
-| `VMGuestOS` | Yes | Enum cases and properties |
-| `MacOSInstallState` | Yes | Phase tracking, progress calculation |
-| `VMToolbarManager` | 22 tests | Item creation, state updates, configuration flags, label toggling |
-| `DataFormatters` | Yes | Byte formatting, CPU count formatting |
-| `NSImageExtensions` | Yes | SF Symbol loading with known symbol validation |
-| `SpiceAgentProtocol` | Yes | VDI chunk/message serialization round-trips, parser with multi-message feeds, partial data, unknown types, clientPort constant, port-parameterized builders |
-| `VsockClipboardService` | Yes | No-Hello-on-start, `isConnected` after start, outbound offer dedup + monotonic generation, request-response, stale request/data drop, inbound offer-driven population, wrong-version frame drop |
-| `VsockControlService` | 15 tests | Host Hello on start, guest Hello populates state, `agentStatus` waiting/current/outdated/newer-than-bundled, numeric ordering for dotted versions, reset on stop, fallback when bundled version missing, heartbeat outbound cadence, inbound heartbeat preserves liveness, silence flips to `.unresponsive`, recovery, terminate closes channel, `stop()` idempotency, `onAgentVersionObserved` fires once per non-empty Hello (skips empty, no caller-side dedup) |
-| `KernovaLogMessage` | Yes | Full privacy-redaction matrix: `.public`/`.private`/`.sensitive`/`.auto`/default, generic fallback (String, Int, Bool), mixed interpolations, literal init |
-| `VsockHostConnection` | Yes | Log ring-buffer cap (256 frames), FIFO ordering, oldest-drop-first eviction, flush-to-channel, partial-flush re-enqueue (index>0 and index=0), cap enforcement after re-enqueue, `forwardLog` live-channel paths, default-disabled drops `forwardLog`, `setEnabled(true)` allows buffering, disabling discards buffered frames, idempotent `setEnabled` |
-| `VsockGuestClient` | Yes | Socket-factory injection, `liveChannel` lifecycle, stop-mid-connect abort, stop-mid-serve, idempotent start, stop-before-start no-op, nil-provider retry, `pause()` suppresses connect, `resume()` allows the loop to connect after pre-start pause |
-| `VsockGuestClipboardAgent` | Yes | Outbound offer on pasteboard change, echo suppression after host write, reconnect resets `lastSeenText`, stale-generation data drop, full offer/request/data round-trip, synchronous publish before read loop, default-disabled at construction, `setEnabled` toggles live channel up/down |
-| `VsockGuestControlAgent` | Yes | Hello on connect, heartbeat cadence, inbound Hello/Heartbeat without crash, reconnect after host close, idempotent stop, inbound `PolicyUpdate` invokes `onPolicy` callback with the supplied snapshot |
-
-### Mocked but Not Directly Tested
-
-These services interact with system processes, the network, or VZ installer internals. They are fully mocked in other tests but don't have their own test suites against real implementations:
-
-- `DiskImageService` — decompresses bundled templates (no subprocess; direct testing feasible but requires bundled resources in test target)
-- `IPSWService` — makes network requests to Apple
-- `MacOSInstallService` — requires a real `VZVirtualMachine` and restore image
-- `SpiceClipboardService` — requires active SPICE pipe I/O (protocol parsing tested via `SpiceAgentProtocol` suite)
-
-### Not Tested
-
-- `VMDirectoryWatcher` — relies on `DispatchSource` file system monitoring
-- `SystemSleepWatcher` — relies on `NSWorkspace` sleep/wake notifications (sleep/wake logic tested via `VMLibraryViewModel`)
-- `KernovaUTType` — static UTType declaration
-- All window controllers (`MainWindowController`, `VMDisplayWindowController`, `ClipboardWindowController`)
-- `AppDelegate` — app lifecycle and window management
-- Pure AppKit view rendering beyond the extracted testable helpers (`DetailRoute`, `MicPermissionPresentation`) and the VC-level tests (`VMSettingsViewControllerTests`, wizard-step tests)
-
-### Test Patterns
-
-- **Framework:** Swift Testing (`@Suite`, `@Test`, `#expect`) — not XCTest
-- **Mocks:** 8 mock implementations conforming to service protocols, supporting call counting and error injection via `throwError` properties. Includes `SuspendingMockVirtualizationService` for testing operation serialization and `SuspendingMockUSBDeviceService` for testing the mount mutex in `mountGuestAgentInstaller` — both suspend mid-operation to verify concurrent rejection. Rely on `@MainActor` cooperative scheduling (documented in the mocks) and enforce single-suspension via `precondition`
-- **Factories:** Shared helpers like `makeInstance()`, `makeViewModel()`, `makeCoordinator()` reduce setup duplication
-- **Error paths:** Mocks support setting `throwError` to inject failures and verify error handling
+Test patterns, the test-plan wiring, the event-driven-waits policy, and coverage gaps are documented in [docs/testing.md](docs/testing.md). Per-suite scope is annotated inline in the [directory tree](#directory-structure) above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-> Design philosophy and UI guidelines are in [SPEC.md](SPEC.md).
+> Design philosophy and UI guidelines are in [SPEC.md](SPEC.md). Architecture is in [ARCHITECTURE.md](ARCHITECTURE.md). Procedure references live in `docs/`: [testing](docs/testing.md), [review feedback handling](docs/reviewing.md), and [git workflow mechanics](docs/git-workflow.md) — read the relevant one before doing that kind of work.
 
 ## Build & Test
 
@@ -27,19 +27,19 @@ Run `make install-hooks` once after cloning to enable the pre-push `make lint` h
 xcodebuild -project Kernova.xcodeproj -scheme Kernova -destination 'platform=macOS' -derivedDataPath DerivedData -configuration Debug <build|test>
 ```
 
-A single `xcodebuild test -scheme Kernova` runs all three test targets (`KernovaTests`, `KernovaGuestAgentTests`, `KernovaProtocolTests`) via `Kernova.xctestplan`. This works because `KernovaProtocol` is referenced as a top-level peer in the project (a `PBXFileReference` in `Kernova.xcodeproj`'s main group) rather than as an `XCLocalSwiftPackageReference` under Package Dependencies. In the dependency form, Xcode treats the package as upstream and hides its `.testTarget`s from the test-plan picker; in the peer form, the package's tests appear in `Edit Scheme → Test → +` as first-class targets and can be added to the test plan. If `KernovaProtocol` ever needs to be re-added, drag the folder into the Project Navigator from Finder rather than using `Add Package Dependencies → Add Local`. `make test-package` exists as a focused shortcut for iterating on package tests in isolation.
+One `xcodebuild test` run covers all three test targets (`KernovaTests`, `KernovaGuestAgentTests`, `KernovaProtocolTests`) via `Kernova.xctestplan` — how that's wired, and how to re-add the `KernovaProtocol` package if it's ever removed, is in [docs/testing.md](docs/testing.md#test-targets-and-the-test-plan).
 
-The `-derivedDataPath DerivedData` flag ensures build output goes to a deterministic local `DerivedData/` directory (already gitignored) instead of the per-path-hashed `~/Library/Developer/Xcode/DerivedData/` location. This avoids glob ambiguity when worktrees or parallel builds create multiple DerivedData folders. Xcode itself still uses the per-user default — they don't need to share.
+The `-derivedDataPath DerivedData` flag keeps build output in a deterministic local `DerivedData/` directory (gitignored) instead of the per-path-hashed `~/Library/Developer/Xcode/DerivedData/` location, avoiding glob ambiguity when worktrees or parallel builds create multiple DerivedData folders. Xcode itself still uses the per-user default — they don't need to share.
 
 ### Build version
 
-`CFBundleVersion` is `git rev-list --count HEAD` (the total commit count), substituted into the source `Info.plist` via `INFOPLIST_PREPROCESS`. The `Set Build Number from Git` build phase generates `KernovaBuildNumber.h` with `#define KERNOVA_BUILD_NUMBER N`, and `Kernova/App/Info.plist` references the symbol directly (`<string>KERNOVA_BUILD_NUMBER</string>`). Substitution happens inside `ProcessInfoPlistFile` so build-graph reordering can't clobber it. The `KernovaGuestAgent` target uses the same pattern with its own `AGENT_BUILD_NUMBER` (scoped to `git rev-list --count HEAD -- KernovaGuestAgent/`). When adding a new top-level target that needs a dynamic build number, replicate this pattern instead of patching the built `Info.plist` after the fact.
+`CFBundleVersion` is `git rev-list --count HEAD` (the total commit count), substituted into the source `Info.plist` via `INFOPLIST_PREPROCESS`: the `Set Build Number from Git` build phase generates a header defining `KERNOVA_BUILD_NUMBER`, which `Kernova/App/Info.plist` references directly. Substitution happens inside `ProcessInfoPlistFile` so build-graph reordering can't clobber it. `KernovaGuestAgent` uses the same pattern with its own `AGENT_BUILD_NUMBER` (scoped to `git rev-list --count HEAD -- KernovaGuestAgent/`). When adding a new top-level target that needs a dynamic build number, replicate this pattern instead of patching the built `Info.plist` after the fact.
 
 Requires the toolchain listed under [Requirements](README.md#requirements) in the README (Apple Silicon is needed for macOS guest support). The app uses the `com.apple.security.virtualization` entitlement.
 
 ## Architecture
 
-> Full directory structure, component map, data flow diagrams, design decisions, and test coverage details are in [ARCHITECTURE.md](ARCHITECTURE.md). Consult it before making structural changes. The summary below is a quick reference; if it conflicts with ARCHITECTURE.md, ARCHITECTURE.md is authoritative.
+> Full directory structure, component map, data flow diagrams, and design decisions are in [ARCHITECTURE.md](ARCHITECTURE.md). Consult it before making structural changes. The summary below is a quick reference; if it conflicts with ARCHITECTURE.md, ARCHITECTURE.md is authoritative.
 
 Kernova is a pure-AppKit app that manages virtual machines via Apple's `Virtualization.framework`, supporting macOS and Linux guests.
 
@@ -53,27 +53,19 @@ Kernova is a pure-AppKit app that manages virtual machines via Apple's `Virtuali
 
 ### Unit Tests
 
-When adding new functionality or modifying existing behavior, include unit tests for the changes. Follow the existing patterns in `KernovaTests/`:
+When adding new functionality or modifying existing behavior, include unit tests for the changes. The essentials (full patterns, the test plan, and seam guidance in [docs/testing.md](docs/testing.md)):
 
 - Use Swift Testing (`@Suite`, `@Test`, `#expect`) — not XCTest
-- Create mock implementations using protocols (see `KernovaTests/Mocks/`)
+- Create mock implementations using protocols (see `KernovaTests/Mocks/`); inject errors via `throwError`
 - Test models, services, and view models — UI views don't need unit tests
-- Test both happy paths and error paths; use error injection in mocks (e.g., setting a `throwError` property)
-- Reuse shared test helpers and factories (e.g., `makeInstance()`) rather than duplicating setup logic across test files
-- Run the full test suite before committing to ensure nothing is broken
-
-#### Test-only seams
-
-When a test needs to observe state that is `private` in production, pick the tightest exposure that still works:
-
-1. **`private(set) var x`** — internal getter, private setter. The idiomatic choice when production code reading the state is harmless; tests reach it via `@testable import`, no extra accessor needed.
-2. **`#if DEBUG`-gated read accessor** — when the state is a test-only implementation detail that production code should *not* read. Keep the field `private` and add a `…ForTesting` computed getter wrapped in `#if DEBUG`, so the seam is physically absent from Release builds and test-only access becomes a compile-time guarantee rather than a naming convention. Place `#if DEBUG` before the doc comment and `#endif` after the accessor.
-
-`AttachmentFileMonitor.watchedParentsForTesting` is the canonical example; the `…ForTesting` accessors in `VsockClipboardService`, `VsockGuestClipboardAgent`, and `VsockHostConnection` follow the same pattern. Because this rationale is shared, the gate itself is the documentation — don't repeat a "DEBUG-only so it can't leak" note at each site.
+- Test both happy paths and error paths; reuse shared factories (`makeInstance()`, …) rather than duplicating setup
+- Timing-sensitive waits must be event-driven (`AsyncGate`, or `await` the production `Task` via a `#if DEBUG` seam) — never poll-with-timeout, and never fix a CI flake by raising a timeout. See [docs/testing.md](docs/testing.md#timing-sensitive-waits-event-driven-not-polling)
+- When a test needs `private` production state, pick the tightest seam: `private(set)`, or a `#if DEBUG`-gated `…ForTesting` accessor — decision rule and canonical examples in [docs/testing.md](docs/testing.md#test-only-seams)
+- Run the full test suite before committing
 
 ### Logging
 
-The app uses Apple's `os.Logger` (subsystem `com.kernova.app`) with per-component categories. Each service, view model, or model that logs declares a `private static let logger`. When adding or modifying functionality, include log calls at appropriate levels:
+The app uses Apple's `os.Logger` (subsystem `com.kernova.app`) with per-component categories. Each service, view model, or model that logs declares a `private static let logger = Logger(subsystem: "com.kernova.app", category: "ComponentName")`.
 
 | Level | When to use | Persistence |
 |-------|-------------|-------------|
@@ -84,11 +76,7 @@ The app uses Apple's `os.Logger` (subsystem `com.kernova.app`) with per-componen
 | `.error` | Failures: operations that did not complete, exceptions caught, error states entered. | Persisted to disk |
 | `.fault` | Programming errors: impossible states, compile-time-known inputs that failed lookup. Paired with `assertionFailure`. | Persisted to disk; always visible; never redacted |
 
-**Guidelines:**
-- Every new service or view model should declare its own `private static let logger = Logger(subsystem: "com.kernova.app", category: "ComponentName")`
-- State transitions and irreversible actions (creating/deleting bundles, starting/stopping VMs) should be `.notice`
-- Method entry points in complex flows should have `.debug` logs with relevant parameter values
-- Do not use `print()`, `NSLog()`, or file-based logging
+State transitions and irreversible actions (creating/deleting bundles, starting/stopping VMs) are `.notice`; method entry points in complex flows get `.debug` with relevant parameter values. Do not use `print()`, `NSLog()`, or file-based logging.
 
 ### Defensive Unwrapping
 
@@ -110,6 +98,10 @@ guard let value = knownGoodAPI("compile-time-constant") else {
 
 - When deleting files, prefer `trash` over `rm` whenever possible (moves to Trash instead of permanent deletion).
 
+### Localization
+
+The app ships English-only — there are no `.lproj` directories or `Localizable.strings` files. Don't wrap user-facing strings in `NSLocalizedString(...)` unless explicitly setting up localization; raw `String` literals are the convention. If real translations ever land, file `review-debt/refactor` issues for bulk-wrapping the existing strings.
+
 ### Review Feedback Handling
 
 When reviewing code — via review tools (`/simplify`, `/review-pr`, etc.), post-implementation review agents, external PR review feedback (bot or human), or while working on adjacent code — every finding must be triaged into one of four categories:
@@ -117,150 +109,28 @@ When reviewing code — via review tools (`/simplify`, `/review-pr`, etc.), post
 | Category | Action | When to use |
 |----------|--------|-------------|
 | **Fix now** | Apply the fix as part of the current work | Valid finding, in scope, reasonable effort |
-| **Fix later** | File a GitHub issue (see [Review Debt Tracking](#review-debt-tracking) below) | Valid finding, but out of scope or too large for the current task |
-| **Annotate** | Add a `RATIONALE:` comment (see [Intentional Pattern Annotations](#intentional-pattern-annotations)) for human/automated reviewer findings, or a `// periphery:ignore - <reason>` directive (see [Periphery Directives](#periphery-directives)) for dead-code scan false positives | Code looks wrong or unconventional but is correct for a project-specific reason |
+| **Fix later** | File a GitHub issue immediately — issue format and `review-debt/*` labels in [docs/reviewing.md](docs/reviewing.md#review-debt-tracking) | Valid finding, but out of scope or too large for the current task |
+| **Annotate** | `RATIONALE:` comment for human/automated reviewer findings, or `// periphery:ignore - <reason>` for dead-code scan false positives — formats in [docs/reviewing.md](docs/reviewing.md#intentional-pattern-annotations) | Code looks wrong or unconventional but is correct for a project-specific reason |
 | **Dismiss** | No action needed | Pure style nits, cosmetic preferences, trivial improvements with negligible impact |
 
-#### Review Debt Tracking
-
-Valid findings that are **out of scope** for the current task must be captured as GitHub issues rather than silently dropped.
-
-**What to capture** (important + moderate severity):
-- Bugs, correctness problems, or logic errors
-- Security concerns
-- Performance issues
-- Meaningful refactoring opportunities or non-trivial code smells
-- Missing test coverage for critical paths
-
-**Issue format:**
-
-~~~bash
-gh issue create \
-  --title "<concise description of the finding>" \
-  --label "<review-debt/label>" \
-  --body "$(cat <<'EOF'
-## Found during
-<PR #N / review of `FileName.swift` / context description>
-
-## Description
-<What the issue is and why it matters>
-
-## Location
-<File path(s) and line number(s) or function name(s)>
-
-## Suggested fix
-<Brief suggestion if one is obvious, otherwise omit this section>
-EOF
-)"
-~~~
-
-**Labels** — use the most specific match:
-
-| Label | When to use |
-|-------|-------------|
-| `review-debt/bug` | Correctness issues, logic errors, potential crashes |
-| `review-debt/security` | Security concerns, unsafe patterns |
-| `review-debt/performance` | Inefficient code paths, unnecessary allocations |
-| `review-debt/refactor` | Code smells, duplication, poor abstractions |
-| `review-debt/test-gap` | Missing or insufficient tests for critical code |
-
-**Guidelines:**
-- **File issues immediately** — do not list qualifying findings as "skipped" and wait for the user to ask. If a finding meets the severity criteria above, create the issue as part of the review flow before summarizing results.
-- Always check for existing issues before creating duplicates
-- Reference the source PR or file context in the issue body
-- Keep issue titles actionable and specific (e.g., "Add error handling for disk-full scenario in BundleManager" not "Improve error handling")
-- When multiple related findings exist, group them into a single issue if they share a root cause
-- After creating issues, mention them in the conversation so the user is aware
-
-#### Intentional Pattern Annotations
-
-When a review flags code that *looks* wrong or unconventional but is **intentionally correct** for a project-specific reason, add an inline comment with the `RATIONALE:` prefix explaining why. This prevents the same pattern from being re-flagged in future reviews.
-
-**When to annotate:**
-- The code contradicts a general best practice but is correct here due to framework constraints, performance requirements, or architectural decisions
-- A reviewer (human or automated) would reasonably flag this without project-specific context
-- The reason is not already documented in CLAUDE.md, ARCHITECTURE.md, or an adjacent comment
-
-**Format:**
-
-```swift
-// RATIONALE: VZVirtualMachine delegates are not actor-isolated by the framework,
-// so we use nonisolated(unsafe) and bridge back via MainActor.assumeIsolated.
-nonisolated(unsafe) func guestDidStop(_ virtualMachine: VZVirtualMachine) {
-```
-
-**Guidelines:**
-- Keep annotations concise — explain *why* the pattern is correct, not *what* the code does
-- If the same rationale applies project-wide (not just at one call site), consider adding it to CLAUDE.md or ARCHITECTURE.md instead of repeating the comment on every instance
-- `RATIONALE:` comments are greppable — use `grep -r "RATIONALE:"` to audit all intentional deviations
-- Do not use `RATIONALE:` for general explanatory comments — reserve it strictly for patterns that would otherwise be flagged as issues
-
-#### Periphery Directives
-
-When the dead-code scan flags a symbol that is alive through machinery Periphery's symbol graph cannot see — protocol witnesses invoked by Swift's compiler-emitted code (string interpolation, `Codable`), members reached through type inference on argument labels, declarations referenced only from a test target Periphery does not currently scan, or symbols intentionally retained for API symmetry — annotate the declaration with `// periphery:ignore - <reason>` instead of deleting it. This is the Periphery-specific counterpart to `RATIONALE:`: same spirit (silence a finding that would otherwise be re-raised every scan), different syntax that the tool itself recognizes.
-
-**When to annotate vs. fix vs. dismiss:**
-- **Annotate** when the symbol is genuinely used through one of the invisible paths above, OR when the surface is intentionally complete (e.g. all `os.Logger` levels exposed even if a particular call isn't used today).
-- **Fix** when the finding is real — delete the symbol, or demote `public` to `internal` if only the access level is redundant.
-- **Dismiss** does not apply: every annotation must include a reason, since silently retained symbols become a maintenance hazard.
-
-**Format:**
-
-```swift
-/// `true` when no buffered bytes remain.
-// periphery:ignore - Used by `VsockFrameTests` via `@testable import`,
-// which Periphery's scheme-based scan doesn't currently index for the
-// SwiftPM package test target.
-var isEmpty: Bool { buffer.count == readOffset }
-```
-
-Place the directive **between** the doc comment (`///`) and the declaration so DocC still associates the doc with the symbol.
-
-**Guidelines:**
-- Keep the rationale on the same comment block as the directive — multi-line if needed, but no blank line between `// periphery:ignore` and the reason text
-- Greppable via `grep -r "periphery:ignore"` for periodic auditing — when the underlying machinery becomes visible to Periphery (e.g. a scan-coverage gap is closed), revisit the annotations and remove any that are no longer needed
-- Prefer per-symbol annotations over re-toggling broad config flags like `retain_public` — see `.periphery.yml` for the project-level guidance
+File qualifying issues **immediately** as part of the review flow — do not list findings as "skipped" and wait for the user to ask — and mention created issues in the conversation so the user is aware.
 
 ## Git Workflow
 
 ### Branch Naming
 
-Worktrees start on an auto-generated `worktree-<name>` branch (the harness also
-mangles any `/` in the name to `+`). **Treat that as a throwaway scratch branch:
-do the work on it without renaming up front.** Don't try to pick a branch name
-before starting — the right name depends on the full scope of the work, which
-you only know once it's ready to push.
-
-When the work is ready to push to origin, rename the scratch branch to a clean
-`<type>/<short-description>`, where `<type>` matches the commit type prefixes
-(e.g., `feat`, `fix`, `refactor`), and push it under that same name so the local
-branch and the origin/PR branch match:
-
-```
-feat/vm-snapshot-support
-fix/display-sizing-on-switch
-refactor/extract-lifecycle-coordinator
-```
+Worktrees start on an auto-generated `worktree-<name>` scratch branch — work on it as-is, without picking a name up front. When the work is ready to push, rename it to a clean `<type>/<short-description>` (type matching the commit prefixes; 2-4 kebab-case words) and push under that same name:
 
 ```bash
 git branch -m <type>/<short-description>        # rename the scratch branch in place
 git push -u origin <type>/<short-description>   # local and remote now match
 ```
 
-Keep descriptions concise (2-4 words, kebab-case). The branch name should make
-the PR's purpose clear at a glance.
-
-**Never push the `worktree-`-prefixed scratch name to origin.** It is a local
-implementation detail; a PR's head branch must always be the clean
-`<type>/<short-description>` name. (Renaming a branch on GitHub *after* a PR
-exists does not retarget the PR — it closes it — so name it correctly at first
-push.)
+**Never push the `worktree-`-prefixed scratch name to origin** — a PR's head branch must be the clean name from the first push (renaming on GitHub after a PR exists closes the PR). Details: [docs/git-workflow.md](docs/git-workflow.md#worktree-scratch-branches).
 
 ### Commit Messages
 
 These conventions apply to **all** forms of committing: local commits, PR squash/merge commits, and any other git operations that produce commits.
-
-Use the following format for all commits:
 
 ```
 <type>: <concise subject line>
@@ -277,8 +147,6 @@ Use the following format for all commits:
 
 A `## Notes` section may be added optionally if there are caveats, follow-ups, or things reviewers should know.
 
-### Type prefixes
-
 | Prefix     | Usage                                      |
 |------------|--------------------------------------------|
 | `feat`     | New feature or capability                  |
@@ -289,57 +157,13 @@ A `## Notes` section may be added optionally if there are caveats, follow-ups, o
 | `chore`    | Build, CI, tooling, or dependency updates  |
 | `style`    | Formatting, whitespace, or cosmetic changes|
 
-### Example
-
-```
-feat: Add VM snapshot support
-
-## Summary
-- Add the ability to take and restore snapshots of running virtual machines
-- Enables users to save and revert VM state at any point
-
-## Changes
-- Add SnapshotService with create/restore/delete operations
-- Add snapshot UI to VMDetailView toolbar
-- Persist snapshot metadata in VMConfiguration
-
-## Test plan
-- [ ] Built successfully on macOS 26
-- [ ] Tested snapshot create/restore cycle with macOS and Linux guests
-- [ ] All existing tests pass
-```
-
-### Scoping the message
-
-Commit messages must reflect the full intent and scope of all changes, not just the last operation performed. Before writing a commit message, review both the conversation context (what the user asked for, the steps taken) and the staged diff holistically. Lead with the primary purpose; secondary details (naming conventions, formatting choices) belong in the body.
+Commit messages must reflect the full intent and scope of all changes, not just the last operation performed. Before writing one, review both the conversation context (what the user asked for, the steps taken) and the staged diff holistically. Lead with the primary purpose; secondary details (naming conventions, formatting choices) belong in the body.
 
 The `Co-Authored-By` trailer is automatically appended by Claude Code and should not be duplicated in the commit message body.
 
 ### Merging Pull Requests
 
-When merging PRs with `gh pr merge`, always squash-merge with `--squash --subject` using the PR title and appending the PR number in parentheses (e.g., `--squash --subject "fix: Title (#11)"`), matching the repo's existing convention.
-
-**Do not use `--delete-branch`.** The repo has `delete_branch_on_merge` enabled on GitHub, so remote branches are auto-deleted. The `--delete-branch` flag causes `gh` to run `git checkout main` locally, which fails in worktree contexts.
-
-**Linking issues for auto-close:** When a PR resolves GitHub issues, include `Closes #N` (or `Fixes #N`) in the PR body — not just a table reference like `| #N |`. GitHub only auto-closes issues when the merge commit or PR body contains the exact keywords `closes`, `fixes`, or `resolves` followed by `#N`. Place them in the summary section or as a standalone line (e.g., `Closes #12, #34, #56`).
-
-#### Post-merge cleanup
-
-After a successful merge, confirm it landed, then tear down the branch and sync `main`:
-
-1. `gh pr view <N> --json state -q .state` — confirm `"MERGED"` before deleting anything.
-
-**In an `EnterWorktree` session** (the usual case), let the tool do the teardown, then sync:
-
-2. `ExitWorktree` with `action: "remove"`. Squash-merge leaves the worktree's commit off `main` by SHA, so the tool refuses unless you also pass `discard_changes: true` — that's expected and safe here, since the content already landed on `main` as the squash commit. This returns the session to the primary checkout and deletes the worktree and its scratch branch in one step.
-3. Now in the primary checkout: `git checkout main` (if not already on it), then `git pull --ff-only` to fast-forward onto the squash commit.
-
-**Working directly in a checkout** (no `EnterWorktree` session), delete the branch by hand instead:
-
-2. Get off the merged branch first: `git switch main`, or `git checkout --detach` in a manually-created worktree (you can't switch to `main` there — the primary checkout holds it).
-3. `git branch -D <merged-branch>` — force `-D`, since the squash commit makes `-d` reject the branch as "not fully merged".
-4. `git branch -d -r origin/<merged-branch>` — drop the stale remote-tracking ref (GitHub auto-deletes the remote branch on merge).
-5. `git pull --ff-only`.
+Squash-merge with the PR title plus number: `gh pr merge <N> --squash --subject "<type>: Title (#N)"`. Do **not** pass `--delete-branch`. Auto-merge is disabled, the head branch must be up-to-date with `main`, three status checks are required, and issue auto-close needs a `Closes #N` keyword per issue in the PR body — the full merge procedure and the post-merge cleanup steps (worktree and plain-checkout variants) are in [docs/git-workflow.md](docs/git-workflow.md#merging-prs). Follow the cleanup steps there after every merge.
 
 ### Post-Commit
 
@@ -350,6 +174,7 @@ After a commit/push, if any new preferences or insights emerged during the work,
 After completing any task that hits one or more of the following triggers, suggest follow-up updates before considering the task complete.
 
 ### Triggers
+
 - Added, removed, renamed, or moved a file or directory
 - Changed how components communicate (new API surface, changed data flow, new service)
 - Added or removed a dependency or framework
@@ -359,13 +184,13 @@ After completing any task that hits one or more of the following triggers, sugge
 
 ### Required Follow-ups
 
-1. **[ARCHITECTURE.md](ARCHITECTURE.md)** — Read the relevant sections first, then propose specific, targeted updates to reflect the change. Update the directory structure, component map, design decisions, or test coverage sections as needed. Do not rewrite the entire file — make surgical edits.
+1. **[ARCHITECTURE.md](ARCHITECTURE.md)** — Read the relevant sections first, then propose specific, targeted updates to reflect the change. Update the directory structure, component map, or design decisions as needed. Do not rewrite the entire file — make surgical edits.
 
 2. **Testing** — For any new public function, type, or component:
-   - Write tests following the patterns in KernovaTests/ (Swift Testing, mocks, factories)
+   - Write tests following the patterns in [docs/testing.md](docs/testing.md)
    - If tests are deferred, explicitly state what's needed and why it was skipped
 
-3. **CLAUDE.md** — Update only if build commands, the concurrency model summary, or the data flow summary changed. Preserve commit message format and development guidelines as-is.
+3. **CLAUDE.md and docs/** — Update CLAUDE.md only if build commands, the concurrency model summary, or the data flow summary changed. Update the relevant `docs/` guide if testing patterns, review process, or git mechanics changed. Preserve the commit message format and development guidelines as-is.
 
 4. **Maintenance Notes** — At the end of your response, include a summary:
 

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -36,7 +36,7 @@ func makeRawSocketPair() throws -> (Int32, Int32) {
 /// Polls `predicate` every 50 ms until it returns `true` or `timeout` elapses.
 ///
 /// Default deadline is generous (5 s) to absorb MainActor scheduling jitter on
-/// CI runners. See feedback memory `feedback_ci_test_timings`. Prefer the
+/// CI runners. See `docs/testing.md` (CI timing characteristics). Prefer the
 /// event-driven `AsyncGate` below for new timing-sensitive waits — polling is
 /// retained for predicates with no underlying signal to await; the 50 ms tick
 /// (up from 10 ms) keeps idle pollers from adding avoidable MainActor churn.

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -535,7 +535,7 @@ struct VMInstanceTests {
         return instance
     }
 
-    // CI timing notes (memory: feedback_ci_test_timings):
+    // CI timing notes (see docs/testing.md, CI timing characteristics):
     //   - macos-26 GitHub Actions runners have substantial MainActor jitter
     //     compared to local hardware. Use cadences ≥100 ms and waitUntil
     //     deadlines ≥10× the cadence; end-state assertions, not per-iteration.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The project has comprehensive test coverage using [Swift Testing](https://develo
 make test
 ```
 
-This runs all three test targets via the test plan; it wraps the canonical `xcodebuild` invocation documented in [CLAUDE.md](CLAUDE.md). See the test coverage section in [ARCHITECTURE.md](ARCHITECTURE.md) for details.
+This runs all three test targets via the test plan; it wraps the canonical `xcodebuild` invocation documented in [CLAUDE.md](CLAUDE.md). See [docs/testing.md](docs/testing.md) for test patterns and coverage details.
 
 ## Architecture
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -9,6 +9,7 @@ Design philosophy and guidelines for Kernova.
 - The bar for acting on a finding is "does this make the code genuinely better today" — a real correctness issue, an observable perf problem, a readability win. Skip findings that only defend against unreachable scenarios, hypothetical future callers, or theoretical perf concerns at current scale.
 - GitHub issues serve as durable context — when a fix is deferred, the issue should capture enough detail to address it later without rediscovery.
 - Prefer the simpler path first. Always attempt or plan the straightforward solution before introducing complexity through flags, intercepts, overrides, special cases, shims, or conditional branching.
+- Prefer the framework's native event API (KVO, delegation, AsyncSequence) over polling/sleep loops. A polling loop is acceptable only when the framework genuinely exposes no event for the condition — and then the rationale comment must say why the canonical option was rejected.
 - When working on window layout issues, verify that the implementation follows AppKit best practices. Cross-reference Apple documentation and well-known code examples where possible before settling on an approach.
 
 ## GUI Design
@@ -22,6 +23,7 @@ Design philosophy and guidelines for Kernova.
 ### Layout
 
 - AppKit owns the entire view layer — `NSSplitViewController`, `NSToolbar`, `NSWindow`, and concrete `NSViewController`s render all content (no SwiftUI / `NSHostingController`).
+- New UI is designed AppKit-first: imperative construction in `loadView()`, target/action, delegation, Auto Layout in code. Never translate SwiftUI patterns line-by-line — visual consistency comes from shared design tokens and atom factories (`CalloutStyle`, `GroupedFormStyle`, `WizardStyle`), not container base classes or inheritance.
 - Main window: 1100×700 default, 800×500 minimum.
 - Sidebar: 200–350pt width.
 - Creation wizard sheet: 550×480.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,0 +1,58 @@
+# Git Workflow Mechanics
+
+Branch naming and the commit-message format live in [CLAUDE.md](../CLAUDE.md#git-workflow) — they apply to every commit. This file covers the machinery around getting a branch onto `main`: scratch-branch handling, branch protection, the merge procedure, and post-merge cleanup.
+
+## Worktree scratch branches
+
+Worktrees start on an auto-generated `worktree-<name>` branch (the harness also mangles any `/` in the name to `+`). Treat that as a throwaway scratch branch: do the work on it without renaming up front. Don't try to pick a branch name before starting — the right name depends on the full scope of the work, which you only know once it's ready to push.
+
+When the work is ready to push to origin, rename the scratch branch to a clean `<type>/<short-description>` and push it under that same name so the local branch and the origin/PR branch match:
+
+```bash
+git branch -m <type>/<short-description>        # rename the scratch branch in place
+git push -u origin <type>/<short-description>   # local and remote now match
+```
+
+**Never push the `worktree-`-prefixed scratch name to origin.** It is a local implementation detail; a PR's head branch must always be the clean `<type>/<short-description>` name. (Renaming a branch on GitHub *after* a PR exists does not retarget the PR — it closes it — so name it correctly at first push.)
+
+## Branch protection (GitHub Rulesets)
+
+`main` is protected via GitHub **Rulesets** (Settings → Rules → Rulesets), not the legacy "Branch protection rules" page — use Rulesets vocabulary when discussing or changing protection:
+
+- There is no "Do not allow bypassing the above settings" toggle. The equivalent is the **Bypass list** — an empty bypass list means *nobody* (including admins) can bypass, which is the strictest setting.
+- Active rulesets (as of 2026-05): "Block Delete & Force Push Main" and "swift-format before merge" (requires the `swift-format` GitHub Actions check, strict mode, no bypass actors).
+- Inspect via `gh api repos/nicholas-lonsinger/kernova/rulesets` and `gh api repos/…/rulesets/<id>`. Verify the current state before recommending changes — the ruleset config can evolve.
+- The checked-in pre-push hook (`make install-hooks`) pairs with the swift-format ruleset.
+- `delete_branch_on_merge` is enabled — remote branches are auto-deleted after merge.
+
+## Merging PRs
+
+Merging is rarely a single command — expect a rebase, a CI wait, and post-merge verification:
+
+- **Auto-merge is disabled** (`gh pr merge --auto` fails with `Auto merge is not allowed for this repository`). Wait for checks to finish, then merge.
+- **The head branch must be up-to-date with `main`** (ruleset "require branches to be up to date"). If `main` moved since the branch was cut, `gh pr merge` fails with `the head branch is not up to date with the base branch`. Fix: `git rebase origin/main`, then `git push --force-with-lease` — which re-triggers checks.
+- **Three required status checks** must pass: `build-and-test` (full `xcodebuild`, ~2–3 min, occasionally flaky on timing-sensitive vsock tests — see [docs/testing.md](testing.md#ci-timing-characteristics-macos-26-runners)), `proto-drift`, and `swift-format`.
+- **Squash-merge with the PR title plus number**: `gh pr merge <N> --squash --subject "<type>: Title (#N)"`, matching the repo's existing convention.
+- **Do not use `--delete-branch`.** GitHub auto-deletes the remote branch on merge; the flag additionally makes `gh` run `git checkout main` locally, which fails in worktree contexts.
+- **Issue auto-close needs the keyword before *each* number.** GitHub's parser only closes the issue immediately following a `closes`/`fixes`/`resolves` keyword — `Closes #132, #249` closes #132 and silently leaves #249 open. Write `Closes #132, Closes #249` (repeat the keyword), or close the extras manually after merge. The keywords must appear in the **PR body** (with `--subject`, GitHub takes auto-close references from the PR body, not the squash commit body) — a table reference like `| #N |` does not count.
+- **Keep the PR title/body in sync with the shipped code.** If commits change the PR's design or scope mid-flight, `gh pr edit <N> --title … --body …` before re-review or merge — reviewers (bot and human) read the description first, and stale framing shapes their feedback against the wrong target. The Summary/Changes/Test-plan structure applies to PR bodies too, not just commit messages.
+
+Practical sequence: check `gh pr view <N> --json mergeStateStatus` (look for `CLEAN` vs `BLOCKED`/`BEHIND`) and `gh pr checks <N>`; if behind, rebase onto `origin/main` and force-push; wait for checks; merge with the squash-subject convention; then verify linked issues actually closed.
+
+## Post-merge cleanup
+
+After a successful merge, confirm it landed, then tear down the branch and sync `main`:
+
+1. `gh pr view <N> --json state -q .state` — confirm `"MERGED"` before deleting anything.
+
+**In an `EnterWorktree` session** (the usual case), let the tool do the teardown, then sync:
+
+2. `ExitWorktree` with `action: "remove"`. Squash-merge leaves the worktree's commit off `main` by SHA, so the tool refuses unless you also pass `discard_changes: true` — that's expected and safe here, since the content already landed on `main` as the squash commit. This returns the session to the primary checkout and deletes the worktree and its scratch branch in one step.
+3. Now in the primary checkout: `git checkout main` (if not already on it), then `git pull --ff-only` to fast-forward onto the squash commit.
+
+**Working directly in a checkout** (no `EnterWorktree` session), delete the branch by hand instead:
+
+2. Get off the merged branch first: `git switch main`, or `git checkout --detach` in a manually-created worktree (you can't switch to `main` there — the primary checkout holds it).
+3. `git branch -D <merged-branch>` — force `-D`, since the squash commit makes `-d` reject the branch as "not fully merged".
+4. `git branch -d -r origin/<merged-branch>` — drop the stale remote-tracking ref (GitHub auto-deletes the remote branch on merge).
+5. `git pull --ff-only`.

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -1,0 +1,110 @@
+# Review Feedback Handling
+
+Every review finding — from review tools (`/simplify`, `/review-pr`, …), post-implementation review agents, external PR review feedback (bot or human), or code noticed while working on adjacent areas — is triaged into **Fix now / Fix later / Annotate / Dismiss**. The triage table lives in [CLAUDE.md](../CLAUDE.md#review-feedback-handling); this file is the reference for the two categories that carry procedure: filing review-debt issues and annotating intentional patterns.
+
+## Review Debt Tracking
+
+Valid findings that are **out of scope** for the current task must be captured as GitHub issues rather than silently dropped.
+
+**What to capture** (important + moderate severity):
+
+- Bugs, correctness problems, or logic errors
+- Security concerns
+- Performance issues
+- Meaningful refactoring opportunities or non-trivial code smells
+- Missing test coverage for critical paths
+
+**Issue format:**
+
+~~~bash
+gh issue create \
+  --title "<concise description of the finding>" \
+  --label "<review-debt/label>" \
+  --body "$(cat <<'EOF'
+## Found during
+<PR #N / review of `FileName.swift` / context description>
+
+## Description
+<What the issue is and why it matters>
+
+## Location
+<File path(s) and line number(s) or function name(s)>
+
+## Suggested fix
+<Brief suggestion if one is obvious, otherwise omit this section>
+EOF
+)"
+~~~
+
+**Labels** — use the most specific match:
+
+| Label | When to use |
+|-------|-------------|
+| `review-debt/bug` | Correctness issues, logic errors, potential crashes |
+| `review-debt/security` | Security concerns, unsafe patterns |
+| `review-debt/performance` | Inefficient code paths, unnecessary allocations |
+| `review-debt/refactor` | Code smells, duplication, poor abstractions |
+| `review-debt/test-gap` | Missing or insufficient tests for critical code |
+
+**Guidelines:**
+
+- **File issues immediately** — do not list qualifying findings as "skipped" and wait for the user to ask. If a finding meets the severity criteria above, create the issue as part of the review flow before summarizing results.
+- Always check for existing issues before creating duplicates.
+- Reference the source PR or file context in the issue body.
+- Keep issue titles actionable and specific (e.g., "Add error handling for disk-full scenario in BundleManager" not "Improve error handling").
+- When multiple related findings exist, group them into a single issue if they share a root cause.
+- Issues serve as durable context — when a fix is deferred, the issue should capture enough detail to address it later without rediscovery.
+- After creating issues, mention them in the conversation so the user is aware.
+
+## Intentional Pattern Annotations
+
+When a review flags code that *looks* wrong or unconventional but is **intentionally correct** for a project-specific reason, add an inline comment with the `RATIONALE:` prefix explaining why. This prevents the same pattern from being re-flagged in future reviews.
+
+**When to annotate:**
+
+- The code contradicts a general best practice but is correct here due to framework constraints, performance requirements, or architectural decisions
+- A reviewer (human or automated) would reasonably flag this without project-specific context
+- The reason is not already documented in CLAUDE.md, ARCHITECTURE.md, or an adjacent comment
+
+**Format:**
+
+```swift
+// RATIONALE: VZVirtualMachine delegates are not actor-isolated by the framework,
+// so we use nonisolated(unsafe) and bridge back via MainActor.assumeIsolated.
+nonisolated(unsafe) func guestDidStop(_ virtualMachine: VZVirtualMachine) {
+```
+
+**Guidelines:**
+
+- Keep annotations concise — explain *why* the pattern is correct, not *what* the code does.
+- If the same rationale applies project-wide (not just at one call site), consider adding it to CLAUDE.md or ARCHITECTURE.md instead of repeating the comment on every instance.
+- `RATIONALE:` comments are greppable — use `grep -r "RATIONALE:"` to audit all intentional deviations.
+- Do not use `RATIONALE:` for general explanatory comments — reserve it strictly for patterns that would otherwise be flagged as issues.
+
+## Periphery Directives
+
+When the dead-code scan flags a symbol that is alive through machinery Periphery's symbol graph cannot see — protocol witnesses invoked by Swift's compiler-emitted code (string interpolation, `Codable`), members reached through type inference on argument labels, declarations referenced only from a test target Periphery does not currently scan, or symbols intentionally retained for API symmetry — annotate the declaration with `// periphery:ignore - <reason>` instead of deleting it. This is the Periphery-specific counterpart to `RATIONALE:`: same spirit (silence a finding that would otherwise be re-raised every scan), different syntax that the tool itself recognizes.
+
+**When to annotate vs. fix vs. dismiss:**
+
+- **Annotate** when the symbol is genuinely used through one of the invisible paths above, OR when the surface is intentionally complete (e.g. all `os.Logger` levels exposed even if a particular call isn't used today).
+- **Fix** when the finding is real — delete the symbol, or demote `public` to `internal` if only the access level is redundant.
+- **Dismiss** does not apply: every annotation must include a reason, since silently retained symbols become a maintenance hazard.
+
+**Format:**
+
+```swift
+/// `true` when no buffered bytes remain.
+// periphery:ignore - Used by `VsockFrameTests` via `@testable import`,
+// which Periphery's scheme-based scan doesn't currently index for the
+// SwiftPM package test target.
+var isEmpty: Bool { buffer.count == readOffset }
+```
+
+Place the directive **between** the doc comment (`///`) and the declaration so DocC still associates the doc with the symbol.
+
+**Guidelines:**
+
+- Keep the rationale on the same comment block as the directive — multi-line if needed, but no blank line between `// periphery:ignore` and the reason text.
+- Greppable via `grep -r "periphery:ignore"` for periodic auditing — when the underlying machinery becomes visible to Periphery (e.g. a scan-coverage gap is closed), revisit the annotations and remove any that are no longer needed.
+- Prefer per-symbol annotations over re-toggling broad config flags like `retain_public` — see `.periphery.yml` for the project-level guidance.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,68 @@
+# Testing
+
+How tests are organized, written, and kept stable. The build/test commands themselves are in [CLAUDE.md](../CLAUDE.md#build--test).
+
+## Test targets and the test plan
+
+A single `xcodebuild test -scheme Kernova` (what `make test` runs) covers all three test targets — `KernovaTests`, `KernovaGuestAgentTests`, and `KernovaProtocolTests` — via `Kernova.xctestplan`. This works because `KernovaProtocol` is referenced as a top-level peer in the project (a `PBXFileReference` in `Kernova.xcodeproj`'s main group) rather than as an `XCLocalSwiftPackageReference` under Package Dependencies. In the dependency form, Xcode treats the package as upstream and hides its `.testTarget`s from the test-plan picker; in the peer form, the package's tests appear in `Edit Scheme → Test → +` as first-class targets and can be added to the test plan. If `KernovaProtocol` ever needs to be re-added, drag the folder into the Project Navigator from Finder rather than using `Add Package Dependencies → Add Local`. `make test-package` exists as a focused shortcut for iterating on the package tests in isolation.
+
+`KernovaGuestAgentTests` is a standalone xctest bundle (no `TEST_HOST`) that compiles the agent's sources directly — see [Helper Targets in ARCHITECTURE.md](../ARCHITECTURE.md#helper-targets) for the rationale. It runs non-parallelized in the scheme because the agent sources include global state (`VsockLogBridge.connection`).
+
+## Writing tests
+
+Follow the existing patterns in `KernovaTests/`:
+
+- **Framework:** Swift Testing (`@Suite`, `@Test`, `#expect`) — not XCTest.
+- **Mocks:** protocol-based mock implementations in `KernovaTests/Mocks/`, supporting call counting and error injection via `throwError` properties. `SuspendingMockVirtualizationService` and `SuspendingMockUSBDeviceService` suspend mid-operation to test operation serialization and the installer-mount mutex; both rely on `@MainActor` cooperative scheduling (documented in the mocks) and enforce single-suspension via `precondition`.
+- **Factories:** reuse shared helpers (`makeInstance()`, `makeViewModel()`, `makeCoordinator()`) rather than duplicating setup logic across test files.
+- **Scope:** test models, services, and view models. UI views don't need unit tests beyond extracted pure helpers (e.g. `DetailRoute.resolve`, `MicPermissionPresentation`) and the VC-level suites that exercise layout-independent behavior.
+- **Error paths:** test both happy and error paths; inject failures by setting a mock's `throwError`.
+- Run the full test suite before committing.
+
+## Test-only seams
+
+When a test needs to observe state that is `private` in production, pick the tightest exposure that still works:
+
+1. **`private(set) var x`** — internal getter, private setter. The idiomatic choice when production code reading the state is harmless; tests reach it via `@testable import`, no extra accessor needed.
+2. **`#if DEBUG`-gated read accessor** — when the state is a test-only implementation detail that production code should *not* read. Keep the field `private` and add a `…ForTesting` computed getter wrapped in `#if DEBUG`, so the seam is physically absent from Release builds and test-only access becomes a compile-time guarantee rather than a naming convention. Place `#if DEBUG` before the doc comment and `#endif` after the accessor.
+
+`AttachmentFileMonitor.watchedParentsForTesting` is the canonical example; the `…ForTesting` accessors in `VsockClipboardService`, `VsockGuestClipboardAgent`, and `VsockHostConnection` follow the same pattern. Because this rationale is shared, the gate itself is the documentation — don't repeat a "DEBUG-only so it can't leak" note at each site.
+
+## Timing-sensitive waits: event-driven, not polling
+
+When a test needs to wait for async state, reach for an **event-driven** wait, not a `waitUntil { predicate }` poll loop. `KernovaTests` and `KernovaGuestAgentTests` each have an `AsyncGate` in their `TestHelpers.swift`: the producer (usually a test double) calls `gate.notify()` after each observable mutation, and the consumer does `await gate.wait(until:)`. For waits on a production `Task` (e.g. the agent post-start watchdog), `await` the task itself via a `#if DEBUG …ForTesting` seam instead of polling the flag it flips.
+
+**Why:** with polling, the timeout IS the success criterion — a load-bearing deadline that fails when the runner is slow, not just when the code is wrong. With an event-driven wait, the timeout is a backstop the happy path never reaches, so a slow runner can't fail the wait; only a genuinely stuck condition can. This was learned the hard way: PR #285's merge turned `main` red purely from poll-based waits (10 ms tick / 5 s deadline) starving under MainActor contention — the merge tree was byte-identical to the branch that had passed CI minutes earlier. The poll budget had already been bumped once (2 s → 5 s) and regressed anyway; PR #286 converted the failing waits to event-driven and `main` went green.
+
+Guidelines:
+
+- New timing-sensitive wait → give the test double an `AsyncGate`, `notify()` on each mutation, `await gate.wait(until:)`. Watchdog/`Task`-style waits → expose the `Task` via a `#if DEBUG` seam and `await task.value`.
+- **Never "fix" a CI timing flake by raising the timeout or poll cadence** — that's a treadmill, not a fix. Make the wait event-driven so the wall-clock budget stops being the pass/fail line.
+- `AsyncGate.wait` is `@MainActor` in `KernovaTests` (predicates touch MainActor state) and `nonisolated` with a `@Sendable` predicate in `KernovaGuestAgentTests` (predicates read `Sendable` boxes). Keep the two copies aligned. `NSLock.lock()/unlock()` are `noasync` — use `withLock` inside async closures.
+- ~40 `waitUntil` poll sites remain (connection/channel/pasteboard/file-monitor waits). Each needs a production event seam, and none were flaking, so they stay on the calmer 50 ms tick. Migrate a site to `AsyncGate` only if and when it actually flakes — no speculative sweeps (the "genuinely better today" bar, [SPEC.md](../SPEC.md#code-approach)).
+- If a wait genuinely *can't* be event-driven (a generic predicate with no underlying signal to await, or a "settle, then assert *absence*" negative check), keep polling but use a generous cadence (the shared `waitUntil` tick is 50 ms) and a generous deadline, and assert **end-state**, not per-iteration.
+
+## CI timing characteristics (macos-26 runners)
+
+macos-26 GitHub Actions runners exhibit heavy `@MainActor` scheduling jitter compared to local Apple Silicon — `Task.sleep` durations are a *minimum*, and under parallel test execution on a contended runner, continuations can be delayed by seconds. Tests that depend on wall-clock timing flake there even when the code under test is correct.
+
+- **Don't diagnose a green-PR/red-`main` failure as a code regression without checking the merge tree first.** If the merged tree is identical to the branch that passed CI, the failure is a runner-load flake, not a regression. These flakes can look like crashes — xcbeautify swallows the failure (exit 65 with no `✘` line); the truth is in the `TestResults.xcresult` artifact.
+- The `build-and-test` required check is occasionally flaky on timing-sensitive vsock tests; a re-run is reasonable once the failure is confirmed to be a known flake rather than a regression.
+- For unavoidable timing-dependent tests, use cadences ≥100 ms, deadlines ≥10× the cadence, and end-state assertions — but prefer converting the wait to event-driven (see above) over tuning budgets.
+
+## Coverage
+
+Most models, services, and view models have a dedicated suite — the per-suite scope is annotated in [ARCHITECTURE.md's directory tree](../ARCHITECTURE.md#directory-structure). The known gaps:
+
+**Mocked but not directly tested** (fully mocked in other suites; no suite exercises the real implementation):
+
+- `DiskImageService` — decompresses bundled templates (no subprocess; direct testing feasible but requires bundled resources in the test target)
+- `MacOSInstallService` — requires a real `VZVirtualMachine` and restore image
+
+**Not tested:**
+
+- `VMDirectoryWatcher` — relies on `DispatchSource` file-system monitoring
+- `SystemSleepWatcher` — relies on `NSWorkspace` sleep/wake notifications (the sleep/wake *logic* is tested via `VMLibraryViewModel`)
+- `KernovaUTType` — static UTType declaration
+- The window controllers (`MainWindowController`, `VMDisplayWindowController`, `ClipboardWindowController`) and `AppDelegate` — app lifecycle and window management
+- Pure AppKit view rendering beyond the extracted testable helpers and the VC-level suites (`SheetPresenter.show()` is also untested — it needs a key window and a run loop)


### PR DESCRIPTION
## Summary
- Slims CLAUDE.md (376 → ~210 lines): always-needed rules stay inline (build commands, concurrency model, commit format, review-triage table, logging levels); procedure references move to a new `docs/` directory that's read on demand
- Rewrites ARCHITECTURE.md's directory tree as accurate one-liners, relocating the paragraph-length annotations into the Component Map, and fixes ~30 files of drift — missing models/services/utilities/test suites added (`MacOSInstallContext`, `USBDeviceInfo`, `USBDeviceService`, `PathValidation`, ~20 test suites, …); two long-removed wizard files (`WizardSelectableCardView`, `WizardTintedBox`) dropped
- Promotes durable project knowledge out of private session memory into repo docs visible to every contributor and CI session: PR-merge mechanics, GitHub Rulesets, the AsyncGate/CI-timing guidance, and localization status

## Changes
- **New `docs/testing.md`** — test-plan wiring (the KernovaProtocol peer-reference rationale), writing-tests patterns, test-only seams, the event-driven-waits policy (AsyncGate; PR #285/#286 history), macos-26 CI timing characteristics, and coverage gaps (moved from ARCHITECTURE.md)
- **New `docs/reviewing.md`** — review-debt issue format + labels, `RATIONALE:` annotations, `periphery:ignore` directives
- **New `docs/git-workflow.md`** — worktree scratch branches, GitHub Rulesets, the merge procedure (auto-merge disabled, up-to-date rule, required checks, per-issue `Closes` keyword), post-merge cleanup
- **CLAUDE.md** — compressed with pointers to the above; new Localization section (English-only, no `NSLocalizedString`)
- **ARCHITECTURE.md** — one-liner tree matching the filesystem; Component Map absorbs the relocated detail (Views split into Sidebar / Detail routing / Settings / Attachments / Popovers / Display / Wizard subsections); Test Coverage section replaced by a pointer to docs/testing.md; stale file counts and the removed-ContentView note dropped
- **SPEC.md** — two new principles: prefer native event APIs over polling; AppKit-first design for new UI
- **README.md** — test-coverage link now points at docs/testing.md
- **KernovaTests/TestHelpers.swift, KernovaTests/VMInstanceTests.swift** — comments that cited a private memory file (`feedback_ci_test_timings`) now cite docs/testing.md

## Test plan
- [x] `make lint` clean
- [x] `make test` — full suite green (`** TEST SUCCEEDED **`, exit 0)
- [x] grep confirms no stale references to removed sections or memory names

## Notes
- The exhaustive per-component "Well Covered" test table was **dropped rather than moved**: it duplicated the per-suite one-liners now in the directory tree and had already drifted (IPSWService and SpiceClipboardService were listed as not-directly-tested despite having suites). docs/testing.md keeps the actionable part — the coverage gaps. Flagging in case you'd rather keep it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)