### PR TITLE
docs: Fix multi-issue auto-close keyword guidance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,7 +369,7 @@ When merging PRs with `gh pr merge`, always squash-merge with `--squash --subjec
 
 **Do not use `--delete-branch`.** The repo has `delete_branch_on_merge` enabled on GitHub, so remote branches are auto-deleted. The `--delete-branch` flag causes `gh` to run `git checkout main` locally, which fails in worktree contexts.
 
-**Linking issues for auto-close:** When a PR resolves GitHub issues, include `Closes #N` (or `Fixes #N`) in the PR body — not just a table reference like `| #N |`. GitHub only auto-closes issues when the merge commit or PR body contains the exact keywords `closes`, `fixes`, or `resolves` followed by `#N`. Place them in the summary section or as a standalone line (e.g., `Closes #12, #34, #56`).
+**Linking issues for auto-close:** When a PR resolves GitHub issues, include `Closes #N` (or `Fixes #N`) in the PR body — not just a table reference like `| #N |`. GitHub only auto-closes an issue when the merge commit or PR body has the keyword `closes`, `fixes`, or `resolves` immediately before its `#N`, **repeated for each issue**: `Closes #12, closes #34, closes #56` (or one `Closes #N` per line).
 
 #### Post-merge cleanup
 


### PR DESCRIPTION
## Summary
The "Linking issues for auto-close" guidance in `CLAUDE.md` showed the **broken** form. GitHub requires the `closes`/`fixes`/`resolves` keyword immediately before **each** issue number; a bare comma list like `Closes #12, #34` silently auto-closes only the first. The old example (`Closes #12, #34, #56`) is exactly that broken form — it's why #406 stayed open after #420 merged with `Closes #405, #406` (closed by hand).

## Changes
- Update the line to the correct form `Closes #12, closes #34, closes #56` (keyword repeated per issue, or one `Closes #N` per line), without enumerating the broken variants.

## Test plan
- [x] Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)