### PR TITLE
test: End the flaky-test treadmill — retry buffer, prevention, event-driven sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,22 @@ When adding new functionality or modifying existing behavior, include unit tests
 - Reuse shared test helpers and factories (e.g., `makeInstance()`) rather than duplicating setup logic across test files
 - Run the full test suite before committing to ensure nothing is broken
 
+#### Async waits in tests
+
+macos-26 CI runners have heavy `@MainActor` scheduling jitter. With a `waitUntil`/`pollUntil` poll loop, the timeout deadline *is* the pass/fail criterion — so a starved scheduler fails a test whose condition would have become true. **When a test waits for async state that has an underlying signal, make the wait event-driven from the start — do not reach for a poll loop.** With event-driven waits the timeout is only a stuck-condition backstop the happy path never reaches.
+
+Pick the seam by what produces the state (helpers live in `KernovaTests/TestHelpers.swift`, `KernovaGuestAgentTests/TestHelpers.swift`, and `KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift`):
+
+| Seam | Use when | Notes |
+|------|----------|-------|
+| `waitForChange(until:)` | The predicate reads a production `@Observable` property directly (e.g. `service.clipboardContent`, `service.agentStatus`) | KernovaTests only. Built on `withObservationTracking`: the predicate must be side-effect-free and read every inspected value through an `@Observable` getter on the arming pass, or only the deadline wakes it. |
+| `AsyncGate` (`notify()` + `wait(until:)`) | The signal flows through a test-owned double/recorder | Call `notify()` after each relevant mutation. `@MainActor` in KernovaTests; `nonisolated` + `@Sendable` predicate in the GuestAgent/KernovaKit bundles — keep the copies aligned. |
+| `await` the production `Task` | A production `Task` does the work | Expose it via a `#if DEBUG …ForTesting` seam and `await task.value` instead of polling the flag it flips. |
+
+If the condition is driven by a *single* event a starved scheduler can miss (e.g. one heartbeat that latches a terminal state), drive it *continuously* — a wait conversion alone won't fix that.
+
+Polling (`waitUntil` / `pollUntil`) is acceptable **only** for a genuine no-signal predicate: a negative assertion ("prove nothing arrived"), a filesystem-appearance poll, or an exception-catch predicate. There, use a generous cadence, assert end-state not per-iteration, and add a `RATIONALE:` comment so reviews don't re-flag it.
+
 #### Test-only seams
 
 When a test needs to observe state that is `private` in production, pick the tightest exposure that still works:

