### PR TITLE
fix: Stop the lazy-pull backstop from silently killing large clipboard pastes

### DIFF
--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -621,13 +621,26 @@ final class VsockClipboardService: ClipboardServicing {
                         Task { @MainActor [weak self] in self?.recordPullDiskFull(info) }
                     }
                     pull.resume(nil)
-                })
+                },
+                // Re-arm the inactivity backstop on each chunk so a large
+                // still-progressing guest→host transfer (e.g. Copy-to-Mac of a
+                // multi-GB file) is never cut off mid-stream. [large-paste]
+                onProgress: { pull.noteProgress() })
             pull.armTimeout(
                 Task {
-                    // A cancelled sleep (the pull resolved first) must NOT resume.
-                    do { try await Task.sleep(for: backstop) } catch { return }
-                    receiver.cancelAwait(transferID)
-                    pull.resume(nil)
+                    // Inactivity backstop: `backstop` is a window, not an absolute
+                    // deadline. Re-arm while chunks keep arriving; fire only after a
+                    // full window of silence. A cancelled sleep (the pull resolved
+                    // first) must NOT resume. This is the async (off-main `Task`)
+                    // counterpart of the guest's blocking `LazyPullCoordinator.pull`
+                    // inactivity loop — keep the two in sync.
+                    while true {
+                        do { try await Task.sleep(for: backstop) } catch { return }
+                        if pull.consumeProgress() { continue }
+                        receiver.cancelAwait(transferID)
+                        pull.resume(nil)
+                        return
+                    }
                 })
             var request = Frame()
             request.protocolVersion = 1
@@ -740,9 +753,30 @@ private final class PullContinuation: @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: CheckedContinuation<ClipboardContent.Representation?, Never>?
     private var timeout: Task<Void, Never>?
+    /// Set by `noteProgress` (a chunk landed), consumed by the backstop loop at
+    /// each window boundary to re-arm instead of firing.
+    private var progressed = false
 
     init(_ continuation: CheckedContinuation<ClipboardContent.Representation?, Never>) {
         self.continuation = continuation
+    }
+
+    /// Records that the transfer made progress so the backstop loop keeps
+    /// waiting past the next window boundary.
+    ///
+    /// No-op once resolved.
+    func noteProgress() {
+        lock.withLock { if continuation != nil { progressed = true } }
+    }
+
+    /// Returns (and clears) whether progress occurred since the last check, so
+    /// the backstop loop re-arms only when a chunk actually landed in the window.
+    func consumeProgress() -> Bool {
+        lock.withLock {
+            guard progressed else { return false }
+            progressed = false
+            return true
+        }
     }
 
     /// Stores the backstop timer so the winning `resume` can cancel it; if the

--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -449,6 +449,10 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
                 return "The guest rejected the transfer as too large"
             case "clipboard.format.unavailable":
                 return "The guest couldn't provide the requested format"
+            case "clipboard.paste.disk.full":
+                return "The guest ran out of disk space receiving the clipboard file"
+            case "clipboard.paste.timeout":
+                return "The clipboard transfer to the guest timed out"
             default:
                 return "Clipboard transfer failed on the guest side"
             }

--- a/KernovaGuestAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaGuestAgent/VsockGuestClipboardAgent.swift
@@ -851,6 +851,11 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             Self.logger.warning(
                 "Not enough disk space to receive clipboard rep '\(info.uti, privacy: .public)' (\(info.byteCount, privacy: .public) bytes)"
             )
+            // The guest has no UI; tell the host so it shows the failure.
+            sendPasteError(
+                code: "clipboard.paste.disk.full",
+                message: "Not enough disk space in the guest to receive \(info.byteCount) bytes",
+                on: channel)
             return nil
         }
         // The guest is the receiver, so it does not set the direction bit. [H3]
