### PR TITLE
chore: Replace CLAUDE.md worktree LS teardown note with an ExitWorktree hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,5 +7,20 @@
   },
   "enabledPlugins": {
     "swift-lsp@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "ExitWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r 'select(.tool_input.action == \"remove\") | .cwd // empty' | { read -r wt; [ -n \"$wt\" ] && /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -u \"$wt/DerivedData/Build/Products/Debug/Kernova.app\"; } 2>/dev/null || true",
+            "timeout": 15,
+            "statusMessage": "Unregistering worktree build from LaunchServices"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,15 +350,6 @@ After a successful merge, confirm it landed, then tear down the branch and sync 
 
 1. `gh pr view <N> --json state -q .state` — confirm `"MERGED"` before deleting anything.
 
-**Before removing any worktree in which the app was built or launched** (e.g. for verification — this applies to abandoned worktrees too, not just merged ones), unregister its build products from LaunchServices. Otherwise LS keeps a ghost registration for the deleted path that can outrank the primary checkout's build and silently break `.kernova` UTI resolution (Quick Look previews) and app-name resolution (TCC/screen-capture grants) system-wide. From the worktree root:
-
-```bash
-/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister \
-  -u "$PWD/DerivedData/Build/Products/Debug/Kernova.app"
-```
-
-`-u` is harmless if the path was never registered, so always run it. If Xcode built the worktree directly (rather than `make build`), also trash the worktree's per-user `~/Library/Developer/Xcode/DerivedData/Kernova-<hash>/` folder — it holds another registered copy that outlives the worktree (check `WorkspacePath` in each `Kernova-<hash>/info.plist` to find the right one).
-
 **In an `EnterWorktree` session** (the usual case), let the tool do the teardown, then sync:
 
 2. `ExitWorktree` with `action: "remove"`. Squash-merge leaves the worktree's commit off `main` by SHA, so the tool refuses unless you also pass `discard_changes: true` — that's expected and safe here, since the content already landed on `main` as the squash commit. This returns the session to the primary checkout and deletes the worktree and its scratch branch in one step (the branch deletion works because the scratch branch still carries its original `worktree-` name — see [Branch Naming](#branch-naming)).


### PR DESCRIPTION
## Summary
- Automate the LaunchServices teardown instead of documenting it: a `PreToolUse` hook on `ExitWorktree` in `.claude/settings.json` unregisters the worktree's built `Kernova.app` when the worktree is removed
- Reverts the CLAUDE.md paragraph added in #335 — the guidance was too situational to occupy always-loaded context, and a hook executes deterministically instead of relying on recall

## Background
Removed worktrees leave ghost LaunchServices registrations for their build products; a ghost with a higher build number outranks the live build for the `.kernova` UTI claim, which broke Quick Look previews and app-name resolution (screen-capture grants) on 2026-06-10. #335 documented a manual teardown command; this PR makes it automatic and takes the prose back out of CLAUDE.md.

## Changes
- `.claude/settings.json`: `hooks.PreToolUse` with an `ExitWorktree` matcher — extracts the session cwd from the hook input, gates on `action == "remove"`, runs `lsregister -u` on the worktree's `DerivedData/Build/Products/Debug/Kernova.app` (harmless for never-registered or already-deleted paths), wrapped non-blocking
- `CLAUDE.md`: remove the Post-merge cleanup teardown paragraph from #335

## Test plan
- [x] Pipe-tested the raw hook command against a registered dummy bundle: remove-action unregisters it (verified via `lsregister -dump`), keep-action never invokes `lsregister`, never-registered path errors harmlessly with no side effects
- [x] Validated hook JSON nesting with `jq` against the settings schema shape

## Notes
- The hook does not cover Xcode-side per-user DerivedData copies, manual `git worktree remove`, or trashed copies still indexed by Spotlight — those remain in the machine-local auto-memory as diagnostics rather than repo docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)