### PR TITLE
chore: Clear dead-code scan findings (#545)

### DIFF
--- a/KernovaKit/Sources/KernovaKit/FileProviderServicingTiming.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderServicingTiming.swift
@@ -13,19 +13,19 @@ import Foundation
 /// files; editing either in isolation silently misaligned them. `maxConnectAttempts`
 /// now *derives* from `connectWait`/`connectRetryDelaySeconds`, so the two sides
 /// cannot drift apart.
-public enum FileProviderServicingTiming {
+enum FileProviderServicingTiming {
     /// Extension-side bounded wait for the owner to connect after the doorbell is
     /// rung, kept well under Finder's ~60 s paste deadline so a missing owner
     /// fails cleanly.
     ///
     /// The source of truth both sides derive from.
-    public static let connectWait: TimeInterval = 30
+    static let connectWait: TimeInterval = 30
 
     /// Owner-side delay between transient connect retries, in seconds.
-    public static let connectRetryDelaySeconds: TimeInterval = 2
+    static let connectRetryDelaySeconds: TimeInterval = 2
 
     /// `connectRetryDelaySeconds` as a `DispatchTimeInterval`, for the connector.
-    public static var connectRetryDelay: DispatchTimeInterval {
+    static var connectRetryDelay: DispatchTimeInterval {
         .seconds(Int(connectRetryDelaySeconds))
     }
 
@@ -39,7 +39,7 @@ public enum FileProviderServicingTiming {
     /// for that: derived, not a separately-maintained literal — editing either
     /// constant above re-derives this (16 today: `⌈30 / 2⌉ + 1`, giving 15
     /// actual retry delays = 30s, matching `connectWait` exactly).
-    public static var maxConnectAttempts: Int {
+    static var maxConnectAttempts: Int {
         max(1, Int((connectWait / connectRetryDelaySeconds).rounded(.up)) + 1)
     }
 
@@ -50,5 +50,5 @@ public enum FileProviderServicingTiming {
     /// full production reply timeout" (see CLAUDE.md's "Async waits in tests")
     /// can reference it instead of independently re-hardcoding `120`, which
     /// would let the two silently drift apart.
-    public static let fetchReplyWait: TimeInterval = 120
+    static let fetchReplyWait: TimeInterval = 120
 }

--- a/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
@@ -114,6 +114,10 @@ public final class AsyncGate: @unchecked Sendable {
     /// — runs on the same actor as the original caller with no hop. The
     /// backstop `Task` touches only `Sendable` state (never `predicate`), so
     /// it needs no isolation of its own.
+    // `isolation` uses the Swift `isolated` keyword to pin this helper to the
+    // caller's actor (forwarded from `wait`, see above), so it is intentionally
+    // never referenced by name. Periphery reports it as an unused parameter.
+    // periphery:ignore:parameters isolation
     private func armOnce(
         deadline: ContinuousClock.Instant,
         isolation: isolated (any Actor)?,
@@ -155,6 +159,10 @@ public final class AsyncGate: @unchecked Sendable {
 
 // MARK: - waitUntil
 
+// `isolation` uses the Swift `isolated` keyword to inherit the caller's actor
+// isolation so the synchronous `predicate()` calls need no hop; it is
+// intentionally never referenced by name. Periphery reports it as unused.
+// periphery:ignore:parameters isolation
 /// Polls `predicate` every 50 ms until it returns `true` or `timeout` elapses.
 ///
 /// Default deadline is generous (5 s) to absorb scheduling jitter on CI

--- a/KernovaKit/Tests/KernovaKitTests/FileProviderDomainHostTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/FileProviderDomainHostTests.swift
@@ -201,7 +201,7 @@ struct FileProviderDomainHostEnablementTests {
 
         var callCount: Int { lock.withLock { callCountStorage } }
 
-        func add(_ domain: NSFileProviderDomain, completion: @escaping @Sendable (Error?) -> Void) {
+        func add(_: NSFileProviderDomain, completion: @escaping @Sendable (Error?) -> Void) {
             let thisCall = lock.withLock {
                 callCountStorage += 1
                 return callCountStorage

--- a/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
+++ b/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
@@ -127,10 +127,6 @@ final class StreamCollector: @unchecked Sendable {
     var abortInfos: [ClipboardStreamAbortInfo] { lock.withLock { aborts } }
     var abortCount: Int { lock.withLock { aborts.count } }
     var timedMetrics: [ClipboardTransferMetrics] { lock.withLock { timings } }
-    /// Every `ClipboardStreamAck` the receiver emitted (in wire order), recorded
-    /// by the harness's sender-side routing task — lets ack-coalescing tests
-    /// assert the exact `bytes_consumed` schedule.
-    var ackFrames: [Kernova_V1_ClipboardStreamAck] { lock.withLock { acks } }
     /// The `bytes_consumed` sequence of every recorded ack for one transfer.
     func ackedByteCounts(_ id: UInt64) -> [UInt64] {
         lock.withLock { acks.filter { $0.transferID == id }.map(\.bytesConsumed) }

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -1,7 +1,6 @@
 import Testing
 import Foundation
 import AppKit
-import KernovaTestSupport
 @testable import Kernova
 
 @Suite("VMInstance Tests")

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -492,6 +492,39 @@ struct VMLifecycleCoordinatorTests {
         #expect(ipswService.lastDiscardResumeDataURL == destination)
     }
 
+    @Test("installMacOS with requestedFreshDownload skips trash when the file is absent")
+    func installMacOSFreshDownloadSkipsTrashWhenAbsent() async throws {
+        // The file-absent counterpart of the test above: the mock reports the
+        // destination as *not* existing, so the fresh-download cleanup must skip
+        // the trash entirely — but still discard any resume data and clear the
+        // flag, since that cleanup runs unconditionally within the honor branch.
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("freshDownloadAbsent-\(UUID().uuidString)", isDirectory: true)
+        let fileSystem = MockFileSystem()
+        fileSystem.fileExistsResult = false
+        let (coordinator, _, _, ipswService, _) = makeCoordinator(
+            downloadsDirectory: temp, fileSystem: fileSystem)
+        let instance = makeInstance()
+
+        let destination = temp.appendingPathComponent("RestoreImage.ipsw")
+
+        let context = MacOSInstallContext(
+            source: .downloadLatest,
+            downloadDestinationPath: destination.path(percentEncoded: false),
+            requestedFreshDownload: true
+        )
+        instance.configuration.installContext = context
+        instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
+
+        try await coordinator.installMacOS(on: instance, context: context)
+
+        // Nothing existed to trash, but the honor-and-clear branch still ran:
+        // resume data was discarded exactly once for the destination.
+        #expect(fileSystem.trashedURLs.isEmpty)
+        #expect(ipswService.discardResumeDataCallCount == 1)
+        #expect(ipswService.lastDiscardResumeDataURL == destination)
+    }
+
     @Test("installMacOS surfaces freshDownloadCleanupFailed when the trash operation throws")
     func installMacOSFreshDownloadSurfacesTrashFailure() async throws {
         // Inject a FileSystemOperating that always throws from `trashItem`.


### PR DESCRIPTION
## Summary
Resolves all 12 findings from the weekly Periphery dead-code scan (#545). Each finding was traced to real usage across every target before deciding, and triaged per the project's dead-code rules (`.periphery.yml`, CLAUDE.md "Review Feedback Handling" + "Periphery Directives").

Closes #545

## Changes
| Finding | Resolution |
|---------|-----------|
| `FileProviderServicingTiming` enum + 5 members "redundant public" | Demote `public` → `internal` (KernovaKit-internal; tests reach via `@testable import`, matching PR #470) |
| `AsyncWaits.armOnce` / `waitUntil` "unused parameter `isolation`" | **Annotate** `// periphery:ignore:parameters isolation` — Swift `isolated`-keyword params that set actor isolation; intentionally never referenced by name (false positives, not dead code) |
| `FakeAddDomain.add` "unused parameter `domain`" | Rename binding to `_` |
| `StreamCollector.ackFrames` "unused property" | Delete (zero reads repo-wide) |
| `VMInstanceTests` "unused import `KernovaTestSupport`" | Remove import |
| `MockFileSystem.fileExistsResult` "unused property" | **Wire up a test** — the knob gated the coordinator's untested fresh-download "IPSW absent → skip trash" branch (`VMLifecycleCoordinator`); the new test closes a coverage gap left by #543 rather than deleting the hook |

## Notes
- The two `isolated` annotations are placed *above* the doc comment (not between doc and declaration) so swift-format's `AllPublicDeclarationsHaveDocumentation` still sees the `///` adjacent to the public `waitUntil`; Periphery accepts a command directly above a declaration's doc comment.
- No `MARKETING_VERSION` bump (no guest-agent behavior change) and no `ARCHITECTURE.md` change (`FileProviderServicingTiming` stays a package-internal timing namespace).
- Periphery isn't installed locally by design; after merge the next `main` scan (weekly, or `gh workflow run dead-code.yml`) runs clean and auto-closes #545.

## Test plan
- [x] `make lint` (swift-format --strict) passes
- [x] `make build` succeeds
- [x] `make test` — full suite green, including the new `installMacOSFreshDownloadSkipsTrashWhenAbsent` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)