### PR TITLE
chore: Adopt Functional Source License (FSL-1.1-ALv2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to Kernova
+
+Thanks for your interest in Kernova!
+
+## Outside contributions are not being accepted yet
+
+Kernova is **source-available** under the [Functional Source License (FSL-1.1-ALv2)](LICENSE) — the source is public so you can read, audit, and build it, but the project is **not currently accepting outside code contributions (pull requests).**
+
+This is deliberate. Because Kernova is offered under a source-available license that reserves commercial-licensing rights, accepting external contributions first requires a Contributor License Agreement (CLA) to be in place, so contributed code can be licensed on the same terms as the rest of the project. That process isn't set up yet.
+
+**This may change.** If and when Kernova opens up to outside contributions, this document will be updated and a CLA will be required before any pull request can be merged.
+
+## In the meantime
+
+- **Bug reports and feedback are welcome** — please [open an issue](https://github.com/nicholas-lonsinger/kernova/issues).
+- Pull requests from outside the project may be closed without review until the contribution process above is in place.
+
+Thanks for understanding.

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -800,7 +800,7 @@
 				DEVELOPMENT_TEAM = 8MT4P4GZL2;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Kernova/App/Info.plist;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright 2025 Kernova. All rights reserved.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright 2025–2026 Nicholas Lonsinger. All rights reserved.";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/KernovaBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
@@ -829,7 +829,7 @@
 				DEVELOPMENT_TEAM = 8MT4P4GZL2;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Kernova/App/Info.plist;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright 2025 Kernova. All rights reserved.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright 2025–2026 Nicholas Lonsinger. All rights reserved.";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/KernovaBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;

--- a/Kernova/App/Info.plist
+++ b/Kernova/App/Info.plist
@@ -23,7 +23,7 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 2025 Kernova. All rights reserved.</string>
+	<string>Copyright 2025–2026 Nicholas Lonsinger. All rights reserved.</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/KernovaGuestAgent/Info.plist
+++ b/KernovaGuestAgent/Info.plist
@@ -27,6 +27,6 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 2025 Kernova. All rights reserved.</string>
+	<string>Copyright 2025–2026 Nicholas Lonsinger. All rights reserved.</string>
 </dict>
 </plist>

--- a/KernovaQuickLook/Info.plist
+++ b/KernovaQuickLook/Info.plist
@@ -41,6 +41,6 @@
 		<string>$(PRODUCT_MODULE_NAME).PreviewViewController</string>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 2025 Kernova. All rights reserved.</string>
+	<string>Copyright 2025–2026 Nicholas Lonsinger. All rights reserved.</string>
 </dict>
 </plist>

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,105 @@
-MIT License
+# Functional Source License, Version 1.1, ALv2 Future License
 
-Copyright (c) 2025–2026 Nicholas Lonsinger
+## Abbreviation
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+FSL-1.1-ALv2
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+## Notice
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Copyright 2025–2026 Nicholas Lonsinger
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Kernova
+Copyright (c) 2025–2026 Nicholas Lonsinger
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Each VM is stored as a directory under `~/Library/Application Support/Kernova/VM
 
 ## License
 
-MIT License. See [LICENSE](LICENSE) for details.
+Kernova is **source-available** under the [Functional Source License (FSL-1.1-ALv2)](LICENSE): you're free to use, modify, and redistribute it for any purpose **except** offering a competing commercial product or service. Internal use, non-commercial education, and non-commercial research are explicitly permitted. Each release converts to Apache 2.0 two years after its publication. See [LICENSE](LICENSE) for the full terms.


### PR DESCRIPTION
## Summary
- **Relicense Kernova from MIT to the [Functional Source License (FSL-1.1-ALv2)](https://fsl.software/)** — a source-available ("Fair Source") license: anyone may use, modify, and redistribute Kernova for any purpose **except a Competing Use** (shipping a competing commercial product or service). Internal use, non-commercial education, and non-commercial research are explicitly permitted. Each release **converts to Apache 2.0 two years after its publication**. This protects against clone-and-resell while keeping the source public and eventually fully open.
- **Fix the copyright notice** (the original scope of #399): name **Nicholas Lonsinger** as the holder of record instead of the bare product name "Kernova", and move to a **2025–2026** year range.
- **Add a closed-door `CONTRIBUTING.md`** documenting that the project isn't accepting outside contributions yet (a CLA must be in place first — tracked in #415).

## Changes
- `LICENSE`: replaced the MIT text with the verbatim **FSL-1.1-ALv2** text; Notice line credits `Copyright 2025–2026 Nicholas Lonsinger`.
- `README.md`: License section now describes the FSL (source-available, competing-use carve-out, 2-year Apache 2.0 conversion) — no longer says "MIT".
- `CONTRIBUTING.md` (new): source-available posture, outside PRs not accepted yet, bug reports/feedback via issues welcome, CLA required when contributions open.
- `Kernova/App/Info.plist`, `KernovaGuestAgent/Info.plist`, `KernovaQuickLook/Info.plist`, and both build configs (`INFOPLIST_KEY_NSHumanReadableCopyright`) in `Kernova.xcodeproj/project.pbxproj`: copyright notice → `Copyright 2025–2026 Nicholas Lonsinger. All rights reserved.` (these are copyright *notices*, not license grants, so they stay accurate under FSL).

## Notes
- **Mac App Store: clean.** FSL has no anti-DRM / anti-additional-restriction clause (the thing that makes GPL/AGPL conflict with the App Store), and as sole copyright holder you can distribute your own binary however you like.
- **Pre-FSL git history remains MIT-licensed** and forkable; relicensing governs releases from here forward.
- **CLA follow-up:** #415 tracks setting up the Contributor License Agreement before opening Kernova to external contributions (a CLA, not a DCO, is required to preserve relicensing/commercial-licensing rights).

## Test plan
- [x] `plutil -lint` passes for all three Info.plist files and `project.pbxproj`
- [x] `LICENSE` is the verbatim FSL-1.1-ALv2 text with the correct holder/year
- [x] No remaining `MIT` license references in the repo (README updated)

Closes #399