### PR TITLE
chore: Auto-bootstrap DEVELOPMENT_TEAM in new worktrees via post-checkout hook

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Auto-bootstrap DEVELOPMENT_TEAM in fresh checkouts. Runs after
+# `git worktree add` — the case that matters: a new worktree never has the
+# gitignored Config/Local.xcconfig, so without this hook its first Xcode
+# build fails signing until `make bootstrap` is run by hand. Also fires on
+# `git switch`/`git checkout`, where the Local.xcconfig guard below makes it
+# a no-op. It cannot fire on a fresh `git clone`: hooks only activate once
+# `make install-hooks` sets core.hooksPath (git never auto-runs checked-in
+# hooks), so a brand-new clone still needs one `make bootstrap`/`make build`
+# — see README "Development setup".
+#
+# Git runs post-checkout from the working-tree root, so the paths below
+# resolve within whichever worktree was just created or switched.
+
+set -uo pipefail
+
+# $3 is 1 for a branch checkout, 0 for a file checkout (git checkout -- <path>),
+# which doesn't create a working tree and is skipped.
+[ "${3:-0}" = "1" ] || exit 0
+
+[ -f Config/Local.xcconfig ] && exit 0
+
+# Best-effort: a failed derivation (e.g. no signing certificate in the
+# keychain) must not fail the checkout; bootstrap prints its own diagnostics
+# and `make doctor` reports the missing team.
+if [ -x Tools/bootstrap-team.sh ]; then
+    Tools/bootstrap-team.sh || true
+fi
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,14 @@ make test-suite SUITE=KernovaTests/VMConfigurationTests   # Run a single suite
 make test-package        # Run only the KernovaKit SwiftPM package tests
 make format              # Rewrite Swift sources in place via swift-format
 make lint                # Check Swift sources with swift-format --strict
-make install-hooks       # One-time: enable .githooks/pre-push (runs `make lint` before push)
+make install-hooks       # One-time: enable .githooks/ (pre-push lint; post-checkout team bootstrap in new worktrees)
 make doctor              # Check the local toolchain (macOS, Xcode, Swift, swift-format) and git hooks
 make clean               # Remove DerivedData/
 ```
 
-Run `make install-hooks` once after cloning to enable the pre-push `make lint` hook (see [Development setup](README.md#development-setup) in the README for the mechanics; bypass an individual push with `git push --no-verify`).
+Run `make install-hooks` once after cloning to enable the checked-in `.githooks/`: pre-push runs `make lint` (bypass an individual push with `git push --no-verify`), and post-checkout runs `make bootstrap`'s derivation in any checkout missing `Config/Local.xcconfig` — so new git worktrees sign without a manual step (see [Development setup](README.md#development-setup) in the README for the mechanics).
 
-`DEVELOPMENT_TEAM` is not hardcoded in the project — it's derived per-developer from your own signing certificate into the gitignored `Config/Local.xcconfig` by `make bootstrap` (#476, see [Development setup](README.md#development-setup)). `make build`/`make test`/`make test-suite` run it automatically; the raw `xcodebuild` form below (and Xcode's own ⌘B/⌘R) assume it has already run, so on a fresh clone or a new worktree run `make bootstrap` once first — otherwise `DEVELOPMENT_TEAM` resolves empty and the Manual/profile-less Debug targets fail to sign.
+`DEVELOPMENT_TEAM` is not hardcoded in the project — it's derived per-developer from your own signing certificate into the gitignored `Config/Local.xcconfig` by `make bootstrap` (#476, see [Development setup](README.md#development-setup)). `make build`/`make test`/`make test-suite` run it automatically, and the post-checkout hook covers new worktrees; the raw `xcodebuild` form below (and Xcode's own ⌘B/⌘R) assume it has already run, so on a fresh clone (where hooks aren't active yet) run `make bootstrap` once first — otherwise `DEVELOPMENT_TEAM` resolves empty and the Manual/profile-less Debug targets fail to sign.
 
 `make test` is the canonical `xcodebuild` invocation:
 

--- a/Makefile
+++ b/Makefile
@@ -100,21 +100,23 @@ format:
 lint:
 	$(SWIFT_FORMAT) lint --strict --recursive $(SWIFT_SOURCE_DIRS)
 
-# One-time per clone: point this repo's git at the checked-in hooks so
-# `.githooks/pre-push` runs `make lint` before each push. Per-repo config
-# (no `--global`); bypass an individual push with `git push --no-verify`.
+# One-time per clone: point this repo's git at the checked-in hooks —
+# `.githooks/pre-push` runs `make lint` before each push (bypass an
+# individual push with `git push --no-verify`), and `.githooks/post-checkout`
+# bootstraps DEVELOPMENT_TEAM in fresh worktrees. Per-repo config
+# (no `--global`); core.hooksPath is shared by all worktrees of this repo.
 install-hooks:
 	git config core.hooksPath .githooks
-	@echo 'Hooks installed. Pre-push will now run `make lint`.'
+	@echo 'Hooks installed. Pre-push runs `make lint`; post-checkout bootstraps DEVELOPMENT_TEAM in new worktrees.'
 
-# Silent when the hook is wired up; otherwise a one-line nudge. Runs as a
+# Silent when the hooks are wired up; otherwise a one-line nudge. Runs as a
 # prerequisite of `build` and `test` so contributors who skipped the
 # install step see the reminder on their first build instead of only when
 # CI fails on their PR.
 check-hooks:
 	@hp=$$(git config --get core.hooksPath 2>/dev/null || true); \
 	if [ "$$hp" != ".githooks" ]; then \
-		printf 'Note: pre-push lint hook is not installed. Run `make install-hooks` (one-time per clone) to catch swift-format issues locally.\n' >&2; \
+		printf 'Note: git hooks are not installed. Run `make install-hooks` (one-time per clone) to lint before push and auto-bootstrap new worktrees.\n' >&2; \
 	fi
 
 # Derives this developer's signing team from their own certificate into the

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ make install-hooks
 make bootstrap
 ```
 