@@ -864,7 +869,10 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         receiver.awaitTransfer(
             transferID,
             onComplete: { rep in coordinator.deliver(transferID, rep) },
-            onAbort: { abort in coordinator.abort(transferID, abort) })
+            onAbort: { abort in coordinator.abort(transferID, abort) },
+            // Re-arm the pull's inactivity backstop on every chunk so a large
+            // still-streaming file is never timed out mid-transfer. [large-paste]
+            onProgress: { coordinator.heartbeat(transferID) })
 
         let outcome = lazyCoordinator.pull(transferID: transferID) {
             var request = Frame()
@@ -910,13 +918,71 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             Self.logger.warning(
                 "Inbound clipboard pull \(transferID, privacy: .public) aborted (\(abort.code, privacy: .public))"
             )
+            // Surface a genuine receive failure to the host UI; stay quiet for a
+            // normal supersession/teardown (the user simply copied something new).
+            if !Self.benignAbortCodes.contains(abort.code) {
+                sendPasteError(
+                    code: Self.pasteErrorCode(forAbortCode: abort.code),
+                    message: abort.message, on: channel)
+            }
         case .timedOut:
             receiver.cancelAwait(transferID)
             Self.logger.warning("Inbound clipboard pull \(transferID, privacy: .public) timed out")
+            // Stop any stream the host is still sending for this abandoned pull,
+            // then surface the failure (the guest has no UI of its own).
+            sendStreamAbort(
+                transferID: transferID, code: "paste.timeout",
+                message: "Receiver gave up waiting for the clipboard transfer", on: channel)
+            sendPasteError(
+                code: "clipboard.paste.timeout",
+                message: "The clipboard transfer to the guest timed out", on: channel)
         case .cancelled:
             receiver.cancelAwait(transferID)
         }
         return nil
+    }
+
+    /// Abort codes that are a normal supersession/teardown, not a failure worth
+    /// surfacing to the user (the user copied something new, or the channel
+    /// closed).
+    private static let benignAbortCodes: Set<String> = ["superseded", "cancelled", "request.stale"]
+
+    /// Maps a receiver/peer abort code to the user-facing `clipboard.paste.*`
+    /// code the host renders.
+    ///
+    /// Disk-full and a stalled (silent-sender) transfer get specific messages;
+    /// every other receive error is a generic failure — the precise internal
+    /// code is still captured in the guest log.
+    private static func pasteErrorCode(forAbortCode code: String) -> String {
+        switch code {
+        case "disk.full": return "clipboard.paste.disk.full"
+        case "stall.timeout": return "clipboard.paste.timeout"
+        default: return "clipboard.paste.failed"
+        }
+    }
+
+    /// Sends an `Error` frame so the host surfaces an inbound-paste failure in
+    /// its clipboard window — the guest agent has no UI of its own.
+    ///
+    /// The host maps a `clipboard.*` code to a
+    /// `ClipboardTransferIssue.peerReportedError`.
+    private func sendPasteError(code: String, message: String, on channel: VsockChannel) {
+        try? channel.sendErrorFrame(code: code, message: message, inReplyTo: "clipboard.request")
+    }
+
+    /// Sends a `ClipboardStreamAbort` for an inbound transfer the receiver is
+    /// abandoning, so the host's sender stops streaming the remaining bytes.
+    private func sendStreamAbort(
+        transferID: UInt64, code: String, message: String, on channel: VsockChannel
+    ) {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.clipboardStreamAbort = .with {
+            $0.transferID = transferID
+            $0.code = code
+            $0.message = message
+        }
+        try? channel.send(frame)
     }
 
     /// Returns the `public.file-url` bytes for a materialized representation,

--- a/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
@@ -1342,6 +1342,45 @@ struct VsockGuestClipboardAgentTests {
         try await expectNoRequest(from: hostChannel)
     }
 
+    @Test("disk full: the guest surfaces the failure to the host as a clipboard.paste error frame")
+    func diskFullSurfacesErrorFrame() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        // Only 1 KiB free, so a 50 MiB file rep fails the pre-flight disk guard.
+        let agent = makeAgent(
+            pasteboard: pasteboard, agentFd: agentFd, freeSpaceProvider: { _ in 1024 })
+        defer { agent.stop() }
+
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        let txtUTI = try #require(UTType(filenameExtension: "txt")).identifier
+        try hostChannel.send(
+            makeOfferFrame(
+                generation: 13,
+                reps: [
+                    RepInfo(
+                        uti: txtUTI, byteCount: 50 * 1024 * 1024, filename: "huge.bin",
+                        isInline: false)
+                ]))
+        try await waitUntil { pasteboard.promisedTypesForTesting == [.fileURL] }
+
+        let pull = lazyPull(pasteboard, forType: .fileURL)
+        #expect(try await pull.value == nil)
+
+        // The guest has no UI, so it tells the host — which surfaces it in the
+        // clipboard window — via a `clipboard.*` Error frame (not a request).
+        let frame = try await maybeNextFrame(from: hostChannel)
+        guard case .error(let error)? = frame?.payload else {
+            Issue.record("Expected an Error frame, got \(String(describing: frame?.payload))")
+            return
+        }
+        #expect(error.code == "clipboard.paste.disk.full")
+    }
+
     // MARK: - Request send failure
 
     @Test("a request-send failure resolves the lazy pull promptly with nil instead of blocking")

