### PR TITLE
refactor: Avoid re-hashing ClipboardContent to set the concealed flag

### DIFF
--- a/Kernova/Views/Clipboard/ClipboardPasteboardIntake.swift
+++ b/Kernova/Views/Clipboard/ClipboardPasteboardIntake.swift
@@ -118,13 +118,9 @@ enum ClipboardPasteboardIntake {
         }
 
         // `evaluate` builds non-concealed content; re-stamp the concealed flag
-        // when the marker called for it (cheap — inline snapshots are small).
-        let content =
-            isConcealed
-            ? ClipboardContent(
-                representations: outcome.content.representations, isConcealed: true)
-            : outcome.content
-        return .content(content, note: nil)
+        // when the marker called for it. `withConcealed` reuses the digest
+        // (isConcealed is excluded from it), so no second hash of the payload.
+        return .content(outcome.content.withConcealed(isConcealed), note: nil)
     }
 
     /// The user-facing reason a snapshot was dropped wholesale by an

--- a/KernovaGuestAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaGuestAgent/VsockGuestClipboardAgent.swift
@@ -525,11 +525,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             )
         }
         // `evaluate` builds non-concealed content; re-stamp the flag when the
-        // marker called for it (inline snapshots are small, so the rehash is cheap).
-        let content =
-            isConcealed
-            ? ClipboardContent(representations: outcome.content.representations, isConcealed: true)
-            : outcome.content
+        // marker called for it. `withConcealed` reuses the digest (isConcealed is
+        // excluded from it), so no second hash of the payload.
+        let content = outcome.content.withConcealed(isConcealed)
         sendOfferIfNeeded(content, channel: channel, changeCount: currentCount)
     }
 

--- a/KernovaProtocol/Sources/KernovaProtocol/ClipboardContent.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/ClipboardContent.swift
@@ -247,6 +247,21 @@ public struct ClipboardContent: Equatable, Sendable {
         )
     }
 
+    /// Returns a copy with `isConcealed` set, **without** recomputing the digest.
+    ///
+    /// `isConcealed` is excluded from the digest (it changes how the content is
+    /// displayed, not its identity), so the flag can be flipped by reusing the
+    /// existing `digest` rather than re-hashing the whole payload — the snapshot
+    /// path re-stamps the concealed marker after `ClipboardSnapshotPolicy.evaluate`
+    /// builds non-concealed content, and that re-stamp must not pay a second
+    /// SHA-256 over a large inline payload. Returns `self` unchanged when the flag
+    /// already matches.
+    public func withConcealed(_ concealed: Bool) -> ClipboardContent {
+        guard concealed != isConcealed else { return self }
+        return ClipboardContent(
+            representations: representations, isConcealed: concealed, precomputedDigest: digest)
+    }
+
     /// Content holding a single UTF-8 plain-text representation.
     ///
     /// The empty string normalizes to `.empty` — "empty text" and "no

