### PR TITLE
feat: Log connecting owner's identity at the File Provider servicing accept point

### DIFF
--- a/KernovaKit/Sources/KernovaKit/FileProviderServiceSource.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderServiceSource.swift
@@ -1,3 +1,4 @@
+import Darwin
 import FileProvider
 import Foundation
 import os
@@ -163,8 +164,18 @@ final class FileProviderServiceSource: NSObject, NSFileProviderServiceSource,
         // Its invalidation handler no-ops (it only clears when still current, and we
         // just replaced it).
         previous?.invalidate()
-        logger.debug(
-            "Accepted owner servicing connection (draining \(drained.count, privacy: .public) pending)")
+        // Identity signal at the XPC choke point (#518): the peer pin above checks
+        // only bundle identifier + team, so a version-mismatched owner (an old
+        // resident copy still answering after a new one was installed) would
+        // otherwise be accepted with no clue in this process's log as to which
+        // copy connected — diagnosable only by correlating logs across
+        // processes. `.notice` (not `.debug`) so the line actually persists for
+        // that post-mortem — accepts are infrequent (one per owner connect), so
+        // persisting them is cheap. Mirrors `AppDelegate.residentProvenanceLine`
+        // (#519), the complementary owner-side startup provenance line.
+        logger.notice(
+            "\(Self.acceptedOwnerLogLine(pid: newConnection.processIdentifier, executablePath: Self.executablePath(forPID: newConnection.processIdentifier), pendingCount: drained.count), privacy: .public)"
+        )
         for pull in drained {
             // Each drained pull's connect timer (if armed) fires later and no-ops —
             // the removal from `pendingPulls` above already claimed the pull.
@@ -177,6 +188,30 @@ final class FileProviderServiceSource: NSObject, NSFileProviderServiceSource,
     /// connection may already have replaced it).
     private func clearConnection(_ connection: NSXPCConnection) {
         lock.withLock { if acceptedConnection === connection { acceptedConnection = nil } }
+    }
+
+    /// Formats the accept-time owner-identity log line — pure and testable
+    /// without standing up an XPC round trip, mirroring
+    /// `AppDelegate.residentProvenanceLine` (#519).
+    static func acceptedOwnerLogLine(pid: pid_t, executablePath: String?, pendingCount: Int) -> String {
+        "Accepted owner servicing connection (pid=\(pid) executable=\(executablePath ?? "unknown") draining \(pendingCount) pending)"
+    }
+
+    /// Best-effort resolution of a process's executable path via `proc_pidpath`.
+    ///
+    /// `nil` on failure (e.g. the peer exited between accept and this call) —
+    /// callers fall back to logging just the PID rather than treating this as
+    /// fatal. Deliberately not `NSRunningApplication`, which pulls AppKit into
+    /// this file — shared `KernovaKit` code compiled into both the host and
+    /// guest File Provider *extension* binaries, neither an AppKit app.
+    private static func executablePath(forPID pid: pid_t) -> String? {
+        // `PROC_PIDPATHINFO_MAXSIZE` itself is unavailable on this SDK
+        // ("structure not supported"); its definition (4 * MAXPATHLEN) is not,
+        // so compute the same bound directly.
+        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN) * 4)
+        let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+        guard length > 0 else { return nil }
+        return String(cString: buffer)
     }
 
     // MARK: - FileProviderControl (activation handshake)

--- a/KernovaKit/Sources/KernovaKit/FileProviderServiceSource.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderServiceSource.swift
@@ -200,11 +200,16 @@ final class FileProviderServiceSource: NSObject, NSFileProviderServiceSource,
 
     /// Best-effort resolution of a process's executable path via `proc_pidpath`.
     ///
