### PR TITLE
fix: Cover Kernova Guest Agent.app in the ExitWorktree LaunchServices cleanup hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r 'select(.tool_input.action == \"remove\") | .cwd // empty' | { read -r wt; [ -n \"$wt\" ] && /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -u \"$wt/DerivedData/Build/Products/Debug/Kernova.app\"; } 2>/dev/null || true",
+            "command": "jq -r 'select(.tool_input.action == \"remove\") | .cwd // empty' | { read -r wt; [ -n \"$wt\" ] && { LSREG=/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister; p=\"$wt/DerivedData/Kernova/Build/Products\"; for app in \"Kernova.app\" \"Kernova Guest Agent.app\"; do for cfg in Debug Release; do \"$LSREG\" -u \"$p/$cfg/$app\"; done; done; }; } 2>/dev/null || true",
             "timeout": 15,
             "statusMessage": "Unregistering worktree build from LaunchServices"
           }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,6 +340,37 @@ ref in the refspec. A PR's head branch must always be the clean
 exists does not retarget the PR — it closes it — so name it correctly at first
 push.)
 
+### Worktree LaunchServices cleanup
+
+Every worktree build registers its app bundles with LaunchServices; when the
+worktree is removed those registrations become ghosts — stale entries that
+accumulate and have previously hijacked UTI and name resolution. A
+`PreToolUse`/`ExitWorktree` hook in `.claude/settings.json` prevents this: on
+`ExitWorktree(action: "remove")` (which runs `git worktree remove`) it runs
+`lsregister -u` on the worktree's built apps. It fires `PreToolUse` so the
+bundles still exist on disk — `lsregister` must read a bundle to unregister it —
+and it is scoped to the one removed worktree via the tool's `.cwd`.
+
+It unregisters both top-level apps, `Kernova.app` and `Kernova Guest Agent.app`
+(#450), across Debug and Release. Products live at the **nested**
+`DerivedData/Kernova/Build/Products/<config>/` path — Xcode "Relative" mode and
+`-derivedDataPath DerivedData/Kernova` both nest a per-project subfolder (see
+[Build & Test](#build--test)) — not the flat `DerivedData/Build/Products/`. The
+embedded appexes (`KernovaFileProvider`, `KernovaQuickLook`,
+`KernovaMacOSAgentFileProvider`) need no separate handling: unregistering a
+parent `.app` cascades to its plugin registrations (verified — a plain
+`lsregister -u` on the app alone clears all three appex entries; the `-R` flag
+governs recursive *scanning*, not unregister cascade).
+
+Two cases stay uncovered by design: a human running `git worktree remove`
+directly triggers nothing (it is not a harness tool call, and git has **no**
+worktree-lifecycle hook — `man githooks` confirms), and Xcode-side hashed
+DerivedData lands outside `.cwd`. Both leave ghosts that only accumulate; clear
+the backlog on demand with a one-time database rebuild — `lsregister -kill -r
+-domain local -domain system -domain user` (the binary is not on `PATH`; it
+lives under `…/CoreServices.framework/…/LaunchServices.framework/…/Support/
+lsregister`).
+
 ### Commit Messages
 
 These conventions apply to **all** forms of committing: local commits, PR squash/merge commits, and any other git operations that produce commits.


### PR DESCRIPTION
## Summary
- On worktree removal, unregister both `Kernova.app` and `Kernova Guest Agent.app` from LaunchServices, not just the app
- Also fixes a deeper latent bug found while re-verifying the issue: the hook targeted a stale flat `DerivedData` path that no current build produces, so it was silently a no-op for either app under today's layout

## Changes
- `.claude/settings.json`: `ExitWorktree` hook now loops `lsregister -u` over both top-level apps across Debug and Release, at the corrected nested `DerivedData/Kernova/Build/Products/<config>/` path
- `CLAUDE.md`: new "Worktree LaunchServices cleanup" subsection documenting the hook (what/why, the nested-path gotcha, verified appex cascade behavior, and the manual `git worktree remove` / Xcode-hashed-DerivedData cases that stay uncovered by design)

## Test plan
- [x] Built Debug (`make build`) and confirmed both apps + all 3 embedded appexes register in LaunchServices
- [x] Ran `lsregister -u` on just the two `.app` paths and confirmed all 3 embedded appexes (`KernovaFileProvider`, `KernovaQuickLook`, `KernovaMacOSAgentFileProvider`) unregister too, cascading from the parent app — no explicit appex handling needed
- [x] Validated the hook's exact `jq`/shell command against `remove`, non-`remove`, and empty-`cwd` payloads
- [ ] Full end-to-end via a live `ExitWorktree(remove)` — not run (optional, harness plumbing is unchanged by this fix)

## Notes
- Existing ghost registrations from already-deleted worktrees (~85 guest-agent, 56+ appex, accumulated because the hook was already broken for the current path layout) are not cleared by this PR — only future accumulation is prevented. Clearing the backlog is a one-time `lsregister -kill -r` rebuild, left as a follow-up on request rather than bundled here.

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)