--- a/KernovaProtocol/Sources/KernovaProtocol/ClipboardContent.swift
+++ b/KernovaProtocol/Sources/KernovaProtocol/ClipboardContent.swift
@@ -219,8 +219,10 @@ public struct ClipboardContent: Equatable, Sendable {
 
     /// Creates content with an already-computed digest.
     ///
-    /// Backs `makeOffActor(representations:)` so the O(payload) hash can run on
-    /// a background executor; the result is assembled here without re-hashing.
+    /// Backs the digest-reusing factories so the O(payload) hash is paid at most
+    /// once: `makeOffActor(representations:)` runs it on a background executor,
+    /// and `withConcealed(_:)` skips it entirely (the flag is excluded from the
+    /// digest). The result is assembled here without re-hashing.
     private init(representations: [Representation], isConcealed: Bool, precomputedDigest: Data) {
         self.representations = representations
         self.isConcealed = isConcealed

--- a/KernovaProtocol/Tests/KernovaProtocolTests/ClipboardContentTests.swift
+++ b/KernovaProtocol/Tests/KernovaProtocolTests/ClipboardContentTests.swift
@@ -532,4 +532,17 @@ struct ClipboardContentConcealedTests {
         #expect(concealed.withConcealed(true).isConcealed)
         #expect(concealed.withConcealed(true).digest == concealed.digest)
     }
+
+    @Test("withConcealed clears the flag and reuses the digest")
+    func withConcealedClearsTheFlag() {
+        let reps = [ClipboardContent.Representation(uti: ClipboardContent.utf8TextUTI, data: Data("pw".utf8))]
+        let concealed = ClipboardContent(representations: reps, isConcealed: true)
+        let revealed = concealed.withConcealed(false)
+        #expect(!revealed.isConcealed)
+        // Clearing reuses the digest too (the flag is excluded), so the revealed
+        // copy stays digest-equal to the concealed original and to a from-scratch
+        // unconcealed build.
+        #expect(revealed.digest == concealed.digest)
+        #expect(revealed == ClipboardContent(representations: reps, isConcealed: false))
+    }
 }

--- a/KernovaProtocol/Tests/KernovaProtocolTests/ClipboardContentTests.swift
+++ b/KernovaProtocol/Tests/KernovaProtocolTests/ClipboardContentTests.swift
@@ -507,4 +507,29 @@ struct ClipboardContentConcealedTests {
         #expect(plain == concealed)
         #expect(plain.digest == concealed.digest)
     }
+
+    @Test("withConcealed sets the flag and reuses the digest (no re-hash)")
+    func withConcealedReusesDigest() {
+        let reps = [ClipboardContent.Representation(uti: ClipboardContent.utf8TextUTI, data: Data("pw".utf8))]
+        let plain = ClipboardContent(representations: reps, isConcealed: false)
+        let concealed = plain.withConcealed(true)
+        #expect(concealed.isConcealed)
+        // The digest must be byte-identical to the unconcealed content's — that is
+        // the whole point: the re-stamp avoids a second SHA-256, and the flag is
+        // excluded from the digest so echo suppression stays unaffected.
+        #expect(concealed.digest == plain.digest)
+        #expect(concealed == plain)
+        // Matches the digest a from-scratch concealed build would produce.
+        #expect(concealed.digest == ClipboardContent(representations: reps, isConcealed: true).digest)
+    }
+
+    @Test("withConcealed returns self unchanged when the flag already matches")
+    func withConcealedNoOpWhenUnchanged() {
+        let reps = [ClipboardContent.Representation(uti: ClipboardContent.utf8TextUTI, data: Data("pw".utf8))]
+        let plain = ClipboardContent(representations: reps, isConcealed: false)
+        #expect(plain.withConcealed(false) == plain)
+        let concealed = ClipboardContent(representations: reps, isConcealed: true)
+        #expect(concealed.withConcealed(true).isConcealed)
+        #expect(concealed.withConcealed(true).digest == concealed.digest)
+    }
 }


### PR DESCRIPTION
## Summary
- Removes a redundant full-payload SHA-256 on the clipboard snapshot path: re-stamping the "concealed" marker rebuilt the whole `ClipboardContent`, re-hashing the payload — even though `isConcealed` is **excluded** from the digest, so the recompute always produced a byte-identical result.

## Changes
- Add `ClipboardContent.withConcealed(_:)` — a digest-preserving copy that reuses the existing private `init(...precomputedDigest:)` and returns `self` when the flag already matches.
- Re-stamp the concealed flag via `withConcealed` at both intake sites (`ClipboardPasteboardIntake.read(from:)`, `VsockGuestClipboardAgent.checkClipboardChange`), dropping the rebuild-and-rehash and the inaccurate "rehash is cheap" comments.
- Add `ClipboardContent` tests: `withConcealed` preserves the digest (so `==`/echo-suppression are unaffected) and is a no-op when the flag already matches.

## Test plan
- [x] `make test-package` (135 tests, incl. the new `withConcealed` tests)
- [x] `make build` (host + guest + QuickLook)
- [x] `make lint`

## Notes
- Digest-identical and presentation-only — **no guest-agent version bump** needed.
- Found during the clipboard copy/paste efficiency audit that also produced #394 and added efficiency motivation to #370 (and earlier #392/#393).

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)