-    /// `nil` on failure (e.g. the peer exited between accept and this call) —
-    /// callers fall back to logging just the PID rather than treating this as
-    /// fatal. Deliberately not `NSRunningApplication`, which pulls AppKit into
-    /// this file — shared `KernovaKit` code compiled into both the host and
-    /// guest File Provider *extension* binaries, neither an AppKit app.
+    /// `nil` on failure (e.g. the peer exited between accept and this call, or
+    /// the App Sandbox denies resolving a non-self PID — both extension
+    /// targets this file compiles into carry `com.apple.security.app-sandbox`,
+    /// and Apple's sandbox profile may scope `proc_pidpath` to the caller's own
+    /// PID). Either way this is best-effort: callers fall back to logging just
+    /// the PID — the primary, always-available identity signal — rather than
+    /// treating an unresolved path as fatal. Deliberately not
+    /// `NSRunningApplication`, which pulls AppKit into this file — shared
+    /// `KernovaKit` code compiled into both the host and guest File Provider
+    /// *extension* binaries, neither an AppKit app.
     private static func executablePath(forPID pid: pid_t) -> String? {
         // `PROC_PIDPATHINFO_MAXSIZE` itself is unavailable on this SDK
         // ("structure not supported"); its definition (4 * MAXPATHLEN) is not,

--- a/KernovaKit/Sources/KernovaKit/FileProviderServiceSource.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderServiceSource.swift
@@ -173,8 +173,9 @@ final class FileProviderServiceSource: NSObject, NSFileProviderServiceSource,
         // that post-mortem — accepts are infrequent (one per owner connect), so
         // persisting them is cheap. Mirrors `AppDelegate.residentProvenanceLine`
         // (#519), the complementary owner-side startup provenance line.
+        let peerPID = newConnection.processIdentifier
         logger.notice(
-            "\(Self.acceptedOwnerLogLine(pid: newConnection.processIdentifier, executablePath: Self.executablePath(forPID: newConnection.processIdentifier), pendingCount: drained.count), privacy: .public)"
+            "\(Self.acceptedOwnerLogLine(pid: peerPID, executablePath: Self.executablePath(forPID: peerPID), pendingCount: drained.count), privacy: .public)"
         )
         for pull in drained {
             // Each drained pull's connect timer (if armed) fires later and no-ops —

--- a/KernovaKit/Tests/KernovaKitTests/FileProviderServiceSourceTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/FileProviderServiceSourceTests.swift
@@ -312,4 +312,29 @@ struct FileProviderServiceSourceTests {
         cancellation.cancel()
         #expect(relay.cancelCall == nil)
     }
+
+    // MARK: - Accept-time owner-identity log line (#518)
+
+    /// The pure formatter behind the accept-time `.notice` log line.
+    ///
+    /// Mirrors `AppDelegate.residentProvenanceLine` (#519), the complementary
+    /// owner-side startup provenance line. Formatting only; resolving the
+    /// peer's actual PID/executable path via `proc_pidpath` isn't exercised here.
+    @Test("formats pid, resolved executable path, and pending count into one line")
+    func acceptedOwnerLogLineFormatsAllFields() {
+        #expect(
+            FileProviderServiceSource.acceptedOwnerLogLine(
+                pid: 4242, executablePath: "/Applications/Kernova.app/Contents/MacOS/Kernova",
+                pendingCount: 3)
+                == "Accepted owner servicing connection (pid=4242 executable=/Applications/Kernova.app/Contents/MacOS/Kernova draining 3 pending)"
+        )
+    }
+
+    @Test("falls back to 'unknown' when the executable path can't be resolved")
+    func acceptedOwnerLogLineToleratesUnresolvedPath() {
+        #expect(
+            FileProviderServiceSource.acceptedOwnerLogLine(pid: 99, executablePath: nil, pendingCount: 0)
+                == "Accepted owner servicing connection (pid=99 executable=unknown draining 0 pending)"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
Closes #518.

`FileProviderServiceSource.listener(_:shouldAcceptNewConnection:)` (shared `KernovaKit`, compiled into both `KernovaFileProvider` and `KernovaMacOSAgentFileProvider`) accepted the owner's servicing connection but logged only a pending-drain count — no identity of which copy connected. The peer pin checks only bundle identifier + team, so a version-mismatched owner (an old resident app/agent copy still answering after a new one was installed) was silently accepted with zero identity signal, making a wrong-copy `fetchFile` interaction diagnosable only by correlating logs across processes.

This adds the connecting owner's PID and resolved executable path to that log line, and elevates it from `.debug` to `.notice` so it actually persists for post-mortem diagnosis. Mirrors `AppDelegate.residentProvenanceLine` (#519), the complementary owner-side startup provenance line that landed just before this issue was filed — together the two make a wrong-copy interaction diagnosable from either side's log alone.

## Changes
- `KernovaKit/Sources/KernovaKit/FileProviderServiceSource.swift`: capture `newConnection.processIdentifier`, resolve its executable path via `proc_pidpath`, and log both plus the drain count via a new pure `acceptedOwnerLogLine` formatter. Level raised `.debug` → `.notice`.
- `KernovaKit/Tests/KernovaKitTests/FileProviderServiceSourceTests.swift`: unit tests for the new formatter (all fields present; unresolved-path fallback).

## Deviations from the issue's suggested fix
- Used `proc_pidpath` instead of `NSRunningApplication(processIdentifier:)` for path resolution — `NSRunningApplication` would pull AppKit into shared `KernovaKit` code compiled into two File Provider *extension* binaries, neither of which is an AppKit app; `proc_pidpath` is lightweight and sandbox-safe.
- Elevated the log level from `.debug` to `.notice` (the issue said "extend the existing `logger.debug(...)` call"). Per CLAUDE.md's logging guidance, `.debug` is discarded unless actively streaming, which defeats the stated goal of post-mortem diagnosability. Accepts are infrequent (one per owner connect), so persisting is cheap.
- No `KernovaMacOSAgent` `MARKETING_VERSION` bump. Per CLAUDE.md's guest-agent-version-bump convention, the trigger is a behavior change that requires the agent to be reinstalled for correct operation. This is a log-only diagnostic addition — no change to the exported XPC interface (`FileProviderControl`/`FileProviderRelay`) or to interop behavior — so there's no correctness reason to force existing installs to update.

## Test plan
- [x] `make test-package` — all KernovaKit package tests pass, including the two new formatter tests
- [x] `make test` — full three-target suite passes
- [x] `make lint` — clean