### PR TITLE
test: Decouple VsockControlService tests from the liveness watchdog

### DIFF
--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -40,13 +40,27 @@ struct VsockControlServiceTests {
         return frame
     }
 
-    /// Default test cadences.
-    ///
-    /// Small enough that liveness assertions don't
-    /// drag the suite, large enough to avoid scheduler-induced flakiness.
+    /// Default outbound-heartbeat cadence: small so `heartbeatOutboundCadence`
+    /// doesn't drag, and harmless to every other test (extra heartbeats only
+    /// keep the connection alive).
     private static let testHeartbeat: Duration = .milliseconds(40)
-    private static let testUnresponsive: Duration = .milliseconds(160)
-    private static let testTerminate: Duration = .milliseconds(400)
+
+    /// Default liveness windows, set far beyond any test's wall-clock budget.
+    ///
+    /// The watchdog can't tear the channel down mid-test at these values. Tests
+    /// that *exercise* the watchdog (silence/recovery/terminate) pass explicit
+    /// short windows to opt back in.
+    ///
+    /// The watchdog measures `ContinuousClock.now - lastInboundFrame`, which
+    /// keeps advancing while a contended CI MainActor stalls the test. With the
+    /// old 160 ms / 400 ms defaults, any non-watchdog test that paused past the
+    /// window (waiting on a frame, a `waitUntil`, or scheduler jitter) saw the
+    /// channel closed out from under it — surfacing as an EOF / `.closed` flake.
+    /// Sixteen tests inherited those defaults despite not testing liveness; this
+    /// makes the watchdog an explicit opt-in instead of an implicit deadline
+    /// coupled to every test's runtime. See `feedback_ci_test_timings`.
+    private static let watchdogDisabledUnresponsive: Duration = .seconds(3_600)
+    private static let watchdogDisabledTerminate: Duration = .seconds(7_200)
 
     /// Builds a service with the test cadences applied.
     ///
@@ -67,8 +81,8 @@ struct VsockControlServiceTests {
             label: "test",
             bundledAgentVersion: bundledAgentVersion,
             heartbeatInterval: heartbeatInterval ?? Self.testHeartbeat,
-            unresponsiveAfter: unresponsiveAfter ?? Self.testUnresponsive,
-            terminateAfter: terminateAfter ?? Self.testTerminate,
+            unresponsiveAfter: unresponsiveAfter ?? Self.watchdogDisabledUnresponsive,
+            terminateAfter: terminateAfter ?? Self.watchdogDisabledTerminate,
             policyProvider: policyProvider,
             onAgentVersionObserved: onAgentVersionObserved
         )


### PR DESCRIPTION
## Summary
- Fixes the recurring CI flake where `VsockControlServiceTests` went red on `main` (most recently right after #310) with EOF / `.closed` errors, despite the PR being green. The #310 merge introduced **no regression** — re-running the identical commit passed and `main` is green again. The failures are a pre-existing, non-deterministic timing flake.
- **Root cause:** the test helper `makeService` defaulted the service's liveness watchdog to a 160 ms / 400 ms window. 16 of 22 tests inherited it despite not testing liveness. The watchdog measures `ContinuousClock.now - lastInboundFrame`, which keeps advancing while a contended CI MainActor stalls the test — so it tore the channel down mid-test, surfacing as the guest seeing EOF on a read (`skipsPolicyWhenProviderAbsent`) or `.closed` on a send (`onAgentVersionObservedFiresPerHello`). This run lost the race on 2 of the 16; prior `main` reds hit a rotating cast of the others.

## Changes
- `KernovaTests/VsockControlServiceTests.swift`: default the `makeService` watchdog windows to 1 h / 2 h so the watchdog can't fire mid-test. Tests that *exercise* the watchdog (`silenceMarksUnresponsive`, `recoveryFromUnresponsive`, `terminateClosesChannel`, `inboundHeartbeatPreservesLiveness`) already pass explicit short windows and are unaffected — the watchdog is now an **explicit opt-in** rather than an implicit deadline coupled to every test's runtime. Split the old `testUnresponsive` / `testTerminate` constants out with documented rationale.

## Notes
- **Test-only change. No production code touched.** `unresponsiveAfter` / `terminateAfter` are existing `VsockControlService` parameters (real defaults 15 s / 30 s, set by the app); only the test helper's defaults change.
- Considered and **rejected** injecting a `Clock` into the service for deterministic time — that would add production complexity solely to serve tests; the existing parameters already suffice.
- Not a timeout bump (the failure mode of the earlier #264 fix). It removes the implicit deadline entirely for tests that never needed it.
- The historical log/clipboard test flakes are a *separate* cause (those services have no watchdog; their waits were already migrated to event-driven `AsyncGate` in #286 and haven't flaked on `main` since). Out of scope here.

## Test plan
- [x] `make test-suite SUITE=KernovaTests/VsockControlServiceTests` — 18/18; the two former failures now complete in ~0.1 s instead of timing out at 7 s
- [x] `make test` — full suite green (`** TEST SUCCEEDED **`)
- [x] `make lint` clean