### PR TITLE
fix: Arm NSFileProviderDomainDidChange eagerly at enable time (#448)

### DIFF
--- a/KernovaKit/Sources/KernovaKit/FileProviderDomainHost.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderDomainHost.swift
@@ -234,8 +234,9 @@ public final class FileProviderDomainHost: NSObject, FileProviderPublishing,
             // invalidation, so this runs on every enable — no outer latch, which
             // would defeat the connector's "re-arm on next enable" recovery.
             relayTransport.startServing(relayService)
-            registerDomain()
             startObservingDomainChanges()
+            primeDomainChangeNotifications()
+            registerDomain()
         } else {
             stopObservingDomainChanges()
             setAvailability(.inactive)
@@ -417,6 +418,19 @@ public final class FileProviderDomainHost: NSObject, FileProviderPublishing,
                 self.setAvailability(availability)
             }
         }
+    }
+
+    /// Fires one throwaway `domains()` read so `NSFileProviderDomainDidChange`
+    /// starts posting. Per Apple's header comment on that notification, it only
+    /// goes live after the process's first `NSFileProviderManager.domains()`
+    /// call completes; `refreshAvailability()`'s first call is gated on
+    /// `addDomain` succeeding, which is async and can fail, leaving a window at
+    /// enable where a System-Settings toggle flip wouldn't be observed. This
+    /// primes delivery immediately and independent of registration outcome. The
+    /// result is intentionally discarded — availability stays driven solely by
+    /// `addDomain`'s outcome and subsequent notification-triggered refreshes.
+    private func primeDomainChangeNotifications() {
+        Task { [fetchDomains] in _ = try? await fetchDomains() }
     }
 
     /// Maps the system's domain registry to availability: a matching domain with

--- a/KernovaKit/Sources/KernovaKit/FileProviderDomainHost.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderDomainHost.swift
@@ -123,6 +123,12 @@ public final class FileProviderDomainHost: NSObject, FileProviderPublishing,
 
     private var enabled = false
     private var domainRegistered = false
+    /// Set once `primeDomainChangeNotifications()` has fired. The underlying
+    /// `NSFileProviderDomainDidChange` notification only needs the process's
+    /// first-ever `domains()` call to go live, so repeat enables (e.g. a policy
+    /// off→on toggle, or a VM stop/start cycling `HostClipboardFileProvider`'s
+    /// `activeServiceCount`) skip the redundant IPC round-trip.
+    private var domainChangeNotificationsPrimed = false
     /// User-visible domain root, resolved after registration; `nil` until then
     /// (the File Provider path is unused while it's `nil`).
     private var rootURL: URL?
@@ -429,8 +435,22 @@ public final class FileProviderDomainHost: NSObject, FileProviderPublishing,
     /// primes delivery immediately and independent of registration outcome. The
     /// result is intentionally discarded — availability stays driven solely by
     /// `addDomain`'s outcome and subsequent notification-triggered refreshes.
