### PR TITLE
chore: Rename app identifiers from com.kernova to app.kernova root

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -143,7 +143,7 @@ KernovaGuestAgent/                      # Guest-side vsock agent for macOS VMs +
 ├── Info.plist                          # Explicit Info.plist with preprocessor macro for CFBundleVersion
 ├── install.command                     # Guest-side installer: copies binary, registers LaunchAgent
 ├── uninstall.command                   # Guest-side uninstaller: stops agent, removes files
-└── com.kernova.agent.plist             # LaunchAgent template (__INSTALL_DIR__ replaced at install time)
+└── app.kernova.agent.plist             # LaunchAgent template (__INSTALL_DIR__ replaced at install time)
 
 KernovaProtocol/                        # SPM package: extensible vsock wire protocol shared host <-> guest
 ├── Package.swift                       # Swift 6 package, depends on apple/swift-protobuf
@@ -297,7 +297,7 @@ Services are split by concurrency requirements:
 
 - **`VsockListenerHost`** — `@MainActor` wrapper around `VZVirtioSocketListener` bound to one vsock port. The nonisolated `VZVirtioSocketListenerDelegate` callback dups the connection's file descriptor and bridges back to MainActor before constructing a `VsockChannel` and handing it to a caller-supplied closure. One instance per service; multiple coexist on the same `VZVirtioSocketDevice`.
 
-- **`VsockGuestLogService`** — `@MainActor` consumer that owns one accepted `VsockChannel` for the lifetime of a guest connection. Forwards `LogRecord` frames through a `GuestLogEmitter` abstraction (default `OSLogGuestLogEmitter`, subsystem `com.kernova.guest`); guest log levels map 1:1 onto `os.Logger` methods. `Error` frames go to the host's own diagnostic logger; `Hello` / `Heartbeat` payloads on this port log a wrong-port warning (those belong on the control channel). The service self-terminates on EOF.
+- **`VsockGuestLogService`** — `@MainActor` consumer that owns one accepted `VsockChannel` for the lifetime of a guest connection. Forwards `LogRecord` frames through a `GuestLogEmitter` abstraction (default `OSLogGuestLogEmitter`, subsystem `app.kernova.guest`); guest log levels map 1:1 onto `os.Logger` methods. `Error` frames go to the host's own diagnostic logger; `Hello` / `Heartbeat` payloads on this port log a wrong-port warning (those belong on the control channel). The service self-terminates on EOF.
 
 - **`VsockPorts`** — Central registry of port assignments (`KernovaVsockPort.control = 49154`, `KernovaVsockPort.clipboard = 49152`, `KernovaVsockPort.log = 49153`) so each service gets its own listener on a distinct port instead of in-band multiplexing. The control listener is always installed for macOS guests with a `VZVirtioSocketDevice`; the log listener is gated on `configuration.agentLogForwardingEnabled`; the clipboard listener is gated on `configuration.clipboardSharingEnabled`. Both gates are also re-evaluated at runtime via `VMInstance.applyLivePolicy(oldConfig:newConfig:)` — flipping the toggle while a macOS VM is running installs or tears down the listener and pushes a fresh `PolicyUpdate` to the guest agent. Linux clipboard sharing is restart-only (the SPICE port must be declared at config-build time).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ When a test needs to observe state that is `private` in production, pick the tig
 
 ### Logging
 
-The app uses Apple's `os.Logger` (subsystem `com.kernova.app`) with per-component categories. Each service, view model, or model that logs declares a `private static let logger`. When adding or modifying functionality, include log calls at appropriate levels:
+The app uses Apple's `os.Logger` (subsystem `app.kernova`) with per-component categories. Each service, view model, or model that logs declares a `private static let logger`. When adding or modifying functionality, include log calls at appropriate levels:
 
 | Level | When to use | Persistence |
 |-------|-------------|-------------|
@@ -85,7 +85,7 @@ The app uses Apple's `os.Logger` (subsystem `com.kernova.app`) with per-componen
 | `.fault` | Programming errors: impossible states, compile-time-known inputs that failed lookup. Paired with `assertionFailure`. | Persisted to disk; always visible; never redacted |
 
 **Guidelines:**
