### PR TITLE
chore: Gitignore Xcode's Relative Derived Data log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Xcode
 build/
 DerivedData/
+# Written next to the .xcodeproj by Xcode's Relative Derived Data setting
+# (see CLAUDE.md); the suffix is a per-install identifier, hence the glob.
+.derived-data-log-*
 *.pbxuser
 !default.pbxuser
 *.mode1v3


### PR DESCRIPTION
## Summary
- Xcode's Relative Derived Data setting (documented in CLAUDE.md) writes a per-install `.derived-data-log-<ID>` JSON file next to the `.xcodeproj`, which was showing up as an untracked file in the primary checkout

## Changes
- Add `.derived-data-log-*` to `.gitignore`'s Xcode section, alongside the existing `DerivedData/` entry

## Test plan
- [x] `git status` no longer lists the stray `.derived-data-log-*` file after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)