### PR TITLE
chore: Remove superfluous periphery:ignore on VMPreviewModel

### DIFF
--- a/KernovaQuickLook/VMPreviewModel.swift
+++ b/KernovaQuickLook/VMPreviewModel.swift
@@ -7,10 +7,6 @@ import Foundation
 /// Compiled into the `KernovaQuickLook` extension (its production consumer)
 /// and into the app target, where `KernovaTests` reaches it via
 /// `@testable import Kernova`.
-// periphery:ignore - The production consumer is the KernovaQuickLook extension
-// target; the app-target membership exists only so KernovaTests can reach the
-// type via `@testable import Kernova`, neither of which the app-scheme scan
-// credits as usage.
 struct VMPreviewModel: Equatable, Sendable {
     /// One label/value row in the details grid.
     struct Field: Equatable, Sendable {


### PR DESCRIPTION
## Summary
- Resolves the 17 dead-code scan findings in #346. All 17 were "Superfluous ignore comment" warnings traced to a single `// periphery:ignore` directive on `VMPreviewModel` — the directive covers the struct and all 16 nested members, so each was reported individually.

## Changes
- Delete the `// periphery:ignore` directive (and its inline rationale) on `VMPreviewModel` in `KernovaQuickLook/VMPreviewModel.swift`. Periphery's cross-target index now resolves the real usages — the `KernovaQuickLook` extension's `PreviewViewController` (built under the `Kernova` scheme) and `KernovaTests` via `@testable import` — so the type is genuinely referenced and the ignore is redundant.
- Keep the doc comment describing the type's cross-target membership; only the periphery directive is removed.

This follows the project's Periphery-directive guidance: revisit and remove `periphery:ignore` annotations once the underlying usage becomes visible to the scan.

## Test plan
- [x] `make lint` passes
- [ ] Next dead-code scan reports 0 findings

Closes #346