### PR TITLE
docs: Add LaunchServices teardown step to worktree cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,6 +350,15 @@ After a successful merge, confirm it landed, then tear down the branch and sync 
 
 1. `gh pr view <N> --json state -q .state` — confirm `"MERGED"` before deleting anything.
 
+**Before removing any worktree in which the app was built or launched** (e.g. for verification — this applies to abandoned worktrees too, not just merged ones), unregister its build products from LaunchServices. Otherwise LS keeps a ghost registration for the deleted path that can outrank the primary checkout's build and silently break `.kernova` UTI resolution (Quick Look previews) and app-name resolution (TCC/screen-capture grants) system-wide:
+
+```bash
+/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister \
+  -u "$PWD/DerivedData/Build/Products/Debug/Kernova.app"
+```
+
+`-u` is harmless if the path was never registered, so always run it. If Xcode built the worktree directly (rather than `make build`), also trash the worktree's per-user `~/Library/Developer/Xcode/DerivedData/Kernova-<hash>/` folder — it holds another registered copy that outlives the worktree (check `WorkspacePath` in each `Kernova-<hash>/info.plist` to find the right one).
+
 **In an `EnterWorktree` session** (the usual case), let the tool do the teardown, then sync:
 
 2. `ExitWorktree` with `action: "remove"`. Squash-merge leaves the worktree's commit off `main` by SHA, so the tool refuses unless you also pass `discard_changes: true` — that's expected and safe here, since the content already landed on `main` as the squash commit. This returns the session to the primary checkout and deletes the worktree and its scratch branch in one step (the branch deletion works because the scratch branch still carries its original `worktree-` name — see [Branch Naming](#branch-naming)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,7 +350,7 @@ After a successful merge, confirm it landed, then tear down the branch and sync 
 
 1. `gh pr view <N> --json state -q .state` — confirm `"MERGED"` before deleting anything.
 
-**Before removing any worktree in which the app was built or launched** (e.g. for verification — this applies to abandoned worktrees too, not just merged ones), unregister its build products from LaunchServices. Otherwise LS keeps a ghost registration for the deleted path that can outrank the primary checkout's build and silently break `.kernova` UTI resolution (Quick Look previews) and app-name resolution (TCC/screen-capture grants) system-wide:
+**Before removing any worktree in which the app was built or launched** (e.g. for verification — this applies to abandoned worktrees too, not just merged ones), unregister its build products from LaunchServices. Otherwise LS keeps a ghost registration for the deleted path that can outrank the primary checkout's build and silently break `.kernova` UTI resolution (Quick Look previews) and app-name resolution (TCC/screen-capture grants) system-wide. From the worktree root:
 
 ```bash
 /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister \


### PR DESCRIPTION
## Summary
- Document unregistering a worktree's built app from LaunchServices before removing the worktree (applies to abandoned worktrees too, not just merged ones)
- Prevents ghost registrations for deleted paths from outranking the primary checkout's build and silently breaking Quick Look (`.kernova` UTI resolution) and app-name resolution (TCC/screen-capture grants) system-wide

## Background
On 2026-06-10, the removed `quicklook-preview` worktree's build was still registered as the **active** owner of the `.kernova` UTI (its build number outranked the live build), which broke Quick Look previews for everyone, and PluginKit's only Quick Look appex registration pointed into another removed worktree's leftover Xcode DerivedData build. The new teardown step prevents the ghost from being left behind in the first place.

## Changes
- CLAUDE.md (Post-merge cleanup): teardown note + `lsregister -u` command, and a pointer to the per-user `~/Library/Developer/Xcode/DerivedData/Kernova-<hash>/` copy that also outlives the worktree

## Test plan
- [x] Docs-only change; the documented command is exactly what fixed the live incident

🤖 Generated with [Claude Code](https://claude.com/claude-code)