### PR TITLE
chore: Add `make doctor` toolchain health check

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -255,6 +255,7 @@ KernovaKit/                        # SPM package: the **shared host <-> guest mo
                                         #   StreamTestSupport.swift holds the shared helpers (channel pairs, AsyncGate, frame factories)
 
 Tools/
+├── doctor.sh                           # `make doctor` — checks the local toolchain (macOS/Xcode/Swift/swift-format) + git hooks
 └── regen-proto.sh                      # Regenerates kernova.pb.swift via protoc + protoc-gen-swift
 
 KernovaTests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ make test-package        # Run only the KernovaKit SwiftPM package tests
 make format              # Rewrite Swift sources in place via swift-format
 make lint                # Check Swift sources with swift-format --strict
 make install-hooks       # One-time: enable .githooks/pre-push (runs `make lint` before push)
+make doctor              # Check the local toolchain (macOS, Xcode, Swift, swift-format) and git hooks
 make clean               # Remove DerivedData/
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SWIFT_FORMAT      := xcrun swift-format
 SWIFT_SOURCE_DIRS := Kernova KernovaTests KernovaGuestAgent KernovaGuestAgentTests KernovaKit KernovaQuickLook KernovaRelaunchHelper KernovaFileProvider KernovaClipboardFileProvider
 
 .DEFAULT_GOAL := help
-.PHONY: help build test test-suite test-package clean format lint install-hooks check-hooks
+.PHONY: help build test test-suite test-package clean format lint install-hooks check-hooks doctor
 
 help:
 	@printf 'Kernova build targets:\n\n'
@@ -38,6 +38,7 @@ help:
 	@printf '  make format              Rewrite Swift sources in place via swift-format\n'
 	@printf '  make lint                Check Swift sources with swift-format (--strict)\n'
 	@printf '  make install-hooks       Point git at .githooks/ (runs lint on pre-push)\n'
+	@printf '  make doctor              Check the local toolchain (macOS, Xcode, Swift, swift-format, hooks)\n'
 	@printf '  make clean               Remove the DerivedData directory\n'
 	@printf '\n'
 	@printf '  Append CONFIGURATION=Release to build/test in Release (default: Debug)\n'
@@ -83,6 +84,13 @@ check-hooks:
 	if [ "$$hp" != ".githooks" ]; then \
 		printf 'Note: pre-push lint hook is not installed. Run `make install-hooks` (one-time per clone) to catch swift-format issues locally.\n' >&2; \
 	fi
+
+# Environment sanity check: verifies the local toolchain (macOS, Xcode, Swift,
+# swift-format) and repo setup (git hooks) match what Kernova needs to build,
+# lint, and push. A starting point — extend Tools/doctor.sh with more checks
+# over time. Exits non-zero if any required check fails, so it's CI-usable too.
+doctor:
+	@Tools/doctor.sh
 
 clean:
 	rm -rf $(DERIVED_DATA)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ make install-hooks
 
 This points the repo at the checked-in `.githooks/` directory so a pre-push hook runs `make lint` locally and matches the swift-format check enforced on `main`. It's a one-time setup per clone (Git does not auto-activate checked-in hooks). Bypass an individual push with `git push --no-verify`.
 
+Run `make doctor` to confirm your local toolchain (macOS, Xcode, Swift, swift-format) and git hooks match what Kernova needs before building.
+
 Run `make` with no arguments to see all build, test, format, and lint targets.
 
 ## Building

