### PR TITLE
refactor: Resolve dead-code scan findings in VMSettingsViewController

### DIFF
--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -1225,7 +1225,7 @@ extension VMSettingsViewController {
             for model in models {
                 let row = makeAttachmentRow(
                     model: model, kind: kind, readOnlySelector: readOnlySelector,
-                    rowsByID: rowsKP, activeRename: activeKP)
+                    activeRename: activeKP)
                 self[keyPath: rowsKP][model.id] = row
                 addFullWidth(row, to: listStack)
                 // Freshly built rows start with an empty subtitle — read once.
@@ -1251,12 +1251,11 @@ extension VMSettingsViewController {
 
     /// Builds one attachment row, wiring its icon Get Info, rename closures, and
     /// context menu — shared by both lists (the per-list differences arrive via
-    /// `kind`, `readOnlySelector`, and the key paths).
+    /// `kind`, `readOnlySelector`, and the active-rename key path).
     private func makeAttachmentRow(
         model: RenderedRow,
         kind: AttachmentKind,
         readOnlySelector: Selector,
-        rowsByID rowsKP: ReferenceWritableKeyPath<VMSettingsViewController, [UUID: AttachmentRowView]>,
         activeRename activeKP: ReferenceWritableKeyPath<VMSettingsViewController, UUID?>
     ) -> AttachmentRowView {
         let ref = AttachmentRef(kind: kind, id: model.id)
@@ -1401,6 +1400,10 @@ extension VMSettingsViewController {
 
     /// Disables the name field's right-click "Rename" while the VM can't be
     /// renamed (e.g. while running), mirroring the disabled name button.
+    // periphery:ignore - AppKit's menu-validation machinery invokes this
+    // informal-protocol method on the name button's menu target (`self`)
+    // before showing the "Rename" item; that framework-driven call is
+    // invisible to Periphery's symbol graph.
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         if menuItem.action == #selector(startRename) {
             return instance.status.canRename


### PR DESCRIPTION
## Summary
- Clears both findings from the weekly dead-code scan (#291): one genuinely dead parameter and one Periphery false positive.

## Changes
- Remove the unused `rowsByID rowsKP:` parameter from `makeAttachmentRow` and drop the argument at its single call site. The caller (`refreshAttachmentList`) already performs the `storageRowsByID` / `removableRowsByID` dictionary insertion itself, so the parameter was vestigial — no behavior change. Doc comment updated accordingly.
- Annotate `validateMenuItem(_:)` with `// periphery:ignore`: AppKit's menu-validation machinery invokes this informal-protocol method on the name button's menu target (`self`), a framework-driven call Periphery's symbol graph can't see.

## Test plan
- [x] `make lint` clean
- [x] `make build` succeeds

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)