--- a/KernovaProtocol/Sources/KernovaProtocol/ClipboardStreamReceiver.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/ClipboardStreamReceiver.swift
@@ -199,6 +199,10 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             self.sendAck(transfer)
             // A chunk arrived — reset the stall clock. [H2]
             self.armStallTimer(transfer)
+            // Tell a parked lazy pull the transfer is alive so it re-arms its
+            // inactivity backstop instead of timing out a slow-but-progressing
+            // large transfer. [large-paste]
+            self.deliverProgress(transfer.transferID)
         }
     }
 
@@ -313,9 +317,13 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     public func awaitTransfer(
         _ transferID: UInt64,
         onComplete: @escaping @Sendable (ClipboardContent.Representation) -> Void,
-        onAbort: @escaping @Sendable (ClipboardStreamAbortInfo) -> Void
+        onAbort: @escaping @Sendable (ClipboardStreamAbortInfo) -> Void,
+        onProgress: (@Sendable () -> Void)? = nil
     ) {
-        lock.withLock { awaiters[transferID] = Awaiter(onComplete: onComplete, onAbort: onAbort) }
+        lock.withLock {
+            awaiters[transferID] = Awaiter(
+                onComplete: onComplete, onAbort: onAbort, onProgress: onProgress)
+        }
     }
 
     /// Deregisters a per-transfer delivery handler without firing it.
@@ -342,6 +350,18 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
         } else {
             onComplete(id, representation)
         }
+    }
+
+    /// Notifies a registered per-transfer awaiter that the transfer made
+    /// progress (a chunk was durably written), so a parked lazy pull can re-arm
+    /// its inactivity backstop.
+    ///
+    /// Peeks the awaiter without removing it — progress fires repeatedly, unlike
+    /// the one-shot complete/abort delivery. A transfer with no registered
+    /// awaiter (the eager channel-wide path) has nothing to notify.
+    private func deliverProgress(_ id: UInt64) {
+        let awaiter = lock.withLock { awaiters[id] }
+        awaiter?.onProgress?()
     }
 
     /// Delivers a failure to a registered per-transfer awaiter, or the
