### PR TITLE
chore: Clear dead-code scan findings (#469)

### DIFF
--- a/KernovaKit/Sources/KernovaKit/ClipboardFileProviderSharing.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileProviderSharing.swift
@@ -22,18 +22,18 @@ import Foundation
 /// extension wraps it. The `clipfile` prefix distinguishes a per-rep file item
 /// from the framework's reserved container identifiers (root / working-set /
 /// trash). Avoids `/` and `:`, which the framework reserves.
-public enum ClipboardFileProviderItemIdentifier {
+enum ClipboardFileProviderItemIdentifier {
     private static let prefix = "clipfile"
     private static let separator: Character = "."
 
     /// Encodes `(generation, repIndex)` into an item identifier string.
-    public static func make(generation: UInt64, repIndex: Int) -> String {
+    static func make(generation: UInt64, repIndex: Int) -> String {
         "\(prefix)\(separator)\(generation)\(separator)\(repIndex)"
     }
 
     /// Decodes an identifier string back to `(generation, repIndex)`, or `nil`
     /// when it isn't one this provider minted.
-    public static func decode(_ identifier: String) -> (generation: UInt64, repIndex: Int)? {
+    static func decode(_ identifier: String) -> (generation: UInt64, repIndex: Int)? {
         let parts = identifier.split(separator: separator, omittingEmptySubsequences: false)
         guard parts.count == 3, parts[0] == prefix,
             let generation = UInt64(parts[1]),

--- a/KernovaKit/Sources/KernovaKit/DarwinNotification.swift
+++ b/KernovaKit/Sources/KernovaKit/DarwinNotification.swift
@@ -18,9 +18,9 @@ import Foundation
 // SDK's Swift module map, so the CoreFoundation Darwin API is used instead.
 
 /// Posts a payload-free Darwin notification by name.
-public enum DarwinNotification {
+enum DarwinNotification {
     /// Posts `name` to every registered observer across the sandbox boundary.
-    public static func post(_ name: String) {
+    static func post(_ name: String) {
         CFNotificationCenterPostNotification(
             CFNotificationCenterGetDarwinNotifyCenter(),
             CFNotificationName(name as CFString),
@@ -36,13 +36,13 @@ public enum DarwinNotification {
 /// `self`, so it must be cancelled (which `deinit` does) before `self` is freed.
 ///
 /// `@unchecked Sendable`: `handler`/`queue`/`name` are immutable after `init`.
-public final class DarwinNotificationObserver: @unchecked Sendable {
+final class DarwinNotificationObserver: @unchecked Sendable {
     private let name: String
     private let queue: DispatchQueue
     private let handler: @Sendable () -> Void
 
     /// Registers for `name`, delivering each post to `handler` on `queue`.
-    public init(name: String, queue: DispatchQueue, handler: @escaping @Sendable () -> Void) {
+    init(name: String, queue: DispatchQueue, handler: @escaping @Sendable () -> Void) {
         self.name = name
         self.queue = queue
         self.handler = handler
@@ -65,7 +65,7 @@ public final class DarwinNotificationObserver: @unchecked Sendable {
     /// Removes the registration.
     ///
     /// Idempotent — a second remove is a no-op.
-    public func cancel() {
+    func cancel() {
         CFNotificationCenterRemoveObserver(
             CFNotificationCenterGetDarwinNotifyCenter(),
             Unmanaged.passUnretained(self).toOpaque(),


### PR DESCRIPTION
## Summary
- Resolves the weekly Periphery dead-code scan's 8 "Redundant public accessibility" findings in KernovaKit by narrowing access from `public` to `internal`
- Closes #469

## Changes
- `DarwinNotification.swift`: demote `DarwinNotification`, `.post(_:)`, `DarwinNotificationObserver`, its initializer, and `.cancel()` — the #460 reconnect doorbell crosses processes at runtime via the Darwin notify center, not via a compile-time Swift symbol, so no target outside KernovaKit ever names these types
- `ClipboardFileProviderSharing.swift`: demote `ClipboardFileProviderItemIdentifier`, `.make(generation:repIndex:)`, and `.decode(_:)` — the #376 item-identity encoder is consumed only inside KernovaKit (`ClipboardFileProviderExtension` and the `ClipboardFileProviderManifest` wrappers); the appex targets only subclass the shared `open` extension base and never reference this enum

## Investigation notes
- Verified no app/agent/extension target references any of the 8 symbols — confirmed via grep across `KernovaClipboardFileProvider`, `KernovaFileProvider`, and `KernovaQuickLook` (the three extension targets Periphery's scan doesn't index), so demoting these symbols cannot break those builds
- Per `.periphery.yml`'s own guidance (`retain_public: false`, prefer demotion over `// periphery:ignore` for non-intentional exports), these are internal implementation details rather than intentional public API, so demotion — not annotation or deletion — is the correct fix
- Matches the resolution pattern of the predecessor issue (#433 → PR #442)

## Test plan
- [x] `make test-package` — 197 tests / 22 suites pass
- [x] Full `make test` (`Kernova.xctestplan`, builds + embeds all three appex targets: `KernovaClipboardFileProvider`, `KernovaFileProvider`, `KernovaQuickLook`) — TEST SUCCEEDED
- [x] `make lint` — clean

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)