### PR TITLE
fix: Bound AppPreferencesTests' leaked preference plist to a single file

### DIFF
--- a/KernovaTests/AppPreferencesTests.swift
+++ b/KernovaTests/AppPreferencesTests.swift
@@ -2,17 +2,37 @@ import Testing
 import Foundation
 @testable import Kernova
 
-@Suite("AppPreferences")
+// A fixed suite name (rather than a fresh UUID per call) bounds the on-disk
+// footprint to a single tombstone plist regardless of how many times the
+// suite runs; `.serialized` below keeps the two tests from racing over that
+// shared domain. See #449.
+@Suite("AppPreferences", .serialized)
 struct AppPreferencesTests {
-    /// Runs `body` with a fresh `AppPreferences` over an isolated, ephemeral
-    /// defaults suite, then tears the suite down so tests never touch the real
+    private static let suiteName = "test.kernova.appprefs"
+
+    /// Runs `body` with a fresh `AppPreferences` over an isolated defaults
+    /// suite, then tears the suite down so tests never touch the real
     /// `.standard` domain, each other's state, or leak a persisted plist.
     private func withEphemeralPreferences(
         _ body: (AppPreferences, UserDefaults) throws -> Void
     ) throws {
-        let suiteName = "test.kernova.appprefs.\(UUID().uuidString)"
+        let suiteName = Self.suiteName
         let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        // Clear before use, not just after: a prior run hard-killed mid-test
+        // (CI timeout, SIGKILL, Xcode stop) skips the `defer` below and can
+        // leave a stale value on disk under this fixed name (#449).
+        defaults.removePersistentDomain(forName: suiteName)
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+            // cfprefsd leaves an empty tombstone plist behind even after
+            // removePersistentDomain empties the in-memory domain; delete it
+            // so repeated test runs don't accumulate files (#449).
+            if let plistURL = FileManager.default.urls(
+                for: .libraryDirectory, in: .userDomainMask
+            ).first?.appending(path: "Preferences/\(suiteName).plist") {
+                try? FileManager.default.removeItem(at: plistURL)
+            }
+        }
         try body(AppPreferences(defaults: defaults), defaults)
     }
 


### PR DESCRIPTION
## Summary
- `withEphemeralPreferences` minted a fresh UUID suite name per test invocation, so every test run left behind a new empty tombstone plist in `~/Library/Preferences` (215 accumulated between 2026-06-08 and 2026-07-02) and cluttered `defaults domains` output

## Changes
- Use a single fixed suite name instead of a per-call UUID, bounding the on-disk footprint to one known file
- Mark the suite `.serialized` since both tests now share one domain
- Delete the suite's plist file in teardown, after `removePersistentDomain`, for a normal-case zero-leftover result
- Clear the domain before the test body runs too (not just after), so a stale value left behind by a hard-killed prior run (CI timeout, SIGKILL, Xcode stop) can't leak into the next run's assertions — caught during a code-review pass on the initial fix

## Test plan
- [x] `make test-suite SUITE=KernovaTests/AppPreferencesTests` passes, repeated runs don't grow the leaked-file count
- [x] Simulated a stale prior-run value via `defaults write` and confirmed `defaultsToFalse()` still passes
- [x] `make test` (full suite) passes
- [x] `make lint` clean

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163a16rhMVyyCt5T8gdJ2YU