### PR TITLE
test: De-flake clipboard/control suites with event-driven waits

### DIFF
--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Darwin
+import Observation
 import KernovaProtocol
 
 // Shared timing/test primitives for the KernovaTests bundle. Mirrors the
@@ -188,6 +189,79 @@ final class AsyncGate: @unchecked Sendable {
                 self.lock.withLock { _ = self.waiters.removeValue(forKey: id) }
                 once.fire { cont.resume() }
             }
+        }
+    }
+}
+
+// MARK: - waitForChange
+
+/// Event-driven replacement for `waitUntil` when the predicate reads
+/// `@Observable` state on a production object directly — i.e. there is no test
+/// double in the loop to call `AsyncGate.notify()`.
+///
+/// `withObservationTracking` suspends the waiter until a property the predicate
+/// actually reads changes, then the loop re-checks — so the wait resolves on the
+/// mutation itself, not on a 50 ms poll tick. Like `AsyncGate`, an idle waiter
+/// adds **zero** wake-ups to the shared (and, on CI, contended) MainActor, and
+/// `timeout` is a stuck-condition backstop the happy path never reaches rather
+/// than the success deadline. This is the fix for the poll-budget flakes in the
+/// flaky-CI investigation; see memory `ci-test-timings`.
+///
+/// The predicate must read every value it inspects through an `@Observable`
+/// getter so tracking registers a dependency (computed properties that read
+/// observed stored properties, like `agentStatus`, qualify). A predicate over
+/// plain non-observed state would never be re-evaluated and must keep
+/// `waitUntil`.
+@MainActor
+func waitForChange(
+    timeout: Duration = .seconds(10),
+    until predicate: @escaping @MainActor () -> Bool
+) async throws {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while !predicate() {
+        if ContinuousClock.now >= deadline {
+            throw TestFailure("Observed condition not met within \(timeout)")
+        }
+        await armObservationOnce(deadline: deadline, predicate: predicate)
+    }
+}
+
+/// Suspends until the next change to any `@Observable` property read by
+/// `predicate`, an immediate hit (the predicate already holds at arm time,
+/// closing the arm-vs-change race), or the `deadline` backstop — whichever
+/// comes first.
+///
+/// Mirrors `AsyncGate.armOnce`, but the wake source is observation tracking
+/// instead of an explicit `notify()`.
+@MainActor
+private func armObservationOnce(
+    deadline: ContinuousClock.Instant,
+    predicate: @escaping @MainActor () -> Bool
+) async {
+    await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+        let once = ResumeOnce()
+        // Arm tracking over whatever observable state the predicate reads. The
+        // `onChange` fires once, during the willSet of the first such property
+        // to change; the awaiting task then resumes and the outer loop
+        // re-checks (by which point the setter has completed).
+        withObservationTracking {
+            _ = predicate()
+        } onChange: {
+            once.fire { cont.resume() }
+        }
+        // Close the arm-vs-change race: a change may have landed between the
+        // outer while-check and arming. If the predicate already holds, resume
+        // now so the loop re-checks instead of waiting for a change that may
+        // never come.
+        if predicate() {
+            once.fire { cont.resume() }
+            return
+        }
+        // Backstop: resume at the deadline so a genuinely stuck condition fails
+        // the wait instead of hanging.
+        Task { @MainActor in
+            try? await Task.sleep(until: deadline, clock: ContinuousClock())
+            once.fire { cont.resume() }
         }
     }
 }

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -10,6 +10,11 @@ import KernovaProtocol
 // Xcode 16 synchronized folders make each bundle's files target-private,
 // so a single file can't be shared across both — the duplication here is
 // deliberate. Keep these signatures aligned with the GuestAgent variant.
+//
+// Exception: `waitForChange` is KernovaTests-only. It observes `@MainActor`
+// `@Observable` production state directly; the GuestAgent bundle's helpers are
+// `nonisolated`/`@Sendable` over `Sendable` boxes and have no such type to
+// track, so there is nothing to mirror there.
 
 // MARK: - TestFailure
 