--- a/Kernova.xcodeproj/xcshareddata/xctestplans/Kernova.xctestplan
+++ b/Kernova.xcodeproj/xcshareddata/xctestplans/Kernova.xctestplan
@@ -9,12 +9,14 @@
     }
   ],
   "defaultOptions" : {
+    "maximumTestRepetitions" : 2,
     "performanceAntipatternCheckerEnabled" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:Kernova.xcodeproj",
       "identifier" : "A1000003",
       "name" : "Kernova"
-    }
+    },
+    "testRepetitionMode" : "retryOnFailure"
   },
   "testTargets" : [
     {

--- a/Kernova/Views/Clipboard/ClipboardCopyProviderRegistry.swift
+++ b/Kernova/Views/Clipboard/ClipboardCopyProviderRegistry.swift
@@ -67,8 +67,8 @@ final class ClipboardCopyProviderRegistry {
 
     /// Fired after every `retain`/`release`, so a test can drive an `AsyncGate`
     /// off the registration/finish signal instead of polling `countForTesting` on
-    /// the MainActor — the timing-sensitive poll the `ci-test-timings` flakes
-    /// trace back to. `releaseAllForTesting` is teardown-only and deliberately
+    /// the MainActor — the timing-sensitive poll the CI MainActor-jitter
+    /// flakes trace back to. `releaseAllForTesting` is teardown-only and deliberately
     /// doesn't fire it (no waiter is armed during a test's `defer`).
     var onChangeForTesting: (() -> Void)?
 

--- a/KernovaGuestAgentTests/VsockGuestClientTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClientTests.swift
@@ -59,6 +59,12 @@ struct VsockGuestClientTests {
 
         _ = try await awaitFirst(enteredStream)
 
+        // RATIONALE: liveChannel exposes the SUT's own connection state — a
+        // lock-protected currentChannel published by the detached reconnect loop and
+        // cleared on socket EOF — not an @Observable property or a test-owned double,
+        // so there is no signal to await. Event-driving these waits would require
+        // adding notify() plumbing to VsockGuestClient (out of scope); polling is the
+        // correct seam. See CLAUDE.md "Async waits in tests".
         try await waitUntil { client.liveChannel != nil }
         #expect(client.liveChannel != nil)
 
@@ -282,8 +288,10 @@ struct VsockGuestClientTests {
 
         client.start { _ in }
 
-        // Wait for the loop to reach terminal state.
-        try await Task.sleep(for: .milliseconds(300))
+        // Wait (event-driven) for the provider to be invoked once; the
+        // permanent failure terminates the loop, so the count never climbs
+        // past 1.
+        try await provideCounter.changed.wait { provideCounter.value >= 1 }
         #expect(provideCounter.value == 1)
 
         // Re-start — must be a no-op because stopped == true.

--- a/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestClipboardAgentTests.swift
@@ -47,6 +47,13 @@ final class FakePasteboard: Pasteboard, @unchecked Sendable {
     private var promisedItems: [PromisedItem] = []
     private var storedWriteFailureCount: Int = 0
 
+    /// Fires after every `FakePasteboard` mutation.
+    ///
+    /// `writeItems`/`clearContents`/`setItem`/`setItems` call `notify()`, so a
+    /// test awaits the promised-state change instead of polling the `…ForTesting`
+    /// accessors on a contended scheduler. See CLAUDE.md "Async waits in tests".
+    let changed = AsyncGate()
+
     var changeCount: Int {
         lock.withLock { storedChangeCount }
     }
@@ -103,12 +110,14 @@ final class FakePasteboard: Pasteboard, @unchecked Sendable {
         // Real NSPasteboard.clearContents() bumps the change count and returns
         // the new value. Mirror that behavior so the fake's echo-suppression
         // delta matches a real pasteboard.
-        lock.withLock {
+        let newCount = lock.withLock {
             storedRepresentations.removeAll()
             promisedItems.removeAll()
             storedChangeCount += 1
             return storedChangeCount
         }
+        changed.notify()
+        return newCount
     }
 
     /// Production protocol method: registers one lazy promise per item.
@@ -119,7 +128,7 @@ final class FakePasteboard: Pasteboard, @unchecked Sendable {
     func writeItems(
         _ items: [(types: [NSPasteboard.PasteboardType], provider: NSPasteboardItemDataProvider)]
     ) -> Bool {
-        lock.withLock {
+        let didWrite = lock.withLock {
             if storedWriteFailureCount > 0 {
                 storedWriteFailureCount -= 1
                 return false
@@ -129,6 +138,8 @@ final class FakePasteboard: Pasteboard, @unchecked Sendable {
             storedChangeCount += 1
             return true
         }
+        if didWrite { changed.notify() }
+        return didWrite
     }
 
     /// Simulates the OS asking the first promised item that offers `type`.
@@ -185,8 +196,9 @@ final class FakePasteboard: Pasteboard, @unchecked Sendable {
             storedRepresentations = representations
             promisedItems.removeAll()
             storedChangeCount += 1
-            return true
         }
+        changed.notify()
+        return true
     }
 
     /// Places several resident pasteboard items, modelling a multi-select copy
@@ -199,8 +211,9 @@ final class FakePasteboard: Pasteboard, @unchecked Sendable {
             storedRepresentations = items.flatMap { $0 }
             promisedItems.removeAll()
             storedChangeCount += 1
-            return true
         }
+        changed.notify()
+        return true
     }
 
     /// Replaces the resident item with a single text representation —
@@ -252,6 +265,13 @@ struct VsockGuestClipboardAgentTests {
     ) async throws {
         agent.start()
         agent.setEnabled(true)
+        // RATIONALE: agent connection/lifecycle state (`liveChannelForTesting`,
+        // `inboundPromiseGenerationForTesting`, `isEnabledForTesting`) is the
+        // system-under-test's own state — not a test double we can fire an
+        // AsyncGate from, and the agent isn't @Observable. These reads stay
+        // polling per CLAUDE.md "Async waits in tests" (sanctioned no-signal
+        // poll); the pasteboard-write waits, where the async timing flake
+        // actually lives, use `pasteboard.changed` instead.
         try await waitUntil { agent.liveChannelForTesting != nil }
     }
 
@@ -449,7 +469,7 @@ struct VsockGuestClipboardAgentTests {
                         uti: txtUTI, byteCount: UInt64(contents.count), filename: "notes.txt",
                         isInline: false)
                 ]))
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.fileURL) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.fileURL) }
         let pull = lazyPull(pasteboard, forType: .fileURL)
         try await driveInboundStream(
             generation: 3, uti: txtUTI, filename: "notes.txt", payload: contents, isInline: false,
@@ -564,7 +584,7 @@ struct VsockGuestClipboardAgentTests {
                 ]))
 
         // The guest promises exactly one item, offering only `.fileURL`.
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.fileURL) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.fileURL) }
         #expect(pasteboard.promisedItemCountForTesting == 1)
         #expect(pasteboard.promisedTypesForTesting == [.fileURL])
 
@@ -773,7 +793,7 @@ struct VsockGuestClipboardAgentTests {
         // Host offers text → agent registers a lazy promise (no pull, no request).
         // The post-write changeCount is captured so the poll can't self-trigger.
         try hostChannel.send(makeTextOfferFrame(generation: 1, text: "from host"))
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.string) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.string) }
         try await expectNoRequest(from: hostChannel)
 
         // A poll right after the promise is registered must not re-offer it.
