### PR TITLE
chore: Drop redundant WebFetch allow-list from project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,4 @@
 {
-  "permissions": {
-    "allow": [
-      "WebFetch(domain:api.github.com)",
-      "WebFetch(domain:github.com)"
-    ]
-  },
   "enabledPlugins": {
     "swift-lsp@claude-plugins-official": true
   },


### PR DESCRIPTION
## Summary
- Removes the two `WebFetch(domain:…github.com)` allow-entries from the project's `.claude/settings.json`. With the global `auto` permission mode, these low-risk public-domain fetches are auto-approved anyway, so the explicit allow-list was redundant.

## Changes
- Delete the `permissions` block from `.claude/settings.json` (it only held the two GitHub WebFetch entries). `enabledPlugins` and the `ExitWorktree` LaunchServices hook are unchanged.

## Test plan
- [ ] `.claude/settings.json` parses as valid JSON
- [ ] Claude Code launches in this folder without the "Ignoring N permissions.allow entries" trust warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