@@ -166,6 +171,10 @@ final class AsyncGate: @unchecked Sendable {
         deadline: ContinuousClock.Instant,
         predicate: () -> Bool
     ) async {
+        // Captured so it can be cancelled once `notify()` (or the immediate-hit
+        // re-check) resolves the wait; otherwise every happy-path arm would leak
+        // a Task sleeping until `deadline`.
+        var backstop: Task<Void, Never>?
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
             let id = UUID()
             let once = ResumeOnce()
@@ -184,12 +193,15 @@ final class AsyncGate: @unchecked Sendable {
             }
             // Backstop: resume at the deadline even if no notify arrives, so a
             // genuinely stuck condition fails the wait instead of hanging.
-            Task {
+            backstop = Task {
                 try? await Task.sleep(until: deadline, clock: ContinuousClock())
                 self.lock.withLock { _ = self.waiters.removeValue(forKey: id) }
                 once.fire { cont.resume() }
             }
         }
+        // Resolved via notify() or the immediate hit; cancel the backstop so it
+        // doesn't linger asleep until `deadline`.
+        backstop?.cancel()
     }
 }
 
@@ -208,10 +220,15 @@ final class AsyncGate: @unchecked Sendable {
 /// flaky-CI investigation; see memory `ci-test-timings`.
 ///
 /// The predicate must read every value it inspects through an `@Observable`
-/// getter so tracking registers a dependency (computed properties that read
-/// observed stored properties, like `agentStatus`, qualify). A predicate over
-/// plain non-observed state would never be re-evaluated and must keep
-/// `waitUntil`.
+/// getter so tracking registers a dependency, and it must be **side-effect-free**
+/// — it is evaluated several times per wait (the arming pass, the immediate-hit
+/// re-check, and each outer-loop iteration). Computed properties that read
+/// observed stored properties qualify (e.g. `agentStatus` reads `isUnresponsive`),
+/// but tracking only registers the properties actually read on the arming pass:
+/// a getter that short-circuits *before* reaching the property that will change
+/// won't wake the waiter, which then resolves only via the deadline backstop. A
+/// predicate over plain non-observed state would never be re-evaluated and must
+/// keep `waitUntil`.
 @MainActor
 func waitForChange(
     timeout: Duration = .seconds(10),
@@ -238,6 +255,10 @@ private func armObservationOnce(
     deadline: ContinuousClock.Instant,
     predicate: @escaping @MainActor () -> Bool
 ) async {
+    // Captured so it can be cancelled once the wait resolves via observation (or
+    // the immediate-hit re-check); otherwise every happy-path arm would leak a
+    // Task sleeping until `deadline`, the opposite of the "zero wake-ups" goal.
+    var backstop: Task<Void, Never>?
     await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
         let once = ResumeOnce()
         // Arm tracking over whatever observable state the predicate reads. The
@@ -259,9 +280,12 @@ private func armObservationOnce(
         }
         // Backstop: resume at the deadline so a genuinely stuck condition fails
         // the wait instead of hanging.
-        Task { @MainActor in
+        backstop = Task { @MainActor in
             try? await Task.sleep(until: deadline, clock: ContinuousClock())
             once.fire { cont.resume() }
         }
     }
+    // Resolved (observation, immediate hit, or the backstop itself) — cancel the
+    // backstop so it doesn't linger asleep until `deadline`.
+    backstop?.cancel()
 }

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -887,7 +887,7 @@ struct VsockClipboardServiceTests {
                     (uti: "public.data", byteCount: fileBytes, filename: "doc.bin", isInline: false),
                 ]))
 
-        try await waitUntil { service.clipboardContent.representations.count == 2 }
+        try await waitForChange { service.clipboardContent.representations.count == 2 }
         let reps = service.clipboardContent.representations
         // Both reps are placeholders, in the guest's offer order.
         #expect(reps.allSatisfy { $0.isPendingRemote })
@@ -927,7 +927,7 @@ struct VsockClipboardServiceTests {
                 generation: 2,
                 reps: [(uti: "public.png", byteCount: 99, filename: "kept.png", isInline: false)]))
 
