### PR TITLE
test: Isolate VMLibraryViewModel/Sidebar tests from the real UserDefaults domain

### DIFF
--- a/Kernova/Utilities/AppPreferences.swift
+++ b/Kernova/Utilities/AppPreferences.swift
@@ -22,6 +22,7 @@ struct AppPreferences {
 
     private enum Keys {
         static let alwaysShowAdvancedOptions = "alwaysShowAdvancedOptions"
+        static let expandedSidebarSections = "KernovaSidebarExpandedSections"
     }
 
     /// When `true`, advanced menu actions (e.g. *Start in Recovery Mode*) are
@@ -32,5 +33,15 @@ struct AppPreferences {
     var alwaysShowAdvancedOptions: Bool {
         get { defaults.bool(forKey: Keys.alwaysShowAdvancedOptions) }
         nonmutating set { defaults.set(newValue, forKey: Keys.alwaysShowAdvancedOptions) }
+    }
+
+    /// Identifiers of the sidebar sections the user has expanded, or `nil` when
+    /// no preference has been saved yet.
+    ///
+    /// When `nil`, the sidebar defaults each section to expanded. Persisted by
+    /// `SidebarViewController` as it expands and collapses group rows.
+    var expandedSidebarSections: [String]? {
+        get { defaults.array(forKey: Keys.expandedSidebarSections) as? [String] }
+        nonmutating set { defaults.set(newValue, forKey: Keys.expandedSidebarSections) }
     }
 }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -16,6 +16,12 @@ final class VMLibraryViewModel {
     let diskImageService: any DiskImageProviding
     let lifecycle: VMLifecycleCoordinator
 
+    /// Backing store for selection/order persistence.
+    ///
+    /// Injectable so tests use an ephemeral suite instead of the real `.standard`
+    /// domain; production passes the default.
+    private let defaults: UserDefaults
+
     // MARK: - State
 
     var instances: [VMInstance] = []
@@ -23,9 +29,9 @@ final class VMLibraryViewModel {
         didSet {
             guard selectedID != oldValue else { return }
             if let selectedID {
-                UserDefaults.standard.set(selectedID.uuidString, forKey: Self.lastSelectedVMIDKey)
+                defaults.set(selectedID.uuidString, forKey: Self.lastSelectedVMIDKey)
             } else {
-                UserDefaults.standard.removeObject(forKey: Self.lastSelectedVMIDKey)
+                defaults.removeObject(forKey: Self.lastSelectedVMIDKey)
             }
         }
     }
@@ -111,10 +117,12 @@ final class VMLibraryViewModel {
         virtualizationService: any VirtualizationProviding = VirtualizationService(),
         installService: any MacOSInstallProviding = MacOSInstallService(),
         ipswService: any IPSWProviding = IPSWService(),
-        usbDeviceService: any USBDeviceProviding = USBDeviceService()
+        usbDeviceService: any USBDeviceProviding = USBDeviceService(),
+        defaults: UserDefaults = .standard
     ) {
         self.storageService = storageService
         self.diskImageService = diskImageService
+        self.defaults = defaults
         self.lifecycle = VMLifecycleCoordinator(
             virtualizationService: virtualizationService,
             installService: installService,
@@ -170,7 +178,7 @@ final class VMLibraryViewModel {
 
             // Load persisted order, sort by it, then normalize customOrder to match
             // the actual instance list (prunes stale UUIDs, incorporates new VMs).
-            if let savedStrings = UserDefaults.standard.stringArray(forKey: Self.vmOrderKey) {
+            if let savedStrings = defaults.stringArray(forKey: Self.vmOrderKey) {
                 customOrder = savedStrings.compactMap { UUID(uuidString: $0) }
                 Self.logger.debug("Loaded custom VM order: \(self.customOrder.count, privacy: .public) UUID(s)")
             } else {
@@ -180,7 +188,7 @@ final class VMLibraryViewModel {
             customOrder = instances.map(\.id)
 
             if selectedID == nil || !instances.contains(where: { $0.id == selectedID }) {
-                if let savedString = UserDefaults.standard.string(forKey: Self.lastSelectedVMIDKey),
+                if let savedString = defaults.string(forKey: Self.lastSelectedVMIDKey),
                     let savedID = UUID(uuidString: savedString),
                     instances.contains(where: { $0.id == savedID })
                 {
@@ -2169,7 +2177,7 @@ final class VMLibraryViewModel {
     /// Snapshots the current instance order into customOrder and persists it to UserDefaults.
     private func persistOrder() {
         customOrder = instances.map(\.id)
-        UserDefaults.standard.set(customOrder.map(\.uuidString), forKey: Self.vmOrderKey)
+        defaults.set(customOrder.map(\.uuidString), forKey: Self.vmOrderKey)
     }
 
     // MARK: - Error Handling

--- a/Kernova/Views/Sidebar/SidebarViewController.swift
+++ b/Kernova/Views/Sidebar/SidebarViewController.swift
@@ -16,6 +16,7 @@ import UniformTypeIdentifiers
 @MainActor
 final class SidebarViewController: NSViewController {
     private let viewModel: VMLibraryViewModel
+    private let preferences: AppPreferences
     private let outlineView = SidebarOutlineView()
     private let scrollView = NSScrollView()
     private let sections: [SidebarSection] = [.virtualMachines]
@@ -36,14 +37,14 @@ final class SidebarViewController: NSViewController {
     private static let rowPasteboardType = NSPasteboard.PasteboardType("app.kernova.sidebar-vm-row")
     private static let groupCellID = NSUserInterfaceItemIdentifier("SidebarGroupHeaderCell")
     private static let mainColumnID = NSUserInterfaceItemIdentifier("main")
-    private static let expandedSectionsKey = "KernovaSidebarExpandedSections"
     private static let leafRowHeight: CGFloat = 42
     private static let groupRowHeight: CGFloat = 24
 
     // MARK: - Init
 
-    init(viewModel: VMLibraryViewModel) {
+    init(viewModel: VMLibraryViewModel, preferences: AppPreferences = .shared) {
         self.viewModel = viewModel
+        self.preferences = preferences
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -342,8 +343,7 @@ final class SidebarViewController: NSViewController {
     // MARK: - Expansion persistence
 
     private func restoreExpansion() {
-        let saved = UserDefaults.standard.array(forKey: Self.expandedSectionsKey) as? [String]
-        let expanded = saved.map(Set.init)
+        let expanded = preferences.expandedSidebarSections.map(Set.init)
         for section in sections {
             // Default to expanded when there's no saved preference yet.
             if expanded?.contains(section.id) ?? true {
@@ -355,8 +355,8 @@ final class SidebarViewController: NSViewController {
     }
 
     private func persistExpansion() {
-        let expandedIDs = sections.filter { outlineView.isItemExpanded($0) }.map(\.id)
-        UserDefaults.standard.set(expandedIDs, forKey: Self.expandedSectionsKey)
+        preferences.expandedSidebarSections = sections.filter { outlineView.isItemExpanded($0) }
+            .map(\.id)
     }
 
     // MARK: - Content-fit width
@@ -674,7 +674,7 @@ extension SidebarViewController {
         // Lifecycle
         var startItem: NSMenuItem?
         if status.canStart {
-            if instance.canStartInRecovery && !AppPreferences.shared.alwaysShowAdvancedOptions {
+            if instance.canStartInRecovery && !preferences.alwaysShowAdvancedOptions {
                 // RATIONALE: Zero-height dummy item at index 0 anchors the context menu so it
                 // doesn't jump downward when "Start" collapses into its Recovery alternate on
                 // ⌥-hold. This is a known AppKit constraint, not a bug in our pairing:
@@ -704,7 +704,7 @@ extension SidebarViewController {
             // `canStartInRecovery` implies `.stopped`, so "Start" was just added and
             // this item immediately precedes this one (required for alternate pairing).
             let recovery = item("Start in Recovery Mode", #selector(menuStartRecovery(_:)), instance)
-            if !AppPreferences.shared.alwaysShowAdvancedOptions {
+            if !preferences.alwaysShowAdvancedOptions {
                 // Keyless Option-reveal: both items have an empty key equivalent, so the
                 // primary's modifier mask must be cleared to [] (its default is [.command])
                 // for AppKit to collapse the pair into ONE row. Otherwise [.command] is not
@@ -733,7 +733,7 @@ extension SidebarViewController {
             // Start/Recovery block above for the anchor rationale and the keyless-reveal
             // requirement that the primary's modifier mask be cleared to [].
             let forceStop = item("Force Stop…", #selector(menuForceStop(_:)), instance)
-            if !AppPreferences.shared.alwaysShowAdvancedOptions {
+            if !preferences.alwaysShowAdvancedOptions {
                 stop.keyEquivalentModifierMask = []
                 forceStop.keyEquivalentModifierMask = [.option]
                 forceStop.isAlternate = true
@@ -795,7 +795,7 @@ extension SidebarViewController {
         // pair sits at the menu's end, so collapsing the primary can't shift the menu.
         let deleteImmediately = item("Delete Immediately…", #selector(menuDeleteImmediately(_:)), instance)
         deleteImmediately.isEnabled = status.canEditSettings
-        if !AppPreferences.shared.alwaysShowAdvancedOptions {
+        if !preferences.alwaysShowAdvancedOptions {
             trash.keyEquivalentModifierMask = []
             deleteImmediately.keyEquivalentModifierMask = [.option]
             deleteImmediately.isAlternate = true

--- a/KernovaTests/AppPreferencesTests.swift
+++ b/KernovaTests/AppPreferencesTests.swift
@@ -17,11 +17,7 @@ struct AppPreferencesTests {
         _ body: (AppPreferences, UserDefaults) throws -> Void
     ) throws {
         let suiteName = Self.suiteName
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        // Clear before use, not just after: a prior run hard-killed mid-test
-        // (CI timeout, SIGKILL, Xcode stop) skips the `defer` below and can
-        // leave a stale value on disk under this fixed name (#449).
-        defaults.removePersistentDomain(forName: suiteName)
+        let defaults = makeEphemeralDefaults(suiteName: suiteName)
         defer {
             defaults.removePersistentDomain(forName: suiteName)
             // cfprefsd leaves an empty tombstone plist behind even after

--- a/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
+++ b/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
@@ -18,8 +18,9 @@ import Testing
 @Suite("ClipboardContentViewController Copy-to-Mac retention")
 @MainActor
 struct ClipboardContentViewControllerRetentionTests {
-    /// Isolated, pre-cleaned defaults so `VMLibraryViewModel`'s selection/order
-    /// persistence never touches the real `.standard` domain.
+    /// Isolated, pre-cleaned defaults for this suite's `VMLibraryViewModel`.
+    ///
+    /// Selection/order persistence never touches the real `.standard` domain.
     private let defaults = makeEphemeralDefaults(suiteName: "test.kernova.clipboard-retention")
 
     private func makeViewModel() -> VMLibraryViewModel {
@@ -169,8 +170,9 @@ struct ClipboardContentViewControllerRetentionTests {
 @Suite("ClipboardContentViewController editor commit")
 @MainActor
 struct ClipboardContentViewControllerEditTests {
-    /// Isolated, pre-cleaned defaults so `VMLibraryViewModel`'s selection/order
-    /// persistence never touches the real `.standard` domain.
+    /// Isolated, pre-cleaned defaults for this suite's `VMLibraryViewModel`.
+    ///
+    /// Selection/order persistence never touches the real `.standard` domain.
     private let defaults = makeEphemeralDefaults(suiteName: "test.kernova.clipboard-edit")
 
     private func makeViewModel() -> VMLibraryViewModel {

--- a/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
+++ b/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
@@ -18,6 +18,10 @@ import Testing
 @Suite("ClipboardContentViewController Copy-to-Mac retention")
 @MainActor
 struct ClipboardContentViewControllerRetentionTests {
+    /// Isolated, pre-cleaned defaults so `VMLibraryViewModel`'s selection/order
+    /// persistence never touches the real `.standard` domain.
+    private let defaults = makeEphemeralDefaults(suiteName: "test.kernova.clipboard-retention")
+
     private func makeViewModel() -> VMLibraryViewModel {
         VMLibraryViewModel(
             storageService: MockVMStorageService(),
@@ -25,7 +29,8 @@ struct ClipboardContentViewControllerRetentionTests {
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
             ipswService: MockIPSWService(),
-            usbDeviceService: MockUSBDeviceService()
+            usbDeviceService: MockUSBDeviceService(),
+            defaults: defaults
         )
     }
 
@@ -164,6 +169,10 @@ struct ClipboardContentViewControllerRetentionTests {
 @Suite("ClipboardContentViewController editor commit")
 @MainActor
 struct ClipboardContentViewControllerEditTests {
+    /// Isolated, pre-cleaned defaults so `VMLibraryViewModel`'s selection/order
+    /// persistence never touches the real `.standard` domain.
+    private let defaults = makeEphemeralDefaults(suiteName: "test.kernova.clipboard-edit")
+
     private func makeViewModel() -> VMLibraryViewModel {
         VMLibraryViewModel(
             storageService: MockVMStorageService(),
@@ -171,7 +180,8 @@ struct ClipboardContentViewControllerEditTests {
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
             ipswService: MockIPSWService(),
-            usbDeviceService: MockUSBDeviceService()
+            usbDeviceService: MockUSBDeviceService(),
+            defaults: defaults
         )
     }
 

--- a/KernovaTests/DetailAlertsPresenterTests.swift
+++ b/KernovaTests/DetailAlertsPresenterTests.swift
@@ -31,6 +31,10 @@ import Testing
 @Suite("DetailAlertsPresenter Tests", .serialized)
 @MainActor
 struct DetailAlertsPresenterTests {
+    /// Isolated, pre-cleaned defaults so `VMLibraryViewModel`'s selection/order
+    /// persistence never touches the real `.standard` domain.
+    private let defaults = makeEphemeralDefaults(suiteName: "test.kernova.detailalerts")
+
     private func makeViewModel() -> VMLibraryViewModel {
         VMLibraryViewModel(
             storageService: MockVMStorageService(),
@@ -38,7 +42,8 @@ struct DetailAlertsPresenterTests {
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
             ipswService: MockIPSWService(),
-            usbDeviceService: MockUSBDeviceService()
+            usbDeviceService: MockUSBDeviceService(),
+            defaults: defaults
         )
     }
 

--- a/KernovaTests/DetailAlertsPresenterTests.swift
+++ b/KernovaTests/DetailAlertsPresenterTests.swift
@@ -31,8 +31,9 @@ import Testing
 @Suite("DetailAlertsPresenter Tests", .serialized)
 @MainActor
 struct DetailAlertsPresenterTests {
-    /// Isolated, pre-cleaned defaults so `VMLibraryViewModel`'s selection/order
-    /// persistence never touches the real `.standard` domain.
+    /// Isolated, pre-cleaned defaults for this suite's `VMLibraryViewModel`.
+    ///
+    /// Selection/order persistence never touches the real `.standard` domain.
     private let defaults = makeEphemeralDefaults(suiteName: "test.kernova.detailalerts")
 
     private func makeViewModel() -> VMLibraryViewModel {

--- a/KernovaTests/SidebarViewControllerTests.swift
+++ b/KernovaTests/SidebarViewControllerTests.swift
@@ -14,19 +14,30 @@ import Testing
 @Suite("Sidebar Tests", .serialized)
 @MainActor
 struct SidebarViewControllerTests {
+    /// Isolated, pre-cleaned defaults for this suite's global state.
+    ///
+    /// Shared by the view model (selection/order) and the sidebar's
+    /// `AppPreferences` (expanded sections + the advanced-options toggle), so no
+    /// test reads or writes the real `.standard` domain. Fresh per test (the
+    /// struct is re-instantiated), so each starts clean.
+    private let defaults: UserDefaults
+    private let preferences: AppPreferences
+
+    init() {
+        let defaults = makeEphemeralDefaults(suiteName: "test.kernova.sidebar")
+        self.defaults = defaults
+        self.preferences = AppPreferences(defaults: defaults)
+    }
+
     private func makeViewModel() -> VMLibraryViewModel {
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.vmOrderKey)
-        // Matches SidebarViewController.expandedSectionsKey; cleared so the group
-        // defaults to expanded regardless of prior test/run state.
-        UserDefaults.standard.removeObject(forKey: "KernovaSidebarExpandedSections")
-        return VMLibraryViewModel(
+        VMLibraryViewModel(
             storageService: MockVMStorageService(),
             diskImageService: MockDiskImageService(),
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
             ipswService: MockIPSWService(),
-            usbDeviceService: MockUSBDeviceService()
+            usbDeviceService: MockUSBDeviceService(),
+            defaults: defaults
         )
     }
 
@@ -143,7 +154,7 @@ struct SidebarViewControllerTests {
         let viewModel = makeViewModel()
         let instance = makeInstance(status: .stopped)
         viewModel.instances.append(instance)
-        let controller = SidebarViewController(viewModel: viewModel)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
 
         let menu = controller.buildContextMenu(for: instance)
         let menuTitles = titles(of: menu)
@@ -161,7 +172,7 @@ struct SidebarViewControllerTests {
         let viewModel = makeViewModel()
         let instance = makeInstance(status: .running)
         viewModel.instances.append(instance)
-        let controller = SidebarViewController(viewModel: viewModel)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
 
         let menu = controller.buildContextMenu(for: instance)
         let menuTitles = titles(of: menu)
@@ -180,7 +191,7 @@ struct SidebarViewControllerTests {
         let viewModel = makeViewModel()
         let instance = makeInstance(status: .paused)  // no live VM ⇒ cold-paused
         viewModel.instances.append(instance)
-        let controller = SidebarViewController(viewModel: viewModel)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
 
         let menu = controller.buildContextMenu(for: instance)
         let menuTitles = titles(of: menu)
@@ -194,11 +205,11 @@ struct SidebarViewControllerTests {
 
     @Test("Force Stop is the Option-alternate of Stop on a running VM (advanced options off)")
     func contextMenuForceStopIsOptionAlternate() {
-        UserDefaults.standard.removeObject(forKey: "alwaysShowAdvancedOptions")
+        preferences.alwaysShowAdvancedOptions = false
         let viewModel = makeViewModel()
         let instance = makeInstance(status: .running)
         viewModel.instances.append(instance)
-        let controller = SidebarViewController(viewModel: viewModel)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
 
         let menu = controller.buildContextMenu(for: instance)
 
@@ -217,12 +228,11 @@ struct SidebarViewControllerTests {
 
     @Test("Force Stop is a plain always-visible item when advanced options are on")
     func contextMenuForceStopVisibleWhenAdvanced() {
-        UserDefaults.standard.set(true, forKey: "alwaysShowAdvancedOptions")
-        defer { UserDefaults.standard.removeObject(forKey: "alwaysShowAdvancedOptions") }
+        preferences.alwaysShowAdvancedOptions = true
         let viewModel = makeViewModel()
         let instance = makeInstance(status: .running)
         viewModel.instances.append(instance)
-        let controller = SidebarViewController(viewModel: viewModel)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
 
         let menu = controller.buildContextMenu(for: instance)
 
@@ -234,11 +244,11 @@ struct SidebarViewControllerTests {
 
     @Test("Transient (starting) VM offers a standalone Force Stop, not an Option-alternate")
     func contextMenuForceStopStandaloneDuringTransition() {
-        UserDefaults.standard.removeObject(forKey: "alwaysShowAdvancedOptions")
+        preferences.alwaysShowAdvancedOptions = false
         let viewModel = makeViewModel()
         let instance = makeInstance(status: .starting)
         viewModel.instances.append(instance)
-        let controller = SidebarViewController(viewModel: viewModel)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
 
         let menu = controller.buildContextMenu(for: instance)
         let menuTitles = titles(of: menu)
@@ -251,11 +261,11 @@ struct SidebarViewControllerTests {
 
     @Test("Delete Immediately is the Option-alternate of Move to Trash (advanced options off)")
     func contextMenuDeleteImmediatelyIsOptionAlternate() {
-        UserDefaults.standard.removeObject(forKey: "alwaysShowAdvancedOptions")
+        preferences.alwaysShowAdvancedOptions = false
         let viewModel = makeViewModel()
         let instance = makeInstance(status: .stopped)
         viewModel.instances.append(instance)
-        let controller = SidebarViewController(viewModel: viewModel)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
 
         let menu = controller.buildContextMenu(for: instance)
 
@@ -274,12 +284,11 @@ struct SidebarViewControllerTests {
 
     @Test("Delete Immediately is a plain always-visible item when advanced options are on")
     func contextMenuDeleteImmediatelyVisibleWhenAdvanced() {
-        UserDefaults.standard.set(true, forKey: "alwaysShowAdvancedOptions")
-        defer { UserDefaults.standard.removeObject(forKey: "alwaysShowAdvancedOptions") }
+        preferences.alwaysShowAdvancedOptions = true
         let viewModel = makeViewModel()
         let instance = makeInstance(status: .stopped)
         viewModel.instances.append(instance)
-        let controller = SidebarViewController(viewModel: viewModel)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
 
         let menu = controller.buildContextMenu(for: instance)
 
@@ -295,7 +304,7 @@ struct SidebarViewControllerTests {
         let instance = makeInstance()
         instance.preparingState = VMInstance.PreparingState(operation: .cloning, task: Task {})
         viewModel.instances.append(instance)
-        let controller = SidebarViewController(viewModel: viewModel)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
 
         let menu = controller.buildContextMenu(for: instance)
         let menuTitles = titles(of: menu)
@@ -329,7 +338,7 @@ struct SidebarViewControllerTests {
     @Test("widthToFitLongestRow is nil with no VMs")
     func fitWidthNilWhenEmpty() {
         let viewModel = makeViewModel()
-        let controller = SidebarViewController(viewModel: viewModel)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
         controller.loadViewIfNeeded()
         #expect(controller.widthToFitLongestRow() == nil)
     }
@@ -338,13 +347,13 @@ struct SidebarViewControllerTests {
     func fitWidthTracksLongestName() {
         let shortModel = makeViewModel()
         shortModel.instances.append(makeInstance(name: "VM"))
-        let shortController = SidebarViewController(viewModel: shortModel)
+        let shortController = SidebarViewController(viewModel: shortModel, preferences: preferences)
         shortController.loadViewIfNeeded()
         shortController.view.layoutSubtreeIfNeeded()
 
         let longModel = makeViewModel()
         longModel.instances.append(makeInstance(name: "An extremely long virtual machine name"))
-        let longController = SidebarViewController(viewModel: longModel)
+        let longController = SidebarViewController(viewModel: longModel, preferences: preferences)
         longController.loadViewIfNeeded()
         longController.view.layoutSubtreeIfNeeded()
 
@@ -364,7 +373,7 @@ struct SidebarViewControllerTests {
         let viewModel = makeViewModel()
         viewModel.instances.append(makeInstance(name: "Alpha"))
         viewModel.instances.append(makeInstance(name: "Beta"))
-        let controller = SidebarViewController(viewModel: viewModel)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
         controller.loadViewIfNeeded()
         controller.view.layoutSubtreeIfNeeded()
 

--- a/KernovaTests/StorageDiskReorderSheetContentViewControllerTests.swift
+++ b/KernovaTests/StorageDiskReorderSheetContentViewControllerTests.swift
@@ -109,7 +109,9 @@ struct StorageDiskReorderSheetContentViewControllerTests {
             Issue.record("Expected an NSPasteboardItem from pasteboardWriterForRow")
             return
         }
-        let pasteboard = NSPasteboard(name: NSPasteboard.Name("test-drag"))
+        // A per-test unique name so parallel/retried runs never share this global
+        // named pasteboard (matches ClipboardPasteboardIntakeTests).
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("kernova-test-\(UUID().uuidString)"))
         pasteboard.clearContents()
         pasteboard.writeObjects([writer])
 
@@ -130,7 +132,8 @@ struct StorageDiskReorderSheetContentViewControllerTests {
             Issue.record("Expected an NSTableView")
             return
         }
-        let dragInfo = StubDraggingInfo(pasteboard: NSPasteboard(name: NSPasteboard.Name("test-validate")))
+        let dragInfo = StubDraggingInfo(
+            pasteboard: NSPasteboard(name: NSPasteboard.Name("kernova-test-\(UUID().uuidString)")))
         #expect(
             vc.tableView(table, validateDrop: dragInfo, proposedRow: 1, proposedDropOperation: .above)
                 == .move

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -32,8 +32,11 @@ struct TestFailure: Error {
 /// mid-test (CI timeout, SIGKILL) skips any `defer`, so clearing *before* use is
 /// the load-bearing half. Pass a fixed `suiteName` unique to the calling suite —
 /// a fixed name (not a per-call UUID) bounds the on-disk footprint to a single
-/// reusable tombstone plist. Mirrors the #506 `AppPreferencesTests` treatment so
-/// a test never reads or writes the real `.standard` domain.
+/// reusable tombstone plist. Shared by every suite (e.g. `AppPreferencesTests`,
+/// #449/#506) that needs a test never to read or write the real `.standard`
+/// domain; callers that also need after-the-fact teardown (e.g. because they
+/// reuse one suite across multiple `@Test`s) should wrap the returned instance
+/// in their own `defer { defaults.removePersistentDomain(forName:) }`.
 func makeEphemeralDefaults(suiteName: String) -> UserDefaults {
     guard let defaults = UserDefaults(suiteName: suiteName) else {
         fatalError("Could not open test UserDefaults suite '\(suiteName)'")

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -24,6 +24,29 @@ struct TestFailure: Error {
     init(_ m: String) { message = m }
 }
 
+// MARK: - Ephemeral UserDefaults
+
+/// Opens an isolated, pre-cleaned `UserDefaults` suite for a `.serialized` test suite.
+///
+/// State never bleeds in from another test or a prior run: a run hard-killed
+/// mid-test (CI timeout, SIGKILL) skips any `defer`, so clearing *before* use is
+/// the load-bearing half. Pass a fixed `suiteName` unique to the calling suite —
+/// a fixed name (not a per-call UUID) bounds the on-disk footprint to a single
+/// reusable tombstone plist. Mirrors the #506 `AppPreferencesTests` treatment so
+/// a test never reads or writes the real `.standard` domain.
+func makeEphemeralDefaults(suiteName: String) -> UserDefaults {
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+        fatalError("Could not open test UserDefaults suite '\(suiteName)'")
+    }
+    defaults.removePersistentDomain(forName: suiteName)
+    if let plistURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
+        .first?.appending(path: "Preferences/\(suiteName).plist")
+    {
+        try? FileManager.default.removeItem(at: plistURL)
+    }
+    return defaults
+}
+
 // MARK: - Socket / channel factories
 
 /// Returns a connected AF_UNIX socketpair as two raw file descriptors.

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -6,6 +6,12 @@ import Foundation
 @MainActor
 struct VMLibraryViewModelTests {
     private let presenter = MockVMLibraryPresenting()
+    /// Isolated, pre-cleaned defaults so selection/order persistence never
+    /// touches the real `.standard` domain.
+    ///
+    /// Fresh per test (the struct is re-instantiated), so each test starts from
+    /// an empty suite.
+    private let defaults = makeEphemeralDefaults(suiteName: "test.kernova.vmlibrary")
     private func makeViewModel(
         storageService: MockVMStorageService = MockVMStorageService(),
         diskImageService: MockDiskImageService = MockDiskImageService(),
@@ -15,15 +21,16 @@ struct VMLibraryViewModelTests {
         VMLibraryViewModel, MockVMStorageService, MockDiskImageService, MockVirtualizationService,
         any USBDeviceProviding
     ) {
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.vmOrderKey)
+        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        defaults.removeObject(forKey: VMLibraryViewModel.vmOrderKey)
         let vm = VMLibraryViewModel(
             storageService: storageService,
             diskImageService: diskImageService,
             virtualizationService: virtualizationService,
             installService: MockMacOSInstallService(),
             ipswService: MockIPSWService(),
-            usbDeviceService: usbDeviceService
+            usbDeviceService: usbDeviceService,
+            defaults: defaults
         )
         vm.presenter = presenter
         return (vm, storageService, diskImageService, virtualizationService, usbDeviceService)
@@ -102,7 +109,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.selectedID = instance.id
 
-        let stored = UserDefaults.standard.string(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        let stored = defaults.string(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
         #expect(stored == instance.id.uuidString)
     }
 
@@ -115,7 +122,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.selectedID = nil
 
-        let stored = UserDefaults.standard.string(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        let stored = defaults.string(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
         #expect(stored == nil)
     }
 
@@ -132,15 +139,16 @@ struct VMLibraryViewModelTests {
         storage.bundles[url2] = config2
 
         // Clear then seed UserDefaults before ViewModel init triggers loadVMs()
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
-        UserDefaults.standard.set(config2.id.uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        defaults.set(config2.id.uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
 
         let viewModel = VMLibraryViewModel(
             storageService: storage,
             diskImageService: MockDiskImageService(),
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
-            ipswService: MockIPSWService()
+            ipswService: MockIPSWService(),
+            defaults: defaults
         )
         viewModel.presenter = presenter
 
@@ -181,15 +189,16 @@ struct VMLibraryViewModelTests {
         storage.bundles[url] = config
 
         // Clear then seed UserDefaults with a UUID that doesn't match any VM
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
-        UserDefaults.standard.set(UUID().uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        defaults.set(UUID().uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
 
         let viewModel = VMLibraryViewModel(
             storageService: storage,
             diskImageService: MockDiskImageService(),
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
-            ipswService: MockIPSWService()
+            ipswService: MockIPSWService(),
+            defaults: defaults
         )
         viewModel.presenter = presenter
 
@@ -832,15 +841,16 @@ struct VMLibraryViewModelTests {
         ipswService: MockIPSWService,
         storage: MockVMStorageService
     ) -> VMLibraryViewModel {
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.vmOrderKey)
+        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        defaults.removeObject(forKey: VMLibraryViewModel.vmOrderKey)
         let vm = VMLibraryViewModel(
             storageService: storage,
             diskImageService: MockDiskImageService(),
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
             ipswService: ipswService,
-            usbDeviceService: MockUSBDeviceService()
+            usbDeviceService: MockUSBDeviceService(),
+            defaults: defaults
         )
         vm.presenter = presenter
         return vm
@@ -1851,7 +1861,8 @@ struct VMLibraryViewModelTests {
             virtualizationService: MockVirtualizationService(),
             installService: raceInstaller,
             ipswService: MockIPSWService(),
-            usbDeviceService: MockUSBDeviceService()
+            usbDeviceService: MockUSBDeviceService(),
+            defaults: defaults
         )
         viewModel.presenter = presenter
         let instance = makeInstance(name: "Race VM")
@@ -2823,7 +2834,7 @@ struct VMLibraryViewModelTests {
         viewModel.moveVM(fromOffsets: IndexSet(integer: 2), toOffset: 0)
 
         #expect(viewModel.instances.map(\.name) == ["C", "A", "B"])
-        let stored = UserDefaults.standard.stringArray(forKey: VMLibraryViewModel.vmOrderKey)
+        let stored = defaults.stringArray(forKey: VMLibraryViewModel.vmOrderKey)
         #expect(stored == [c.id.uuidString, a.id.uuidString, b.id.uuidString])
     }
 
@@ -2847,8 +2858,8 @@ struct VMLibraryViewModelTests {
         storage.bundles[url3] = config3
 
         // Set custom order: Third, First, Second
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
-        UserDefaults.standard.set(
+        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        defaults.set(
             [config3.id.uuidString, config1.id.uuidString, config2.id.uuidString],
             forKey: VMLibraryViewModel.vmOrderKey
         )
@@ -2858,7 +2869,8 @@ struct VMLibraryViewModelTests {
             diskImageService: MockDiskImageService(),
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
-            ipswService: MockIPSWService()
+            ipswService: MockIPSWService(),
+            defaults: defaults
         )
         viewModel.presenter = presenter
 
@@ -2922,7 +2934,7 @@ struct VMLibraryViewModelTests {
 
         viewModel.deleteConfirmed(b)
 
-        let stored = UserDefaults.standard.stringArray(forKey: VMLibraryViewModel.vmOrderKey)
+        let stored = defaults.stringArray(forKey: VMLibraryViewModel.vmOrderKey)
         #expect(stored == [a.id.uuidString])
     }
 
@@ -2936,8 +2948,8 @@ struct VMLibraryViewModelTests {
 
         // Set custom order with a stale UUID followed by the real one
         let staleID = UUID()
-        UserDefaults.standard.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
-        UserDefaults.standard.set(
+        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        defaults.set(
             [staleID.uuidString, config.id.uuidString],
             forKey: VMLibraryViewModel.vmOrderKey
         )
@@ -2947,7 +2959,8 @@ struct VMLibraryViewModelTests {
             diskImageService: MockDiskImageService(),
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
-            ipswService: MockIPSWService()
+            ipswService: MockIPSWService(),
+            defaults: defaults
         )
         viewModel.presenter = presenter
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -21,8 +21,6 @@ struct VMLibraryViewModelTests {
         VMLibraryViewModel, MockVMStorageService, MockDiskImageService, MockVirtualizationService,
         any USBDeviceProviding
     ) {
-        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
-        defaults.removeObject(forKey: VMLibraryViewModel.vmOrderKey)
         let vm = VMLibraryViewModel(
             storageService: storageService,
             diskImageService: diskImageService,
@@ -138,8 +136,7 @@ struct VMLibraryViewModelTests {
         storage.bundles[url1] = config1
         storage.bundles[url2] = config2
 
-        // Clear then seed UserDefaults before ViewModel init triggers loadVMs()
-        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        // Seed UserDefaults before ViewModel init triggers loadVMs()
         defaults.set(config2.id.uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
 
         let viewModel = VMLibraryViewModel(
@@ -188,8 +185,7 @@ struct VMLibraryViewModelTests {
             .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
         storage.bundles[url] = config
 
-        // Clear then seed UserDefaults with a UUID that doesn't match any VM
-        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
+        // Seed UserDefaults with a UUID that doesn't match any VM
         defaults.set(UUID().uuidString, forKey: VMLibraryViewModel.lastSelectedVMIDKey)
 
         let viewModel = VMLibraryViewModel(
@@ -841,8 +837,6 @@ struct VMLibraryViewModelTests {
         ipswService: MockIPSWService,
         storage: MockVMStorageService
     ) -> VMLibraryViewModel {
-        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
-        defaults.removeObject(forKey: VMLibraryViewModel.vmOrderKey)
         let vm = VMLibraryViewModel(
             storageService: storage,
             diskImageService: MockDiskImageService(),
@@ -2858,7 +2852,6 @@ struct VMLibraryViewModelTests {
         storage.bundles[url3] = config3
 
         // Set custom order: Third, First, Second
-        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
         defaults.set(
             [config3.id.uuidString, config1.id.uuidString, config2.id.uuidString],
             forKey: VMLibraryViewModel.vmOrderKey
@@ -2948,7 +2941,6 @@ struct VMLibraryViewModelTests {
 
         // Set custom order with a stale UUID followed by the real one
         let staleID = UUID()
-        defaults.removeObject(forKey: VMLibraryViewModel.lastSelectedVMIDKey)
         defaults.set(
             [staleID.uuidString, config.id.uuidString],
             forKey: VMLibraryViewModel.vmOrderKey

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -8,8 +8,9 @@ import Testing
 struct VMSettingsViewControllerTests {
     // MARK: - Fixtures
 
-    /// Isolated, pre-cleaned defaults so `VMLibraryViewModel`'s selection/order
-    /// persistence never touches the real `.standard` domain.
+    /// Isolated, pre-cleaned defaults for this suite's `VMLibraryViewModel`.
+    ///
+    /// Selection/order persistence never touches the real `.standard` domain.
     private let defaults = makeEphemeralDefaults(suiteName: "test.kernova.vmsettings")
 
     private func makeViewModel() -> VMLibraryViewModel {

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -8,6 +8,10 @@ import Testing
 struct VMSettingsViewControllerTests {
     // MARK: - Fixtures
 
+    /// Isolated, pre-cleaned defaults so `VMLibraryViewModel`'s selection/order
+    /// persistence never touches the real `.standard` domain.
+    private let defaults = makeEphemeralDefaults(suiteName: "test.kernova.vmsettings")
+
     private func makeViewModel() -> VMLibraryViewModel {
         VMLibraryViewModel(
             storageService: MockVMStorageService(),
@@ -15,7 +19,8 @@ struct VMSettingsViewControllerTests {
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
             ipswService: MockIPSWService(),
-            usbDeviceService: MockUSBDeviceService()
+            usbDeviceService: MockUSBDeviceService(),
+            defaults: defaults
         )
     }
 


### PR DESCRIPTION
## Summary
The #506 fix isolated `AppPreferencesTests`' leaked preference plist, but the same "poke `UserDefaults.standard` directly, clean up asymmetrically" pattern survived in two sibling suites:

- `VMLibraryViewModelTests` wrote the real `lastSelectedVMID` / `vmOrder` keys.
- `SidebarViewControllerTests` wrote those plus `KernovaSidebarExpandedSections` and `alwaysShowAdvancedOptions`.

All of it landed in the developer's / CI's real `.standard` domain, cleaned only at the *next* test's start (asymmetric teardown — a hard-killed run leaks into the next). No observed flake yet; this is latent global-state hygiene, and it's the same reinforced pattern #506 began unwinding.

This applies the #506 treatment to both suites so no test reads or writes `.standard`, and gives the drag-reorder pasteboard tests per-test-unique names.

## Changes
**Production (injection seams, no behavior change):**
- `VMLibraryViewModel`: add `defaults: UserDefaults = .standard`; route the four selection/order persistence sites through it.
- `AppPreferences`: add `expandedSidebarSections`, consolidating the sidebar's ad-hoc `KernovaSidebarExpandedSections` key into the type #506 established as *the* home for app-wide `.standard`-backed prefs. `SidebarViewController` now takes `preferences: AppPreferences = .shared` and reads both expanded-sections and advanced-options through it — one injection point, zero remaining `.standard` access.

**Tests:**
- `TestHelpers.makeEphemeralDefaults(suiteName:)` — a fixed-name, pre-cleaned suite (mirrors #506: clear *before* use so a hard-killed prior run can't leak in; fixed name bounds the on-disk footprint to a single tombstone).
- `VMLibraryViewModelTests` / `SidebarViewControllerTests` construct their subjects over an ephemeral suite and assert against it. Both suites were already `.serialized`, so the fixed suite name adds **no** serialization cost.
- `StorageDiskReorderSheetContentViewControllerTests`: `"test-drag"` / `"test-validate"` → `kernova-test-<UUID>` (matches `ClipboardPasteboardIntakeTests`).

## Test plan
- [x] `make build` — production compiles (the sole production caller of `SidebarViewController` uses the `.shared` default)
- [x] `make test` — full suite passes (`** TEST SUCCEEDED **`)
- [x] `make test-suite` for VMLibraryViewModel / Sidebar / StorageDiskReorder — all pass
- [x] `make lint` clean
- [ ] Green CI on the PR

## Notes
PR 3 of 3 from an investigation into intermittent Build & Test failures: #523 fixed the actual flaky test, #524 surfaces retry-masked flakes, and this closes the reinforced global-state pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)