### PR TITLE
chore: Preserve the .xcresult wrapper in the CI test-results artifact

### DIFF
--- a/.github/workflows/xcodebuild-test.yml
+++ b/.github/workflows/xcodebuild-test.yml
@@ -55,7 +55,7 @@ jobs:
             -scheme Kernova \
             -destination 'platform=macOS' \
             -derivedDataPath DerivedData \
-            -resultBundlePath TestResults.xcresult \
+            -resultBundlePath artifacts/TestResults.xcresult \
             -skipPackagePluginValidation \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
@@ -68,5 +68,13 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: test-results
-          path: TestResults.xcresult
+          # RATIONALE: upload the PARENT dir, not the `.xcresult` bundle directly.
+          # upload-artifact roots the archive at the lowest common ancestor of the
+          # matched files, so pointing it at the bundle drops the `.xcresult`
+          # wrapper — the download then unpacks as a bare Info.plist + Data/ that
+          # xcresulttool can't open without first renaming it back. Uploading the
+          # enclosing `artifacts/` keeps `TestResults.xcresult/` intact in the
+          # download (matching the `-resultBundlePath artifacts/TestResults.xcresult`
+          # above), so `gh run download` yields a directly-usable result bundle.
+          path: artifacts/
           retention-days: 7


### PR DESCRIPTION
## Summary
The Build & Test workflow uploaded the result bundle with `path: TestResults.xcresult`, so `actions/upload-artifact` rooted the archive at the **bundle's contents** and dropped the `.xcresult` wrapper. Downloading the `test-results` artifact yielded a bare `Info.plist` + `Data/`, which `xcresulttool` can't open without first `cp -R`-ing it back to a `*.xcresult`-named directory — a needless detour every time CI test failures are triaged from the result bundle (hit while diagnosing the masked failure on #409).

## Changes
- `.github/workflows/xcodebuild-test.yml`: write the result bundle into a wrapper dir (`-resultBundlePath artifacts/TestResults.xcresult`) and upload the parent (`path: artifacts/`). upload-artifact roots the archive at the lowest common ancestor of the matched files, so uploading the enclosing dir keeps `TestResults.xcresult/` intact and `gh run download` yields a directly-usable result bundle.
- Added a `RATIONALE:` comment so the indirection isn't "simplified" back into the bug.

## Test plan
- [x] Workflow YAML validates.
- [x] Confirmed locally that `xcodebuild -resultBundlePath` auto-creates the nested parent dir (no `mkdir` needed).
- [ ] This PR's own Build & Test run uploads a `test-results` artifact that unpacks to `TestResults.xcresult/` (Info.plist at that level), readable by `xcresulttool` with no rename — verified post-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
