### PR TITLE
refactor: Consolidate the triplicated AsyncGate/waitUntil test helpers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -206,7 +206,7 @@ KernovaQuickLook/                       # Quick Look preview extension (.appex e
 └── KernovaQuickLook.entitlements       # App sandbox + user-selected read-only (appexes must be sandboxed)
 
 KernovaKit/                        # SPM package: the **shared host <-> guest module** — everything both the app and the guest agent need. The vsock wire protocol was its first tenant and still dominates it, but membership is "shared between the two targets," not "wire-only": it also holds the clipboard domain model (`ClipboardContent`) + file staging/archive, cross-cutting helpers (`KernovaVersionComparison`), and the shared `NSPasteboardItemDataProvider`. New host/guest-identical code (e.g. a shared progress component) belongs here too. The name reflects this broader scope — the package was renamed from `KernovaProtocol` (its wire-protocol origin) to `KernovaKit` in #407
-├── Package.swift                       # Swift 6 package, depends on apple/swift-protobuf
+├── Package.swift                       # Swift 6 package, depends on apple/swift-protobuf; also vends the `KernovaTestSupport` product (see Sources/KernovaTestSupport/ below)
 ├── Proto/
 │   └── kernova.proto                   # Frame envelope + Hello/Error/Heartbeat + clipboard payloads (metadata offer/request + chunk-streamed begin/chunk/end/ack/abort; legacy single-frame ClipboardData + ClipboardFormat retired/reserved) + log records
 ├── Sources/KernovaKit/
@@ -243,6 +243,8 @@ KernovaKit/                        # SPM package: the **shared host <-> guest mo
 │   ├── KernovaLogMessage.swift         # Custom interpolation supporting OSLogPrivacy-shaped privacy attrs (moved from KernovaMacOSAgent/ in #434)
 │   ├── KernovaVersionComparison.swift  # `isAtLeast` numeric version comparator — the single current-vs-outdated rule shared by the host's AgentStatus and the guest's update line
 │   └── KernovaCodeSignature.swift      # Resolves the running executable's own Developer Team Identifier from its code signature (`SecCodeCopySelf` → `SecCodeCopyStaticCode` → `SecCodeCopySigningInformation(kSecCSSigningInformation)` → `kSecCodeInfoTeamIdentifier`, cached); `nil` for unsigned/ad-hoc code. Backs `FileProviderConfig.host()`'s peer pins (#476)
+├── Sources/KernovaTestSupport/          # Plain-Foundation `KernovaTestSupport` product (#526) — the single shared copy of the event-driven/poll wait primitives all three test targets (KernovaTests, KernovaMacOSAgentTests, KernovaKitTests) depend on
+│   └── AsyncWaits.swift                # `TestFailure`, `ResumeOnce`, `AsyncGate` (`wait`/`waitUntil` take the caller's isolation via `isolation: isolated (any Actor)? = #isolation`, so one implementation serves both `@MainActor` and nonisolated callers), `waitUntil` — formerly triplicated across the three bundles (see CLAUDE.md's "Async waits in tests"); has no dependency on `KernovaKit` and is never linked into a shipping target
 └── Tests/KernovaKitTests/              # One suite per package area — regenerate this inventory with `ls` rather than trusting a snapshot. Areas:
                                         #   wire protocol (VsockFrameTests, VsockChannelTests); clipboard domain model + snapshot policy
                                         #   (ClipboardContentTests); the streaming engine end-to-end (ClipboardStreamTests, ClipboardFileStagingTests,
@@ -254,7 +256,9 @@ KernovaKit/                        # SPM package: the **shared host <-> guest mo
                                         #   FileProviderServicingTimingTests — #466's connect-timeout/retry-budget coupling); KernovaLogMessageTests
                                         #   (privacy-redaction matrix, moved here with its source in #434), KernovaVersionComparisonTests, and
                                         #   KernovaCodeSignatureTests (#476 — the running code's own team-identifier resolution).
-                                        #   StreamTestSupport.swift holds the shared helpers (channel pairs, AsyncGate, frame factories)
+                                        #   StreamTestSupport.swift holds the package-specific helpers (channel pairs, frame factories,
+                                        #   pollUntil, StreamTestFailure); AsyncGate/waitUntil/TestFailure come from the shared
+                                        #   KernovaTestSupport product (#526)
 
 Config/
 ├── Base.xcconfig                       # Tracked project-level base config (wired via baseConfigurationReference on both project XCBuildConfigurations); carries no team — just `#include? "Local.xcconfig"` (#476)
@@ -279,8 +283,9 @@ KernovaTests/
 │   ├── MockUSBDeviceService.swift
 │   ├── SuspendingMockUSBDeviceService.swift
 │   └── MockVMLibraryPresenting.swift   # Records VMLibraryViewModel presentation requests for test assertions