@@ -806,7 +826,7 @@ struct VsockGuestClipboardAgentTests {
                         uti: txtUTI, byteCount: UInt64(contents.count), filename: "notes.txt",
                         isInline: false)
                 ]))
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.fileURL) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.fileURL) }
 
         let pull = lazyPull(pasteboard, forType: .fileURL)
         try await driveInboundStream(
@@ -842,7 +862,7 @@ struct VsockGuestClipboardAgentTests {
         // Host announces one inline text rep. The agent registers a lazy promise
         // for the text UTI and pulls NOTHING — no ClipboardRequest is sent.
         try hostChannel.send(makeTextOfferFrame(generation: 42, text: "clipboard payload"))
-        try await waitUntil { pasteboard.promisedTypesForTesting == [.string] }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.string] }
         try await expectNoRequest(from: hostChannel)
 
         // The promise generation is recorded; a poll afterward does not re-offer.
@@ -866,7 +886,7 @@ struct VsockGuestClipboardAgentTests {
         try await startAgentAndWaitForLiveChannel(agent: agent)
 
         try hostChannel.send(makeTextOfferFrame(generation: 42, text: "clipboard payload"))
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.string) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.string) }
 
         // OS asks for the text type → exactly one ClipboardRequest → host streams
         // → the provider returns the exact bytes. The pull blocks, so run it off
@@ -902,7 +922,7 @@ struct VsockGuestClipboardAgentTests {
         let payload = Data(big.utf8)
 
         try hostChannel.send(makeTextOfferFrame(generation: 7, text: big))
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.string) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.string) }
 
         let pull = lazyPull(pasteboard, forType: .string)
         try await driveInboundStream(
@@ -936,7 +956,7 @@ struct VsockGuestClipboardAgentTests {
                         uti: txtUTI, byteCount: UInt64(contents.count), filename: "notes.txt",
                         isInline: false)
                 ]))
-        try await waitUntil { pasteboard.promisedTypesForTesting == [.fileURL] }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.fileURL] }
         #expect(!pasteboard.promisedTypesForTesting.contains(NSPasteboard.PasteboardType(txtUTI)))
 
         let pull = lazyPull(pasteboard, forType: .fileURL)
@@ -976,7 +996,7 @@ struct VsockGuestClipboardAgentTests {
                         uti: UTType.png.identifier, byteCount: UInt64(png.count), filename: "shot.png",
                         isInline: true)
                 ]))
-        try await waitUntil { pasteboard.promisedTypesForTesting.count == 2 }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.count == 2 }
         #expect(Set(pasteboard.promisedTypesForTesting) == [pngType, .fileURL])
 
         // Paste the image UTI: the inline bytes are returned verbatim.
@@ -1020,7 +1040,7 @@ struct VsockGuestClipboardAgentTests {
                         uti: UTType.png.identifier, byteCount: UInt64(png.count), filename: "shot.png",
                         isInline: true)
                 ]))
-        try await waitUntil { pasteboard.promisedTypesForTesting.count == 2 }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.count == 2 }
 
         // First `.fileURL` pull stages the inline bytes to a temp file.
         let pull1 = lazyPull(pasteboard, forType: .fileURL)
@@ -1070,7 +1090,7 @@ struct VsockGuestClipboardAgentTests {
                         isInline: false),
                 ]))
         // Two promised items, each promising exactly `.fileURL`.
-        try await waitUntil { pasteboard.promisedItemCountForTesting == 2 }
+        try await pasteboard.changed.wait { pasteboard.promisedItemCountForTesting == 2 }
         #expect(pasteboard.promisedTypesForTesting == [.fileURL, .fileURL])
 
         // Pull item 0's `.fileURL` → a request for rep 0 (transfer_id low bits 0).
@@ -1129,7 +1149,7 @@ struct VsockGuestClipboardAgentTests {
                         uti: UTType.png.identifier, byteCount: UInt64(png.count), filename: "img.png",
                         isInline: true)
                 ]))
-        try await waitUntil { pasteboard.promisedTypesForTesting.count == 2 }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.count == 2 }
 
         // First pull (`.fileURL`) drives exactly one request + stream.
         let firstPull = lazyPull(pasteboard, forType: .fileURL)
@@ -1160,7 +1180,7 @@ struct VsockGuestClipboardAgentTests {
         try await startAgentAndWaitForLiveChannel(agent: agent)
 
         try hostChannel.send(makeTextOfferFrame(generation: 13, text: "never delivered"))
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.string) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.string) }
 
         // OS pastes the text type; the host opens the transfer (Begin) then
         // aborts it mid-flight instead of streaming the bytes. The receiver
@@ -1194,7 +1214,7 @@ struct VsockGuestClipboardAgentTests {
         try await startAgentAndWaitForLiveChannel(agent: agent)
 
         try hostChannel.send(makeTextOfferFrame(generation: 14, text: "dropped"))
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.string) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.string) }
 
         // OS pastes the text type; the host drops the request WITHOUT ever sending
         // a Begin — exactly what `rejectRequest` does for a stale/out-of-range/UTI-
