### PR TITLE
docs: Make the commit trailer track the authoring model dynamically

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,7 +334,7 @@ feat: Add VM snapshot support
 
 Commit messages must reflect the full intent and scope of all changes, not just the last operation performed. Before writing a commit message, review both the conversation context (what the user asked for, the steps taken) and the staged diff holistically. Lead with the primary purpose; secondary details (naming conventions, formatting choices) belong in the body.
 
-End every commit message with the `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` trailer. It is **not** appended automatically — add it explicitly (e.g. `git commit --trailer "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"`). Include it exactly once; do not duplicate it in the message body.
+End every commit message with a `Co-Authored-By: Claude <Model> <noreply@anthropic.com>` trailer, where `<Model>` is the model actually authoring the commit — Claude Code states the current model's exact trailer in each session (e.g. `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`); use that rather than copying a model name from documentation or earlier commits. It is **not** appended automatically — add it explicitly (e.g. `git commit --trailer "Co-Authored-By: Claude <Model> <noreply@anthropic.com>"`). Include it exactly once; do not duplicate it in the message body.
 
 ### Merging Pull Requests
 


### PR DESCRIPTION
## Summary
CLAUDE.md hardcoded `Claude Opus 4.8` in the `Co-Authored-By` trailer guidance, which goes stale whenever the session model changes — the identifier-rename commit (#328) was authored by Fable 5 but attributed to Opus 4.8 because the doc said so.

The guidance now defers to the exact trailer Claude Code states in each session, so every commit attributes the model that actually authored it. No git-side machinery (hooks/templates) is needed: the authoring model always knows its own name when it writes the message, and Claude Code supplies the exact trailer string per session.

## Changes
- Rewrote the trailer paragraph under *Scoping the message* in CLAUDE.md; grep confirms no other site in the repo hardcodes a model name

## Test plan
- [x] Docs-only change; `git grep "Opus 4.8"` returns nothing
- [x] This PR's own commit demonstrates the rule (trailer names Fable 5, the authoring model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)