-├── TestHelpers.swift                   # Shared helpers: waitForChange (Observation-armed), AsyncGate (@MainActor variant), waitUntil,
-│                                       # socket-pair factories — see CLAUDE.md's async-wait table for when to use which
+├── TestHelpers.swift                   # Bundle-specific helpers: waitForChange (Observation-armed, KernovaTests-only), nextFrame,
+│                                       # socket-pair factories, AppKit window factory — AsyncGate/waitUntil/TestFailure come from the
+│                                       # shared KernovaTestSupport product (#526); see CLAUDE.md's async-wait table for when to use which
 └── …Tests.swift                        # ~70 suites, roughly one per component — regenerate this inventory with `ls` rather than
                                         # trusting a snapshot. Areas:
                                         #   models (VMConfiguration + clone, VMInstance + recovery eligibility, VMBundleLayout, VMStatus /
@@ -304,9 +309,9 @@ KernovaMacOSAgentTests/                 # Unit tests for the guest agent (standa
 │                                       # Compiles KernovaMacOSAgent source files directly (except AgentAppDelegate.swift)
 │                                       # so internal members are accessible without @testable import.
 │                                       # See Helper Targets section for the source-compilation rationale.
-├── TestHelpers.swift                   # Shared helpers: makeRawSocketPair, makeChannelPair, waitUntil, AsyncGate (nonisolated
-│                                       # variant, kept aligned with the KernovaTests copy — see CLAUDE.md's async-wait table),
-│                                       # nextFrame, awaitFirst, AtomicInt, frame factories (makeLogFrame etc.)
+├── TestHelpers.swift                   # Bundle-specific helpers: makeRawSocketPair, makeChannelPair, nextFrame, awaitFirst, AtomicInt
+│                                       # (built on the shared AsyncGate), frame factories (makeLogFrame etc.) — AsyncGate/waitUntil/
+│                                       # TestFailure come from the shared KernovaTestSupport product (#526; see CLAUDE.md's async-wait table)
 ├── AgentMenuTextTests.swift       # Pure menu-text mappers: identity/about titles, updateAvailableLine, hostStatusLine, statusSubmenu, logForwardingLine, clipboardLine
 ├── VsockHostConnectionTests.swift      # Log ring-buffer cap, partial-flush re-enqueue, forwardLog live-channel paths
 ├── VsockGuestClientTests.swift         # Connect/retry/stop lifecycle; socket-factory injection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,12 +86,12 @@ When adding new functionality or modifying existing behavior, include unit tests
 
 macos-26 CI runners have heavy `@MainActor` scheduling jitter. With a `waitUntil`/`pollUntil` poll loop, the timeout deadline *is* the pass/fail criterion — so a starved scheduler fails a test whose condition would have become true. **When a test waits for async state that has an underlying signal, make the wait event-driven from the start — do not reach for a poll loop.** With event-driven waits the timeout is only a stuck-condition backstop the happy path never reaches.
 
-Pick the seam by what produces the state (helpers live in `KernovaTests/TestHelpers.swift`, `KernovaMacOSAgentTests/TestHelpers.swift`, and `KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift`):
+Pick the seam by what produces the state. `AsyncGate`/`waitUntil`/`TestFailure` live in the shared `KernovaTestSupport` SwiftPM product (`KernovaKit/Sources/KernovaTestSupport/`), imported by all three test targets; `waitForChange` is KernovaTests-only and stays in `KernovaTests/TestHelpers.swift`:
 
 | Seam | Use when | Notes |
 |------|----------|-------|
 | `waitForChange(until:)` | The predicate reads a production `@Observable` property directly (e.g. `service.clipboardContent`, `service.agentStatus`) | KernovaTests only. Built on `withObservationTracking`: the predicate must be side-effect-free and read every inspected value through an `@Observable` getter on the arming pass, or only the deadline wakes it. |
-| `AsyncGate` (`notify()` + `wait(until:)`) | The signal flows through a test-owned double/recorder | Call `notify()` after each relevant mutation. `@MainActor` in KernovaTests; `nonisolated` + `@Sendable` predicate in the GuestAgent/KernovaKit bundles — keep the copies aligned. |
+| `AsyncGate` (`notify()` + `wait(until:)`) | The signal flows through a test-owned double/recorder | Call `notify()` after each relevant mutation. A single implementation serves every bundle: `wait`/`waitUntil` take the caller's isolation via `isolation: isolated (any Actor)? = #isolation`, so the same code runs isolation-free for `@MainActor` KernovaTests predicates and nonisolated GuestAgent/KernovaKit predicates alike — no per-bundle fork to keep in sync (#526). |
 | `await` the production `Task` | A production `Task` does the work | Expose it via a `#if DEBUG …ForTesting` seam and `await task.value` instead of polling the flag it flips. |
 
 If the condition is driven by a *single* event a starved scheduler can miss (e.g. one heartbeat that latches a terminal state), drive it *continuously* — a wait conversion alone won't fix that.

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		A2000006 /* KernovaKit in Frameworks */ = {isa = PBXBuildFile; productRef = A2000007 /* KernovaKit */; };
 		A2000009 /* KernovaKit in Frameworks */ = {isa = PBXBuildFile; productRef = A2000008 /* KernovaKit */; };
 		A200000A /* KernovaKit in Frameworks */ = {isa = PBXBuildFile; productRef = A200000B /* KernovaKit */; };