@@ -512,6 +532,9 @@ public struct ClipboardStreamAbortInfo: Sendable, Equatable {
 private struct Awaiter {
     let onComplete: @Sendable (ClipboardContent.Representation) -> Void
     let onAbort: @Sendable (ClipboardStreamAbortInfo) -> Void
+    /// Fired (off the owning actor) on each durably-written chunk so a blocked
+    /// lazy pull can re-arm its inactivity backstop. `nil` for the eager path.
+    let onProgress: (@Sendable () -> Void)?
 }
 
 // MARK: - Per-transfer state

--- a/KernovaProtocol/Sources/KernovaProtocol/ClipboardStreamTuning.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/ClipboardStreamTuning.swift
@@ -72,16 +72,21 @@ public enum ClipboardStreamTuning {
     /// 10 s no-ack timeout so a slow-but-live transfer is never killed.
     public static let inboundStallTimeout: Duration = .seconds(30)
 
-    /// Backstop ceiling on how long a lazy pull blocks the consuming thread
-    /// waiting for a representation: 120 s.
+    /// Backstop on how long a lazy pull blocks the consuming thread *without
+    /// progress* before giving up: 120 s of **inactivity**.
     ///
-    /// This is **not** the primary liveness guard — the receiver's
-    /// `inboundStallTimeout` (30 s of no chunk) already aborts a dead transfer
-    /// and wakes the blocked pull, and channel teardown unblocks it immediately.
-    /// A legitimate large transfer makes steady progress and completes well
-    /// inside this window; it only fires if neither the receiver nor teardown
-    /// delivers an outcome (a coordinator/receiver bug), so the consuming app's
-    /// paste can't hang forever. Tests inject a tiny value to exercise it.
+    /// This is an inactivity window, not an absolute deadline — each arriving
+    /// chunk re-arms it (`LazyPullCoordinator.heartbeat`, driven by the
+    /// receiver's per-chunk progress hook), so a healthy transfer of any size
+    /// never trips it no matter how long it runs. (An earlier absolute 120 s
+    /// ceiling silently killed large, still-progressing transfers — e.g. a
+    /// multi-GB file that simply needed more than two minutes to stream, which
+    /// left the paste hanging then failing with no feedback.) It is not the
+    /// primary liveness guard either: the receiver's `inboundStallTimeout` (30 s
+    /// of no chunk) aborts a dead transfer and wakes the blocked pull first, and
+    /// channel teardown unblocks it immediately. The backstop fires only if
+    /// neither delivers an outcome after a full window of silence (a
+    /// coordinator/receiver bug). Tests inject a tiny value to exercise it.
     public static let lazyPullTimeout: Duration = .seconds(120)
 
     /// Sentinel `maxAcceptByteCount` meaning "no explicit ceiling" — the

--- a/KernovaProtocol/Sources/KernovaProtocol/LazyPullCoordinator.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/LazyPullCoordinator.swift
@@ -41,6 +41,9 @@ public final class LazyPullCoordinator: @unchecked Sendable {
         let semaphore = DispatchSemaphore(value: 0)
         var outcome: LazyPullOutcome = .cancelled
         var resolved = false
+        /// Set by `heartbeat` when a chunk lands; consumed by `pull` at each
+        /// window boundary to re-arm the inactivity backstop.
+        var progressed = false
     }
 
     private let lock = NSLock()
@@ -50,18 +53,27 @@ public final class LazyPullCoordinator: @unchecked Sendable {
     public init() {}
 
     /// Sends a request (via `send`) and blocks the calling thread until the
-    /// matching transfer is delivered, aborts, is cancelled, or the timeout
-    /// fires.
+    /// matching transfer is delivered, aborts, is cancelled, or the pull goes a
+    /// full `timeout` window without progress.
     ///
     /// The slot is registered **before** `send` runs so a fast completion can't
     /// be missed. MUST be called off the thread that `deliver`/`abort`/`failAll`
     /// run on (e.g. off the guest agent's main thread), or the wakeup deadlocks.
     ///
+    /// `timeout` is an **inactivity** window, not an absolute deadline: each
+    /// `heartbeat` (one per durably-written chunk) re-arms it, so a healthy
+    /// transfer of any size never times out no matter how long it runs. The
+    /// backstop fires only after a full window with no chunk *and* no terminal
+    /// outcome — and the receiver's own 30 s stall timer normally aborts a dead
+    /// transfer first. (An earlier absolute deadline silently killed large,
+    /// still-progressing transfers that needed more than one window to stream.)
+    /// The host runs the equivalent inactivity loop for the reverse direction in
+    /// `VsockClipboardService.pull`.
+    ///
     /// - Parameters:
     ///   - transferID: correlates this pull with its `ClipboardRequest` and the
     ///     streamed reply.
-    ///   - timeout: backstop ceiling on the block (see
-    ///     `ClipboardStreamTuning.lazyPullTimeout`).
+    ///   - timeout: inactivity window (see `ClipboardStreamTuning.lazyPullTimeout`).
     ///   - send: emits the `ClipboardRequest`; runs synchronously on the calling
     ///     thread after the slot is registered.
     /// - Returns: the outcome the matching transfer resolved with — delivered,
@@ -74,14 +86,45 @@ public final class LazyPullCoordinator: @unchecked Sendable {
         let slot = Slot()
         lock.withLock { slots[transferID] = slot }
         send()
-        let waitResult = slot.semaphore.wait(timeout: .now() + timeout.timeInterval)
-        return lock.withLock {
-            slots[transferID] = nil
-            if waitResult == .timedOut && !slot.resolved {
+        while true {
+            // The wait blocks one window; the slot's flags — not the wait result —
+            // decide the outcome, so a signal that races the deadline is still
+            // honored via `resolved` below.
+            _ = slot.semaphore.wait(timeout: .now() + timeout.timeInterval)
+            let outcome: LazyPullOutcome? = lock.withLock {
+                // A terminal resolve (deliver/abort/cancel) sets `resolved` before
+                // signaling, so it's observed here whether the wait was signaled or
+                // raced the deadline.
+                if slot.resolved {
+                    slots[transferID] = nil
+                    return slot.outcome
+                }
+                // The window elapsed with no terminal outcome. If a chunk landed
+                // during it (heartbeat), re-arm; otherwise give up.
+                if slot.progressed {
+                    slot.progressed = false
+                    return nil
+                }
                 slot.resolved = true
                 slot.outcome = .timedOut
+                slots[transferID] = nil
+                return .timedOut
             }
-            return slot.outcome
+            if let outcome { return outcome }
+        }
+    }
+
+    /// Re-arms the inactivity backstop for `transferID`: records that a chunk
+    /// landed so the blocked `pull` keeps waiting past the next window boundary.
+    ///
+    /// Off-actor and idempotent; a heartbeat for a resolved or unknown pull is a
+    /// no-op. Does not signal the semaphore — the blocked `pull` reads the flag
+    /// when its current wait window elapses, so a heartbeat costs nothing while
+    /// bytes flow.
+    public func heartbeat(_ transferID: UInt64) {
+        lock.withLock {
+            guard let slot = slots[transferID], !slot.resolved else { return }
+            slot.progressed = true
         }
     }
 

--- a/KernovaProtocol/Tests/KernovaProtocolTests/LazyPullCoordinatorTests.swift
+++ b/KernovaProtocol/Tests/KernovaProtocolTests/LazyPullCoordinatorTests.swift
@@ -17,6 +17,14 @@ struct LazyPullCoordinatorTests {
         var abortInfo: ClipboardStreamAbortInfo? { lock.withLock { abort } }
     }
 
+    /// A `Sendable` tally for counting off-actor `onProgress` callbacks.
+    private final class ProgressCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+        func bump() { lock.withLock { count += 1 } }
+        var value: Int { lock.withLock { count } }
+    }
+
     /// Runs the blocking `pull` on a global queue so the test's cooperative
     /// thread stays free to deliver/abort/failAll and `await` the outcome.
     private func runPull(
@@ -83,6 +91,43 @@ struct LazyPullCoordinatorTests {
             return
         }
         #expect(coordinator.pendingSlotCountForTesting == 0)
+    }
+
+    @Test("heartbeats re-arm the inactivity window so a slow-but-live pull is not timed out")
+    func heartbeatExtendsTimeout() async throws {
+        let coordinator = LazyPullCoordinator()
+        // A short window: an absolute deadline would fire long before delivery.
+        async let outcome = runPull(coordinator, transferID: 11, timeout: .milliseconds(300))
+        try await pollUntil { coordinator.pendingSlotCountForTesting == 1 }
+        // Beat far faster than the window for well over a window's worth of
+        // wall-clock, so an un-reset (absolute) backstop would have fired by now.
+        for _ in 0..<24 {
+            try await Task.sleep(for: .milliseconds(25))
+            coordinator.heartbeat(11)
+        }
+        coordinator.deliver(11, inlineRep("slow but alive"))
+
+        guard case .delivered(let rep) = await outcome else {
+            Issue.record("Expected .delivered — heartbeats should have prevented the timeout")
+            return
+        }
+        #expect(rep.inMemoryData == Data("slow but alive".utf8))
+        #expect(coordinator.pendingSlotCountForTesting == 0)
+    }
+
+    @Test("a heartbeat for an unknown or resolved pull is a harmless no-op")
+    func heartbeatNoOpWhenAbsent() async throws {
+        let coordinator = LazyPullCoordinator()
+        coordinator.heartbeat(404)  // nobody waiting
+        async let outcome = runPull(coordinator, transferID: 12, timeout: .seconds(5))
+        try await pollUntil { coordinator.pendingSlotCountForTesting == 1 }
+        coordinator.deliver(12, inlineRep("done"))
+        // A late heartbeat after the slot resolves must not crash or hang.
+        coordinator.heartbeat(12)
+        guard case .delivered = await outcome else {
+            Issue.record("Expected .delivered")
+            return
+        }
     }
 
     @Test("failAll unblocks every waiting pull with .cancelled")
@@ -193,6 +238,42 @@ struct LazyPullCoordinatorTests {
         // transfer.
         #expect(harness.collector.representation(1) == nil)
         #expect(harness.collector.completedCount == 0)
+    }
+
+    @Test("awaitTransfer fires onProgress once per durably-written chunk")
+    func awaitTransferReportsProgress() async throws {
+        let harness = try StreamHarness(
+            chunkSize: 4096, windowBytes: 1 << 20,
+            freeSpaceProvider: { _ in 100 * 1024 * 1024 * 1024 })
+        defer { harness.tearDown() }
+
+        let progress = ProgressCounter()
+        let box = RepBox()
+        let gate = AsyncGate()
+        harness.receiver.awaitTransfer(
+            1,
+            onComplete: { rep in
+                box.setRep(rep)
+                gate.notify()
+            },
+            onAbort: { info in
+                box.setAbort(info)
+                gate.notify()
+            },
+            onProgress: { progress.bump() })
+
+        // 3 full chunks + a partial → 4 chunks → 4 progress callbacks, all of
+        // which precede onComplete on the transfer's serial queue.
+        var bytes = Data()
+        for i in 0..<(4096 * 3 + 7) { bytes.append(UInt8((i * 7 + 1) & 0xFF)) }
+        let rep = ClipboardContent.Representation(uti: ClipboardContent.utf8TextUTI, data: bytes)
+        harness.sender.startTransfer(
+            transferID: 1, generation: 1, representation: rep, maxAcceptByteCount: .max,
+            isInline: true, isCurrent: { _ in true })
+
+        try await gate.wait { box.representation != nil }
+        #expect(box.representation?.inMemoryData == bytes)
+        #expect(progress.value == 4)
     }
 
     @Test("a registered awaiter receives a peer abort instead of the channel-wide onAbort")


### PR DESCRIPTION
## Summary
Pasting a large file (the reporter's case: a ~20 GB disk image) from the host into a macOS guest beachballed for a while, then **silently** stopped — the paste never completed and no error appeared anywhere.

**Root cause.** A host→guest paste makes the guest's `NSPasteboardItemDataProvider` callback "lazily pull" the whole file from the host, synchronously, on the agent's main thread. That pull blocked on a flat **120 s absolute deadline** (`LazyPullCoordinator.pull` → `semaphore.wait(.now() + 120s)`) that — unlike the receiver's 30 s per-chunk stall timer — **never reset on progress**. A ~21 GB transfer has to sustain >~165 MB/s to beat 120 s; below that (very likely with `F_NOCACHE` on both ends and a VM virtual disk) it was timed out mid-stream, the provider returned `nil`, and the paste yielded nothing. The failure was invisible because guest-side inbound-paste failures were only `logger.warning` — there is no `ClipboardTransferIssue` on the guest and nothing was reported back to the host UI.

## What changed
- **Inactivity backstop, not an absolute deadline.** `LazyPullCoordinator.pull` (guest) and `VsockClipboardService.pull` (host) now treat the timeout as an *inactivity window* that each arriving chunk re-arms, via a new `ClipboardStreamReceiver` `onProgress` hook (`heartbeat` / `noteProgress`). A healthy transfer of any size never times out; the receiver's 30 s stall timer stays the real liveness guard, and the backstop only fires after a full window of true silence.
- **Failures are surfaced.** On disk-full / abort / timeout the guest sends a `clipboard.paste.*` `Error` frame, which the host already maps to a `ClipboardTransferIssue.peerReportedError` shown in the clipboard window. The guest also sends a `ClipboardStreamAbort` on timeout so the host stops streaming into a dead pull.

## Honest limitation
Even fixed, a multi-GB clipboard paste blocks the guest UI for the whole transfer — the pasteboard-provider contract is synchronous. A shared folder is the right channel for very large files. The *silent failure* is the bug; this makes the paste complete and visible.

## Follow-ups filed
- Closes nothing automatically; two adjacent issues captured during review:
  - #370 — image files >256 MiB are force-inlined and rejected before streaming.
  - #371 — Finder's copy of the staged temp file to the destination needs ~2× the file size.

## Test plan
- [x] `make build` on macOS 26
- [x] `make test` (full suite green) + `make lint` (strict)
- [x] New tests: `heartbeatExtendsTimeout`, `heartbeatNoOpWhenAbsent`, `awaitTransferReportsProgress`, `diskFullSurfacesErrorFrame`
- [ ] Manual: paste a multi-GB file host→guest; confirm it completes (or shows a disk-full notice) instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