--- a/Tools/doctor.sh
+++ b/Tools/doctor.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Kernova environment doctor.
+#
+# Verifies that the local toolchain matches what Kernova needs to build, test,
+# lint, and push. Run via `make doctor` (or directly: `Tools/doctor.sh`).
+#
+# It prints one line per check and keeps going after failures so a single run
+# reports *everything* that's wrong, then exits non-zero if any REQUIRED check
+# failed (optional/tooling checks only warn). That makes it usable both as a
+# human sanity check and as a scriptable gate in CI.
+#
+# This is intentionally a starting point — grow it by appending checks in the
+# sections below (a `pass`/`warn`/`fail` per check).
+#
+# Requirements checked here mirror README.md "Requirements" and the toolchain
+# the Makefile actually invokes (e.g. `xcrun swift-format`).
+
+set -uo pipefail
+
+# ---- output helpers ---------------------------------------------------------
+
+# Count REQUIRED failures so the run can exit non-zero at the end rather than
+# bailing on the first one.
+fail_count=0
+
+# Colour only when writing to a TTY — keep CI logs and pipes plain.
+if [ -t 1 ]; then
+    c_green=$'\033[0;32m'; c_red=$'\033[0;31m'; c_yellow=$'\033[0;33m'
+    c_dim=$'\033[0;90m'; c_bold=$'\033[1m'; c_reset=$'\033[0m'
+else
+    c_green=''; c_red=''; c_yellow=''; c_dim=''; c_bold=''; c_reset=''
+fi
+
+pass()    { printf '  %s✓%s %s\n' "$c_green"  "$c_reset" "$1"; }
+warn()    { printf '  %s⚠%s %s\n' "$c_yellow" "$c_reset" "$1"; }
+fail()    { printf '  %s✗%s %s\n' "$c_red"    "$c_reset" "$1"; fail_count=$((fail_count + 1)); }
+detail()  { printf '    %s%s%s\n' "$c_dim"    "$1" "$c_reset"; }
+section() { printf '\n%s%s%s\n' "$c_bold" "$1" "$c_reset"; }
+
+# major_of "26.5.2" -> "26"; empty input stays empty.
+major_of() { printf '%s' "${1:-}" | cut -d. -f1; }
+
+# ge_major MAJOR MIN -> 0 (true) when MAJOR is a number >= MIN. Guards against
+# non-numeric input so a failed version probe can't crash the `[` comparison.
+ge_major() {
+    case "${1:-}" in
+        ''|*[!0-9]*) return 1 ;;
+        *) [ "$1" -ge "$2" ] ;;
+    esac
+}
+
+printf '%sKernova environment doctor%s\n' "$c_bold" "$c_reset"
+
+# ---- platform ---------------------------------------------------------------
+
+section 'Platform'
+
+os_ver=$(sw_vers -productVersion 2>/dev/null || echo '')
+if ge_major "$(major_of "$os_ver")" 26; then
+    pass "macOS $os_ver (>= 26 required)"
+else
+    fail "macOS 26 (Tahoe) or later required — found ${os_ver:-unknown}"
+fi
+
+# Probe the hardware, not the running process's slice: `uname -m` reports the
+# caller's architecture, so an x86_64/Rosetta shell on an Apple-Silicon Mac
+# would wrongly report x86_64. `hw.optional.arm64` reflects the CPU itself.
+if [ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" = "1" ]; then
+    pass "Apple Silicon ($(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo arm64))"
+else
+    fail "Apple Silicon (arm64) required — this Mac is not Apple Silicon"
+    detail "Virtualization.framework's macOS-guest and save/restore APIs are arm64-only."
+fi
+
+# ---- toolchain --------------------------------------------------------------
+
+section 'Toolchain'
+
+# `xcodebuild` needs a full Xcode selected, not the Command Line Tools.
+dev_dir=$(xcode-select -p 2>/dev/null || echo '')
+case "$dev_dir" in
+    '')
+        fail "Xcode not found — xcode-select has no active developer directory"
+        detail "Install Xcode 26+ then: sudo xcode-select -s /Applications/Xcode.app"
+        ;;
+    *CommandLineTools*)
+        fail "Full Xcode required, but Command Line Tools are selected ($dev_dir)"
+        detail "Fix: sudo xcode-select -s /Applications/Xcode.app"
+        ;;
+    *)
+        xc_ver=$(xcodebuild -version 2>/dev/null | head -1 | awk '{print $2}')
+        if ge_major "$(major_of "$xc_ver")" 26; then
+            pass "Xcode $xc_ver (>= 26 required)"
+        else
+            fail "Xcode 26 or later required — found ${xc_ver:-unknown}"
+        fi
+        ;;
+esac
+
+# Swift 6 (strict concurrency is assumed throughout the codebase). Probe via
+# `xcrun` so this reflects the selected Xcode's toolchain — the one the build
+# actually uses — not whatever a bare `swift` resolves to on PATH (same
+# rationale as the swift-format probe below).
+swift_ver=$(xcrun swift --version 2>/dev/null | sed -n 's/.*Swift version \([0-9][0-9.]*\).*/\1/p')
+if ge_major "$(major_of "$swift_ver")" 6; then
+    pass "Swift $swift_ver (>= 6 required)"
+else
+    fail "Swift 6 or later required — found ${swift_ver:-unknown}"
+fi
+
+# swift-format ships inside the Xcode toolchain; `make format`/`make lint`
+# reach it via `xcrun swift-format`, so probe it the same way.
+if sf_path=$(xcrun --find swift-format 2>/dev/null); then
+    pass "swift-format available (make format / make lint)"
+    detail "$sf_path"
+else
+    fail "swift-format not found in the active Xcode toolchain"
+    detail "It ships with Xcode 26+. Confirm your Xcode is selected: xcode-select -p"
+fi
+
+# ---- repository -------------------------------------------------------------
+
+section 'Repository'
+
+# core.hooksPath is shared across worktrees, so this is accurate from anywhere
+# in the checkout. Missing hooks don't block a build, so warn rather than fail
+# (same stance as the Makefile's check-hooks nudge).
+hooks_path=$(git config --get core.hooksPath 2>/dev/null || echo '')
+if [ "$hooks_path" = ".githooks" ]; then
+    pass "pre-push lint hook installed (core.hooksPath = .githooks)"
+else
+    warn "pre-push lint hook not installed — run 'make install-hooks' (one-time per clone)"
+fi
+
+# ---- optional tooling -------------------------------------------------------
+
+section 'Optional tooling'
+
+# Only needed to regenerate kernova.pb.swift after editing the .proto; the
+# generated files are checked in, so a normal build/test loop doesn't need it.
+if command -v protoc >/dev/null 2>&1 && command -v protoc-gen-swift >/dev/null 2>&1; then
+    pass "proto toolchain present (protoc + protoc-gen-swift) — Tools/regen-proto.sh"
+else
+    warn "proto toolchain absent — only needed to regenerate .pb.swift from kernova.proto"
+    detail "Install with: brew install protobuf swift-protobuf"
+fi
+
+# ---- summary ----------------------------------------------------------------
+
+if [ "$fail_count" -eq 0 ]; then
+    printf '\n%sAll required checks passed.%s\n' "$c_green" "$c_reset"
+    exit 0
+else
+    printf '\n%s%d required check(s) failed — see above.%s\n' "$c_red" "$fail_count" "$c_reset"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds a `make doctor` target that verifies the local toolchain and repo setup match what Kernova needs to build, test, lint, and push — a one-command sanity check for contributors that doubles as a CI-usable gate.

