### PR TITLE
fix: Route host clipboard control frames fire-and-forget, not awaited

### DIFF
--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -430,11 +430,12 @@ final class VsockClipboardService: ClipboardServicing {
     /// actor.
     ///
     /// `nonisolated`, so the loop and its per-frame routing run on a cooperative
-    /// thread, not the main actor: stream frames (begin/chunk/end/ack/abort) go
-    /// straight to the thread-safe engine, and only the low-frequency control
-    /// frames (offer/request/release/error) hop to main via `onControlFrame`.
-    /// This keeps a multi-GB transfer's tens of thousands of chunk/ack frames off
-    /// the main actor entirely. [M1]
+    /// thread, not the main actor: stream frames (begin/chunk/end/ack, and a
+    /// receiver-bound abort) go straight to the thread-safe engine, and the
+    /// low-frequency control frames (offer/request/release/error), plus a
+    /// sender-bound abort, hop to main via `onControlFrame`. This keeps a
+    /// multi-GB transfer's tens of thousands of chunk/ack frames off the main
+    /// actor entirely. [M1]
     ///
     /// `onControlFrame` dispatches fire-and-forget rather than being awaited, so
     /// the loop never suspends on the main-actor hop: a control frame arriving
@@ -468,7 +469,18 @@ final class VsockClipboardService: ClipboardServicing {
                     if ClipboardTransferID.hostReceives(abort.transferID) {
                         receiver.handleAbort(abort)
                     } else {
-                        sender.handleAbort(transferID: abort.transferID)
+                        // A sender-bound abort (e.g. the peer cancelling its own
+                        // in-flight pull, #464/#500) must not be handled directly
+                        // here: `handleRequest` now registers the transfer via
+                        // `sender.startTransfer` fire-and-forget on main (#458),
+                        // so an abort for the same transfer_id handled
+                        // synchronously off-main could race ahead of that
+                        // registration and land as a silent no-op on an
+                        // unregistered id — the transfer then streams anyway
+                        // despite having been cancelled. Routing it through the
+                        // same `onControlFrame` main-queue dispatch as the
+                        // request preserves their relative order (#503).
+                        onControlFrame(frame)
                     }
                 default:
                     onControlFrame(frame)
@@ -502,8 +514,14 @@ final class VsockClipboardService: ClipboardServicing {
                     kind: .peerReportedError(code: error.code, message: error.message),
                     date: Date())
             }
-        case .clipboardStreamBegin, .clipboardChunk, .clipboardStreamEnd, .clipboardStreamAck,
-            .clipboardStreamAbort:
+        case .clipboardStreamAbort(let abort):
+            // Only a sender-bound abort reaches here (routed through this same
+            // dispatch, not off-main, so it can't race ahead of a still-pending
+            // `sender.startTransfer` registration for the same transfer_id —
+            // see the routing comment in `consume`, #503). A receiver-bound
+            // abort is routed off-main directly and never reaches here.
+            sender?.handleAbort(transferID: abort.transferID)
+        case .clipboardStreamBegin, .clipboardChunk, .clipboardStreamEnd, .clipboardStreamAck:
             // Routed off-main by the consume loop; never reaches here.
             break
         case .hello, .heartbeat, .policyUpdate, .logRecord, .none:

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -251,7 +251,18 @@ final class VsockClipboardService: ClipboardServicing {
         consumeTask = Task { [weak self] in
             await Self.consume(
                 channel: channel, label: label, sender: sender, receiver: receiver,
-                onControlFrame: { @MainActor frame in self?.handleControlFrame(frame) })
+                onControlFrame: { [weak self] frame in
+                    // Fire-and-forget onto the serial main queue so the consume loop
+                    // never suspends on the main-actor hop — a control frame arriving
+                    // while main is blocked in a toggle-off paste's
+                    // performBlockingPull must not halt stream-frame routing (#458).
+                    // Serial DispatchQueue.main preserves control-frame FIFO order; a
+                    // per-frame detached Task would not. Mirrors the guest's #357
+                    // pattern (VsockGuestClipboardAgent.serve).
+                    DispatchQueue.main.async {
+                        MainActor.assumeIsolated { self?.handleControlFrame(frame) }
+                    }
+                })
             // Channel closed — wake any pull parked on a transfer whose Begin will
             // now never arrive, so an async materialize doesn't hang forever, and
             // unblock any synchronous file pull (FP relay / toggle-off paste).
@@ -424,12 +435,18 @@ final class VsockClipboardService: ClipboardServicing {
     /// frames (offer/request/release/error) hop to main via `onControlFrame`.
     /// This keeps a multi-GB transfer's tens of thousands of chunk/ack frames off
     /// the main actor entirely. [M1]
+    ///
+    /// `onControlFrame` dispatches fire-and-forget rather than being awaited, so
+    /// the loop never suspends on the main-actor hop: a control frame arriving
+    /// while main is blocked elsewhere (e.g. `performBlockingPull`) must not halt
+    /// stream-frame routing (#458), mirroring the guest's fire-and-forget
+    /// `DispatchQueue.main.async` dispatch (#357).
     nonisolated private static func consume(
         channel: VsockChannel,
         label: String,
         sender: ClipboardStreamSender,
         receiver: ClipboardStreamReceiver,
-        onControlFrame: @MainActor @Sendable @escaping (Frame) -> Void
+        onControlFrame: @Sendable @escaping (Frame) -> Void
     ) async {
         do {
             for try await frame in channel.incoming where frame.protocolVersion == 1 {
@@ -454,7 +471,7 @@ final class VsockClipboardService: ClipboardServicing {
                         sender.handleAbort(transferID: abort.transferID)
                     }
                 default:
-                    await onControlFrame(frame)
+                    onControlFrame(frame)
                 }
             }
             logger.info("Vsock clipboard channel closed for '\(label, privacy: .public)'")
@@ -465,7 +482,9 @@ final class VsockClipboardService: ClipboardServicing {
         }
     }
 
-    /// Handles the control frames the consume loop hops to the main actor for.
+    /// Handles the control frames the consume loop dispatches to the main actor
+    /// for, fire-and-forget (#458) — never awaited, so a control frame processed
+    /// here can never itself hold up the consume loop's stream-frame routing.
     private func handleControlFrame(_ frame: Frame) {
         switch frame.payload {
         case .clipboardOffer(let offer):
@@ -1203,7 +1222,9 @@ extension VsockClipboardService: HostClipboardFileRepProviding {
     /// `provide` callback already runs there); off-main it snapshots via
     /// `DispatchQueue.main.sync` (the relay's XPC queue). It then blocks the
     /// calling thread on `performBlockingPull`, woken off-main by the receiver, so
-    /// blocking main is safe — the stream receive runs on its own queue.
+    /// blocking main is safe — the stream receive runs on `consume`'s own
+    /// cooperative thread, which routes control frames to main fire-and-forget
+    /// (never awaited) and so never parks waiting on this very thread (#458).
     nonisolated func pullStagedFile(
         generation: UInt64, repIndex: Int
     ) -> Result<String, FileProviderPullError> {

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -1462,6 +1462,113 @@ struct VsockClipboardServiceTests {
         }
     }
 
+    @Test(
+        "A control frame arriving while pullStagedFile blocks main does not stall stream-frame routing (#458)"
+    )
+    func controlFrameDuringBlockingPullDoesNotStallRouting() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        // A backstop, not the success path: under the fix this resolves in
+        // milliseconds via genuine delivery. A few seconds' slack absorbs macOS
+        // CI's heavy @MainActor scheduling jitter (CLAUDE.md's "Async waits in
+        // tests") without masking a real regression with an overly generous wait.
+        let service = VsockClipboardService(
+            channel: host, label: "test-\(UUID().uuidString)", lazyPullTimeout: .seconds(5))
+        service.start()
+        defer { service.stop() }
+
+        // A single lazy-eligible file rep (non-inline, named) — pullStagedFile's target.
+        try guest.send(
+            makeOffer(
+                generation: 30,
+                reps: [(uti: "public.data", byteCount: 4, filename: "f.bin", isInline: false)]))
+        try await waitForChange {
+            service.clipboardContent.representations.first?.isPendingRemote == true
+        }
+
+        let payload = Data([0xDE, 0xAD, 0xBE, 0xEF])
+        let xid = inboundTransferID(generation: 30, repIndex: 0)
+
+        // Drains the guest side independently of the host's main thread: on seeing
+        // the host's ClipboardRequest, sends an inert control frame FIRST — the
+        // interleaving #458 describes, a control frame landing mid-pull — THEN the
+        // stream frames that resolve the pull. `.detached` (not plain `Task {}`,
+        // which would inherit this MainActor test struct's isolation) so this
+        // truly never touches the host's main actor and isn't blocked by the
+        // pullStagedFile call below; it is the guest-side analog of the "peer
+        // keeps talking while we're mid-transfer" scenario.
+        let responderTask = Task.detached {
+            for try await frame in guest.incoming {
+                guard case .clipboardRequest(let req) = frame.payload, req.transferID == xid
+                else { continue }
+                try guest.sendErrorFrame(
+                    code: "clipboard.interleaved", message: "control frame mid-pull",
+                    inReplyTo: "clipboard.request")
+                var begin = Frame()
+                begin.protocolVersion = 1
+                begin.clipboardStreamBegin = Kernova_V1_ClipboardStreamBegin.with {
+                    $0.generation = req.generation
+                    $0.transferID = req.transferID
+                    $0.uti = req.uti
+                    $0.totalBytes = UInt64(payload.count)
+                    $0.filename = "f.bin"
+                    $0.isInline = false
+                }
+                try guest.send(begin)
+                // Inlined rather than calling the suite's `sendChunkAndEnd` helper:
+                // that helper is `@MainActor`-isolated (an instance method on this
+                // struct), and this closure must stay genuinely off-actor.
+                var chunkFrame = Frame()
+                chunkFrame.protocolVersion = 1
+                chunkFrame.clipboardChunk = Kernova_V1_ClipboardChunk.with {
+                    $0.transferID = req.transferID
+                    $0.offset = 0
+                    $0.data = payload
+                }
+                try guest.send(chunkFrame)
+                var endFrame = Frame()
+                endFrame.protocolVersion = 1
+                endFrame.clipboardStreamEnd = Kernova_V1_ClipboardStreamEnd.with {
+                    $0.transferID = req.transferID
+                    $0.totalBytes = UInt64(payload.count)
+                    $0.sha256 = Data(SHA256.hash(data: payload))
+                }
+                try guest.send(endFrame)
+                return
+            }
+        }
+        defer { responderTask.cancel() }
+
+        // The toggle-off paste `provide` callback calls this directly on main — a
+        // real synchronous block of the main thread, exactly like production.
+        // Under the old `await onControlFrame` code this would hang until the
+        // lazyPullTimeout backstop fired and resolved to `.pullFailed`: the
+        // interleaved control frame suspends the whole consume loop on the
+        // unavailable main actor, so the Begin/Chunk/End behind it in the channel
+        // never route and the pull's semaphore never signals. Under the fix, the
+        // consume loop dispatches the control frame fire-and-forget and keeps
+        // draining — Begin/Chunk/End route immediately regardless of main being
+        // blocked — so this resolves promptly.
+        let outcome = service.pullStagedFile(generation: 30, repIndex: 0)
+        guard case .success(let path) = outcome else {
+            Issue.record("Expected pullStagedFile to succeed, got \(outcome)")
+            return
+        }
+        #expect(try Data(contentsOf: URL(fileURLWithPath: path)) == payload)
+
+        // The interleaved control frame wasn't dropped — it's processed
+        // fire-and-forget, so it surfaces once main frees up.
+        try await waitForChange { service.lastTransferIssue != nil }
+        if case .peerReportedError(let code, _) = service.lastTransferIssue?.kind {
+            #expect(code == "clipboard.interleaved")
+        } else {
+            Issue.record("Expected the interleaved control frame's error to surface")
+        }
+    }
+
     @Test("A newer offer supersedes an in-flight pull — the pull resolves to nothing, new placeholders publish")
     func newerOfferSupersedesInFlightPull() async throws {
         let (guest, host) = try makePair()
@@ -2213,6 +2320,18 @@ struct VsockClipboardServiceTests {
         let info = try #require(offer.repInfo.first)
         let xid = transferID(generation: offer.generation, repIndex: 0)
         try guest.send(makeRequest(generation: offer.generation, repIndex: 0, uti: info.uti))
+
+        // Wait for Begin before acking: handleRequest (a control frame, now
+        // dispatched fire-and-forget per #458) registers the transfer with the
+        // sender — an ack sent before that registration lands would be for a
+        // transfer_id the sender doesn't know yet. A real guest can't ack before
+        // it, either — Begin is what startTransfer sends, so there's nothing to
+        // ack until it arrives.
+        let beginFrame = try await nextFrame(from: guest)
+        guard case .clipboardStreamBegin = beginFrame.payload else {
+            Issue.record("Expected clipboardStreamBegin, got \(String(describing: beginFrame.payload))")
+            return
+        }
 
         // First ack: a one-chunk window → the host sends a single 64 KiB chunk
         // then blocks on credit, so progress shows but the transfer isn't done.


### PR DESCRIPTION
## Summary
- Fixes #458: the host's vsock clipboard consume loop suspended ALL stream-frame routing whenever it awaited a control frame's main-actor hop, so a control frame arriving while main was synchronously blocked in the toggle-off paste's `performBlockingPull` stalled the very Begin/Chunk/End frames that pull needed to resolve, failing the paste once the backstop timeout fired.
- `VsockClipboardService.consume` now dispatches control frames to the main actor fire-and-forget via a serial `DispatchQueue.main.async` instead of `await`ing them, mirroring the guest's existing #357 pattern (`VsockGuestClipboardAgent.serve`). The serial queue preserves control-frame FIFO order; the loop no longer suspends on the hop.

Closes #458

## Changes
- `Kernova/Services/VsockClipboardService.swift`: fire-and-forget control-frame dispatch in `consume`; updated doc comments on `consume`, `handleControlFrame`, and `pullStagedFile` to state the corrected invariant.
- `KernovaTests/VsockClipboardServiceTests.swift`:
  - New regression test reproducing the exact interleaving (a control frame landing while `pullStagedFile` blocks main).
  - Fixed a latent ordering assumption in `outboundTransferProgressSetThenCleared` that the fix legitimately exposed: it sent a stream Ack before waiting for the Begin frame, relying on the old synchronous-await ordering guarantee rather than realistic peer behavior (a real guest can't Ack before Begin is sent).

## Test plan
- [x] `make lint` clean
- [x] Full `make test` suite passes
- [x] `VsockClipboardServiceTests` (89 tests) passes reliably across multiple repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oRgkfhq6pKtPHY5rjS91a