### PR TITLE
chore: Surface masked test retries in Build & Test CI

### DIFF
--- a/.github/workflows/xcodebuild-test.yml
+++ b/.github/workflows/xcodebuild-test.yml
@@ -71,6 +71,51 @@ jobs:
             COMPILER_INDEX_STORE_ENABLE=NO \
             2>&1 | if command -v xcbeautify &>/dev/null; then xcbeautify --renderer github-actions; else cat; fi
 
+      # Kernova.xctestplan runs with retryOnFailure (maximumTestRepetitions: 2):
+      # it re-runs the whole bundle and lets a test that failed its first attempt
+      # pass the job on a retry, silently masking the flake — a green run can hide
+      # a ~35%-flaky test (which is exactly how #523 stayed green for a day). This
+      # step reads the result bundle and warns on any test with a failed attempt,
+      # so a passed-on-retry flake is visible instead of an invisible green. It is
+      # visibility-only and never fails the job (retryOnFailure still guards merges).
+      - name: Report flaky (retried) tests
+        if: always()
+        run: |
+          bundle="artifacts/TestResults.xcresult"
+          if [ ! -d "$bundle" ]; then
+            echo "No test result bundle at $bundle — skipping flake report."
+            exit 0
+          fi
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "jq not found — skipping flake report."
+            exit 0
+          fi
+          # Each attempt is a "Repetition" node; a genuine flake has at least one
+          # Repetition with result "Failed" (a bundle-wide retry marks every
+          # passed test's repetitions "Passed", so this does not false-positive on
+          # the other tests dragged through the retry). `|| true` keeps this step
+          # from ever failing the job on an xcresulttool/jq hiccup.
+          report="$(xcrun xcresulttool get test-results tests --path "$bundle" 2>/dev/null || true)"
+          flaky="$(printf '%s' "$report" | jq -r '[ .. | objects
+                     | select(.nodeType? == "Test Case")
+                     | select(any(.children[]?; .nodeType == "Repetition" and .result == "Failed"))
+                     | .name ] | unique[]' 2>/dev/null || true)"
+          if [ -z "$flaky" ]; then
+            echo "No flaky (failed-then-retried) tests in this run."
+            exit 0
+          fi
+          {
+            echo "### ⚠️ Flaky tests (failed at least one attempt)"
+            echo ""
+            echo "Retried via \`retryOnFailure\`, so these may have passed the job on a later attempt. Investigate before they degrade further:"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r name; do
+            [ -z "$name" ] && continue
+            echo "::warning title=Flaky test (failed then retried)::${name}"
+            echo "- \`${name}\`" >> "$GITHUB_STEP_SUMMARY"
+          done <<< "$flaky"
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v6

--- a/.github/workflows/xcodebuild-test.yml
+++ b/.github/workflows/xcodebuild-test.yml
@@ -90,16 +90,23 @@ jobs:
             echo "jq not found — skipping flake report."
             exit 0
           fi
-          # Each attempt is a "Repetition" node; a genuine flake has at least one
-          # Repetition with result "Failed" (a bundle-wide retry marks every
-          # passed test's repetitions "Passed", so this does not false-positive on
-          # the other tests dragged through the retry). `|| true` keeps this step
-          # from ever failing the job on an xcresulttool/jq hiccup.
-          report="$(xcrun xcresulttool get test-results tests --path "$bundle" 2>/dev/null || true)"
-          flaky="$(printf '%s' "$report" | jq -r '[ .. | objects
-                     | select(.nodeType? == "Test Case")
-                     | select(any(.children[]?; .nodeType == "Repetition" and .result == "Failed"))
-                     | .name ] | unique[]' 2>/dev/null || true)"
+          # Each attempt is a "Repetition" node; a genuine flake failed at least
+          # one Repetition but still passed overall (a bundle-wide retry marks
+          # every passed test's repetitions "Passed", so this does not
+          # false-positive on the other tests dragged through the retry). A test
+          # that failed every repetition is broken, not flaky — it already fails
+          # the job on its own via xcodebuild's exit code, so `result == "Passed"`
+          # excludes it here to avoid mislabeling it as a mere flake. Dedup on
+          # `.nodeIdentifier` (suite-qualified) rather than `.name` (bare display
+          # name), since two unrelated suites can share a test's display name.
+          if ! flaky="$(xcrun xcresulttool get test-results tests --path "$bundle" 2>&1 | jq -r '
+                [ .. | objects
+                  | select(.nodeType? == "Test Case" and .result == "Passed")
+                  | select(any(.children[]?; .nodeType == "Repetition" and .result == "Failed"))
+                  | (.nodeIdentifier // .name) ] | unique[]' 2>&1)"; then
+            echo "Could not read/parse test results at $bundle — skipping flake report. Output: $flaky"
+            exit 0
+          fi
           if [ -z "$flaky" ]; then
             echo "No flaky (failed-then-retried) tests in this run."
             exit 0
@@ -109,11 +116,13 @@ jobs:
             echo ""
             echo "Retried via \`retryOnFailure\`, so these may have passed the job on a later attempt. Investigate before they degrade further:"
             echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
+          } >> "$GITHUB_STEP_SUMMARY" || true
           while IFS= read -r name; do
-            [ -z "$name" ] && continue
-            echo "::warning title=Flaky test (failed then retried)::${name}"
-            echo "- \`${name}\`" >> "$GITHUB_STEP_SUMMARY"
+            # GitHub's `::` workflow-command protocol requires literal `%` in the
+            # message to be percent-encoded so it isn't misparsed as an escape.
+            escaped="${name//%/%25}"
+            echo "::warning title=Flaky test (failed then retried)::${escaped}"
+            echo "- \`${name}\`" >> "$GITHUB_STEP_SUMMARY" || true
           done <<< "$flaky"
 
       - name: Upload test results


### PR DESCRIPTION
## Summary
`Kernova.xctestplan` runs with `retryOnFailure` (`maximumTestRepetitions: 2`). On a first-attempt failure it re-runs the whole bundle and lets the retry pass the job green — silently masking the flake. A ~35%-flaky test can ride a green run indefinitely: that is exactly how the flake fixed in #523 stayed green on `main` for over a day while failing ~7 of the last 20 "successful" runs on their first attempt.

This adds a **visibility-only** step that reads the result bundle and warns on any test that failed at least one attempt, so passed-on-retry flakes surface instead of hiding behind a clean green.

## How it works
After the test step, `Report flaky (retried) tests` runs `xcrun xcresulttool get test-results tests` and a `jq` filter selecting `Test Case` nodes that have a `Repetition` child with `result == "Failed"`. A bundle-wide retry marks every *passed* test's repetitions `"Passed"`, so the filter does not false-positive on the tests dragged along by the retry — only genuinely-flaked tests match. Each match becomes a `::warning::` annotation plus a job-summary section.

The step is guarded to **never fail the job**: a missing bundle, absent `jq`, or an `xcresulttool`/`jq` hiccup all skip cleanly (`retryOnFailure` continues to guard merges).

## Test plan
Simulated the exact step script under the runner's `bash -eo pipefail` against real downloaded result bundles:

- [x] Flaky bundle (480 repetition nodes, 1 genuine flake) → emits exactly one warning + summary entry, exit 0
- [x] Clean bundle (0 repetition nodes) → "No flaky tests", empty summary, exit 0
- [x] Missing bundle → skips with a message, exit 0
- [x] YAML validates
- [ ] Green CI on the PR (its own report step should show no flakes)

## Notes
PR 2 of 3 from an investigation into intermittent Build & Test failures. PR 1 (#523) fixes the actual flaky test; PR 3 applies the #506 shared-state-isolation treatment to the remaining leaky `UserDefaults`/pasteboard test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)