### PR TITLE
fix: Wire --remove-clipboard-domain in the host app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ CLAUDE.local.md
 *.pem
 *.p12
 *.key
+*.profraw

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -212,6 +212,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     // MARK: - Entry Point
 
     static func main() {
+        // Teardown helper (#467) — removes the host clipboard File Provider domain
+        // so no Finder location lingers (e.g. a ghost domain left by a deleted
+        // build). Handled before any NSApplication setup so it works headless.
+        if CommandLine.arguments.contains("--remove-clipboard-domain") {
+            FileProviderDomainHost.removeAllDomainsBlocking()
+            exit(0)
+        }
+
         let isTestHost = ProcessInfo.processInfo.isRunningXCTests
         let app = NSApplication.shared
 

--- a/KernovaKit/Sources/KernovaKit/FileProviderDomainHost.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderDomainHost.swift
@@ -732,9 +732,10 @@ public final class FileProviderDomainHost: NSObject, FileProviderPublishing,
         }
     }
 
-    /// Removes this app's File Provider domains, blocking until done — for the
-    /// `--remove-clipboard-domain` teardown flag so host-side iteration leaves no
-    /// lingering Finder location behind.
+    /// Removes this app's File Provider domains, blocking until done — backs the
+    /// `--remove-clipboard-domain` teardown flag wired by both the host app
+    /// (`AppDelegate.main()`) and the guest agent (`AgentAppDelegate.main()`), so
+    /// dev/test iteration on either side leaves no lingering Finder location behind.
     public static func removeAllDomainsBlocking() {
         let semaphore = DispatchSemaphore(value: 0)
         NSFileProviderManager.removeAllDomains { error in

--- a/KernovaMacOSAgent/AgentAppDelegate.swift
+++ b/KernovaMacOSAgent/AgentAppDelegate.swift
@@ -80,8 +80,9 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
             exit(0)
         }
 
-        // Teardown helper for host-side iteration (#376) — removes the clipboard
-        // File Provider domain so no Finder location lingers after a test.
+        // Dev/test teardown helper (#376) — removes the guest clipboard File
+        // Provider domain so no Finder location lingers after a test. The host app
+        // wires the same flag for its own domain (#467).
         if CommandLine.arguments.contains("--remove-clipboard-domain") {
             FileProviderDomainHost.removeAllDomainsBlocking()
             exit(0)


### PR DESCRIPTION
## Summary
- Implements the host-side `--remove-clipboard-domain` teardown flag that the `removeAllDomainsBlocking()` doc comment promised but the host app never wired, so both ends — host app and guest agent — can remove their clipboard File Provider domain from the command line.
- Re-tested the empirical blocker recorded in #467 (`NSFileProviderErrorDomain -2001`, underlying `-2014`, when calling `removeAllDomains` from a shell-exec'd build): it **no longer reproduces** after the signing/provisioning cleanup (#471/#472/#479/#484). A fresh worktree Debug build exec'd directly from a shell removed the live domain cleanly:

  ```
  $ DerivedData/Kernova/Build/Products/Debug/Kernova.app/Contents/MacOS/Kernova --remove-clipboard-domain
  Removed all Kernova File Provider domains
  ```

  `~/Library/CloudStorage/Kernova-KernovaClipboard(Mac)` disappeared and the running File Provider appex terminated; a subsequent normal launch with a VM clipboard service running re-added the domain.

Closes #467

## Changes
- `AppDelegate.main()` (host): handle `--remove-clipboard-domain` before any `NSApplication` setup, mirroring the guest agent's early-flag pattern; ungated, matching the agent.
- `FileProviderDomainHost.removeAllDomainsBlocking()` doc comment: names both callers instead of the ambiguous "host-side iteration" phrasing.
- `AgentAppDelegate.main()` comment: reworded the same way.
- `.gitignore`: ignore `*.profraw` coverage droppings from local test runs.

## Test plan
- [x] Live end-to-end run of the new flag (above): domain removed, CloudStorage entry gone, appex terminated, `-2001` absent
- [x] Domain re-adds on a normal app launch once a VM clipboard service starts
- [x] `make lint` clean
- [x] `make test` — 1569 tests passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r3HGmRSRYu8uwtw6MJyTN