-- Every new service or view model should declare its own `private static let logger = Logger(subsystem: "com.kernova.app", category: "ComponentName")`
+- Every new service or view model should declare its own `private static let logger = Logger(subsystem: "app.kernova", category: "ComponentName")`
 - State transitions and irreversible actions (creating/deleting bundles, starting/stopping VMs) should be `.notice`
 - Method entry points in complex flows should have `.debug` logs with relevant parameter values
 - Do not use `print()`, `NSLog()`, or file-based logging

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -80,7 +80,7 @@
 		A1000308 /* Exceptions for "KernovaGuestAgent" folder in "KernovaGuestAgentTests" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				com.kernova.agent.plist,
+				app.kernova.agent.plist,
 				Info.plist,
 				install.command,
 				main.swift,
@@ -425,7 +425,7 @@
 				"$(BUILT_PRODUCTS_DIR)/KernovaGuestAgent",
 				"$(SRCROOT)/KernovaGuestAgent/install.command",
 				"$(SRCROOT)/KernovaGuestAgent/uninstall.command",
-				"$(SRCROOT)/KernovaGuestAgent/com.kernova.agent.plist",
+				"$(SRCROOT)/KernovaGuestAgent/app.kernova.agent.plist",
 			);
 			name = "Package Guest Agent DMG";
 			outputFileListPaths = (
@@ -436,7 +436,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "set -euo pipefail\n\nSTAGING_DIR=$(mktemp -d \"${DERIVED_FILE_DIR}/guest-agent-dmg-staging.XXXXXX\")\nTEMP_DMG=\"$(mktemp -u \"${DERIVED_FILE_DIR}/guest-agent-temp.XXXXXX\").dmg\"\ntrap 'rm -rf \"${STAGING_DIR}\" \"${TEMP_DMG}\"' EXIT\n\nRAW_PREFIX=\"${DERIVED_FILE_DIR}/guest-agent-raw\"\nDMG_OUTPUT=\"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Resources/KernovaGuestAgent.dmg\"\nVERSION_OUTPUT=\"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Resources/KernovaGuestAgentVersion.txt\"\n\ncp \"${BUILT_PRODUCTS_DIR}/KernovaGuestAgent\" \"${STAGING_DIR}/kernova-agent\"\ncp \"${SRCROOT}/KernovaGuestAgent/install.command\" \"${STAGING_DIR}/install.command\"\ncp \"${SRCROOT}/KernovaGuestAgent/uninstall.command\" \"${STAGING_DIR}/uninstall.command\"\nchmod +x \"${STAGING_DIR}/install.command\" \"${STAGING_DIR}/uninstall.command\"\ncp \"${SRCROOT}/KernovaGuestAgent/com.kernova.agent.plist\" \"${STAGING_DIR}/com.kernova.agent.plist\"\n\nmkdir -p \"$(dirname \"${DMG_OUTPUT}\")\"\n\n# Create a UDRW DMG then convert to DVD/CD-R master (UDTO/.cdr).\n# VZDiskImageStorageDeviceAttachment needs a format it can present as a\n# USB block device — the .cdr export works reliably for guest-mountable volumes.\nhdiutil create \\\n    -volname \"Kernova Guest Agent\" \\\n    -srcfolder \"${STAGING_DIR}\" \\\n    -ov -format UDRW \\\n    \"${TEMP_DMG}\"\nhdiutil convert \"${TEMP_DMG}\" -format UDTO -ov -o \"${RAW_PREFIX}\"\nmv \"${RAW_PREFIX}.cdr\" \"${DMG_OUTPUT}\"\n\n# Strip extended attributes that break code signing\nxattr -cr \"${DMG_OUTPUT}\"\n\n# Extract the agent's CFBundleShortVersionString from its embedded Info.plist\n# and write a sidecar the host reads at runtime. Keeping the agent binary as the\n# single source of truth means the host cannot drift from what it actually ships.\nAGENT_VERSION=$(otool -X -P \"${BUILT_PRODUCTS_DIR}/KernovaGuestAgent\" | plutil -extract CFBundleShortVersionString raw -)\nif [ -z \"${AGENT_VERSION}\" ]; then\n    echo \"error: Could not extract agent version from binary\" >&2\n    exit 1\nfi\nprintf '%s' \"${AGENT_VERSION}\" > \"${VERSION_OUTPUT}\"\n";
+			shellScript = "set -euo pipefail\n\nSTAGING_DIR=$(mktemp -d \"${DERIVED_FILE_DIR}/guest-agent-dmg-staging.XXXXXX\")\nTEMP_DMG=\"$(mktemp -u \"${DERIVED_FILE_DIR}/guest-agent-temp.XXXXXX\").dmg\"\ntrap 'rm -rf \"${STAGING_DIR}\" \"${TEMP_DMG}\"' EXIT\n\nRAW_PREFIX=\"${DERIVED_FILE_DIR}/guest-agent-raw\"\nDMG_OUTPUT=\"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Resources/KernovaGuestAgent.dmg\"\nVERSION_OUTPUT=\"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Resources/KernovaGuestAgentVersion.txt\"\n\ncp \"${BUILT_PRODUCTS_DIR}/KernovaGuestAgent\" \"${STAGING_DIR}/kernova-agent\"\ncp \"${SRCROOT}/KernovaGuestAgent/install.command\" \"${STAGING_DIR}/install.command\"\ncp \"${SRCROOT}/KernovaGuestAgent/uninstall.command\" \"${STAGING_DIR}/uninstall.command\"\nchmod +x \"${STAGING_DIR}/install.command\" \"${STAGING_DIR}/uninstall.command\"\ncp \"${SRCROOT}/KernovaGuestAgent/app.kernova.agent.plist\" \"${STAGING_DIR}/app.kernova.agent.plist\"\n\nmkdir -p \"$(dirname \"${DMG_OUTPUT}\")\"\n\n# Create a UDRW DMG then convert to DVD/CD-R master (UDTO/.cdr).\n# VZDiskImageStorageDeviceAttachment needs a format it can present as a\n# USB block device — the .cdr export works reliably for guest-mountable volumes.\nhdiutil create \\\n    -volname \"Kernova Guest Agent\" \\\n    -srcfolder \"${STAGING_DIR}\" \\\n    -ov -format UDRW \\\n    \"${TEMP_DMG}\"\nhdiutil convert \"${TEMP_DMG}\" -format UDTO -ov -o \"${RAW_PREFIX}\"\nmv \"${RAW_PREFIX}.cdr\" \"${DMG_OUTPUT}\"\n\n# Strip extended attributes that break code signing\nxattr -cr \"${DMG_OUTPUT}\"\n\n# Extract the agent's CFBundleShortVersionString from its embedded Info.plist\n# and write a sidecar the host reads at runtime. Keeping the agent binary as the\n# single source of truth means the host cannot drift from what it actually ships.\nAGENT_VERSION=$(otool -X -P \"${BUILT_PRODUCTS_DIR}/KernovaGuestAgent\" | plutil -extract CFBundleShortVersionString raw -)\nif [ -z \"${AGENT_VERSION}\" ]; then\n    echo \"error: Could not extract agent version from binary\" >&2\n    exit 1\nfi\nprintf '%s' \"${AGENT_VERSION}\" > \"${VERSION_OUTPUT}\"\n";
 		};
 		A100020C /* Set Build Number from Git */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -670,7 +670,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 0.9.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kernova.app;
