### PR TITLE
docs: Add issue-hygiene guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ gh issue create \
 <What the issue is and why it matters>
 
 ## Location
-<File path(s) and line number(s) or function name(s)>
+<Symbol/function name(s) and file path(s) — prefer names over line numbers, which drift>
 
 ## Suggested fix
 <Brief suggestion if one is obvious, otherwise omit this section>
@@ -171,6 +171,16 @@ EOF
 - Keep issue titles actionable and specific (e.g., "Add error handling for disk-full scenario in BundleManager" not "Improve error handling")
 - When multiple related findings exist, group them into a single issue if they share a root cause
 - After creating issues, mention them in the conversation so the user is aware
+
+#### Issue Hygiene
+
+These rules apply to **all** issues you file — feature/enhancement as well as review-debt — so the body stays useful until the work is actually picked up:
+
+- **Keep it to what/why.** Summary, motivation, scope, considerations, open questions. Do **not** include a "Files likely involved" sketch or other forward-looking file/API/wiring plan — design that when the work starts, not at filing time.
+- **Never cite a line number.** They drift within an edit or two. Name the **symbol** instead (`startSerialReading()`, `capturesSystemKeys`) — it survives edits and is greppable.
+- **Expect your own type/file names to be renamed.** A 2026 audit found ~7 issues pointing at things that no longer existed after the SwiftUI→AppKit rename (`VMSettingsView` → `VMSettingsViewController`, and `VMDetailView`/`VMConsoleView`/`SidebarView`/`VMRowView` gone) and the SPICE→vsock clipboard migration (`GuestClipboardAgent.swift` → `VsockGuestClipboardAgent.swift`). Apple/framework type names (`VZ…`, `NSPasteboardItemDataProvider`) are stable and fine to cite as the *what*.
+- **Bug reports are the exception to "no file refs":** the `## Location` field above points at where the defect lives, which is the finding's evidence — keep it, but by symbol/method, not line number.
+- If you deliberately omit an implementation sketch, add a one-line note saying so ("design when picked up") so a future reader knows the omission was intentional.
 
 #### Intentional Pattern Annotations
 


### PR DESCRIPTION
## Summary
- Codify how GitHub issues should be written so their bodies stay useful until the work is picked up. An audit of the open issues found ~7 pointing at files/types/line-numbers that no longer existed after the SwiftUI→AppKit rename and the SPICE→vsock clipboard migration; this captures the lesson so future issues don't repeat it.

## Changes
- Add an **Issue Hygiene** subsection under *Review Feedback Handling* (applies to all issues, not just review-debt): keep bodies to what/why, no "Files likely involved" sketches, never cite line numbers (name symbols instead), expect own type/file names to be renamed (Apple framework types are stable), and treat a bug report's `## Location` as the documented exception.
- Update the Review Debt issue-format `## Location` placeholder to prefer symbol/function names over line numbers.

## Notes
- Companion to a same-session aggressive cleanup pass that stripped stale file/line references from 12 open issues (#80, #82, #85, #86, #87, #92, #112, #135, #279, #280, #281, #294) and rescoped #135.

## Test plan
- [ ] Docs-only change — no Swift sources touched; `make lint` pre-push hook passes