+    ///
+    /// Only needs to run once per process (the notification, once armed, stays
+    /// armed) — `domainChangeNotificationsPrimed` skips the IPC round-trip on
+    /// every subsequent enable.
     private func primeDomainChangeNotifications() {
-        Task { [fetchDomains] in _ = try? await fetchDomains() }
+        guard !domainChangeNotificationsPrimed else { return }
+        domainChangeNotificationsPrimed = true
+        Task { [weak self, fetchDomains] in
+            do {
+                _ = try await fetchDomains()
+            } catch {
+                self?.logger.warning(
+                    "Priming domains() read failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
     }
 
     /// Maps the system's domain registry to availability: a matching domain with

--- a/KernovaKit/Tests/KernovaKitTests/FileProviderDomainHostTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/FileProviderDomainHostTests.swift
@@ -60,6 +60,13 @@ struct FileProviderDomainHostAvailabilityTests {
 /// injected `notificationCenter` re-probes availability through the injected
 /// `fetchDomains`, and a post while never enabled is a no-op.
 ///
+/// `setEnabled(true)` also fires a throwaway, discarded `fetchDomains` read via
+/// `primeDomainChangeNotifications()` (issue #448) to arm the real
+/// `NSFileProviderDomainDidChange` notification immediately rather than waiting
+/// on registration to succeed — so `domainSource.callCount` is no longer
+/// guaranteed zero right after enable. Tests below that care about call count
+/// use relative deltas or gate on a specific count rather than asserting zero.
+///
 /// `setEnabled(true)` also runs the *real*, non-stubbable `registerDomain()` →
 /// `NSFileProviderManager.add(domain)` — there is no injected seam for domain
 /// registration itself (see the type's doc comment on why: it's shared,
@@ -76,11 +83,13 @@ struct FileProviderDomainHostEnablementTests {
 
     /// Stands in for `NSFileProviderManager.domains()`, returning (or throwing)
     /// whatever a test last configured and counting invocations so a test can
-    /// tell a probe actually ran.
+    /// tell a probe actually ran. `gate` fires on every `fetch()` call so a test
+    /// can wait for a specific call count without polling.
     private final class FakeDomainSource: @unchecked Sendable {
         private let lock = NSLock()
         private var result: Result<[NSFileProviderDomain], Error> = .success([])
         private var callCountStorage = 0
+        let gate = AsyncGate()
 
         var callCount: Int { lock.withLock { callCountStorage } }
 
@@ -93,6 +102,7 @@ struct FileProviderDomainHostEnablementTests {
                 callCountStorage += 1
                 return result
             }
+            gate.notify()
             return try outcome.get()
         }
     }
@@ -256,7 +266,9 @@ struct FileProviderDomainHostEnablementTests {
         #expect(host.availability == .inactive)
     }
 
-    @Test("addDomain's registration failure reports .unavailable directly, without consulting fetchDomains")
+    @Test(
+        "addDomain's registration failure reports .unavailable directly, without routing through the fetchDomains-driven mapping"
+    )
     func registrationFailureReportsUnavailable() async throws {
         // Validates the `addDomain` failure branch's `self.setAvailability(.unavailable)`
         // consistency fix (previously a direct `self.availabilityStorage = .unavailable`
@@ -267,11 +279,25 @@ struct FileProviderDomainHostEnablementTests {
         // which is what this test process is. If that ever stops being true (e.g. a
         // future test host where registration spuriously succeeds), this test would
         // need a real seam for `addDomain` to stay meaningful.
+        //
+        // `setEnabled(true)` also fires the discarded, throwaway priming
+        // `fetchDomains` read (see the suite doc comment / issue #448), so
+        // `domainSource.callCount == 0` no longer holds. Stage a *matching* domain
+        // instead — one that would map to `.ready`/`.needsEnabling` if it were ever
+        // consulted — and assert neither of those values is ever observed. Since
+        // the priming read's result is always discarded, the only way either value
+        // could appear is if the failure branch routed through the fetch-driven
+        // mapping helper instead of writing `.unavailable` directly.
+        let domainIdentifierString = "kernova-clipboard-test-\(UUID().uuidString)"
         let domainSource = FakeDomainSource()
+        let matching = NSFileProviderDomain(
+            identifier: NSFileProviderDomainIdentifier(domainIdentifierString),
+            displayName: "Test")
+        domainSource.setResult(.success([matching]))
         let collector = AvailabilityCollector()
         let center = NotificationCenter()
         let host = makeHost(
-            domainIdentifier: "kernova-clipboard-test-\(UUID().uuidString)",
+            domainIdentifier: domainIdentifierString,
             domainSource: domainSource, notificationCenter: center)
         host.setAvailabilityObserver { collector.record($0) }
 
@@ -281,8 +307,31 @@ struct FileProviderDomainHostEnablementTests {
             collector.values.contains(.unavailable)
         }
         #expect(
-            domainSource.callCount == 0,
-            "the addDomain failure branch writes .unavailable directly — it must not consult fetchDomains")
+            !collector.values.contains(.ready) && !collector.values.contains(.needsEnabling),
+            "the addDomain failure branch must write .unavailable directly — a .ready/.needsEnabling here would mean it consulted the discarded priming read's result"
+        )
+    }
+
+    @Test(
+        "enabling arms NSFileProviderDomainDidChange delivery via an eager, throwaway fetchDomains read, independent of registration outcome"
+    )
+    func enableEagerlyPrimesDomainNotifications() async throws {
+        // The real `NSFileProviderManager.add(domain)` call in this test process
+        // never succeeds (see the suite doc comment), so if the priming read were
+        // gated on registration succeeding — as `refreshAvailability()` normally
+        // is, via `addDomain`'s success completion — `domainSource` would never be
+        // consulted here. Proves `primeDomainChangeNotifications()` runs
+        // unconditionally at enable, arming the notification without waiting on
+        // (or being blocked by) registration (issue #448).
+        let domainSource = FakeDomainSource()
+        let center = NotificationCenter()
+        let host = makeHost(
+            domainIdentifier: "kernova-clipboard-test-\(UUID().uuidString)",
+            domainSource: domainSource, notificationCenter: center)
+
+        host.setEnabled(true)
+
+        try await domainSource.gate.wait(timeout: .seconds(20)) { domainSource.callCount >= 1 }
     }
 
     @Test("disabling stops observing the domain-change notification; a later post is a no-op")

--- a/KernovaKit/Tests/KernovaKitTests/FileProviderDomainHostTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/FileProviderDomainHostTests.swift
@@ -64,8 +64,11 @@ struct FileProviderDomainHostAvailabilityTests {
 /// `primeDomainChangeNotifications()` (issue #448) to arm the real
 /// `NSFileProviderDomainDidChange` notification immediately rather than waiting
 /// on registration to succeed — so `domainSource.callCount` is no longer
-/// guaranteed zero right after enable. Tests below that care about call count
-/// use relative deltas or gate on a specific count rather than asserting zero.
+/// guaranteed zero right after enable. That read is gated to fire at most once
+/// per host instance (the notification, once armed, stays armed), so a single
+/// enable in a fresh test host contributes exactly one extra call. Tests below
+/// that care about call count use relative deltas, gate on a specific count, or
+/// (for the one-enable-per-test common case) pin the exact expected count.
 ///
 /// `setEnabled(true)` also runs the *real*, non-stubbable `registerDomain()` →
 /// `NSFileProviderManager.add(domain)` — there is no injected seam for domain
@@ -281,13 +284,14 @@ struct FileProviderDomainHostEnablementTests {
         // need a real seam for `addDomain` to stay meaningful.
         //
         // `setEnabled(true)` also fires the discarded, throwaway priming
-        // `fetchDomains` read (see the suite doc comment / issue #448), so
-        // `domainSource.callCount == 0` no longer holds. Stage a *matching* domain
-        // instead — one that would map to `.ready`/`.needsEnabling` if it were ever
-        // consulted — and assert neither of those values is ever observed. Since
-        // the priming read's result is always discarded, the only way either value
-        // could appear is if the failure branch routed through the fetch-driven
-        // mapping helper instead of writing `.unavailable` directly.
+        // `fetchDomains` read exactly once (see the suite doc comment / issue
+        // #448), so `domainSource.callCount == 0` no longer holds. Stage a
+        // *matching* domain instead — one that would map to
+        // `.ready`/`.needsEnabling` if it were ever consulted — and assert it's
+        // never observed, while pinning `callCount == 1` to prove the priming
+        // read is the *only* call: an exact count (not just "not zero") still
+        // catches a future failure-branch edit that added its own extra,
+        // similarly-discarded `fetchDomains` call.
         let domainIdentifierString = "kernova-clipboard-test-\(UUID().uuidString)"
         let domainSource = FakeDomainSource()
         let matching = NSFileProviderDomain(
@@ -306,9 +310,17 @@ struct FileProviderDomainHostEnablementTests {
         try await collector.gate.wait(timeout: .seconds(20)) {
             collector.values.contains(.unavailable)
         }
+        // The priming read is dispatched from an independent `Task`, so it can
+        // still be in flight when `.unavailable` lands — wait for it too before
+        // pinning the exact count.
+        try await domainSource.gate.wait(timeout: .seconds(20)) { domainSource.callCount >= 1 }
         #expect(
             !collector.values.contains(.ready) && !collector.values.contains(.needsEnabling),
             "the addDomain failure branch must write .unavailable directly — a .ready/.needsEnabling here would mean it consulted the discarded priming read's result"
+        )
+        #expect(
+            domainSource.callCount == 1,
+            "only the priming read should ever call fetchDomains here — the addDomain failure branch must not consult it too"
         )
     }
 


### PR DESCRIPTION
## Summary
- Close a narrow window where a System-Settings File-Provider toggle flip would be missed by the event-driven availability refresh added in #447
- Per Apple's own header comment, `NSFileProviderDomainDidChange` only begins posting after the process's first `NSFileProviderManager.domains()` call completes. In `FileProviderDomainHost`, that first call previously only happened lazily, inside `addDomain`'s async **success** completion — leaving a window between `setEnabled(true)` returning and registration completing where the notification wasn't actually live yet

## Changes
- Add `FileProviderDomainHost.primeDomainChangeNotifications()`, which fires one throwaway, discarded `fetchDomains()` read at enable time so the notification starts posting immediately, independent of registration outcome
- Reorder `applyEnabledOnMain`'s enable branch so the observer is installed before the priming read, and the priming read runs unconditionally rather than being gated on `registerDomain()`'s async outcome
- Re-scope `FileProviderDomainHostTests.registrationFailureReportsUnavailable` to stage a matching domain and assert neither `.ready` nor `.needsEnabling` is ever observed (proving the registration-failure branch still writes `.unavailable` directly, not through the fetch-driven mapping), since `domainSource.callCount == 0` no longer holds now that the priming read runs unconditionally
- Add `enableEagerlyPrimesDomainNotifications` to cover the new behavior, and give `FakeDomainSource` an `AsyncGate` for event-driven waits

## Test plan
- [x] `make test-package` (KernovaKit package suite, 230 tests, all pass)
- [x] `make test` (full `Kernova.xctestplan`, all three targets, pass)
- [x] `make lint`

Closes #448

Co-Authored-By: Claude <noreply@anthropic.com>