+				PRODUCT_BUNDLE_IDENTIFIER = app.kernova;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
@@ -699,7 +699,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 0.9.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kernova.app;
+				PRODUCT_BUNDLE_IDENTIFIER = app.kernova;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
@@ -715,7 +715,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 0.9.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kernova.app.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;
@@ -732,7 +732,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 0.9.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kernova.app.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;
@@ -772,7 +772,7 @@
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
 				MARKETING_VERSION = 0.10.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kernova.agent;
+				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.agent;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 6.0;
 			};
@@ -789,7 +789,7 @@
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
 				MARKETING_VERSION = 0.10.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kernova.agent;
+				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.agent;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 6.0;
 			};
@@ -803,7 +803,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 0.9.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kernova.agent.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.agent.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;
@@ -818,7 +818,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 0.9.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kernova.agent.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.agent.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -40,7 +40,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         "com.apple.settings.PrivacySecurity.extension"
     ]
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "AppDelegate")
+    private static let logger = Logger(subsystem: "app.kernova", category: "AppDelegate")
     private static let guestAgentDiskPath: String? = {
         guard
             let path = Bundle.main.url(forResource: "KernovaGuestAgent", withExtension: "dmg")?.path(

--- a/Kernova/App/ClipboardContentViewController.swift
+++ b/Kernova/App/ClipboardContentViewController.swift
@@ -10,7 +10,7 @@ import os
 /// manager — the affordance is hidden for them.
 @MainActor
 final class ClipboardContentViewController: NSViewController, NSTextViewDelegate {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "ClipboardContentViewController")
+    private static let logger = Logger(subsystem: "app.kernova", category: "ClipboardContentViewController")
 
     private let instance: VMInstance
     private weak var viewModel: VMLibraryViewModel?

--- a/Kernova/App/ClipboardWindowController.swift
+++ b/Kernova/App/ClipboardWindowController.swift
@@ -10,7 +10,7 @@ import os
 /// the VM stops or enters an error state.
 @MainActor
 final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "ClipboardWindowController")
+    private static let logger = Logger(subsystem: "app.kernova", category: "ClipboardWindowController")
 
     let instance: VMInstance
     private var statusObservation: ObservationLoop?

--- a/Kernova/App/DetailContainerViewController.swift
+++ b/Kernova/App/DetailContainerViewController.swift
@@ -40,7 +40,7 @@ final class DetailContainerViewController: NSViewController {
     /// `viewDidAppear` honors it once the window is available.
     private var pendingWizard = false
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "DetailContainerVC")
+    private static let logger = Logger(subsystem: "app.kernova", category: "DetailContainerVC")
 
     // MARK: - Init
 

--- a/Kernova/App/Info.plist
+++ b/Kernova/App/Info.plist
@@ -28,7 +28,7 @@
 	<array>
 		<dict>
 			<key>UTTypeIdentifier</key>
-			<string>com.kernova.vm</string>
+			<string>app.kernova.vm</string>
 			<key>UTTypeDescription</key>
 			<string>Kernova Virtual Machine</string>
 			<key>UTTypeConformsTo</key>
@@ -45,7 +45,7 @@
 		</dict>
 		<dict>
 			<key>UTTypeIdentifier</key>
-			<string>com.kernova.app.in-progress-download</string>
+			<string>app.kernova.in-progress-download</string>
 			<key>UTTypeDescription</key>
 			<string>Kernova In-Progress Download</string>
 			<key>UTTypeConformsTo</key>
@@ -74,7 +74,7 @@
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>com.kernova.vm</string>
+				<string>app.kernova.vm</string>
 			</array>
 		</dict>
 	</array>

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -15,7 +15,7 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
     private var sidebarCollapseObservation: NSKeyValueObservation?
     private var toolbarObservation: ObservationLoop?
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "MainWindowController")
+    private static let logger = Logger(subsystem: "app.kernova", category: "MainWindowController")
     private static let toolbarNewVM = NSToolbarItem.Identifier("newVM")
 
     // MARK: - Init

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -21,7 +21,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     private let backingView: VMDisplayBackingView
     private var instanceObservation: ObservationLoop?
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMDisplayWindowController")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VMDisplayWindowController")
 
     init(
         instance: VMInstance, enterFullscreen: Bool, onResume: @escaping () -> Void,

--- a/Kernova/App/VMToolbarManager.swift
+++ b/Kernova/App/VMToolbarManager.swift
@@ -52,7 +52,7 @@ final class VMToolbarManager: NSObject {
     private let configuration: Configuration
     private let instanceProvider: () -> VMInstance?
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMToolbarManager")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VMToolbarManager")
 
     // MARK: - Tooltip Constants
 

--- a/Kernova/Models/KernovaUTType.swift
+++ b/Kernova/Models/KernovaUTType.swift
@@ -4,9 +4,9 @@ import os
 extension UTType {
     /// The document type for Kernova VM bundles (`.kernova` packages).
     static let kernovaVM: UTType = {
-        let identifier = "com.kernova.vm"
+        let identifier = "app.kernova.vm"
         guard let type = UTType(identifier) else {
-            let logger = Logger(subsystem: "com.kernova.app", category: "UTType")
+            let logger = Logger(subsystem: "app.kernova", category: "UTType")
             logger.fault("UTType lookup failed for identifier '\(identifier, privacy: .public)'")
             assertionFailure("UTType lookup failed for identifier: \(identifier)")
             return .data
@@ -25,7 +25,7 @@ extension UTType {
 
     private static func resolvedFilenameExtension(_ ext: String, fallback: UTType = .data) -> UTType {
         guard let type = UTType(filenameExtension: ext) else {
-            let logger = Logger(subsystem: "com.kernova.app", category: "UTType")
+            let logger = Logger(subsystem: "app.kernova", category: "UTType")
             logger.fault("UTType lookup failed for extension '\(ext, privacy: .public)'")
             assertionFailure("UTType lookup failed for extension: \(ext)")
             return fallback
@@ -38,7 +38,7 @@ extension UTType {
     /// `.raw` is deliberately mapped to `.data` because `UTType(filenameExtension: "raw")`
     /// resolves to `public.camera-raw-image` (digital camera photos), not raw disk images.
     static let diskImageTypes: [UTType] = {
-        let logger = Logger(subsystem: "com.kernova.app", category: "UTType")
+        let logger = Logger(subsystem: "app.kernova", category: "UTType")
         // Extensions where the system UTType correctly represents a disk image format.
         let resolvedExtensions: [(ext: String, fallback: UTType)] = [
             ("iso", .diskImage), ("img", .data), ("asif", .data),

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -77,7 +77,7 @@ struct VMConfiguration: Codable, Sendable, Equatable {
 
     /// When `true`, the macOS guest agent forwards `os.Logger` records to the
     /// host over vsock so they appear in Console.app under
-    /// `com.kernova.guest`.
+    /// `app.kernova.guest`.
     ///
     /// Defaults to `false` for new and existing VMs:
     /// log forwarding is opt-in. Linux guests have no Kernova agent and ignore

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -243,7 +243,7 @@ final class VMInstance {
     /// `serialSocketRelayEnabled` drives start/stop, including live hot-toggle.
     private var serialSocketRelay: SerialSocketRelay?
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMInstance")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VMInstance")
 
     nonisolated var id: UUID { instanceID }
     var name: String { configuration.name }
@@ -951,7 +951,7 @@ final class VMInstance {
 /// Bridges `VZVirtualMachineDelegate` callbacks to update the `VMInstance` status.
 @MainActor
 private final class VMDelegateAdapter: NSObject, VZVirtualMachineDelegate {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMDelegateAdapter")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VMDelegateAdapter")
 
     weak var instance: VMInstance?
 

--- a/Kernova/Services/AttachmentFileMonitor.swift
+++ b/Kernova/Services/AttachmentFileMonitor.swift
@@ -21,7 +21,7 @@ import os
 @MainActor
 @Observable
 final class AttachmentFileMonitor {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "AttachmentFileMonitor")
+    private static let logger = Logger(subsystem: "app.kernova", category: "AttachmentFileMonitor")
 
     /// Latest known existence flag for each watched path.
     ///

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -30,7 +30,7 @@ struct ConfigurationBuilder: Sendable {
         let coldRemovableMedia: [USBDeviceInfo]
     }
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "ConfigurationBuilder")
+    private static let logger = Logger(subsystem: "app.kernova", category: "ConfigurationBuilder")
 
     /// Builds a validated `VZVirtualMachineConfiguration` from the given VM configuration and bundle URL.
     func build(from config: VMConfiguration, bundleURL: URL) throws -> BuildResult {

--- a/Kernova/Services/DiskImageService.swift
+++ b/Kernova/Services/DiskImageService.swift
@@ -12,7 +12,7 @@ import os
 /// sizes (~3 KB each). At VM creation time, the template is decompressed and
 /// written to the destination — fully sandbox-safe with no process spawning.
 struct DiskImageService: Sendable {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "DiskImageService")
+    private static let logger = Logger(subsystem: "app.kernova", category: "DiskImageService")
 
     /// Creates an ASIF sparse disk image at the specified URL by decompressing a bundled template.
     ///

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -8,7 +8,7 @@ import os
 /// can be invalidated in `deinit`. Per Apple's docs, a session retains itself
 /// until `finishTasksAndInvalidate()` or `invalidateAndCancel()` is called.
 final class IPSWService: Sendable {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "IPSWService")
+    private static let logger = Logger(subsystem: "app.kernova", category: "IPSWService")
 
     private let session: URLSession
 

--- a/Kernova/Services/KernovaGuestAgentInfo.swift
+++ b/Kernova/Services/KernovaGuestAgentInfo.swift
@@ -11,7 +11,7 @@ import os
 /// that sidecar at runtime guarantees the host can never claim to bundle a
 /// version different from what actually ships in the DMG.
 enum KernovaGuestAgentInfo {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "KernovaGuestAgentInfo")
+    private static let logger = Logger(subsystem: "app.kernova", category: "KernovaGuestAgentInfo")
 
     /// Filename of the version sidecar in `Kernova.app/Contents/Resources/`.
     private static let versionResourceName = "KernovaGuestAgentVersion"

--- a/Kernova/Services/MacOSInstallService.swift
+++ b/Kernova/Services/MacOSInstallService.swift
@@ -11,7 +11,7 @@ import os
 /// 4. Run the installer with progress tracking via KVO
 @MainActor
 final class MacOSInstallService {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "MacOSInstallService")
+    private static let logger = Logger(subsystem: "app.kernova", category: "MacOSInstallService")
 
     private let configBuilder = ConfigurationBuilder()
     private let storageService = VMStorageService()

--- a/Kernova/Services/SerialSocketRelay.swift
+++ b/Kernova/Services/SerialSocketRelay.swift
@@ -52,7 +52,7 @@ final class SerialSocketRelay: @unchecked Sendable {
     private var clientFd: Int32 = -1
     private var clientSource: DispatchSourceRead?
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "SerialSocketRelay")
+    private static let logger = Logger(subsystem: "app.kernova", category: "SerialSocketRelay")
 
     /// Process-wide `SIGPIPE` suppression so a write to a client whose read
     /// side has vanished surfaces as `EPIPE` from `write(2)` instead of killing
@@ -72,7 +72,7 @@ final class SerialSocketRelay: @unchecked Sendable {
         self.path = path
         self.guestInput = guestInputWriteHandle
         self.label = label
-        self.queue = DispatchQueue(label: "com.kernova.app.serial-relay")
+        self.queue = DispatchQueue(label: "app.kernova.serial-relay")
         _ = Self.suppressSIGPIPEOnce
     }
 

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -59,7 +59,7 @@ final class SpiceClipboardService: ClipboardServicing {
     /// instead of waiting for a REQUEST.
     private var guestSupportsByDemand = false
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "SpiceClipboardService")
+    private static let logger = Logger(subsystem: "app.kernova", category: "SpiceClipboardService")
 
     // MARK: - Init
 

--- a/Kernova/Services/SystemSleepWatcher.swift
+++ b/Kernova/Services/SystemSleepWatcher.swift
@@ -7,7 +7,7 @@ import os
 /// with `nonisolated(unsafe)` for observer references needed in `deinit`.
 @MainActor
 final class SystemSleepWatcher {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "SystemSleepWatcher")
+    private static let logger = Logger(subsystem: "app.kernova", category: "SystemSleepWatcher")
 
     /// `nonisolated(unsafe)` because `NSObjectProtocol` observer tokens are not `Sendable`
     /// and we need to remove them in `deinit` (which is nonisolated).

--- a/Kernova/Services/USBDeviceService.swift
+++ b/Kernova/Services/USBDeviceService.swift
@@ -5,7 +5,7 @@ import os
 /// Manages runtime USB mass storage device attach/detach via XHCI controller.
 @MainActor
 final class USBDeviceService: USBDeviceProviding {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "USBDeviceService")
+    private static let logger = Logger(subsystem: "app.kernova", category: "USBDeviceService")
 
     func attach(
         diskImagePath: String,

--- a/Kernova/Services/VMStorageService.swift
+++ b/Kernova/Services/VMStorageService.swift
@@ -9,7 +9,7 @@ import os
 /// - macOS-specific files: `AuxiliaryStorage`, `HardwareModel`, `MachineIdentifier`
 /// - Optional: `SaveFile.vzvmsave`
 struct VMStorageService: Sendable {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMStorageService")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VMStorageService")
 
     static let bundleExtension = "kernova"
 

--- a/Kernova/Services/VirtualizationService.swift
+++ b/Kernova/Services/VirtualizationService.swift
@@ -7,7 +7,7 @@ import os
 /// All operations run on the main actor since `VZVirtualMachine` must be used on the main thread.
 @MainActor
 final class VirtualizationService {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VirtualizationService")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VirtualizationService")
 
     private let configBuilder = ConfigurationBuilder()
 

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -90,7 +90,7 @@ final class VsockClipboardService: ClipboardServicing {
     var pendingInboundGenerationForTesting: UInt64? { pendingInboundGeneration }
     #endif
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VsockClipboardService")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VsockClipboardService")
 
     private static let errorCodeFormatUnavailable = "clipboard.format.unavailable"
     private static let errorCodeEncodingFailure = "clipboard.transfer.encoding.failure"

--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -108,7 +108,7 @@ final class VsockControlService {
     /// peer does not respond to a specific nonce.
     private var nextHeartbeatNonce: UInt64 = 1
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VsockControlService")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VsockControlService")
 
     // MARK: - Init
 

--- a/Kernova/Services/VsockGuestLogService.swift
+++ b/Kernova/Services/VsockGuestLogService.swift
@@ -10,7 +10,7 @@ import os
 /// disconnect or local teardown).
 @MainActor
 final class VsockGuestLogService {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VsockGuestLogService")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VsockGuestLogService")
 
     private let channel: VsockChannel
     private let emitter: any GuestLogEmitter
@@ -26,7 +26,7 @@ final class VsockGuestLogService {
     ///   - emitter: where to publish translated guest log records.
     ///     When `nil` (the default), an `OSLogGuestLogEmitter` is built
     ///     using `label` so each VM's forwarded records appear under their
-    ///     own `com.kernova.guest:<vmName>` category.
+    ///     own `app.kernova.guest:<vmName>` category.
     init(
         channel: VsockChannel,
         label: String,
@@ -123,7 +123,7 @@ struct OSLogGuestLogEmitter: GuestLogEmitter {
     init(label: String) {
         // Use a distinct subsystem so guest logs are filterable separately
         // from host logs in Console.app and `log stream` queries.
-        self.logger = Logger(subsystem: "com.kernova.guest", category: label)
+        self.logger = Logger(subsystem: "app.kernova.guest", category: label)
     }
 
     func emit(_ record: Kernova_V1_LogRecord) {

--- a/Kernova/Services/VsockListenerHost.swift
+++ b/Kernova/Services/VsockListenerHost.swift
@@ -13,7 +13,7 @@ import Virtualization
 final class VsockListenerHost: NSObject, VZVirtioSocketListenerDelegate {
     typealias OnConnect = @MainActor (VsockChannel) -> Void
 
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VsockListenerHost")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VsockListenerHost")
 
     let port: UInt32
     private let onConnect: OnConnect

--- a/Kernova/Utilities/NSImageExtensions.swift
+++ b/Kernova/Utilities/NSImageExtensions.swift
@@ -2,7 +2,7 @@ import Cocoa
 import os
 
 extension NSImage {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "NSImage")
+    private static let logger = Logger(subsystem: "app.kernova", category: "NSImage")
 
     /// Returns a system symbol image, or a zero-size fallback if the symbol is not found.
     ///

--- a/Kernova/ViewModels/VMDirectoryWatcher.swift
+++ b/Kernova/ViewModels/VMDirectoryWatcher.swift
@@ -5,7 +5,7 @@ import os
 /// and triggers a reconciliation callback after a debounce period.
 @MainActor
 final class VMDirectoryWatcher {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMDirectoryWatcher")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VMDirectoryWatcher")
 
     /// `nonisolated(unsafe)` because `DispatchSource` is not `Sendable` and we need
     /// to cancel it in `deinit` (which is nonisolated).

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -6,7 +6,7 @@ import os
 @MainActor
 @Observable
 final class VMLibraryViewModel {
-    nonisolated private static let logger = Logger(subsystem: "com.kernova.app", category: "VMLibraryViewModel")
+    nonisolated private static let logger = Logger(subsystem: "app.kernova", category: "VMLibraryViewModel")
     static let lastSelectedVMIDKey = "lastSelectedVMID"
     static let vmOrderKey = "vmOrder"
 

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -19,7 +19,7 @@ import os
 /// clobber a subsequent operation's entry.
 @MainActor
 final class VMLifecycleCoordinator {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "VMLifecycleCoordinator")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VMLifecycleCoordinator")
 
     let virtualizationService: any VirtualizationProviding
     let installService: any MacOSInstallProviding

--- a/Kernova/Views/Console/VMDisplayPlaceholderContentViewController.swift
+++ b/Kernova/Views/Console/VMDisplayPlaceholderContentViewController.swift
@@ -18,7 +18,7 @@ final class VMDisplayPlaceholderContentViewController: NSViewController {
     private var observation: ObservationLoop?
 
     private static let logger = Logger(
-        subsystem: "com.kernova.app", category: "VMDisplayPlaceholderVC"
+        subsystem: "app.kernova", category: "VMDisplayPlaceholderVC"
     )
 
     init(instance: VMInstance) {

--- a/Kernova/Views/Detail/StorageDiskReorderSheetContentViewController.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheetContentViewController.swift
@@ -67,7 +67,7 @@ final class StorageDiskReorderSheetContentViewController: NSViewController {
     /// Scoped to this controller (`forLocal: true`) so other apps can't
     /// accept the drag and so we don't accept foreign drags.
     private static let rowPasteboardType = NSPasteboard.PasteboardType(
-        "com.kernova.storagedisk-row"
+        "app.kernova.storagedisk-row"
     )
 
     init(

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -22,7 +22,7 @@ import os
 @MainActor
 final class VMSettingsViewController: NSViewController {
     private static let logger = Logger(
-        subsystem: "com.kernova.app", category: "VMSettingsViewController")
+        subsystem: "app.kernova", category: "VMSettingsViewController")
 
     private(set) var instance: VMInstance
     private var viewModel: VMLibraryViewModel
@@ -762,7 +762,7 @@ extension VMSettingsViewController {
                 "Forward guest logs", control: logForwardingSwitch,
                 paragraphs: [
                     .body(
-                        "Streams `os.Logger` records from the macOS guest agent to the host so they appear in Console.app under `com.kernova.guest`. Off by default; can be toggled while the VM is running."
+                        "Streams `os.Logger` records from the macOS guest agent to the host so they appear in Console.app under `app.kernova.guest`. Off by default; can be toggled while the VM is running."
                     )
                 ]),
             makeToggleRowWithInfo(

--- a/Kernova/Views/Settings/SettingsTabViewController.swift
+++ b/Kernova/Views/Settings/SettingsTabViewController.swift
@@ -7,7 +7,7 @@ import os
 /// further panes can be added later as additional `NSTabViewItem`s.
 @MainActor
 final class SettingsTabViewController: NSTabViewController {
-    private static let logger = Logger(subsystem: "com.kernova.app", category: "SettingsTabViewController")
+    private static let logger = Logger(subsystem: "app.kernova", category: "SettingsTabViewController")
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Kernova/Views/Sidebar/SidebarViewController.swift
+++ b/Kernova/Views/Sidebar/SidebarViewController.swift
@@ -33,7 +33,7 @@ final class SidebarViewController: NSViewController {
     /// rename loop doesn't restart an in-flight edit.
     private var editingItemID: UUID?
 
-    private static let rowPasteboardType = NSPasteboard.PasteboardType("com.kernova.sidebar-vm-row")
+    private static let rowPasteboardType = NSPasteboard.PasteboardType("app.kernova.sidebar-vm-row")
     private static let groupCellID = NSUserInterfaceItemIdentifier("SidebarGroupHeaderCell")
     private static let mainColumnID = NSUserInterfaceItemIdentifier("main")
     private static let expandedSectionsKey = "KernovaSidebarExpandedSections"

--- a/KernovaGuestAgent/KernovaLogger.swift
+++ b/KernovaGuestAgent/KernovaLogger.swift
@@ -9,7 +9,7 @@ import os
 /// Construction matches `os.Logger`:
 ///
 ///     private static let logger = KernovaLogger(
-///         subsystem: "com.kernova.agent",
+///         subsystem: "app.kernova.agent",
 ///         category: "GuestAgent"
 ///     )
 ///

--- a/KernovaGuestAgent/VsockGuestClient.swift
+++ b/KernovaGuestAgent/VsockGuestClient.swift
@@ -49,7 +49,7 @@ final class VsockGuestClient: @unchecked Sendable {
         case terminate
     }
 
-    private static let logger = Logger(subsystem: "com.kernova.agent", category: "VsockGuestClient")
+    private static let logger = Logger(subsystem: "app.kernova.agent", category: "VsockGuestClient")
     private static let socketTimeoutSeconds: Int = 30
     // RATIONALE: vsock is a local-only transport with no SYN dance, so connect
     // is normally immediate-success or immediate-ECONNREFUSED. 3s is a generous

--- a/KernovaGuestAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaGuestAgent/VsockGuestClipboardAgent.swift
@@ -39,7 +39,7 @@ extension NSPasteboard: Pasteboard {}
 // used because @MainActor is impractical here — the entry point is
 // main.swift top-level code (nonisolated in Swift 6), not an @main app.
 final class VsockGuestClipboardAgent: @unchecked Sendable {
-    private static let logger = KernovaLogger(subsystem: "com.kernova.agent", category: "VsockGuestClipboardAgent")
+    private static let logger = KernovaLogger(subsystem: "app.kernova.agent", category: "VsockGuestClipboardAgent")
     private static let pollingInterval: TimeInterval = 0.5
 
     private static let errorCodeFormatUnavailable = "clipboard.format.unavailable"

--- a/KernovaGuestAgent/VsockGuestControlAgent.swift
+++ b/KernovaGuestAgent/VsockGuestControlAgent.swift
@@ -28,7 +28,7 @@ import os
 /// loop where a heartbeat send failure schedules another forwarded log frame
 /// through the same broken transport.
 final class VsockGuestControlAgent: @unchecked Sendable {
-    private static let logger = Logger(subsystem: "com.kernova.agent", category: "VsockGuestControlAgent")
+    private static let logger = Logger(subsystem: "app.kernova.agent", category: "VsockGuestControlAgent")
 
     private let client: VsockGuestClient
     private let heartbeatInterval: Duration

--- a/KernovaGuestAgent/VsockHostConnection.swift
+++ b/KernovaGuestAgent/VsockHostConnection.swift
@@ -16,7 +16,7 @@ import os
 /// frames are buffered in a bounded ring (oldest dropped first) and flushed
 /// once the next connection comes up.
 final class VsockHostConnection: @unchecked Sendable {
-    private static let logger = Logger(subsystem: "com.kernova.agent", category: "VsockHostConnection")
+    private static let logger = Logger(subsystem: "app.kernova.agent", category: "VsockHostConnection")
 
     /// Maximum number of `LogRecord` frames buffered while the channel is
     /// down.

--- a/KernovaGuestAgent/app.kernova.agent.plist
+++ b/KernovaGuestAgent/app.kernova.agent.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Label</key>
-	<string>com.kernova.agent</string>
+	<string>app.kernova.agent</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>__INSTALL_DIR__/kernova-agent</string>

--- a/KernovaGuestAgent/install.command
+++ b/KernovaGuestAgent/install.command
@@ -42,7 +42,7 @@ else
 fi
 echo ""
 echo "  Binary:      ~/Library/Application Support/Kernova/kernova-agent"
-echo "  LaunchAgent: ~/Library/LaunchAgents/com.kernova.agent.plist"
+echo "  LaunchAgent: ~/Library/LaunchAgents/app.kernova.agent.plist"
 echo ""
 echo "To uninstall later, run uninstall.command from this disk."
 echo ""
@@ -51,7 +51,7 @@ if [[ "${choice}" =~ ^[Yy]$ ]]; then
     echo ""
     echo "----------------------------------------"
 
-    LABEL="com.kernova.agent"
+    LABEL="app.kernova.agent"
     LAUNCHAGENTS_DIR="${HOME}/Library/LaunchAgents"
     PLIST_NAME="${LABEL}.plist"
 

--- a/KernovaGuestAgent/main.swift
+++ b/KernovaGuestAgent/main.swift
@@ -12,7 +12,7 @@ import Foundation
 // Designed to run as a macOS LaunchAgent (auto-start on login,
 // auto-restart on crash).
 
-private let logger = KernovaLogger(subsystem: "com.kernova.agent", category: "GuestAgent")
+private let logger = KernovaLogger(subsystem: "app.kernova.agent", category: "GuestAgent")
 
 // MARK: - Version
 

--- a/KernovaGuestAgent/uninstall.command
+++ b/KernovaGuestAgent/uninstall.command
@@ -9,14 +9,14 @@ echo ""
 echo "This will remove the Kernova guest agent from this Mac."
 echo ""
 echo "  Binary:      ~/Library/Application Support/Kernova/kernova-agent"
-echo "  LaunchAgent: ~/Library/LaunchAgents/com.kernova.agent.plist"
+echo "  LaunchAgent: ~/Library/LaunchAgents/app.kernova.agent.plist"
 echo ""
 read -p "Proceed with uninstall? [y/N] " choice
 if [[ "${choice}" =~ ^[Yy]$ ]]; then
     echo ""
     echo "----------------------------------------"
 
-    LABEL="com.kernova.agent"
+    LABEL="app.kernova.agent"
     INSTALL_DIR="${HOME}/Library/Application Support/Kernova"
     LAUNCHAGENTS_DIR="${HOME}/Library/LaunchAgents"
     BINARY_NAME="kernova-agent"

--- a/KernovaProtocol/Proto/kernova.proto
+++ b/KernovaProtocol/Proto/kernova.proto
@@ -89,7 +89,7 @@ message LogRecord {
 
   Level level = 2;
 
-  // Logger subsystem and category from the guest, e.g. "com.kernova.agent" /
+  // Logger subsystem and category from the guest, e.g. "app.kernova.agent" /
   // "GuestClipboardAgent". Treated as opaque labels by the host.
   string subsystem = 3;
   string category = 4;

--- a/KernovaProtocol/Sources/KernovaProtocol/Generated/kernova.pb.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/Generated/kernova.pb.swift
@@ -260,7 +260,7 @@ public nonisolated struct Kernova_V1_LogRecord: Sendable {
 
   public var level: Kernova_V1_LogRecord.Level = .unspecified
 
-  /// Logger subsystem and category from the guest, e.g. "com.kernova.agent" /
+  /// Logger subsystem and category from the guest, e.g. "app.kernova.agent" /
   /// "GuestClipboardAgent". Treated as opaque labels by the host.
   public var subsystem: String = String()
 

--- a/KernovaRelaunchHelper/main.swift
+++ b/KernovaRelaunchHelper/main.swift
@@ -9,7 +9,7 @@ import os
 //
 // Usage: KernovaRelaunchHelper <pid> <app-bundle-path>
 
-private let logger = Logger(subsystem: "com.kernova.app", category: "RelaunchHelper")
+private let logger = Logger(subsystem: "app.kernova", category: "RelaunchHelper")
 
 // MARK: - Argument parsing
 

--- a/KernovaTests/VsockGuestLogServiceTests.swift
+++ b/KernovaTests/VsockGuestLogServiceTests.swift
@@ -30,7 +30,7 @@ struct VsockGuestLogServiceTests {
 
     private func makeLogFrame(
         level: Kernova_V1_LogRecord.Level,
-        subsystem: String = "com.kernova.agent",
+        subsystem: String = "app.kernova.agent",
         category: String = "Test",
         message: String = "hello",
         timestampMs: Int64 = 1_700_000_000_000


### PR DESCRIPTION
## Summary
Moves every reverse-DNS identifier from the unowned `com.kernova.*` namespace to `app.kernova.*`, rooted at the newly registered **kernova.app** domain. This is the full namespace move decided in the issue: bundle IDs, UTTypes, pasteboard types, the LaunchAgent label, `DispatchQueue` label, and all `os.Logger` subsystems. A side benefit: the old mixed `com.kernova.X` / `com.kernova.app.X` scheme collapses into a single consistent root.

Closes #295

## Mapping
| Current | New |
|---------|-----|
| `com.kernova.app` (host bundle ID + host logger subsystems) | `app.kernova` |
| `com.kernova.app.tests` | `app.kernova.tests` |
| `com.kernova.agent` (agent bundle ID + loggers + launchd `Label`) | `app.kernova.agent` |
| `com.kernova.agent.tests` | `app.kernova.agent.tests` |
| `com.kernova.guest` (forwarded guest log subsystem) | `app.kernova.guest` |
| `com.kernova.vm` (UTType, `.kernova` bundle) | `app.kernova.vm` |
| `com.kernova.app.in-progress-download` (UTType) | `app.kernova.in-progress-download` |
| `com.kernova.sidebar-vm-row` / `com.kernova.storagedisk-row` (pasteboard) | `app.kernova.sidebar-vm-row` / `app.kernova.storagedisk-row` |
| `com.kernova.app.serial-relay` (queue label) | `app.kernova.serial-relay` |

## Changes
- `project.pbxproj`: all 8 `PRODUCT_BUNDLE_IDENTIFIER` settings plus the LaunchAgent plist filename references (group child, build-phase input, DMG-staging `cp`)
- LaunchAgent plist renamed `com.kernova.agent.plist` → `app.kernova.agent.plist` (`git mv`); `install.command`/`uninstall.command` labels updated
- ~35 `os.Logger` subsystem strings across host app, guest agent, and relaunch helper
- UTTypes in `Info.plist` + `KernovaUTType.swift`; `.kernova`/`.kernovadownload` extension mappings unchanged, so existing bundles stay recognized
- `kernova.proto` example comment, mirrored identically in generated `kernova.pb.swift` — comment-only and copied verbatim by protoc, so `proto-drift` stays green
- `CLAUDE.md` logging guidance and `ARCHITECTURE.md` references

## Accepted implications (per #295)
- One-time TCC microphone re-prompt (grant was keyed to `com.kernova.app`)
- `UserDefaults` reset (bundle-ID domain change) — minor UI state, no migration machinery
- Existing guests keep the old agent under `com.kernova.agent`; one-time manual cleanup + reinstall in any existing guest

## Test plan
- [x] `make build` succeeds; built app's `CFBundleIdentifier` verified as `app.kernova`
- [x] Guest-agent DMG verified to stage `app.kernova.agent.plist` with `Label` `app.kernova.agent`
- [x] `make test` — full suite passes (all three targets)
- [x] `make lint` clean
- [x] `git grep com.kernova` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)