@@ -1286,7 +1306,7 @@ struct VsockGuestClipboardAgentTests {
         // adds nothing); `.fileURL`'s rawValue IS "public.file-url", which is the
         // legit file-url promise for the PNG — distinct from the smuggled content
         // rep that shares that UTI. The discriminating check is the request's UTI.
-        try await waitUntil { Set(pasteboard.promisedTypesForTesting) == [pngType, .fileURL] }
+        try await pasteboard.changed.wait { Set(pasteboard.promisedTypesForTesting) == [pngType, .fileURL] }
 
         let pull = lazyPull(pasteboard, forType: .fileURL)
         try await driveInboundStream(
@@ -1334,7 +1354,7 @@ struct VsockGuestClipboardAgentTests {
 
         // Only the legit text rep is promised; neither skip rep contributes a
         // promised type (the raw file-url never yields a `.fileURL` promise).
-        try await waitUntil { pasteboard.promisedTypesForTesting == [.string] }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.string] }
         let promised = pasteboard.promisedTypesForTesting
         #expect(promised == [.string])
         #expect(!promised.contains(.fileURL))
@@ -1373,7 +1393,7 @@ struct VsockGuestClipboardAgentTests {
                         uti: txtUTI, byteCount: 50 * 1024 * 1024, filename: "huge.bin",
                         isInline: false)
                 ]))
-        try await waitUntil { pasteboard.promisedTypesForTesting == [.fileURL] }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.fileURL] }
 
         let pull = lazyPull(pasteboard, forType: .fileURL)
         let provided = try await pull.value
@@ -1405,7 +1425,7 @@ struct VsockGuestClipboardAgentTests {
                         uti: txtUTI, byteCount: 50 * 1024 * 1024, filename: "huge.bin",
                         isInline: false)
                 ]))
-        try await waitUntil { pasteboard.promisedTypesForTesting == [.fileURL] }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.fileURL] }
 
         let pull = lazyPull(pasteboard, forType: .fileURL)
         #expect(try await pull.value == nil)
@@ -1438,7 +1458,7 @@ struct VsockGuestClipboardAgentTests {
         // Register a promise: the offer writes a lazy `.string` promise without
         // pulling anything.
         try hostChannel.send(makeTextOfferFrame(generation: 99, text: "undeliverable"))
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.string) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.string) }
 
         // Drive the close + provider invocation in a single main-queue block so
         // the read loop's EOF teardown (dispatched to main) can't nil liveChannel
@@ -1648,7 +1668,7 @@ struct VsockGuestClipboardAgentTests {
         // when the frame arrived. The lazy offer pulls nothing, so the read
         // loop's only observable effect is the promise landing on the pasteboard.
         try hostChannel.send(makeTextOfferFrame(generation: 1, text: "ping"))
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.string) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.string) }
         let promiseGen = DispatchQueue.main.sync { agent.inboundPromiseGenerationForTesting }
         #expect(promiseGen == 1)
         try await expectNoRequest(from: hostChannel)
@@ -1676,7 +1696,7 @@ struct VsockGuestClipboardAgentTests {
 
         // The write attempt bumps the changeCount via clearContents; wait for
         // that observable side effect, then confirm no promise was retained.
-        try await waitUntil { pasteboard.changeCount > 0 }
+        try await pasteboard.changed.wait { pasteboard.changeCount > 0 }
         try await expectNoRequest(from: hostChannel)
         let promiseGen = DispatchQueue.main.sync { agent.inboundPromiseGenerationForTesting }
         #expect(promiseGen == nil)
@@ -1817,7 +1837,7 @@ struct VsockGuestClipboardAgentTests {
         try await startAgentAndWaitForLiveChannel(agent: agent)
 
         try hostChannel.send(makeTextOfferFrame(generation: 1, text: "payload"))
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.string) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.string) }
 
         let payload = Data("payload".utf8)
         let pull = lazyPull(pasteboard, forType: .string)
@@ -1845,7 +1865,7 @@ struct VsockGuestClipboardAgentTests {
         // Registering the promise (and setting the activity) happen together in
         // handleOffer; once the promise is observable the activity is set too.
         try hostChannel.send(makeTextOfferFrame(generation: 1, text: "payload"))
-        try await waitUntil { pasteboard.promisedTypesForTesting.contains(.string) }
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting.contains(.string) }
 
         let after = await MainActor.run { agent.clipboardActivity }
         #expect(after == .offeredFromHost)

