### PR TITLE
chore: Add `make fp-reset` and a File Provider domain report to ghosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ SWIFT_FORMAT      := xcrun swift-format
 SWIFT_SOURCE_DIRS := Kernova KernovaTests KernovaMacOSAgent KernovaMacOSAgentTests KernovaKit KernovaQuickLook KernovaRelaunchHelper KernovaMacOSAgentFileProvider KernovaFileProvider
 
 .DEFAULT_GOAL := help
-.PHONY: help build test test-suite test-package clean format lint install-hooks check-hooks doctor ghosts clean-ghosts
+.PHONY: help build test test-suite test-package clean format lint install-hooks check-hooks doctor ghosts clean-ghosts fp-reset
 
 help:
 	@printf 'Kernova build targets:\n\n'
@@ -68,6 +68,7 @@ help:
 	@printf '  make doctor              Check the local toolchain (macOS, Xcode, Swift, swift-format, hooks)\n'
 	@printf '  make ghosts              Report stale Kernova Launch Services/process/worktree registrations\n'
 	@printf '  make clean-ghosts        Same as ghosts, but also unregisters/kills/prunes what it finds\n'
+	@printf '  make fp-reset            Restart fileproviderd to clear stale Kernova File Provider bindings\n'
 	@printf '  make clean               Remove the DerivedData directory\n'
 	@printf '\n'
 	@printf '  Append CONFIGURATION=Release to build/test in Release (default: Debug)\n'
@@ -130,6 +131,18 @@ ghosts:
 
 clean-ghosts:
 	@Tools/ghosts.sh --fix
+
+# Restarts the File Provider daemon to clear stale Kernova domain/extension
+# bindings — e.g. after a rebuild leaves fileproviderd pointing at a deleted or
+# moved extension binary (Copy to Mac then beeps because the extension can't
+# launch), or a domain wedged in a dead-end state. Kept separate from
+# clean-ghosts and opt-in because it briefly interrupts ALL File Providers
+# (iCloud Drive reconnects within seconds). macOS 26's fileproviderctl has no
+# domain-remove command; the app self-heals a dead domain on next launch.
+fp-reset:
+	@printf 'Restarting fileproviderd to clear stale Kernova File Provider bindings...\n'
+	@printf '(briefly interrupts all File Providers; iCloud Drive reconnects in a few seconds)\n'
+	@killall fileproviderd 2>/dev/null && printf 'fileproviderd restarted.\n' || printf 'fileproviderd was not running; it will start on demand.\n'
 
 clean:
 	rm -rf $(DERIVED_DATA_ROOT)

--- a/Tools/ghosts.sh
+++ b/Tools/ghosts.sh
@@ -162,6 +162,31 @@ else
     fi
 fi
 
+# ---- stale File Provider domains ---------------------------------------------
+
+section 'File Provider domains'
+
+# fileproviderd binds each registered domain to its extension by bundle id and
+# caches the launch path. A rebuild that moves or deletes the extension binary —
+# or a competing copy at a different DerivedData path — can wedge the binding
+# (Copy to Mac then beeps, because the extension can't launch), and a torn-down
+# extension can strand a dead-end domain. macOS 26's fileproviderctl can only
+# `dump`, not remove, so this only REPORTS; clear it with `make fp-reset`, which
+# restarts fileproviderd — the app re-registers a fresh domain on next launch.
+# The dead-end check isn't domain-scoped (the dump groups backends per-domain
+# but is awkward to parse), so on a machine with other providers it can
+# over-report; running fp-reset is harmless either way.
+fp_dump=$(fileproviderctl dump 2>/dev/null || true)
+if ! printf '%s\n' "$fp_dump" | grep -qiE "app\.kernova|kernova-clipboard"; then
+    clean 'No Kernova File Provider domains registered'
+elif printf '%s\n' "$fp_dump" | grep -q "DeadEndBackend"; then
+    ghost 'A File Provider domain looks wedged (dead-end backend) with Kernova registered'
+    detail 'Run `make fp-reset`, then relaunch Kernova to re-register a fresh domain.'
+else
+    clean 'Kernova File Provider domain(s) registered, none dead-ended'
+    detail 'If Copy to Mac beeps or hangs, `make fp-reset` clears stale fileproviderd bindings.'
+fi
+
 # ---- summary ------------------------------------------------------------------
 
 section 'Summary'


### PR DESCRIPTION
## Summary

Gives the ghost tooling visibility into File Provider **daemon** state and a way to clear stale bindings — something the existing Launch Services-level cleanup (`make ghosts` / `clean-ghosts`) can't reach.

## Changes

- **`make fp-reset`** — restarts `fileproviderd` to clear stale Kernova domain/extension bindings. Two failure modes this fixes: (1) a rebuild leaves `fileproviderd` pointing at a deleted or moved extension binary, so **Copy to Mac beeps** because the extension can't launch; (2) a torn-down extension strands a **dead-end domain**. Kept **separate from `clean-ghosts` and opt-in** because it briefly interrupts *all* File Providers (iCloud Drive reconnects within seconds).
- **`Tools/ghosts.sh` File Provider section** (`make ghosts`) — reports whether Kernova File Provider domains are registered and flags a dead-end backend, pointing to `make fp-reset`. **Report-only**: macOS 26's `fileproviderctl` has no domain-remove command, and the app self-heals a dead domain on next launch.

## Notes

Motivated by a Copy-to-Mac debugging session where `fileproviderd` had cached a binding to a deleted `DerivedData` extension copy (a competing CLI build shadowing the Xcode build). A `killall fileproviderd` fixed it, but nothing surfaced or cleared that state. Independent of the app-group work in #472.

## Test plan

- [x] `bash -n Tools/ghosts.sh` passes; `make ghosts` reports the new section.
- [x] `make help` lists `fp-reset`; `make -n fp-reset` shows the expected `killall`.
- [ ] `make fp-reset` restarts `fileproviderd` (not run in CI / a live session).