### PR TITLE
chore: Self-heal worktree LaunchServices ghosts via a post-checkout sweep

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,20 +1,5 @@
 {
   "enabledPlugins": {
     "swift-lsp@claude-plugins-official": true
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "ExitWorktree",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r 'select(.tool_input.action == \"remove\") | .cwd // empty' | { read -r wt; [ -n \"$wt\" ] && { LSREG=/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister; p=\"$wt/DerivedData/Kernova/Build/Products\"; for app in \"Kernova.app\" \"Kernova Guest Agent.app\"; do for cfg in Debug Release; do \"$LSREG\" -u \"$p/$cfg/$app\"; done; done; }; } 2>/dev/null || true",
-            "timeout": 15,
-            "statusMessage": "Unregistering worktree build from LaunchServices"
-          }
-        ]
-      }
-    ]
   }
 }

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -10,7 +10,7 @@
 # auto-runs checked-in hooks), so a brand-new clone still needs one
 # `make bootstrap`/`make build` — see README "Development setup".
 #
-# Two steps:
+# Three steps:
 #   1. Copy the gitignored local files listed in .worktreeinclude from the
 #      main checkout. Claude Code (and other worktree tools, e.g.
 #      git-worktreeinclude, Conductor) consume that file natively when they
@@ -19,6 +19,11 @@
 #   2. Derive DEVELOPMENT_TEAM via Tools/bootstrap-team.sh when step 1
 #      didn't deliver Config/Local.xcconfig (no main-checkout copy to
 #      inherit — e.g. the main checkout of a fresh clone).
+#   3. Sweep dead app.kernova.* Launch Services registrations left by
+#      removed worktrees (see CLAUDE.md "Worktree LaunchServices cleanup").
+#      Initial checkouts only ($1 is the null ref for `git worktree add`/
+#      `git clone` but not `git switch`), so the multi-second lsregister
+#      dump never taxes a plain branch switch.
 #
 # Git runs post-checkout from the working-tree root, so the relative paths
 # below resolve within whichever worktree was just created or switched.
@@ -54,13 +59,19 @@ fi
 
 # ---- 2. derive DEVELOPMENT_TEAM if still missing ----------------------------
 
-[ -f Config/Local.xcconfig ] && exit 0
-
 # Best-effort: a failed derivation (e.g. no signing certificate in the
 # keychain) must not fail the checkout; bootstrap prints its own diagnostics
 # and `make doctor` reports the missing team.
-if [ -x Tools/bootstrap-team.sh ]; then
+if [ ! -f Config/Local.xcconfig ] && [ -x Tools/bootstrap-team.sh ]; then
     Tools/bootstrap-team.sh || true
+fi
+
+# ---- 3. sweep dead LaunchServices registrations ------------------------------
+
+# Best-effort: a failed sweep must not fail the checkout; `make ghosts`
+# reports anything left behind.
+if [ "${1:-}" = "0000000000000000000000000000000000000000" ] && [ -x Tools/ghosts.sh ]; then
+    Tools/ghosts.sh --sweep-ls || true
 fi
 
 exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,34 +344,20 @@ push.)
 
 ### Worktree LaunchServices cleanup
 
