### PR TITLE
docs: Point test comments at renamed ci-test-timings memory

### DIFF
--- a/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
@@ -45,7 +45,7 @@ struct VsockGuestControlAgentTests {
     /// short default, any non-watchdog test that paused past the window saw the
     /// channel closed out from under it — surfacing as an EOF / `.closed` flake.
     /// Making the watchdog an explicit opt-in removes that coupling. Mirrors
-    /// `VsockControlServiceTests` / `makeService`. See `feedback_ci_test_timings`.
+    /// `VsockControlServiceTests` / `makeService`. See `ci-test-timings`.
     private static let watchdogDisabledUnresponsive: Duration = .seconds(3_600)
     private static let watchdogDisabledTerminate: Duration = .seconds(7_200)
 

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -36,7 +36,7 @@ func makeRawSocketPair() throws -> (Int32, Int32) {
 /// Polls `predicate` every 50 ms until it returns `true` or `timeout` elapses.
 ///
 /// Default deadline is generous (5 s) to absorb MainActor scheduling jitter on
-/// CI runners. See feedback memory `feedback_ci_test_timings`. Prefer the
+/// CI runners. See memory `ci-test-timings`. Prefer the
 /// event-driven `AsyncGate` below for new timing-sensitive waits — polling is
 /// retained for predicates with no underlying signal to await; the 50 ms tick
 /// (up from 10 ms) keeps idle pollers from adding avoidable MainActor churn.

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -535,7 +535,7 @@ struct VMInstanceTests {
         return instance
     }
 
-    // CI timing notes (memory: feedback_ci_test_timings):
+    // CI timing notes (memory: ci-test-timings):
     //   - macos-26 GitHub Actions runners have substantial MainActor jitter
     //     compared to local hardware. Use cadences ≥100 ms and waitUntil
     //     deadlines ≥10× the cadence; end-state assertions, not per-iteration.

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -58,7 +58,7 @@ struct VsockControlServiceTests {
     /// channel closed out from under it — surfacing as an EOF / `.closed` flake.
     /// Sixteen tests inherited those defaults despite not testing liveness; this
     /// makes the watchdog an explicit opt-in instead of an implicit deadline
-    /// coupled to every test's runtime. See `feedback_ci_test_timings`.
+    /// coupled to every test's runtime. See `ci-test-timings`.
     private static let watchdogDisabledUnresponsive: Duration = .seconds(3_600)
     private static let watchdogDisabledTerminate: Duration = .seconds(7_200)
 


### PR DESCRIPTION
## Summary
Four test-file comments referenced the project memory by its old name
`feedback_ci_test_timings`. That memory was renamed to `ci-test-timings`
during a memory-store normalization pass, leaving these comment pointers
hanging on a name that no longer exists. This updates them to the current
name so the "see this memory" references resolve.

## Changes
- Comment-only reference rename (`feedback_ci_test_timings` → `ci-test-timings`) in:
  - `KernovaTests/TestHelpers.swift` (also drops the now-inaccurate "feedback " qualifier)
  - `KernovaTests/VMInstanceTests.swift`
  - `KernovaTests/VsockControlServiceTests.swift`
  - `KernovaGuestAgentTests/VsockGuestControlAgentTests.swift`

No code, behavior, or test logic changes — four doc-comment lines only.

## Test plan
- [ ] CI `build-and-test` / `swift-format` / `proto-drift` pass (comment-only, no functional impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)