### PR TITLE
fix: Replace deprecated String(cString:) array overload

### DIFF
--- a/KernovaKit/Sources/KernovaKit/FileProviderServiceSource.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderServiceSource.swift
@@ -217,7 +217,7 @@ final class FileProviderServiceSource: NSObject, NSFileProviderServiceSource,
         var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN) * 4)
         let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
         guard length > 0 else { return nil }
-        return String(cString: buffer)
+        return String(decoding: buffer[0..<Int(length)].map(UInt8.init(bitPattern:)), as: UTF8.self)
     }
 
     // MARK: - FileProviderControl (activation handshake)


### PR DESCRIPTION
## Summary
- Clears a SourceKit deprecation warning (`'init(cString:)' is deprecated: Use String(decoding: array, as: UTF8.self) instead, after truncating the null termination`) introduced by #520's servicing-accept identity logging

## Changes
- `FileProviderServiceSource.executablePath(forPID:)` now truncates the `proc_pidpath` buffer to its actual returned length and decodes it via `String(decoding:as:)`, instead of the deprecated array-based `String(cString:)` overload

## Test plan
- [x] `make test-package` (235 tests pass, including `FileProviderServiceSource` suite)
- [x] `make lint`

Co-Authored-By: Claude <noreply@anthropic.com>