-        try await waitUntil {
+        try await waitForChange {
             service.clipboardContent.representations.first?.filename == "kept.png"
         }
         let rep = try #require(service.clipboardContent.representations.first)
@@ -959,7 +959,7 @@ struct VsockClipboardServiceTests {
             makeOffer(
                 generation: 42,
                 reps: [(uti: ClipboardContent.utf8TextUTI, byteCount: bytes.count, filename: "", isInline: true)]))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         await service.materializeForPreview()
 
@@ -998,7 +998,7 @@ struct VsockClipboardServiceTests {
             makeOffer(
                 generation: 53,
                 reps: [(uti: UTType.flatRTFD.identifier, byteCount: bytes.count, filename: "", isInline: true)]))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         await service.materializeForPreview()
 
@@ -1051,7 +1051,7 @@ struct VsockClipboardServiceTests {
                     (uti: "public.data", byteCount: 4096, filename: "doc.bin", isInline: false),
                     (uti: "public.png", byteCount: oversizeImage, filename: "", isInline: true),
                 ]))
-        try await waitUntil { service.clipboardContent.representations.count == 3 }
+        try await waitForChange { service.clipboardContent.representations.count == 3 }
 
         await service.materializeForPreview()
 
@@ -1085,7 +1085,7 @@ struct VsockClipboardServiceTests {
         responder.start()
 
         try guest.send(makeTextOffer(generation: 4, text: "x"))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         await service.materializeForPreview()
         #expect(service.clipboardContent.text == "x")
@@ -1163,7 +1163,7 @@ struct VsockClipboardServiceTests {
             makeOffer(
                 generation: 3,
                 reps: [(uti: textUTI, byteCount: bytes.count, filename: "", isInline: true)]))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         await service.materializeForPreview()
         #expect(service.clipboardContent.representations.first?.inMemoryData == bytes)
@@ -1200,7 +1200,7 @@ struct VsockClipboardServiceTests {
                     (uti: ClipboardContent.utf8TextUTI, byteCount: inlineBytes.count, filename: "", isInline: true),
                     (uti: "public.data", byteCount: fileBytes.count, filename: "from-guest.bin", isInline: false),
                 ]))
-        try await waitUntil { service.clipboardContent.representations.count == 2 }
+        try await waitForChange { service.clipboardContent.representations.count == 2 }
 
         let resolved = await service.materializeForCopy()
 
@@ -1269,7 +1269,7 @@ struct VsockClipboardServiceTests {
             ]
         }
         try guest.send(offer)
-        try await waitUntil { service.clipboardContent.representations.count == 1 }
+        try await waitForChange { service.clipboardContent.representations.count == 1 }
 
         let resolved = await service.materializeForCopy()
         #expect(resolved.representations.count == 1)
@@ -1312,7 +1312,7 @@ struct VsockClipboardServiceTests {
                     (uti: ClipboardContent.utf8TextUTI, byteCount: inlineBytes.count, filename: "", isInline: true),
                     (uti: "public.data", byteCount: fileBytes.count, filename: "doc.bin", isInline: false),
                 ]))
-        try await waitUntil { service.clipboardContent.representations.count == 2 }
+        try await waitForChange { service.clipboardContent.representations.count == 2 }
 
         // Preview pulls only rep 0 (the inline text); the file rep stays pending.
         await service.materializeForPreview()
@@ -1358,7 +1358,7 @@ struct VsockClipboardServiceTests {
             makeOffer(
                 generation: 1,
                 reps: [(uti: "public.data", byteCount: 4096, filename: "stale.bin", isInline: false)]))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         // Start a copy that issues the gen=1 pull and parks (no End ever arrives).
         let copyTask = Task { await service.materializeForCopy() }
