### PR TITLE
refactor: Unify host/guest clipboard offer-metadata builders

### DIFF
--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -401,7 +401,7 @@ final class VsockClipboardService: ClipboardServicing {
         offer.protocolVersion = 1
         offer.clipboardOffer = Kernova_V1_ClipboardOffer.with {
             $0.generation = generation
-            $0.repInfo = content.representations.map(Self.repInfo(for:))
+            $0.repInfo = content.representations.map(\.offerRepresentationInfo)
             $0.isConcealed = content.isConcealed
         }
 
@@ -1209,21 +1209,6 @@ final class VsockClipboardService: ClipboardServicing {
         Self.logger.debug(
             "Guest released clipboard offer (gen=\(release.generation, privacy: .public)) for '\(self.label, privacy: .public)'"
         )
-    }
-
-    // MARK: - Helpers
-
-    /// Builds the metadata advertised for a representation in an offer.
-    private static func repInfo(
-        for representation: ClipboardContent.Representation
-    ) -> Kernova_V1_ClipboardRepresentationInfo {
-        Kernova_V1_ClipboardRepresentationInfo.with {
-            $0.uti = representation.uti
-            $0.byteCount = UInt64(representation.byteCount)
-            $0.filename = representation.filename
-            $0.isInline = representation.shouldInlineOnPasteboard
-            $0.isDirectory = representation.isDirectory
-        }
     }
 }
 