--- a/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
@@ -51,7 +51,7 @@ struct VsockGuestControlAgentTests {
     /// short default, any non-watchdog test that paused past the window saw the
     /// channel closed out from under it — surfacing as an EOF / `.closed` flake.
     /// Making the watchdog an explicit opt-in removes that coupling. Mirrors
-    /// `VsockControlServiceTests` / `makeService`. See `ci-test-timings`.
+    /// `VsockControlServiceTests` / `makeService`. See CLAUDE.md "Async waits in tests".
     private static let watchdogDisabledUnresponsive: Duration = .seconds(3_600)
     private static let watchdogDisabledTerminate: Duration = .seconds(7_200)
 

--- a/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaGuestAgentTests/VsockGuestControlAgentTests.swift
@@ -66,7 +66,8 @@ struct VsockGuestControlAgentTests {
         heartbeatInterval: Duration? = nil,
         unresponsiveAfter: Duration? = nil,
         terminateAfter: Duration? = nil,
-        onPolicy: (@Sendable (Kernova_V1_PolicyUpdate) -> Void)? = nil
+        onPolicy: (@Sendable (Kernova_V1_PolicyUpdate) -> Void)? = nil,
+        onStateChange: (@Sendable (HostConnectionState) -> Void)? = nil
     ) -> VsockGuestControlAgent {
         let provided = AtomicInt()
         let client = VsockGuestClient(
@@ -81,7 +82,8 @@ struct VsockGuestControlAgentTests {
             heartbeatInterval: heartbeatInterval ?? Self.testHeartbeat,
             unresponsiveAfter: unresponsiveAfter ?? Self.watchdogDisabledUnresponsive,
             terminateAfter: terminateAfter ?? Self.watchdogDisabledTerminate,
-            onPolicy: onPolicy
+            onPolicy: onPolicy,
+            onStateChange: onStateChange
         )
     }
 
@@ -243,11 +245,13 @@ struct VsockGuestControlAgentTests {
 
         // Short unresponsive window, long terminate window: the watchdog flags
         // "unresponsive" without tearing the channel down during the test.
+        let states = StateBox()
         let agent = makeAgent(
             agentFd: agentFd,
             heartbeatInterval: .milliseconds(50),
             unresponsiveAfter: .milliseconds(150),
-            terminateAfter: .seconds(3_600))
+            terminateAfter: .seconds(3_600),
+            onStateChange: { states.record($0) })
         defer { agent.stop() }
         agent.start()
 
@@ -255,7 +259,7 @@ struct VsockGuestControlAgentTests {
         // Host stays silent (sends nothing): liveness needs a first inbound frame
         // to start its clock, so send one Hello, then go quiet.
         try host.send(makeHostHelloFrame())
-        try await waitUntil { agent.connectionState == .unresponsive }
+        try await states.changed.wait { states.value == .unresponsive }
     }
 
     // MARK: - Liveness teardown + reconnect
@@ -329,6 +333,20 @@ struct VsockGuestControlAgentTests {
             changed.notify()
         }
         var value: Kernova_V1_PolicyUpdate? { lock.withLock { storedValue } }
+    }
+
+    /// Lock-protected box recording the latest connection state delivered via
+    /// the agent's `onStateChange` callback.
+    private final class StateBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storedValue: HostConnectionState?
+        /// Fires on every `record`; await it instead of polling `value`.
+        let changed = AsyncGate()
+        func record(_ s: HostConnectionState) {
+            lock.withLock { storedValue = s }
+            changed.notify()
+        }
+        var value: HostConnectionState? { lock.withLock { storedValue } }
     }
 
     @Test("Inbound PolicyUpdate is forwarded to the onPolicy callback")

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
@@ -286,6 +286,12 @@ struct ClipboardStreamTests {
                 $0.transferID = 1; $0.offset = 0; $0.data = Data(count: Self.chunk)
             })
 