+		A200000C /* KernovaTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = A200000D /* KernovaTestSupport */; };
+		A200000E /* KernovaTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = A200000F /* KernovaTestSupport */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -240,6 +242,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A200000C /* KernovaTestSupport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -263,6 +266,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A2000006 /* KernovaKit in Frameworks */,
+				A200000E /* KernovaTestSupport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -385,6 +389,7 @@
 			);
 			name = KernovaTests;
 			packageProductDependencies = (
+				A200000D /* KernovaTestSupport */,
 			);
 			productName = KernovaTests;
 			productReference = A1000005 /* KernovaTests.xctest */;
@@ -457,6 +462,7 @@
 			name = KernovaMacOSAgentTests;
 			packageProductDependencies = (
 				A2000007 /* KernovaKit */,
+				A200000F /* KernovaTestSupport */,
 			);
 			productName = KernovaMacOSAgentTests;
 			productReference = A1000300 /* KernovaMacOSAgentTests.xctest */;
@@ -1455,6 +1461,14 @@
 		A200000B /* KernovaKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = KernovaKit;
+		};
+		A200000D /* KernovaTestSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KernovaTestSupport;
+		};
+		A200000F /* KernovaTestSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KernovaTestSupport;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/KernovaKit/Package.swift
+++ b/KernovaKit/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
         .macOS(.v15)
     ],
     products: [
-        .library(name: "KernovaKit", targets: ["KernovaKit"])
+        .library(name: "KernovaKit", targets: ["KernovaKit"]),
+        .library(name: "KernovaTestSupport", targets: ["KernovaTestSupport"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.38.0")
@@ -22,9 +23,15 @@ let package = Package(
                 .swiftLanguageMode(.v6)
             ]
         ),
+        .target(
+            name: "KernovaTestSupport",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
         .testTarget(
             name: "KernovaKitTests",
-            dependencies: ["KernovaKit"],
+            dependencies: ["KernovaKit", "KernovaTestSupport"],
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]

--- a/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+// Shared event-driven/poll wait primitives for the three test bundles
+// (KernovaTests, KernovaMacOSAgentTests, KernovaKitTests). Formerly
+// triplicated — each bundle carried its own copy because Xcode 16
+// synchronized folders make each bundle's own files target-private — and had
+// already drifted once (#526). `KernovaTestSupport` is a plain Foundation
+// SwiftPM product all three test targets depend on, so there is now exactly
+// one copy.
+//
+// `AsyncGate.wait`/`waitUntil` take the caller's isolation via `#isolation`,
+// so the same implementation serves both `@MainActor` callers (predicates
+// reading MainActor-isolated state, e.g. KernovaTests) and nonisolated
+// callers (predicates reading `Sendable` boxes, e.g. the GuestAgent/
+// KernovaKit bundles) without forking the type. `waitForChange` — the one
+// genuinely KernovaTests-only helper, built on `withObservationTracking`
+// over `@MainActor` `@Observable` production state — stays local to
+// `KernovaTests/TestHelpers.swift`; it was never one of the triplicated
+// copies.
+
+// MARK: - TestFailure
+
+/// A test failure with a diagnostic message, thrown by the wait helpers below.
+///
+/// Shared by all three test bundles. `KernovaKitTests`'s `pollUntil` and
+/// stream helpers keep their own `StreamTestFailure` (see
+/// `StreamTestSupport.swift`) — that type is package-specific and was never
+/// one of the triplicated copies this module consolidates.
+public struct TestFailure: Error, CustomStringConvertible {
+    /// The diagnostic text describing what condition was not met.
+    public let message: String
+
+    /// Creates a failure carrying `message`.
+    public init(_ message: String) { self.message = message }
+
+    /// The failure's diagnostic message.
+    public var description: String { message }
+}
+
+// MARK: - ResumeOnce
+
+/// Resumes its continuation at most once, regardless of how many racing paths
+/// (a `notify()` and the timeout backstop) try to fire it. `CheckedContinuation`
+/// traps on a second resume, so this guard makes the race safe.
+public final class ResumeOnce: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+
+    /// Creates a fresh, unfired guard.
+    public init() {}
+
+    /// Runs `body` only on the first call; every later call is a no-op.
+    public func fire(_ body: () -> Void) {
+        lock.lock()
+        let already = fired
+        fired = true
+        lock.unlock()
+        if !already { body() }
+    }
+}
+
+// MARK: - AsyncGate
+
+/// Event-driven replacement for a `waitUntil` poll loop.
+///
+/// A producer calls `notify()` after each observable state change; the consumer
+/// awaits `wait(until:)`, which suspends until the predicate holds — re-checked
+/// on every `notify()` — or throws `TestFailure` after `timeout`.
+///
+/// Unlike a poll loop, an idle waiter adds **zero** wake-ups to the shared (and,
+/// on CI, contended) executor, and `timeout` is a stuck-condition backstop the
+/// happy path never reaches rather than the success deadline — so a slow runner
+/// no longer fails the wait, only a genuinely stuck condition does. This is the
+/// fix for the timing-sensitive flakes documented in the flaky-CI investigation
+/// (see CLAUDE.md's "Async waits in tests").
+public final class AsyncGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var waiters: [UUID: () -> Void] = [:]
+
+    /// Creates a fresh gate with no waiters.
+    public init() {}
+
+    /// Wake every current waiter; call right after mutating observed state.
+    public func notify() {
+        lock.lock()
+        let resumes = Array(waiters.values)
+        waiters.removeAll()
+        lock.unlock()
+        resumes.forEach { $0() }
+    }
+
+    /// Suspend until `predicate()` holds (re-checked on each `notify()`), or
+    /// throw `TestFailure` after `timeout`.
+    public func wait(
+        timeout: Duration = .seconds(10),
+        isolation: isolated (any Actor)? = #isolation,
+        until predicate: () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while !predicate() {
+            if ContinuousClock.now >= deadline {
+                throw TestFailure("Condition not met within \(timeout)")
+            }
+            await armOnce(deadline: deadline, isolation: isolation, predicate: predicate)
+        }
+    }
+
+    /// Suspends until the next `notify()`, an immediate hit (the predicate
+    /// already holds at arm time, closing the arm-vs-notify race), or the
+    /// `deadline` backstop — whichever comes first.
+    ///
+    /// `isolation` is forwarded from `wait` rather than re-derived via
+    /// `#isolation`, so the synchronous body below — which calls `predicate()`
+    /// — runs on the same actor as the original caller with no hop. The
+    /// backstop `Task` touches only `Sendable` state (never `predicate`), so
+    /// it needs no isolation of its own.
+    private func armOnce(
+        deadline: ContinuousClock.Instant,
+        isolation: isolated (any Actor)?,
+        predicate: () -> Bool
+    ) async {
+        // Captured so it can be cancelled once `notify()` (or the immediate-hit
+        // re-check) resolves the wait; otherwise every happy-path arm would leak
+        // a Task sleeping until `deadline`.
+        var backstop: Task<Void, Never>?
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            let id = UUID()
+            let once = ResumeOnce()
+            lock.lock()
+            waiters[id] = { once.fire { cont.resume() } }
+            lock.unlock()
+            // Close the arm-vs-notify race: if the state already satisfies the
+            // predicate (a notify may have landed before we registered), resume
+            // now so the outer loop re-checks promptly instead of blocking.
+            if predicate() {
+                lock.lock()
+                waiters.removeValue(forKey: id)
+                lock.unlock()
+                once.fire { cont.resume() }
+                return
+            }
+            // Backstop: resume at the deadline even if no notify arrives, so a
+            // genuinely stuck condition fails the wait instead of hanging.
+            backstop = Task {
+                try? await Task.sleep(until: deadline, clock: ContinuousClock())
+                self.lock.withLock { _ = self.waiters.removeValue(forKey: id) }
+                once.fire { cont.resume() }
+            }
+        }
+        // Resolved via notify() or the immediate hit; cancel the backstop so it
+        // doesn't linger asleep until `deadline`.
+        backstop?.cancel()
+    }
+}
+
+// MARK: - waitUntil
+
+/// Polls `predicate` every 50 ms until it returns `true` or `timeout` elapses.
+///
+/// Default deadline is generous (5 s) to absorb scheduling jitter on CI
+/// runners. See CLAUDE.md's "Async waits in tests" — prefer the event-driven
+/// `AsyncGate` above for new timing-sensitive waits; polling is retained for
+/// predicates with no underlying signal to await.
+public func waitUntil(
+    timeout: Duration = .seconds(5),
+    isolation: isolated (any Actor)? = #isolation,
+    _ predicate: () -> Bool
+) async throws {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while !predicate() && ContinuousClock.now < deadline {
+        try await Task.sleep(for: .milliseconds(50))
+    }
+    guard predicate() else {
+        throw TestFailure("Predicate did not become true within \(timeout)")
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
@@ -1,6 +1,7 @@
 import CryptoKit
 import Foundation
 import Testing
+import KernovaTestSupport
 
 @testable import KernovaKit
 

--- a/KernovaKit/Tests/KernovaKitTests/FileProviderDomainHostTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/FileProviderDomainHostTests.swift
@@ -1,6 +1,7 @@
 import FileProvider
 import Foundation
 import Testing
+import KernovaTestSupport
 
 @testable import KernovaKit
 

--- a/KernovaKit/Tests/KernovaKitTests/FileProviderRelayServiceTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/FileProviderRelayServiceTests.swift
@@ -1,6 +1,7 @@
 import FileProvider
 import Foundation
 import Testing
+import KernovaTestSupport
 
 @testable import KernovaKit
 

--- a/KernovaKit/Tests/KernovaKitTests/FileProviderServiceSourceTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/FileProviderServiceSourceTests.swift
@@ -2,6 +2,7 @@ import FileProvider
 import Foundation
 import Testing
 import os
+import KernovaTestSupport
 
 @testable import KernovaKit
 

--- a/KernovaKit/Tests/KernovaKitTests/FileProviderServicingConnectorTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/FileProviderServicingConnectorTests.swift
@@ -1,6 +1,7 @@
 import FileProvider
 import Foundation
 import Testing
+import KernovaTestSupport
 
 @testable import KernovaKit
 

--- a/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import KernovaTestSupport
 
 @testable import KernovaKit
 

--- a/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
+++ b/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
@@ -1,6 +1,7 @@
 import Darwin
 import FileProvider
 import Foundation
+import KernovaTestSupport
 
 @testable import KernovaKit
 
@@ -47,76 +48,6 @@ func makeTestFileProviderConfig() -> FileProviderConfig {
         extensionLoggerSubsystem: "app.kernova.test.fileprovider",
         ownerCodeSigningRequirement: nil,
         extensionCodeSigningRequirement: nil)
-}
-
-// MARK: - AsyncGate (package-test copy)
-
-/// Resumes its continuation at most once across the `notify()`/timeout race.
-private final class ResumeOnce: @unchecked Sendable {
-    private let lock = NSLock()
-    private var fired = false
-    func fire(_ body: () -> Void) {
-        lock.lock()
-        let already = fired
-        fired = true
-        lock.unlock()
-        if !already { body() }
-    }
-}
-
-/// Event-driven wait primitive — a producer calls `notify()` after each state
-/// change; the consumer awaits `wait(until:)`.
-///
-/// Mirrors the app/guest test
-/// bundles' `AsyncGate` (kept in sync per the flaky-CI investigation), copied
-/// here because Xcode synchronized folders make those copies target-private.
-final class AsyncGate: @unchecked Sendable {
-    private let lock = NSLock()
-    private var waiters: [UUID: () -> Void] = [:]
-
-    func notify() {
-        lock.lock()
-        let resumes = Array(waiters.values)
-        waiters.removeAll()
-        lock.unlock()
-        resumes.forEach { $0() }
-    }
-
-    func wait(
-        timeout: Duration = .seconds(10),
-        until predicate: @Sendable () -> Bool
-    ) async throws {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while !predicate() {
-            if ContinuousClock.now >= deadline {
-                throw StreamTestFailure("Condition not met within \(timeout)")
-            }
-            await armOnce(deadline: deadline, predicate: predicate)
-        }
-    }
-
-    private func armOnce(
-        deadline: ContinuousClock.Instant,
-        predicate: @Sendable () -> Bool
-    ) async {
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            let id = UUID()
-            let once = ResumeOnce()
-            lock.lock()
-            waiters[id] = { once.fire { cont.resume() } }
-            lock.unlock()
-            if predicate() {
-                lock.withLock { _ = waiters.removeValue(forKey: id) }
-                once.fire { cont.resume() }
-                return
-            }
-            Task {
-                try? await Task.sleep(until: deadline, clock: ContinuousClock())
-                self.lock.withLock { _ = self.waiters.removeValue(forKey: id) }
-                once.fire { cont.resume() }
-            }
-        }
-    }
 }
 
 // MARK: - Socket pair

--- a/KernovaMacOSAgentTests/TestHelpers.swift
+++ b/KernovaMacOSAgentTests/TestHelpers.swift
@@ -2,13 +2,12 @@ import CryptoKit
 import Foundation
 import Darwin
 import KernovaKit
+import KernovaTestSupport
 
-// MARK: - TestFailure
-
-struct TestFailure: Error {
-    let message: String
-    init(_ m: String) { message = m }
-}
+// Bundle-specific test helpers for KernovaMacOSAgentTests. The event-driven/
+// poll wait primitives (`AsyncGate`, `waitUntil`, `TestFailure`) live in the
+// shared `KernovaTestSupport` package product — see its doc comment for why
+// they were hoisted out of this file (formerly triplicated, #526).
 
 // MARK: - Socket / channel factories
 
@@ -32,27 +31,6 @@ func makeChannelPair() throws -> (VsockChannel, VsockChannel) {
     a.start()
     b.start()
     return (a, b)
-}
-
-// MARK: - waitUntil
-
-/// Polls `predicate` every 50 ms until it returns `true` or `timeout` elapses.
-///
-/// Prefer the event-driven `AsyncGate` below for new timing-sensitive waits —
-/// polling is retained for predicates with no underlying signal to await; the
-/// 50 ms tick (up from 10 ms) keeps idle pollers from adding avoidable
-/// executor churn under parallel CI load.
-func waitUntil(
-    timeout: Duration = .seconds(5),
-    _ predicate: @Sendable () -> Bool
-) async throws {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while !predicate() && ContinuousClock.now < deadline {
-        try await Task.sleep(for: .milliseconds(50))
-    }
-    guard predicate() else {
-        throw TestFailure("Predicate did not become true within \(timeout)")
-    }
 }
 
 // MARK: - nextFrame
@@ -353,99 +331,4 @@ func makeLogFrame(message: String) -> Frame {
         $0.message = message
     }
     return frame
-}
-
-// MARK: - AsyncGate
-
-/// Resumes its continuation at most once, regardless of how many racing paths
-/// (a `notify()` and the timeout backstop) try to fire it. `CheckedContinuation`
-/// traps on a second resume, so this guard makes the race safe.
-private final class ResumeOnce: @unchecked Sendable {
-    private let lock = NSLock()
-    private var fired = false
-    func fire(_ body: () -> Void) {
-        lock.lock()
-        let already = fired
-        fired = true
-        lock.unlock()
-        if !already { body() }
-    }
-}
-
-/// Event-driven replacement for `waitUntil` polling.
-///
-/// A producer calls `notify()` after each observable state change; the consumer
-/// awaits `wait(until:)`, which suspends until the predicate holds — re-checked
-/// on every `notify()` — or throws `TestFailure` after `timeout`.
-///
-/// Unlike the poll loop, an idle waiter adds **zero** wake-ups to the shared
-/// (and, on CI, contended) executor, and the `timeout` is a backstop the happy
-/// path never reaches rather than the success deadline — so a slow runner no
-/// longer fails the wait, only a genuinely stuck condition does. This is the
-/// fix for the timing-sensitive flakes documented in the flaky-CI
-/// investigation; keep it aligned with the KernovaTests bundle's copy.
-///
-/// `wait` is `nonisolated` with a `@Sendable` predicate to match this bundle's
-/// `waitUntil` (its suites are not `@MainActor`); predicates read `Sendable`
-/// boxes (`AtomicInt`, `PolicyBox`).
-final class AsyncGate: @unchecked Sendable {
-    private let lock = NSLock()
-    private var waiters: [UUID: () -> Void] = [:]
-
-    /// Wake every current waiter; call right after mutating observed state.
-    func notify() {
-        lock.lock()
-        let resumes = Array(waiters.values)
-        waiters.removeAll()
-        lock.unlock()
-        resumes.forEach { $0() }
-    }
-
-    /// Suspend until `predicate()` holds (re-checked on each `notify()`), or
-    /// throw `TestFailure` after `timeout`.
-    func wait(
-        timeout: Duration = .seconds(10),
-        until predicate: @Sendable () -> Bool
-    ) async throws {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while !predicate() {
-            if ContinuousClock.now >= deadline {
-                throw TestFailure("Condition not met within \(timeout)")
-            }
-            await armOnce(deadline: deadline, predicate: predicate)
-        }
-    }
-
-    /// Suspends until the next `notify()`, an immediate hit (the predicate
-    /// already holds at arm time, closing the arm-vs-notify race), or the
-    /// `deadline` backstop — whichever comes first.
-    private func armOnce(
-        deadline: ContinuousClock.Instant,
-        predicate: @Sendable () -> Bool
-    ) async {
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            let id = UUID()
-            let once = ResumeOnce()
-            lock.lock()
-            waiters[id] = { once.fire { cont.resume() } }
-            lock.unlock()
-            // Close the arm-vs-notify race: if the state already satisfies the
-            // predicate (a notify may have landed before we registered), resume
-            // now so the outer loop re-checks promptly instead of blocking.
-            if predicate() {
-                lock.lock()
-                waiters.removeValue(forKey: id)
-                lock.unlock()
-                once.fire { cont.resume() }
-                return
-            }
-            // Backstop: resume at the deadline even if no notify arrives, so a
-            // genuinely stuck condition fails the wait instead of hanging.
-            Task {
-                try? await Task.sleep(until: deadline, clock: ContinuousClock())
-                self.lock.withLock { _ = self.waiters.removeValue(forKey: id) }
-                once.fire { cont.resume() }
-            }
-        }
-    }
 }

--- a/KernovaMacOSAgentTests/VsockGuestClientTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClientTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 import Darwin
 import KernovaKit
+import KernovaTestSupport
 
 @Suite("VsockGuestClient connect/retry/stop lifecycle")
 struct VsockGuestClientTests {

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -4,6 +4,7 @@ import AppKit
 import CryptoKit
 import Darwin
 import KernovaKit
+import KernovaTestSupport
 import UniformTypeIdentifiers
 
 // MARK: - Fake Pasteboard

--- a/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 import Darwin
 import KernovaKit
+import KernovaTestSupport
 
 @Suite("VsockGuestControlAgent")
 struct VsockGuestControlAgentTests {

--- a/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
+++ b/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import Testing
+import KernovaTestSupport
 
 @testable import Kernova
 @testable import KernovaKit

--- a/KernovaTests/HostClipboardPullRouterTests.swift
+++ b/KernovaTests/HostClipboardPullRouterTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import KernovaKit
+import KernovaTestSupport
 import Testing
 
 @testable import Kernova

--- a/KernovaTests/SerialSocketRelayTests.swift
+++ b/KernovaTests/SerialSocketRelayTests.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import Testing
+import KernovaTestSupport
 
 @testable import Kernova
 

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -3,26 +3,18 @@ import Foundation
 import Darwin
 import Observation
 import KernovaKit
+import KernovaTestSupport
 
-// Shared timing/test primitives for the KernovaTests bundle. Mirrors the
-// shape of `KernovaMacOSAgentTests/TestHelpers.swift` so the two bundles
-// give the same diagnostic detail (timeout vs EOF) when frame waits fail.
+// Bundle-specific test helpers for KernovaTests. The event-driven/poll wait
+// primitives (`AsyncGate`, `waitUntil`, `TestFailure`) live in the shared
+// `KernovaTestSupport` package product — see its doc comment for why they
+// were hoisted out of this file (formerly triplicated, #526).
 //
-// Xcode 16 synchronized folders make each bundle's files target-private,
-// so a single file can't be shared across both — the duplication here is
-// deliberate. Keep these signatures aligned with the GuestAgent variant.
-//
-// Exception: `waitForChange` is KernovaTests-only. It observes `@MainActor`
-// `@Observable` production state directly; the GuestAgent bundle's helpers are
-// `nonisolated`/`@Sendable` over `Sendable` boxes and have no such type to
-// track, so there is nothing to mirror there.
-
-// MARK: - TestFailure
-
-struct TestFailure: Error {
-    let message: String
-    init(_ m: String) { message = m }
-}
+// `waitForChange` below is KernovaTests-only and was never one of the
+// triplicated copies: it observes `@MainActor` `@Observable` production state
+// directly via `withObservationTracking`, which only this bundle's tests need
+// — the GuestAgent/KernovaKit bundles' predicates read `Sendable` boxes
+// (`AtomicInt`, `PolicyBox`) with no such observable type to track.
 
 // MARK: - Ephemeral UserDefaults
 
@@ -64,34 +56,6 @@ func makeRawSocketPair() throws -> (Int32, Int32) {
     return (fds[0], fds[1])
 }
 
-// MARK: - waitUntil
-
-/// Polls `predicate` every 50 ms until it returns `true` or `timeout` elapses.
-///
-/// Default deadline is generous (5 s) to absorb MainActor scheduling jitter on
-/// CI runners. See CLAUDE.md "Async waits in tests". Prefer the
-/// event-driven `AsyncGate` below for new timing-sensitive waits — polling is
-/// retained for predicates with no underlying signal to await; the 50 ms tick
-/// (up from 10 ms) keeps idle pollers from adding avoidable MainActor churn.
-///
-/// `@MainActor`-isolated because every test in `KernovaTests` is MainActor and
-/// the predicates routinely close over MainActor-isolated state (services,
-/// view models). Keeping the helper on the same actor sidesteps Swift 6's
-/// non-Sendable-closure errors on MainActor → nonisolated boundaries.
-@MainActor
-func waitUntil(
-    timeout: Duration = .seconds(5),
-    _ predicate: () -> Bool
-) async throws {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while !predicate() && ContinuousClock.now < deadline {
-        try await Task.sleep(for: .milliseconds(50))
-    }
-    guard predicate() else {
-        throw TestFailure("Predicate did not become true within \(timeout)")
-    }
-}
-
 // MARK: - nextFrame
 
 /// Reads the next frame from `channel`, distinguishing timeout from EOF.
@@ -128,107 +92,6 @@ func nextFrame(
         return frame
     } catch is CancellationError {
         throw TestFailure("Timed out waiting for a frame after \(timeout)")
-    }
-}
-
-// MARK: - AsyncGate
-
-/// Resumes its continuation at most once, regardless of how many racing paths
-/// (a `notify()` and the timeout backstop) try to fire it. `CheckedContinuation`
-/// traps on a second resume, so this guard makes the race safe.
-private final class ResumeOnce: @unchecked Sendable {
-    private let lock = NSLock()
-    private var fired = false
-    func fire(_ body: () -> Void) {
-        lock.lock()
-        let already = fired
-        fired = true
-        lock.unlock()
-        if !already { body() }
-    }
-}
-
-/// Event-driven replacement for `waitUntil` polling.
-///
-/// A producer calls `notify()` after each observable state change; the consumer
-/// awaits `wait(until:)`, which suspends until the predicate holds — re-checked
-/// on every `notify()` — or throws `TestFailure` after `timeout`.
-///
-/// Unlike the poll loop, an idle waiter adds **zero** wake-ups to the shared
-/// (and, on CI, contended) MainActor, and the `timeout` is a backstop the happy
-/// path never reaches rather than the success deadline — so a slow runner no
-/// longer fails the wait, only a genuinely stuck condition does. This is the
-/// fix for the timing-sensitive flakes documented in the flaky-CI
-/// investigation; keep it aligned with the GuestAgent bundle's copy.
-final class AsyncGate: @unchecked Sendable {
-    private let lock = NSLock()
-    private var waiters: [UUID: () -> Void] = [:]
-
-    /// Wake every current waiter; call right after mutating observed state.
-    func notify() {
-        lock.lock()
-        let resumes = Array(waiters.values)
-        waiters.removeAll()
-        lock.unlock()
-        resumes.forEach { $0() }
-    }
-
-    /// Suspend until `predicate()` holds (re-checked on each `notify()`), or
-    /// throw `TestFailure` after `timeout`. `@MainActor` so predicates may read
-    /// MainActor-isolated test state, matching this bundle's `waitUntil`.
-    @MainActor
-    func wait(
-        timeout: Duration = .seconds(10),
-        until predicate: () -> Bool
-    ) async throws {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while !predicate() {
-            if ContinuousClock.now >= deadline {
-                throw TestFailure("Condition not met within \(timeout)")
-            }
-            await armOnce(deadline: deadline, predicate: predicate)
-        }
-    }
-
-    /// Suspends until the next `notify()`, an immediate hit (the predicate
-    /// already holds at arm time, closing the arm-vs-notify race), or the
-    /// `deadline` backstop — whichever comes first.
-    @MainActor
-    private func armOnce(
-        deadline: ContinuousClock.Instant,
-        predicate: () -> Bool
-    ) async {
-        // Captured so it can be cancelled once `notify()` (or the immediate-hit
-        // re-check) resolves the wait; otherwise every happy-path arm would leak
-        // a Task sleeping until `deadline`.
-        var backstop: Task<Void, Never>?
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            let id = UUID()
-            let once = ResumeOnce()
-            lock.lock()
-            waiters[id] = { once.fire { cont.resume() } }
-            lock.unlock()
-            // Close the arm-vs-notify race: if the state already satisfies the
-            // predicate (a notify may have landed before we registered), resume
-            // now so the outer loop re-checks promptly instead of blocking.
-            if predicate() {
-                lock.lock()
-                waiters.removeValue(forKey: id)
-                lock.unlock()
-                once.fire { cont.resume() }
-                return
-            }
-            // Backstop: resume at the deadline even if no notify arrives, so a
-            // genuinely stuck condition fails the wait instead of hanging.
-            backstop = Task {
-                try? await Task.sleep(until: deadline, clock: ContinuousClock())
-                self.lock.withLock { _ = self.waiters.removeValue(forKey: id) }
-                once.fire { cont.resume() }
-            }
-        }
-        // Resolved via notify() or the immediate hit; cancel the backstop so it
-        // doesn't linger asleep until `deadline`.
-        backstop?.cancel()
     }
 }
 

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import AppKit
+import KernovaTestSupport
 @testable import Kernova
 
 @Suite("VMInstance Tests")

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Darwin
 import CryptoKit
 import KernovaKit
+import KernovaTestSupport
 import UniformTypeIdentifiers
 @testable import Kernova
 

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 import Darwin
 import KernovaKit
+import KernovaTestSupport
 @testable import Kernova
 
 @Suite("VsockControlService")

--- a/KernovaTests/VsockGuestLogServiceTests.swift
+++ b/KernovaTests/VsockGuestLogServiceTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 import Darwin
 import KernovaKit
+import KernovaTestSupport
 @testable import Kernova
 
 @Suite("VsockGuestLogService")


### PR DESCRIPTION
## Summary
- The event-driven `AsyncGate`/`waitUntil`/`TestFailure` wait primitives were triplicated across `KernovaTests/TestHelpers.swift`, `KernovaMacOSAgentTests/TestHelpers.swift`, and `KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift`, despite CLAUDE.md's "Async waits in tests" section carrying a standing "keep the copies aligned" mandate — itself a sign the duplication was a maintenance hazard.
- The copies had already drifted: only the KernovaTests copy cancelled its timeout backstop `Task` on early resolution ("cancel the backstop so it doesn't linger asleep until deadline"); the other two leaked it until the full deadline on every happy-path wait.
- This PR hoists the primitives into a new shared `KernovaTestSupport` SwiftPM product all three test targets import, eliminating both the duplication and the isolation fork the copies previously required.

## Changes
- Add `KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift` — the single canonical `TestFailure`, `ResumeOnce`, `AsyncGate`, and `waitUntil`.
- `AsyncGate.wait`/`waitUntil` take the caller's isolation via `isolation: isolated (any Actor)? = #isolation`, so one implementation now serves both `@MainActor` callers (KernovaTests) and nonisolated callers (GuestAgent/KernovaKit bundles) — no per-bundle fork to keep in sync.
- Add the `KernovaTestSupport` library product/target to `KernovaKit/Package.swift` and wire it into `Kernova.xcodeproj/project.pbxproj` (new `XCSwiftPackageProductDependency`/`PBXBuildFile` entries, linked into `KernovaTests` and `KernovaMacOSAgentTests`'s Frameworks phases), mirroring the existing `KernovaKit` folder-peer package wiring — Xcode 16 synchronized folders make each test target's own source folder target-private, so a shared SwiftPM product (not a shared file) is what lets all three targets depend on one copy.
- Strip the duplicated primitives out of the three original files, replacing them with `import KernovaTestSupport`, and add the same import to every other test file that referenced these symbols directly.
- Update CLAUDE.md's "Async waits in tests" table and ARCHITECTURE.md's KernovaKit/KernovaTests/KernovaMacOSAgentTests package layout to describe the new shared module.

## Scope notes (what stayed put)
- `waitForChange` stays local to `KernovaTests/TestHelpers.swift` — it's `@MainActor`/`Observation`-specific and was never one of the triplicated copies.
- `pollUntil`/`StreamTestFailure` stay local to `KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift` — a package-specific, single-copy, 10ms no-signal poll with ~17 sanctioned callers, not part of the drift this cleans up.

## Deviation from the issue
The issue proposed keeping the `@MainActor` + non-`Sendable` (KernovaTests) vs. `nonisolated` + `@Sendable` (elsewhere) split as a "documented specialization" alongside the shared file. This PR instead eliminates that split entirely via `isolation: isolated (any Actor)? = #isolation`, so there's a true single implementation rather than a shared file hiding a fork.

## Test plan
- [x] `make test` — all three test targets pass via `Kernova.xctestplan`
- [x] `swift test` inside `KernovaKit/` — 239 package tests pass standalone, confirming the isolation-agnostic `AsyncGate` compiles and behaves correctly for both `@MainActor` and nonisolated callers
- [x] `make lint` — swift-format strict passes
- [x] `make build` — full app build succeeds

Fixes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)