--- a/KernovaKit/Sources/KernovaKit/ClipboardContent+Offer.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardContent+Offer.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension ClipboardContent.Representation {
+    /// The wire metadata advertised for this representation in a `ClipboardOffer`.
+    ///
+    /// Both ends of the clipboard bridge build the same offer entry: the host
+    /// "Copy to Mac" path and the guest inbound-offer path each map their capped
+    /// `representations` through this to populate `ClipboardOffer.repInfo`.
+    /// `isInline` reuses the shared `shouldInlineOnPasteboard` rule, so the
+    /// offered bit and the pasteboard-write decision can never diverge.
+    public var offerRepresentationInfo: Kernova_V1_ClipboardRepresentationInfo {
+        Kernova_V1_ClipboardRepresentationInfo.with {
+            $0.uti = uti
+            $0.byteCount = UInt64(byteCount)
+            $0.filename = filename
+            $0.isInline = shouldInlineOnPasteboard
+            $0.isDirectory = isDirectory
+        }
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardRepresentationOfferTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardRepresentationOfferTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+@testable import KernovaKit
+
+/// Exercises the shared `offerRepresentationInfo` projection that both the host
+/// "Copy to Mac" offer path and the guest inbound-offer path use to populate
+/// `ClipboardOffer.repInfo` from a representation.
+@Suite("ClipboardContent.Representation.offerRepresentationInfo")
+struct ClipboardRepresentationOfferTests {
+    private let dummyURL = URL(fileURLWithPath: "/tmp/kernova-clipboard-test")
+
+    @Test("inline (filename-less) content offers isInline with no filename")
+    func filenamelessContentOffersInline() {
+        let rep = ClipboardContent.Representation(
+            uti: ClipboardContent.utf8TextUTI, data: Data("hi".utf8))
+        let info = rep.offerRepresentationInfo
+        #expect(info.uti == ClipboardContent.utf8TextUTI)
+        #expect(info.byteCount == UInt64(rep.byteCount))
+        #expect(info.filename.isEmpty)
+        #expect(info.isInline)
+        #expect(!info.isDirectory)
+    }
+
+    @Test("an image file payload offers isInline with its filename")
+    func imageFileOffersInline() {
+        let rep = ClipboardContent.Representation(
+            uti: "public.png", fileURL: dummyURL, byteCount: 10, filename: "photo.png")
+        let info = rep.offerRepresentationInfo
+        #expect(info.uti == "public.png")
+        #expect(info.byteCount == 10)
+        #expect(info.filename == "photo.png")
+        #expect(info.isInline)
+        #expect(!info.isDirectory)
+    }
+
+    @Test("a non-image file payload offers file-only")
+    func nonImageFileOffersFileOnly() {
+        let rep = ClipboardContent.Representation(
+            uti: "public.plain-text", fileURL: dummyURL, byteCount: 10, filename: "notes.txt")
+        let info = rep.offerRepresentationInfo
+        #expect(info.uti == "public.plain-text")
+        #expect(info.byteCount == 10)
+        #expect(info.filename == "notes.txt")
+        #expect(!info.isInline)
+        #expect(!info.isDirectory)
+    }
+
+    @Test("a directory payload offers file-only and isDirectory")
+    func directoryOffersFileOnlyAndDirectory() {
+        let rep = ClipboardContent.Representation(
+            uti: "public.folder", fileURL: dummyURL, byteCount: 10, filename: "Pictures",
+            isDirectory: true)
+        let info = rep.offerRepresentationInfo
+        #expect(info.uti == "public.folder")
+        #expect(info.byteCount == 10)
+        #expect(info.filename == "Pictures")
+        #expect(!info.isInline)
+        #expect(info.isDirectory)
+    }
+}

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -594,7 +594,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         offer.protocolVersion = 1
         offer.clipboardOffer = Kernova_V1_ClipboardOffer.with {
             $0.generation = generation
-            $0.repInfo = offered.representations.map(Self.repInfo(for:))
+            $0.repInfo = offered.representations.map(\.offerRepresentationInfo)
             $0.isConcealed = offered.isConcealed
         }
         do {
@@ -1392,20 +1392,6 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         }
         Self.logger.debug(
             "Host released clipboard offer (gen=\(release.generation, privacy: .public))")
-    }
-
-    // MARK: - Helpers
-
-    private static func repInfo(
-        for representation: ClipboardContent.Representation
-    ) -> Kernova_V1_ClipboardRepresentationInfo {
-        Kernova_V1_ClipboardRepresentationInfo.with {
-            $0.uti = representation.uti
-            $0.byteCount = UInt64(representation.byteCount)
-            $0.filename = representation.filename
-            $0.isInline = representation.shouldInlineOnPasteboard
-            $0.isDirectory = representation.isDirectory
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Dedupes the host and guest `repInfo(for:)` helpers, which each built a `ClipboardRepresentationInfo` from a `ClipboardContent.Representation` almost identically (`uti`, `byteCount`, `filename`, `isInline = shouldInlineOnPasteboard`, `isDirectory`). A change to the offered metadata shape previously had to be applied on both sides.

## Changes
- Add `ClipboardContent.Representation.offerRepresentationInfo` in `KernovaKit/Sources/KernovaKit/ClipboardContent+Offer.swift`, following the same #406 unification pattern as `shouldInlineOnPasteboard` in `ClipboardContent+Pasteboard.swift`
- Rewire `VsockClipboardService` (host) and `VsockGuestClipboardAgent` (guest) offer-building call sites to `.map(\.offerRepresentationInfo)` and remove each side's now-dead `repInfo(for:)` helper
- Add `KernovaKit/Tests/KernovaKitTests/ClipboardRepresentationOfferTests.swift` covering inline/file/directory projection cases

## Deviations from the issue
- The issue suggested "a shared factory" without specifying its form. Implemented as a computed property (`offerRepresentationInfo`) on `ClipboardContent.Representation` rather than a free/static function, so both call sites use the clean keypath form `.map(\.offerRepresentationInfo)` and it sits naturally beside the `shouldInlineOnPasteboard` computed property it depends on.
- The issue said to place it "alongside the other #406 unifications" (which live one-per-concern across KernovaKit: `ClipboardContent+Pasteboard.swift`, `ClipboardPasteboardPlan.swift`, `LazyClipboardProviderRegistry.swift`). Added a new per-concern extension file `ClipboardContent+Offer.swift` rather than folding the wire projection into the pasteboard-named file, consistent with that granular file convention.

## Test plan
- [x] `make test-package` — new suite passes, all 239 KernovaKit tests pass
- [x] `make build` — builds successfully
- [x] `make test` — full three-target suite (KernovaTests, KernovaMacOSAgentTests, KernovaKitTests) passes, including existing `VsockClipboardServiceTests` / `VsockGuestClipboardAgentTests` coverage of `offer.repInfo`
- [x] `make lint` — clean

Fixes #418