This is deliberately a **basic starting point** we can grow over time: adding a check means dropping a `pass`/`warn`/`fail` line into the relevant section of `Tools/doctor.sh`.

## What it checks

```
Kernova environment doctor

Platform
  ✓ macOS 26.5.2 (>= 26 required)
  ✓ Apple Silicon (Apple M1 Max)

Toolchain
  ✓ Xcode 26.6 (>= 26 required)
  ✓ Swift 6.3.3 (>= 6 required)
  ✓ swift-format available (make format / make lint)

Repository
  ⚠ pre-push lint hook not installed — run 'make install-hooks' (one-time per clone)

Optional tooling
  ⚠ proto toolchain absent — only needed to regenerate .pb.swift from kernova.proto

All required checks passed.
```

- **Required** failures (macOS/arch/Xcode/Swift/swift-format) exit non-zero; **soft** warnings (hooks, proto tooling) don't. Reports every problem in one pass.

## Changes
- Add `Tools/doctor.sh` (mirrors the existing `Tools/regen-proto.sh` pattern rather than inlining growing logic in the Makefile).
- Wire up the `doctor` target in the `Makefile` (`.PHONY` + `help` line).
- Document it in `README.md` (Development setup), `ARCHITECTURE.md` (`Tools/` listing), and `CLAUDE.md` (Build & Test list).

## Design notes
- Checks are grounded in what the build actually needs: `swift`/`swift-format` are probed via `xcrun` (the selected-Xcode toolchain, not bare `PATH`), Apple Silicon is probed via `sysctl hw.optional.arm64` (reflects the CPU regardless of an x86_64/Rosetta caller slice), and it catches Command Line Tools being selected instead of full Xcode.

## Test plan
- [x] `make doctor` on a healthy machine — all required checks pass, exit 0
- [x] Injected old-macOS shim — required check fails, remaining checks still run, exit 1
- [x] Version-parse guards: empty/non-numeric probes fail-closed (no crash, no false-pass)
- [x] Adversarial shell review; Rosetta arch + PATH-vs-toolchain Swift findings fixed and re-verified
- [ ] Live x86_64/Rosetta arch regression not run (Rosetta absent locally; the `sysctl` fix is slice-independent by construction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