@@ -1382,7 +1382,7 @@ struct VsockClipboardServiceTests {
         #expect(resolved.representations.allSatisfy { $0.isPendingRemote })
 
         // The new offer's placeholder is what's published.
-        try await waitUntil {
+        try await waitForChange {
             service.clipboardContent.representations.first?.filename == "new.png"
         }
         let rep = try #require(service.clipboardContent.representations.first)
@@ -1435,7 +1435,7 @@ struct VsockClipboardServiceTests {
             makeOffer(
                 generation: 1,
                 reps: [(uti: "public.data", byteCount: 4096, filename: "stale.bin", isInline: false)]))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         // Copy issues the gen=1 pull; it completes and parks in the seam.
         let copyTask = Task { await service.materializeForCopy() }
@@ -1447,7 +1447,7 @@ struct VsockClipboardServiceTests {
             makeOffer(
                 generation: 2,
                 reps: [(uti: "public.png", byteCount: 64, filename: "new.png", isInline: false)]))
-        try await waitUntil { service.clipboardContent.representations.first?.uti == "public.png" }
+        try await waitForChange { service.clipboardContent.representations.first?.uti == "public.png" }
 
         // Release: materialize resumes, the guard sees inboundPromise(gen2) !==
         // promise(gen1) and returns WITHOUT republishing gen=1's bytes.
@@ -1499,7 +1499,7 @@ struct VsockClipboardServiceTests {
             makeOffer(
                 generation: 1,
                 reps: [(uti: "public.data", byteCount: 4096, filename: "stale.bin", isInline: false)]))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         let copyTask = Task { await service.materializeForCopy() }
         try await entered.wait(timeout: .seconds(5)) { didEnter }
@@ -1540,7 +1540,7 @@ struct VsockClipboardServiceTests {
         responder.start()
 
         try guest.send(makeTextOffer(generation: 8, text: "x"))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         // The guest releases the offer before the host pulls anything.
         var release = Frame()
@@ -1555,7 +1555,7 @@ struct VsockClipboardServiceTests {
         try guest.sendErrorFrame(
             code: "clipboard.barrier", message: "release processed",
             inReplyTo: "clipboard.release")
-        try await waitUntil { service.lastTransferIssue != nil }
+        try await waitForChange { service.lastTransferIssue != nil }
 
         // After release, the promise is gone: materializeForCopy resolves nothing
         // new and never requests the rep.
@@ -1583,7 +1583,7 @@ struct VsockClipboardServiceTests {
             makeOffer(
                 generation: 1,
                 reps: [(uti: "public.png", byteCount: 1024, filename: "p.png", isInline: false)]))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         // grabIfChanged must NOT echo placeholder content back to the guest.
         let before = recorder.frames.count
@@ -1663,7 +1663,7 @@ struct VsockClipboardServiceTests {
             makeOffer(
                 generation: generation,
                 reps: [(uti: textUTI, byteCount: payload.count, filename: "", isInline: true)]))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         // First caller: preview pull for rep 0. It sends one request and parks
         // (no End arrives). Run it detached so the test keeps driving.
@@ -1751,7 +1751,7 @@ struct VsockClipboardServiceTests {
             makeOffer(
                 generation: 5,
                 reps: [(uti: ClipboardContent.utf8TextUTI, byteCount: 5, filename: "", isInline: true)]))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         // Copy issues the pull; with no answer and the channel open, it must
         // resolve (not hang) once the backstop fires — dropping the un-pulled rep.
@@ -1785,7 +1785,7 @@ struct VsockClipboardServiceTests {
         responder.start()
 
         try guest.send(makeTextOffer(generation: 3, text: "from guest"))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
         await service.materializeForPreview()
         #expect(service.clipboardContent.text == "from guest")
 
@@ -1818,7 +1818,7 @@ struct VsockClipboardServiceTests {
         responder.start()
 
         try guest.send(makeTextOffer(generation: 2, text: "retry me"))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         // First attempt: the pull times out, the rep stays a placeholder.
         await service.materializeForPreview()
@@ -1859,7 +1859,7 @@ struct VsockClipboardServiceTests {
         // Barrier: an error frame after the offer; once it surfaces, handleOffer ran.
         try guest.sendErrorFrame(
             code: "clipboard.barrier", message: "offer processed", inReplyTo: "clipboard.offer")
-        try await waitUntil { service.lastTransferIssue != nil }
+        try await waitForChange { service.lastTransferIssue != nil }
 
         #expect(service.clipboardContent.isEmpty)
         // No promise is held: Copy-to-Mac resolves nothing and sends no request
@@ -1894,7 +1894,7 @@ struct VsockClipboardServiceTests {
             makeOffer(
                 generation: 5,
                 reps: [(uti: "public.data", byteCount: 4096, filename: "big.bin", isInline: false)]))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         let copyTask = Task { await service.materializeForCopy() }
         let xid = inboundTransferID(generation: 5, repIndex: 0)
@@ -1912,7 +1912,7 @@ struct VsockClipboardServiceTests {
         try guest.send(abort)
 
         _ = await copyTask.value
-        try await waitUntil {
+        try await waitForChange {
             if case .diskFull = service.lastTransferIssue?.kind { return true }
             return false
         }
@@ -1945,7 +1945,7 @@ struct VsockClipboardServiceTests {
 
         // The published placeholders exclude both identity-skip reps — only the
         // legit PNG file rep survives.
-        try await waitUntil {
+        try await waitForChange {
             service.clipboardContent.representations.map(\.uti) == ["public.png"]
         }
         let reps = service.clipboardContent.representations
@@ -1987,7 +1987,7 @@ struct VsockClipboardServiceTests {
             inReplyTo: "clipboard.request"
         )
 
-        try await waitUntil { service.lastTransferIssue != nil }
+        try await waitForChange { service.lastTransferIssue != nil }
         guard case .peerReportedError(let code, let message) = service.lastTransferIssue?.kind
         else {
             Issue.record("Expected peerReportedError issue, got \(String(describing: service.lastTransferIssue))")

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -397,13 +397,11 @@ struct VsockControlServiceTests {
         host.start()
         defer { guest.close() }
 
-        // `terminateAfter` is set well beyond the test's wall-clock budget
-        // (two 5 s `waitUntil` calls plus per-test setup overhead) so the
-        // watchdog cannot close the channel before the recovery heartbeat
-        // lands. Same CI-jitter rationale as `terminateClosesChannel`: on
-        // slow runners the original 2 s value occasionally fired between
-        // detecting `.unresponsive` and sending the heartbeat, leaving the
-        // service stuck and timing out the second `waitUntil`.
+        // `terminateAfter` is set well beyond the test's wall-clock budget so
+        // the watchdog cannot close the channel before recovery lands. Same
+        // CI-jitter rationale as `terminateClosesChannel`: on slow runners the
+        // original 2 s value occasionally fired between detecting `.unresponsive`
+        // and recovery, leaving the service stuck.
         let service = makeService(
             channel: host,
             bundledAgentVersion: "0.9.0",
@@ -416,16 +414,33 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         // Go silent → unresponsive.
-        try await waitUntil(timeout: .seconds(5)) {
+        try await waitForChange(timeout: .seconds(5)) {
             service.agentStatus == .unresponsive(version: "0.9.0")
         }
 
-        // Resume heartbeats. The next liveness tick clears the flag.
-        try guest.send(makeHeartbeat(nonce: 99))
-        try await waitUntil(timeout: .seconds(5)) {
+        // Resume heartbeats. A live guest sends them continuously, so emit a
+        // sustained stream rather than a single frame: recovery is driven by a
+        // liveness tick observing a fresh `lastInboundFrame`, and that clock is
+        // refreshed *only* by inbound frames. A lone heartbeat opens just one
+        // ~unresponsiveAfter-wide window for a tick to land; if MainActor jitter
+        // starves that tick the next one sees a stale timestamp, re-latches
+        // `.unresponsive`, and — with no further inbound frames — the service
+        // stays stuck forever. Sustained heartbeats guarantee some tick sees a
+        // recent frame regardless of scheduling. Cancelled once recovered.
+        let resumeHeartbeats = Task {
+            var nonce: UInt64 = 99
+            while !Task.isCancelled {
+                try? guest.send(makeHeartbeat(nonce: nonce))
+                nonce += 1
+                try? await Task.sleep(for: .milliseconds(60))
+            }
+        }
+        defer { resumeHeartbeats.cancel() }
+
+        try await waitForChange(timeout: .seconds(5)) {
             service.agentStatus == .current(version: "0.9.0")
         }
         #expect(service.agentStatus == .current(version: "0.9.0"))

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -414,10 +414,10 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
-        try await waitForChange { service.isConnected }
+        try await waitUntil { service.isConnected }
 
         // Go silent → unresponsive.
-        try await waitForChange(timeout: .seconds(5)) {
+        try await waitUntil(timeout: .seconds(5)) {
             service.agentStatus == .unresponsive(version: "0.9.0")
         }
 
@@ -429,17 +429,21 @@ struct VsockControlServiceTests {
         // starves that tick the next one sees a stale timestamp, re-latches
         // `.unresponsive`, and — with no further inbound frames — the service
         // stays stuck forever. Sustained heartbeats guarantee some tick sees a
-        // recent frame regardless of scheduling. Cancelled once recovered.
+        // recent frame regardless of scheduling. Cancelled once recovered. (The
+        // heartbeat nonce is ignored by the service — recovery keys only off the
+        // frame arriving — so the default nonce is fine.)
         let resumeHeartbeats = Task {
-            var nonce: UInt64 = 99
             while !Task.isCancelled {
-                try? guest.send(makeHeartbeat(nonce: nonce))
-                nonce += 1
+                try? guest.send(makeHeartbeat())
                 try? await Task.sleep(for: .milliseconds(60))
             }
         }
         defer { resumeHeartbeats.cancel() }
 
+        // Only the recovery → .current transition was the proven CI flake (the
+        // poll budget timed out under jitter), so it alone uses the event-driven
+        // wait; the suite's other agentStatus/isConnected waits stay on the poll
+        // per the project's migrate-on-flake stance.
         try await waitForChange(timeout: .seconds(5)) {
             service.agentStatus == .current(version: "0.9.0")
         }


### PR DESCRIPTION
## Summary
Fix the intermittent **Build & Test** failures on `main`. Across the last 5 red runs (#379, #382, #384, #358, #322) every failure was the **test step** (the build always passed), and every failing assertion was the same message — `Predicate did not become true within 5.0 seconds` — the legacy poll-based `waitUntil` helper exhausting its 5s budget under macOS-26 main-actor scheduling jitter. The awaited state was always produced correctly; only the busy-polling observer lost the race on a contended runner.

Two buckets:
- **June-23 cluster (#379/#382/#384):** recent clipboard work grew `VsockClipboardServiceTests` to 27 poll-waits on `@Observable` service state; on a congested runner the suite's poll loops starve at once (#384 timed out ~the entire suite).
- **Older offender (#358/#322):** `recoveryFromUnresponsive` also had a real defect — a single recovery heartbeat opened just one `~unresponsiveAfter`-wide liveness-tick window, so a starved tick latched `.unresponsive` permanently (only inbound frames refresh the recovery clock; a live guest sends heartbeats continuously).

No product code changed — this is a test-reliability fix.

## Changes
- **`TestHelpers.swift`** — add `waitForChange`, an event-driven wait built on `withObservationTracking`: suspends until an `@Observable` property the predicate reads actually mutates, then re-checks. Zero poll wake-ups on the shared (CI-contended) MainActor; `timeout` becomes a stuck-condition backstop, not the success deadline. Complements the existing `AsyncGate` (which needs an explicit `notify()` from a test double) by observing production state directly.
- **`VsockClipboardServiceTests.swift`** — convert all 27 `waitUntil` waits (each reads `clipboardContent`/`lastTransferIssue`, both observed) to `waitForChange`.
- **`VsockControlServiceTests.swift`** — `recoveryFromUnresponsive` now sends *sustained* recovery heartbeats (cancelled once recovered) and uses `waitForChange`.

## Notes
Scoped to the proven offenders; remaining `waitUntil` sites are left as-is, matching the project's documented migrate-on-flake stance.

## Test plan
- [x] `** TEST BUILD SUCCEEDED **`
- [x] Both suites: 6× back-to-back, 116 passed / 0 failed each run
- [x] `recoveryFromUnresponsive`: 9.1s (CI timeout) → 0.14s; race eliminated
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)