-`install-hooks` points the repo at the checked-in `.githooks/` directory so a pre-push hook runs `make lint` locally and matches the swift-format check enforced on `main`. It's a one-time setup per clone (Git does not auto-activate checked-in hooks). Bypass an individual push with `git push --no-verify`.
+`install-hooks` points the repo at the checked-in `.githooks/` directory. It's a one-time setup per clone (Git does not auto-activate checked-in hooks) and enables two hooks: a pre-push hook that runs `make lint` locally, matching the swift-format check enforced on `main` (bypass an individual push with `git push --no-verify`), and a post-checkout hook that re-runs `bootstrap` (below) in any checkout missing `Config/Local.xcconfig` — so a new git worktree builds in Xcode immediately with no manual step.
 
-`bootstrap` derives your own signing team from your Apple Development (or Developer ID) certificate into a gitignored `Config/Local.xcconfig`, so a Debug build signs as *you* rather than a hardcoded team — see [Signing: Debug vs Release](#signing-debug-vs-release) below. `make build` and `make test` run it automatically, so this is only a manual step if you're building straight from Xcode without ever running a `make` target first, or working in a second git worktree (each one needs its own `Config/Local.xcconfig`, since gitignored files aren't shared between worktrees).
+`bootstrap` derives your own signing team from your Apple Development (or Developer ID) certificate into a gitignored `Config/Local.xcconfig`, so a Debug build signs as *you* rather than a hardcoded team — see [Signing: Debug vs Release](#signing-debug-vs-release) below. `make build` and `make test` run it automatically, and the post-checkout hook covers additional git worktrees (each needs its own `Config/Local.xcconfig`, since gitignored files aren't shared between worktrees), so this is only a manual step if you're building a fresh clone straight from Xcode without ever running a `make` target first.
 
 Run `make doctor` to confirm your local toolchain (macOS, Xcode, Swift, swift-format), signing team, and git hooks match what Kernova needs before building.
 

--- a/Tools/doctor.sh
+++ b/Tools/doctor.sh
@@ -133,9 +133,9 @@ section 'Repository'
 # (same stance as the Makefile's check-hooks nudge).
 hooks_path=$(git config --get core.hooksPath 2>/dev/null || echo '')
 if [ "$hooks_path" = ".githooks" ]; then
-    pass "pre-push lint hook installed (core.hooksPath = .githooks)"
+    pass "git hooks installed (core.hooksPath = .githooks): pre-push lint, post-checkout team bootstrap"
 else
-    warn "pre-push lint hook not installed — run 'make install-hooks' (one-time per clone)"
+    warn "git hooks not installed — run 'make install-hooks' (one-time per clone)"
 fi
 
 # ---- signing ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New git worktrees now derive the developer's signing team automatically at creation, so their first Xcode build signs with no manual `make bootstrap`
- Closes the recurring per-worktree setup gap: `Config/Local.xcconfig` is gitignored, so every fresh worktree was missing it and hit "Signing for … requires a development team" on all five signed targets until bootstrap was run by hand

## Changes
- Add `.githooks/post-checkout`: on branch checkouts (including `git worktree add`), runs `Tools/bootstrap-team.sh` when `Config/Local.xcconfig` is missing; instant no-op otherwise, and best-effort so a failed derivation (e.g. no signing certificate) never breaks a checkout
- Update `make install-hooks` echo and the `check-hooks` nudge to describe both hooks
- Update `Tools/doctor.sh`'s Repository check wording to cover both hooks
- Update README Development setup and CLAUDE.md Build & Test docs: worktrees are now automatic; a fresh clone (where hooks aren't active yet — git never auto-runs checked-in hooks) remains the one documented manual `make bootstrap` case

## Why not a pre-build step
Xcode resolves build settings (including the xcconfig include) at build-planning time, before any build phase or scheme pre-action reliably takes effect — a pre-build write can't fix the build it runs in, so the first build in a fresh worktree would still fail. Checkout time is the only point guaranteed to precede the first settings evaluation. Team drift (switching developer teams) stays covered by `make doctor`'s keychain cross-check and `Tools/bootstrap-team.sh --force`.

## Test plan
- [x] `git worktree add --detach` of this commit auto-created `Config/Local.xcconfig` with the derived team during worktree creation
- [x] Checkout in an already-bootstrapped tree is a no-op (Local.xcconfig guard)
- [x] `make doctor` passes: hooks installed, team resolved and matching keychain
- [x] Pre-push lint hook ran on this PR's push (hooksPath wiring verified live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkZwM8wHfY3xjCPHSdJy6S