### PR TITLE
docs: Add Universal Clipboard cross-boundary reference model to CLIPBOARD.md

### DIFF
--- a/CLIPBOARD.md
+++ b/CLIPBOARD.md
@@ -19,7 +19,13 @@ Guiding principles for host↔guest clipboard sharing in Kernova.
   not constrain the macOS↔macOS design.
 - **The reference target is native macOS.** The yardstick for every decision is: *what would
   this copy/paste do if both ends were the same Mac?* We match that on capability and aim to
-  match or beat it on resource cost.
+  match or beat it on resource cost. For the *cross-boundary behavior* — host and guest are two
+  separate machines — the closest model is Apple's own **Universal Clipboard** between two
+  devices: advertise lightweight **metadata** on copy, then transfer the bytes **on demand at
+  paste** — asynchronously, with progress, and with no blocking deadline. Never an eager
+  broadcast of the content, never a synchronous blocking pull. §2 (File Provider for files) and
+  §3 (pay on consume) are how we match that; the synchronous pasteboard provider is reserved for
+  inline content that comfortably fits the OS paste deadline.
 
 ---
 


### PR DESCRIPTION
## Summary
- Sharpen CLIPBOARD.md's reference target with Apple's **Universal Clipboard** cross-device model — advertise lightweight metadata on copy, transfer bytes **on demand at paste** (asynchronously, with progress, no blocking deadline) — as the closest analog for the host↔guest case, which is cross-*machine* rather than same-Mac.
- Corrects an over-stated "eager prefetch" assumption surfaced during planning: macOS advertises only a one-byte "clipboard has data" flag over BLE and pulls bytes on demand at paste (P2P AWDL/Wi-Fi, or iCloud KVS for small items), never an eager broadcast.

## Changes
- Extend the Scope "reference target is native macOS" bullet with the cross-boundary behavioral model, tying it to §2 (File Provider for files) and §3 (pay on consume) — the existing principles that already implement that model.

## Why
Captures a durable, principle-level insight (the corrected reference model) in the authoritative doc where every contributor sees it, rather than only in private session notes. Grounds *why* §2 prefers File Provider for files and §3 mandates laziness.

## Test plan
- [ ] Docs-only change — no code paths affected; required checks (build-and-test, proto-drift, swift-format) are unaffected by prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)