-Every worktree build registers its app bundles with LaunchServices; when the
-worktree is removed those registrations become ghosts — stale entries that
-accumulate and have previously hijacked UTI and name resolution. A
-`PreToolUse`/`ExitWorktree` hook in `.claude/settings.json` prevents this: on
-`ExitWorktree(action: "remove")` (which runs `git worktree remove`) it runs
-`lsregister -u` on the worktree's built apps. It fires `PreToolUse` so the
-bundles still exist on disk — `lsregister` must read a bundle to unregister it —
-and it is scoped to the one removed worktree via the tool's `.cwd`.
-
-It unregisters both top-level apps, `Kernova.app` and `Kernova Guest Agent.app`
-(#450), across Debug and Release. Products live at the **nested**
-`DerivedData/Kernova/Build/Products/<config>/` path — Xcode "Relative" mode and
-`-derivedDataPath DerivedData/Kernova` both nest a per-project subfolder (see
-[Build & Test](#build--test)) — not the flat `DerivedData/Build/Products/`. The
-embedded appexes (`KernovaFileProvider`, `KernovaQuickLook`,
-`KernovaMacOSAgentFileProvider`) need no separate handling: unregistering a
-parent `.app` cascades to its plugin registrations (verified — a plain
-`lsregister -u` on the app alone clears all three appex entries; the `-R` flag
-governs recursive *scanning*, not unregister cascade).
-
-Two cases stay uncovered by design: a human running `git worktree remove`
-directly triggers nothing (it is not a harness tool call, and git has **no**
-worktree-lifecycle hook — `man githooks` confirms), and Xcode-side hashed
-DerivedData lands outside `.cwd`. Both leave ghosts that only accumulate; clear
-the backlog on demand with `make ghosts` (report) / `make clean-ghosts` (also
-unregisters/kills/prunes) and `make ls-reset` for the legacy pre-#471-rename
-`com.kernova.app` identifier a plain regex update to `ghosts.sh` doesn't yet
-cover (`Tools/ghosts.sh`, `Tools/ls-reset.sh`, #454). `make ghosts` also
+Every worktree build registers its app bundles (and their embedded appexes)
+with LaunchServices; when the worktree is removed those registrations become
+ghosts — stale entries that accumulate and have previously hijacked UTI and
+name resolution. Dead-path ghosts self-heal lazily: the `post-checkout` git
+hook's step 3 runs `Tools/ghosts.sh --sweep-ls` on every *initial* checkout
+(`git worktree add` passes the null ref as `$1`; a plain `git switch` never
+pays the multi-second `lsregister` dump), unregistering every registered
+`app.kernova.*` path that no longer exists on disk (`lsregister -u` works
+even after the path is gone). The sweep only heals dead paths; LIVE stray
+copies still need the on-demand tools: `make ghosts` (report) /
+`make clean-ghosts` (also unregisters/kills/prunes) and `make ls-reset` for
+the legacy pre-#471-rename `com.kernova.app` identifier a plain regex update
+to `ghosts.sh` doesn't yet cover (`Tools/ghosts.sh`, `Tools/ls-reset.sh`,
+#454). `make ghosts` also
 inventories LIVE Kernova.app copies still on disk under Trash and
 `~/Library/Developer/Xcode/DerivedData` — exactly the hashed-DerivedData case
 above — and flags any that outrank the installed `/Applications` copy in the

--- a/Makefile
+++ b/Makefile
@@ -169,12 +169,13 @@ doctor: ## Check the local toolchain (macOS, Xcode, Swift, swift-format) and rep
 	@Tools/doctor.sh
 
 # Diagnoses ghost Launch Services registrations, orphaned processes, and
-# prunable git worktrees left behind when a worktree is torn down by hand
-# instead of through Claude Code's ExitWorktree unregister hook — plus LIVE
-# on-disk Kernova.app copies (Trash, DerivedData) that outrank the installed
-# /Applications copy in the LaunchServices/PluginKit CFBundleVersion election
-# (#454). `ghosts` only reports; `clean-ghosts` also unregisters/kills/prunes,
-# and offers to evict (trash) a competing copy it finds.
+# prunable git worktrees left behind by torn-down worktrees (the post-checkout
+# hook sweeps dead registrations on new checkouts; this reports whatever
+# remains) — plus LIVE on-disk Kernova.app copies (Trash, DerivedData) that
+# outrank the installed /Applications copy in the LaunchServices/PluginKit
+# CFBundleVersion election (#454). `ghosts` only reports; `clean-ghosts` also
+# unregisters/kills/prunes, and offers to evict (trash) a competing copy it
+# finds.
 ghosts: ## Report stale/competing Kernova Launch Services, process, and worktree registrations
 	@Tools/ghosts.sh
 

--- a/Tools/ghosts.sh
+++ b/Tools/ghosts.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Find (and optionally clean up) ghost Kernova registrations left behind by
-# worktrees that were torn down without going through Claude Code's
-# ExitWorktree unregister hook (a manual `git worktree remove`, dragging the
-# worktree to Trash, etc.).
+# torn-down worktrees (Claude Code's session-end auto-removal of a clean
+# worktree, a manual `git worktree remove`, dragging the worktree to Trash,
+# etc.).
 #
 # Both KernovaFileProvider (host) and KernovaMacOSAgentFileProvider (guest
 # agent) are ordinary macOS/arm64 .appex bundles — nothing about them is
@@ -29,15 +29,55 @@
 #     (#454). Deregistration/eviction is the only lever.
 #
 # Run via `make ghosts` (report only) or `make clean-ghosts` (also fixes).
-# Direct invocation: Tools/ghosts.sh [--fix]
+# Direct invocation: Tools/ghosts.sh [--fix | --sweep-ls]
 
 set -uo pipefail
 
 FIX=0
-[ "${1:-}" = "--fix" ] && FIX=1
+SWEEP=0
+case "${1:-}" in
+    --fix) FIX=1 ;;
+    --sweep-ls) SWEEP=1 ;;
+esac
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LSREGISTER=/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister
+
+# lsregister's dump lists `path:` a few lines before the `identifier:` line
+# for the same entry, with entries separated by a full-width dash rule —
+# track the most recently seen path and reset it at each rule so an
+# identifier never gets paired with a path from a different entry.
+kernova_registered_paths() {
+    "$LSREGISTER" -dump 2>/dev/null | awk '
+        /^-+$/ { path = "" }
+        /^path:/ {
+            line = $0
+            sub(/^path:[ \t]*/, "", line)
+            sub(/ \(0x[0-9a-fA-F]+\)[ \t]*$/, "", line)
+            path = line
+        }
+        /^identifier:[ \t]+app\.kernova($|\.)/ {
+            if (path != "") print path
+        }
+    ' | sort -u
+}
+
+# --sweep-ls: the quiet, non-interactive subset for hooks — unregister dead
+# app.kernova.* Launch Services registrations and exit. The post-checkout git
+# hook runs it on every new worktree, so registrations left by torn-down
+# worktrees self-heal at the next worktree creation. Best-effort by design:
+# always exits 0 so a failed sweep can never fail the checkout that triggered
+# it, and skips the fix path's re-dump verification — `make ghosts` still
+# reports anything left behind.
+if [ "$SWEEP" = 1 ]; then
+    while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        [ -e "$path" ] && continue
+        "$LSREGISTER" -u "$path" >/dev/null 2>&1
+        printf 'ghosts.sh: swept dead Launch Services registration: %s\n' "$path"
+    done < <(kernova_registered_paths)
+    exit 0
+fi
 
 # ---- output helpers (matches Tools/doctor.sh) --------------------------------
 
@@ -67,25 +107,6 @@ printf '%sKernova ghost cleanup%s\n' "$c_bold" "$c_reset"
 # ---- Launch Services ghost registrations -------------------------------------
 
 section 'Launch Services registrations'
-
-# lsregister's dump lists `path:` a few lines before the `identifier:` line
-# for the same entry, with entries separated by a full-width dash rule —
-# track the most recently seen path and reset it at each rule so an
-# identifier never gets paired with a path from a different entry.
-kernova_registered_paths() {
-    "$LSREGISTER" -dump 2>/dev/null | awk '
-        /^-+$/ { path = "" }
-        /^path:/ {
-            line = $0
-            sub(/^path:[ \t]*/, "", line)
-            sub(/ \(0x[0-9a-fA-F]+\)[ \t]*$/, "", line)
-            path = line
-        }
-        /^identifier:[ \t]+app\.kernova($|\.)/ {
-            if (path != "") print path
-        }
-    ' | sort -u
-}
 
 # Built via a plain read loop rather than `mapfile`/`readarray`: macOS ships
 # bash 3.2 (GPLv3), which predates both builtins.


### PR DESCRIPTION
## Summary
- Worktree removals that bypass the ExitWorktree tool — Claude Code's session-end auto-removal of a clean worktree, the interactive `/exit` remove prompt, a manual `git worktree remove` — left ghost LaunchServices registrations that the `PreToolUse`/`ExitWorktree` hook could never see (`PreToolUse` hooks only fire on tool calls).
- Replaces that event-driven unregister hook with a lazy sweep: dead `app.kernova.*` registrations self-heal the next time any worktree is created, regardless of how the previous one was removed.

## Changes
- **`Tools/ghosts.sh`**: new quiet `--sweep-ls` mode that unregisters every registered `app.kernova.*` path missing on disk, sharing the existing `lsregister -dump` parser. Best-effort: always exits 0, no re-dump verification — `make ghosts` still reports anything left behind.
- **`.githooks/post-checkout`**: new step 3 runs the sweep on *initial* checkouts only (`$1` is the null ref for `git worktree add`/`git clone` but not `git switch`, so plain branch switches never pay the multi-second `lsregister` dump). Step 2's early exit restructured so step 3 is reachable.
- **`.claude/settings.json`**: drops the `PreToolUse`/`ExitWorktree` unregister hook — it only covered conversational exits, and the sweep covers every removal path.
- **`CLAUDE.md`**: "Worktree LaunchServices cleanup" collapsed to one paragraph describing the sweep plus the on-demand tools (`make ghosts` / `make clean-ghosts` / `make ls-reset`) that remain necessary for LIVE stray copies.

## Test plan
- [x] `Tools/ghosts.sh --sweep-ls` cleared 5 real ghosts left by a removed worktree, plus a synthetic registered-then-deleted `app.kernova.*` bundle (confirming identifier-based scoping)
- [x] Verified `git worktree add` invokes post-checkout with the null ref and the hook completes end-to-end (exit 0, `.worktreeinclude` copy intact)
- [x] `make ghosts` LaunchServices section clean afterwards
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbqQMgYfwg7mM4TXrfDqPX