### PR TITLE
fix: Rename "Attach Disc…" to "Attach Disk…" and align disc/disk terminology

### DIFF
--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -5,7 +5,7 @@ import os
 
 /// Translates a `VMConfiguration` into a `VZVirtualMachineConfiguration`.
 ///
-/// Resolves symlinks and validates all user-supplied file paths (kernel, initrd, disc image,
+/// Resolves symlinks and validates all user-supplied file paths (kernel, initrd, disk image,
 /// additional disks, shared directories) before passing them to Virtualization.framework.
 ///
 /// Supports three boot paths:

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -1079,7 +1079,7 @@ final class VMLibraryViewModel {
     /// to what is actually attached and the user sees an alert describing
     /// the failure. `deviceNotFound` and `noVirtualMachine` errors are
     /// handled as confirmed-gone / silent bail respectively (this is also
-    /// what covers the case where the user ejected the disc from inside
+    /// what covers the case where the user ejected the disk from inside
     /// the guest).
     private func applyLiveRemovableMediaChange(
         for instance: VMInstance,

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -605,7 +605,7 @@ extension VMSettingsViewController {
 
     private func buildStorageSection() -> NSView {
         storageListStack = makeListStack()
-        attachStorageButton = makePushButton("Attach Disc…", action: #selector(attachStorageTapped))
+        attachStorageButton = makePushButton("Attach Disk…", action: #selector(attachStorageTapped))
         createStorageButton = makePushButton("Create New Disk…", action: #selector(createStorageTapped))
         editBootOrderButton = makePushButton("Edit Boot Order…", action: #selector(editBootOrderTapped))
         persistentLockableControls += [attachStorageButton, createStorageButton, editBootOrderButton]
@@ -638,7 +638,7 @@ extension VMSettingsViewController {
 
     private func buildRemovableMediaSection() -> NSView {
         removableListStack = makeListStack()
-        let attach = makePushButton("Attach Disc…", action: #selector(attachRemovableTapped))
+        let attach = makePushButton("Attach Disk…", action: #selector(attachRemovableTapped))
         let create = makePushButton("Create New Disk…", action: #selector(createRemovableTapped))
         createRemovableButton = create
         // Not lockable — removable media is hot-pluggable.
@@ -1941,7 +1941,7 @@ extension VMSettingsViewController {
     /// `removeRemovableMedia(_:from:trashFile:)` with `trashFile: false` removes
     /// the `removableMedia` entry — which the live reconcile hot-detaches from a
     /// running VM — and never touches the file. No alert: ejecting is the safe,
-    /// reversible action (re-attach via "Attach Disc…").
+    /// reversible action (re-attach via "Attach Disk…").
     private func ejectRemovableMedia(forItemID id: UUID) {
         guard let item = currentRemovableMedia.first(where: { $0.id == id }) else { return }
         _ = viewModel.removeRemovableMedia(item, from: instance, trashFile: false)

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -618,7 +618,7 @@ struct ConfigurationBuilderTests {
         }
     }
 
-    // MARK: - Dangling Symlink Tests (Kernel / Initrd / Disc Image)
+    // MARK: - Dangling Symlink Tests (Kernel / Initrd / Disk Image)
 
     @Test("Builder throws for dangling symlink as kernel path")
     func builderThrowsForDanglingSymlinkKernelPath() throws {
@@ -694,7 +694,7 @@ struct ConfigurationBuilderTests {
         }
     }
 
-    // MARK: - Directory-as-File Tests (Kernel / Initrd / Disc Image)
+    // MARK: - Directory-as-File Tests (Kernel / Initrd / Disk Image)
 
     @Test("Builder throws for directory as kernel path")
     func builderThrowsForDirectoryAsKernelPath() throws {
@@ -769,7 +769,7 @@ struct ConfigurationBuilderTests {
         }
     }
 
-    // MARK: - Symlink-to-Directory Tests (Kernel / Initrd / Disc Image)
+    // MARK: - Symlink-to-Directory Tests (Kernel / Initrd / Disk Image)
 
     @Test("Builder throws for symlink to directory as kernel path")
     func builderThrowsForSymlinkToDirectoryAsKernelPath() throws {

--- a/KernovaTests/Mocks/MockUSBDeviceService.swift
+++ b/KernovaTests/Mocks/MockUSBDeviceService.swift
@@ -22,7 +22,7 @@ final class MockUSBDeviceService: USBDeviceProviding {
         lastAttachedReadOnly = readOnly
         lastAttachedDesiredUUID = desiredUUID
         if let error = attachError { throw error }
-        // Honor the desired UUID so callers that pass one (e.g. the disc
+        // Honor the desired UUID so callers that pass one (e.g. the disk
         // image hot-swap flow) get back a USBDeviceInfo whose `id` matches
         // what they asked for. Falls back to a fresh UUID when nil.
         let id = desiredUUID ?? UUID()

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -937,7 +937,7 @@ struct VMConfigurationTests {
             removableMedia: [
                 RemovableMediaItem(
                     id: UUID(uuidString: "44444444-4444-4444-4444-444444444444")!,
-                    path: "/path/to/disc.iso",
+                    path: "/path/to/disk.iso",
                     readOnly: false,
                     label: "Installer"
                 )

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A macOS GUI application for creating and managing virtual machines using Apple's
 
 - **Creation wizard** — Step-by-step VM creation with IPSW download for macOS guests
 - **Linux boot modes** — EFI/UEFI boot or direct kernel boot with kernel, initrd, and command-line args
-- **ISO attachment** — Mount disc images as USB drives for installation media, with boot priority support
+- **ISO attachment** — Mount disk images as USB drives for installation media, with boot priority support
 - **Shared directories** — Host-to-guest directory sharing via VirtioFS (read-only or read-write)
 - **Display settings** — Configurable resolution and DPI (width, height, PPI)
 - **Network** — MAC address management with persistent, stable addresses


### PR DESCRIPTION
## Summary
- The Storage Disks and Removable Media sections both labeled their attach button **"Attach Disc…"**, sitting next to **"Create New Disk…"** under a header literally titled **"Storage Disks"** — *disc* and *disk* in the same breath.
- Apple's style guide reserves *disc* for optical media (CD/DVD). These buttons attach disk image files (.iso/.dmg/.img) that surface as removable USB drives in the guest, so **Disk** is the correct term on both counts.
- Closes #302 — this was the last actionable item deferred from PR #316's notes. The other two deferred notes were evaluated and dropped: the sidebar/popover label review found the Install/Update/Reinstall labels already consistent across all three surfaces (the menu-bar-only "Manage" affordance is deliberate per #316), and auto-eject for non-agent removable media has no completion signal to trigger on (guest-side ejects are already reconciled via the `deviceNotFound` path).

## Changes
- Rename both "Attach Disc…" button titles in `VMSettingsViewController`, plus the doc comment on `ejectRemovableMedia(forItemID:)` that cites the title
- Align "disc" → "disk" in comments (`VMLibraryViewModel`, `ConfigurationBuilder`, `MockUSBDeviceService`), test MARK headers and a fixture path (`ConfigurationBuilderTests`, `VMConfigurationTests`), and the README feature list
- String/comment-only change — no behavior difference

## Test plan
- [x] `make test` — full suite green
- [x] `make lint` — clean
- [x] grep confirms no remaining "disc" usages in sources, tests, or README

🤖 Generated with [Claude Code](https://claude.com/claude-code)