+        // RATIONALE: Filesystem-appearance polls with no gate-able signal. The
+        // receiver creates and deletes the staging partial on its private
+        // per-transfer DispatchQueue; the only test-owned signal
+        // (StreamCollector.gate) fires on onComplete/onAbort, never on partial-file
+        // I/O. Per CLAUDE.md "Async waits in tests", a filesystem-appearance poll is
+        // a sanctioned `pollUntil` use.
         // The partial temp file is created off the transfer queue.
         try await pollUntil {
             materializedFiles(under: harness.stagingTempRoot).contains {

--- a/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
@@ -62,6 +62,15 @@ struct LazyPullCoordinatorTests {
 
     // MARK: - Slot machinery
 
+    // RATIONALE: The `pollUntil` waits in this section read the SUT's own
+    // `pendingSlotCountForTesting`, a DEBUG getter over an NSLock-guarded dict on
+    // `LazyPullCoordinator` (not @Observable), registered inside `pull()` running on
+    // a background `DispatchQueue`. There is no test-owned signal to await: the
+    // file's `AsyncGate` gates the harness receiver's onComplete/onAbort closures,
+    // not slot registration, and wiring a gate into production `pull()` is out of
+    // scope. Polling the coordinator's own state is correct here. See CLAUDE.md
+    // "Async waits in tests".
+
     @Test("pull blocks until deliver wakes it with the representation")
     func deliverWakesPull() async throws {
         let coordinator = LazyPullCoordinator()

--- a/KernovaTests/AttachmentFileMonitorTests.swift
+++ b/KernovaTests/AttachmentFileMonitorTests.swift
@@ -108,7 +108,7 @@ struct AttachmentFileMonitorTests {
 
         FileManager.default.createFile(atPath: target, contents: Data([0]))
 
-        try await waitUntil(timeout: .seconds(5)) {
+        try await waitForChange(timeout: .seconds(5)) {
             monitor.exists(target) == true
         }
     }
@@ -126,7 +126,7 @@ struct AttachmentFileMonitorTests {
 
         try FileManager.default.removeItem(atPath: target)
 
-        try await waitUntil(timeout: .seconds(5)) {
+        try await waitForChange(timeout: .seconds(5)) {
             monitor.exists(target) == false
         }
     }

--- a/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
+++ b/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
@@ -40,7 +40,7 @@ struct ClipboardContentViewControllerRetentionTests {
     /// isolated provider registry, and an `AsyncGate` already wired to the
     /// registry's retain/release signal so a test awaits the registration event
     /// rather than polling `countForTesting` — the one-shot effect a starved CI
-    /// MainActor can miss inside a poll deadline (memory `ci-test-timings`).
+    /// MainActor can miss inside a poll deadline (CLAUDE.md "Async waits in tests").
     ///
     /// The caller still owns teardown (`pasteboard.releaseGlobally()` and
     /// `registry.releaseAllForTesting()` in `defer`), since a `defer` only fires

--- a/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
+++ b/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
@@ -202,11 +202,13 @@ struct ClipboardContentViewControllerEditTests {
     @Test("a keystroke burst commits the buffer to the model off-actor after the debounce")
     func debouncedCommitLandsInModel() async throws {
         let service = FakeClipboardService(content: .empty)
+        let committed = AsyncGate()
+        service.onChangeForTesting = { committed.notify() }
         let vc = makeController(service: service, debounce: .milliseconds(1))
 
         vc.setEditorTextForTesting("hello off-actor")
 
-        try await waitUntil { service.clipboardContent == ClipboardContent(text: "hello off-actor") }
+        try await committed.wait { service.clipboardContent == ClipboardContent(text: "hello off-actor") }
     }
 
     @Test("flushPendingEdit commits the latest text before the debounce fires")
@@ -253,7 +255,16 @@ struct ClipboardContentViewControllerEditTests {
 /// live VM transport.
 @MainActor
 private final class FakeClipboardService: ClipboardServicing {
-    var clipboardContent: ClipboardContent
+    var clipboardContent: ClipboardContent {
+        didSet { onChangeForTesting?() }
+    }
+
+    /// Fires after each post-init `clipboardContent` write.
+    ///
+    /// Lets a test `AsyncGate` wake on the controller's debounced off-actor commit
+    /// instead of polling.
+    var onChangeForTesting: (() -> Void)?
+
     var isConnected: Bool = true
     var supportsBinaryRepresentations: Bool = true
     var lastTransferIssue: ClipboardTransferIssue?

--- a/KernovaTests/SerialSocketRelayTests.swift
+++ b/KernovaTests/SerialSocketRelayTests.swift
@@ -10,6 +10,14 @@ import Testing
 @MainActor
 @Suite("SerialSocketRelay")
 struct SerialSocketRelayTests {
+    // RATIONALE: Every `waitUntil` in this suite stays a poll rather than
+    // `waitForChange`/`AsyncGate` (see CLAUDE.md "Async waits in tests"). The only
+    // two signals are a kernel socket/pipe becoming readable (`readChunk`) and
+    // `relay.hasClientForTesting`, which `SerialSocketRelay` (`@unchecked Sendable`,
+    // not `@Observable`) flips on its private background GCD queue under `NSLock`.
+    // Neither is an `@Observable` property nor a test-owned recorder, so making them
+    // event-driven would require adding a seam to production code, out of scope here.
+
     // MARK: - Helpers
 
     private func tempSocketPath() -> String {

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -42,7 +42,7 @@ func makeRawSocketPair() throws -> (Int32, Int32) {
 /// Polls `predicate` every 50 ms until it returns `true` or `timeout` elapses.
 ///
 /// Default deadline is generous (5 s) to absorb MainActor scheduling jitter on
-/// CI runners. See memory `ci-test-timings`. Prefer the
+/// CI runners. See CLAUDE.md "Async waits in tests". Prefer the
 /// event-driven `AsyncGate` below for new timing-sensitive waits — polling is
 /// retained for predicates with no underlying signal to await; the 50 ms tick
 /// (up from 10 ms) keeps idle pollers from adding avoidable MainActor churn.
@@ -217,7 +217,7 @@ final class AsyncGate: @unchecked Sendable {
 /// adds **zero** wake-ups to the shared (and, on CI, contended) MainActor, and
 /// `timeout` is a stuck-condition backstop the happy path never reaches rather
 /// than the success deadline. This is the fix for the poll-budget flakes in the
-/// flaky-CI investigation; see memory `ci-test-timings`.
+/// flaky-CI investigation; see CLAUDE.md "Async waits in tests".
 ///
 /// The predicate must read every value it inspects through an `@Observable`
 /// getter so tracking registers a dependency, and it must be **side-effect-free**

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -602,7 +602,7 @@ struct VMInstanceTests {
         return instance
     }
 
-    // CI timing notes (memory: ci-test-timings):
+    // CI timing notes (see CLAUDE.md "Async waits in tests"):
     //   - macos-26 GitHub Actions runners have substantial MainActor jitter
     //     compared to local hardware. Use cadences ≥100 ms and waitUntil
     //     deadlines ≥10× the cadence; end-state assertions, not per-iteration.

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -1142,7 +1142,7 @@ struct VsockClipboardServiceTests {
                     )
                 ],
                 isConcealed: true))
-        try await waitUntil { service.clipboardContent.representations.first?.isPendingRemote == true }
+        try await waitForChange { service.clipboardContent.representations.first?.isPendingRemote == true }
 
         // The published content is flagged concealed so the window hides it.
         #expect(service.clipboardContent.isConcealed)

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -61,7 +61,7 @@ struct VsockControlServiceTests {
     /// channel closed out from under it — surfacing as an EOF / `.closed` flake.
     /// Sixteen tests inherited those defaults despite not testing liveness; this
     /// makes the watchdog an explicit opt-in instead of an implicit deadline
-    /// coupled to every test's runtime. See `ci-test-timings`.
+    /// coupled to every test's runtime. See CLAUDE.md "Async waits in tests".
     private static let watchdogDisabledUnresponsive: Duration = .seconds(3_600)
     private static let watchdogDisabledTerminate: Duration = .seconds(7_200)
 
@@ -130,7 +130,7 @@ struct VsockControlServiceTests {
         _ = try await nextFrame(from: guest)  // host hello
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
 
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
         #expect(service.isConnected)
         #expect(service.agentVersion == "0.9.0")
     }
@@ -164,7 +164,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         #expect(service.agentStatus == .current(version: "0.9.0"))
     }
@@ -182,7 +182,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.8.5"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         #expect(service.agentStatus == .outdated(installed: "0.8.5", bundled: "0.9.0"))
     }
@@ -200,7 +200,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "1.0.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         // Newer-than-bundled should not flag .outdated against the user.
         #expect(service.agentStatus == .current(version: "1.0.0"))
@@ -219,7 +219,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         // Lexicographic compare would put "0.9.0" > "0.10.0" — wrong.
         #expect(service.agentStatus == .outdated(installed: "0.9.0", bundled: "0.10.0"))
@@ -238,7 +238,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.5.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         // Without a bundled version to compare against, accept the guest's
         // report rather than prompting the user to "update" against missing data.
@@ -257,7 +257,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
         #expect(service.agentStatus == .current(version: "0.9.0"))
 
         service.stop()
@@ -347,7 +347,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         // Send heartbeats every 100 ms (well below the 400 ms unresponsive
         // window) for ~800 ms total — twice unresponsiveAfter.
@@ -381,10 +381,10 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         // Don't send any further inbound. After ~100ms+ the watchdog flips.
-        try await waitUntil(timeout: .seconds(5)) {
+        try await waitForChange(timeout: .seconds(5)) {
             service.agentStatus == .unresponsive(version: "0.9.0")
         }
         #expect(service.agentStatus == .unresponsive(version: "0.9.0"))
@@ -414,10 +414,10 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         // Go silent → unresponsive.
-        try await waitUntil(timeout: .seconds(5)) {
+        try await waitForChange(timeout: .seconds(5)) {
             service.agentStatus == .unresponsive(version: "0.9.0")
         }
 
@@ -440,10 +440,9 @@ struct VsockControlServiceTests {
         }
         defer { resumeHeartbeats.cancel() }
 
-        // Only the recovery → .current transition was the proven CI flake (the
-        // poll budget timed out under jitter), so it alone uses the event-driven
-        // wait; the suite's other agentStatus/isConnected waits stay on the poll
-        // per the project's migrate-on-flake stance.
+        // The recovery → .current transition was the original CI flake (the poll
+        // budget timed out under jitter). This suite's agentStatus/isConnected
+        // waits are all event-driven now; see CLAUDE.md "Async waits in tests".
         try await waitForChange(timeout: .seconds(5)) {
             service.agentStatus == .current(version: "0.9.0")
         }
@@ -473,11 +472,15 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)  // host hello
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         // Wait for a few terminateAfter windows. By then `checkLiveness`
         // should have fired and called `channel.close()` on the host side.
         // After teardown, `host.send(...)` raises `VsockChannelError.closed`.
+        // RATIONALE: channel closure is detected by attempting a send and
+        // catching `.closed` — there is no @Observable property or signal to
+        // await (the watchdog closes the socket directly), so this is one of the
+        // sanctioned no-signal polls per CLAUDE.md "Async waits in tests".
         try await waitUntil(timeout: .seconds(5)) {
             do {
                 try host.send(makeHeartbeat(nonce: 1))
@@ -502,7 +505,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         service.stop()
         #expect(!service.isConnected)
@@ -561,7 +564,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)  // host hello
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         // Read a few frames; none should be PolicyUpdate. Each read returns as
         // soon as a frame arrives (heartbeats fire every 40 ms), so the timeout
@@ -595,7 +598,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)  // host hello
         try guest.send(makeGuestHello(agentVersion: "0.9.2"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         // The Hello handler runs synchronously after the inbound frame is
         // dispatched on the main actor, so by the time isConnected flips the
@@ -620,7 +623,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: ""))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
 
         // Connection succeeds (isConnected is set unconditionally on Hello),
         // but agentVersion stays nil and the observer must not fire — the
@@ -646,7 +649,7 @@ struct VsockControlServiceTests {
 
         _ = try await nextFrame(from: guest)
         try guest.send(makeGuestHello(agentVersion: "0.9.2"))
-        try await waitUntil { service.isConnected }
+        try await waitForChange { service.isConnected }
         try guest.send(makeGuestHello(agentVersion: "0.9.2"))
 
         // Service fires the closure verbatim each time. Suppressing duplicate
@@ -672,7 +675,7 @@ struct VsockControlServiceTests {
         // guest must Hello with the capability before a clipboard=true policy
         // survives the gate — and the service must have *observed* that Hello.
         try guest.send(makeGuestHello(agentVersion: "0.16.0"))
-        try await waitUntil { service.guestSupportsClipboardStreamingForTesting }
+        try await waitForChange { service.guestSupportsClipboardStreamingForTesting }
 
         service.sendPolicyUpdate(
             AgentPolicySnapshot(logForwardingEnabled: false, clipboardSharingEnabled: true)


### PR DESCRIPTION
## Summary
Ends the recurring "de-flake one test at a time" treadmill on CI with three coordinated changes:
- **Retry buffer** — a residual MainActor-jitter flake self-heals on CI instead of failing the job (immediate relief).
- **Prevention** — a CLAUDE.md rule so new test waits start event-driven (stops the inflow that kept the treadmill turning).
- **Root-cause sweep** — migrate every polling wait that has a *clean* event-driven seam (a test-double `AsyncGate` or an `@Observable` property) to event-driven; annotate the rest as sanctioned.

Root cause: macos-26 runners have heavy `@MainActor` scheduling jitter; with a `waitUntil`/`pollUntil` poll loop the timeout deadline *is* the success criterion, so a starved scheduler fails a test whose condition would have become true. Event-driven waits make the timeout a backstop the happy path never reaches.

## Changes
**Foundation**
- `Kernova.xctestplan`: `testRepetitionMode: retryOnFailure` + `maximumTestRepetitions: 2`.
- `CLAUDE.md`: new "Async waits in tests" subsection (the three event-driven seams + when polling is still acceptable).
- Removed the superseded `ci-test-timings` personal memory and repointed its in-code references to CLAUDE.md.

**Sweep — event-driven migration (no production code touched)**
- [x] `VsockControlServiceTests` — 19 `waitUntil`→`waitForChange` (worst offender, de-flaked 4×)
- [x] `VsockGuestClipboardAgentTests` — 23 waits → `pasteboard.changed.wait` via an `AsyncGate` on the test-only `FakePasteboard`
- [x] `AttachmentFileMonitorTests` (2), `VsockClipboardServiceTests` (1) — `waitForChange` on `@Observable` state
- [x] `VsockGuestControlAgentTests` (1) — test `StateBox` recorder driven by the agent's existing `onStateChange` callback
- [x] `ClipboardContentViewControllerRetentionTests` (1) — `AsyncGate` via a `didSet` on the test-owned `FakeClipboardService`
- [x] `VsockGuestClientTests` (1) — sleep-then-assert → the test-owned `AtomicInt`'s gate

**Sweep — sanctioned polls annotated with `RATIONALE`**
- [x] `SerialSocketRelayTests`, `LazyPullCoordinatorTests`, `ClipboardStreamTests`, `VsockGuestClientTests`: kernel socket/pipe readiness, filesystem-appearance, and non-`@Observable` SUT state behind background queues — no test-owned signal; event-driving would need production seams (out of scope).

## Notes
- Swift Testing carries Apple bug FB20922425: `retryOnFailure` re-runs every `@Test` in the *failing target*, not just the failed test. `maximumTestRepetitions` kept at 2.
- Did NOT add `testTimeoutsEnabled` / `defaultTestExecutionTimeAllowance` — XCTest-only, no-op on this Swift-Testing suite.
- `VMInstanceTests`' watchdog tests were already on the await-Task seam; its 5 remaining `Task.sleep` are negative-assertion/no-op verifications, left as-is.

## Test plan
- [x] full `make test` green locally (`** TEST SUCCEEDED **`)
- [x] `make lint` clean
- [ ] CI build-and-test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
