### PR TITLE
chore: Clear dead-code scan findings (#433)

### DIFF
--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -1364,14 +1364,13 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
 ///
 /// `NSPasteboard` is a class cluster with no public initializer and can't be
 /// subclassed, so its write can't be made to fail from a test. This write-only
-/// seam (clear, an objects-write returning `Bool`, and a read-back for
-/// assertions) is deliberately separate from the guest agent's richer
-/// `Pasteboard` protocol, which also carries poll/read members the host write
-/// path never uses. `NSPasteboard` satisfies all three requirements as-is.
+/// seam (clear plus an objects-write returning `Bool`) is deliberately separate
+/// from the guest agent's richer `Pasteboard` protocol, which also carries
+/// poll/read members the host write path never uses. `NSPasteboard` satisfies
+/// both requirements as-is.
 protocol HostWritePasteboard: AnyObject {
     @discardableResult func clearContents() -> Int
     func writeObjects(_ objects: [any NSPasteboardWriting]) -> Bool
-    func data(forType type: NSPasteboard.PasteboardType) -> Data?
 }
 
 extension NSPasteboard: HostWritePasteboard {}

--- a/KernovaGuestAgent/GuestAgentMenuText.swift
+++ b/KernovaGuestAgent/GuestAgentMenuText.swift
@@ -1,5 +1,4 @@
 import Foundation
-import KernovaKit
 
 /// Pure text mappers for the guest agent's menu-bar dropdown.
 ///

--- a/KernovaGuestAgentTests/GuestAgentMenuTextTests.swift
+++ b/KernovaGuestAgentTests/GuestAgentMenuTextTests.swift
@@ -1,7 +1,5 @@
 import Testing
 
-import KernovaKit
-
 @Suite("GuestAgentMenuText")
 struct GuestAgentMenuTextTests {
     // MARK: - about

--- a/KernovaKit/Sources/KernovaKit/ClipboardFileProviderSharing.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileProviderSharing.swift
@@ -104,7 +104,7 @@ public struct ClipboardFileProviderManifest: Codable, Sendable, Equatable {
 }
 
 /// Failure reaching the shared app-group container.
-public enum ClipboardFileProviderContainerError: Error {
+enum ClipboardFileProviderContainerError: Error {
     /// The app-group container couldn't be resolved (e.g. the entitlement is
     /// absent, as in a CI test host).
     case containerUnavailable

--- a/KernovaKit/Sources/KernovaKit/KernovaLogger.swift
+++ b/KernovaKit/Sources/KernovaKit/KernovaLogger.swift
@@ -68,10 +68,6 @@ public struct KernovaLogger: Sendable {
         forward(level: .debug, message: message.wireRendered)
     }
 
-    // periphery:ignore - Preserves a complete `os.Logger`-shaped surface
-    // (debug / info / notice / warning / error / fault). No code currently
-    // calls `.info`, but keeping the level lets new call sites pick the right
-    // severity without asymmetric workarounds.
     /// Logs at `.info` and forwards the wire form.
     public func info(_ message: KernovaLogMessage) {
         osLogger.info("\(message.localRendered, privacy: .public)")

--- a/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
+++ b/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
@@ -284,11 +284,9 @@ private final class FakeWritePasteboard: HostWritePasteboard {
     private(set) var writeAttempts = 0
     var failNextWrite = false
     var onWrite: (() -> Void)?
-    private var stored: [NSPasteboard.PasteboardType: Data] = [:]
 
     @discardableResult func clearContents() -> Int {
         clearCount += 1
-        stored.removeAll()
         return clearCount
     }
 
@@ -299,6 +297,4 @@ private final class FakeWritePasteboard: HostWritePasteboard {
         onWrite?()
         return !shouldFail
     }
-
-    func data(forType type: NSPasteboard.PasteboardType) -> Data? { stored[type] }
 }


### PR DESCRIPTION
## Summary
- Resolve all 6 Periphery dead-code findings from the weekly scan issue #433

## Changes
- Remove the unused `data(forType:)` requirement from `HostWritePasteboard` (never dispatched through the protocol — production only calls `clearContents()`/`writeObjects()`, and the retention tests read bytes back via a real `NSPasteboard`) and its only fake conformer's now-dead impl + orphaned `stored` backing store
- Remove unused `import KernovaKit` from `GuestAgentMenuText.swift` and its test (both referenced types live in the same `KernovaGuestAgent` target)
- Remove the now-superfluous `periphery:ignore` on `KernovaLogger.info(_:)` — it is genuinely called from `ClipboardFileProviderDomainHost.swift`
- Demote `ClipboardFileProviderContainerError` from `public` to internal — referenced only inside KernovaKit and never named in a public signature

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes (full suite, including the touched `ClipboardContentViewControllerRetentionTests` and `GuestAgentMenuText` suites)
- [x] `make lint` clean

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)