### PR TITLE
fix: Stabilize and de-flicker the macOS install download-progress subtitle

### DIFF
--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -701,8 +701,13 @@ private final class StreamingDataTaskDelegate: NSObject, URLSessionDataDelegate,
 /// keeps the same progress-bar feel.
 struct DownloadSpeedSmoother {
     /// EWMA smoothing factor — lower values produce smoother output.
-    static let smoothingAlpha: Double = 0.2
-    /// Minimum interval between progress reports.
+    ///
+    /// The filter is sample-indexed, so its effective window is roughly
+    /// `((1 - alpha) / alpha)` samples wide. At `alpha = 0.02` and the 0.1 s
+    /// reporting interval below that is ~49 samples ≈ 5 s of transfer, which
+    /// keeps the reported speed/ETA steady to read without noticeable lag.
+    static let smoothingAlpha: Double = 0.02
+    /// Minimum interval between progress reports (paces the progress bar).
     static let progressInterval: TimeInterval = 0.1
 
     private var lastReportTime: TimeInterval = 0

--- a/Kernova/Utilities/DataFormatters.swift
+++ b/Kernova/Utilities/DataFormatters.swift
@@ -57,15 +57,40 @@ enum DataFormatters {
             .replacingOccurrences(of: " ", with: "\u{2007}")
     }
 
-    /// Formats an ETA from remaining bytes and current speed into a human-readable string.
+    /// Formats an ETA from remaining bytes and current speed into a fixed-width
+    /// `H:MM:SS` clock (e.g. `"\u{2007}0:04:33"`, `"12:33:22"`).
     ///
-    /// Returns `nil` if speed is negligible, the estimate exceeds 100 hours, or the result is non-finite.
+    /// The hour field is one or two characters left-padded with a figure space
+    /// (U+2007), and every other slot is a digit or a colon, so the rendered
+    /// width is constant under a monospaced-digit font regardless of the value —
+    /// the ETA never shifts the surrounding line as it crosses unit boundaries.
+    /// Use ``etaUnknownPlaceholder`` for the same-width dash rendering when this
+    /// returns `nil` but an ETA slot still needs to be shown.
+    ///
+    /// Returns `nil` if speed is negligible, the estimate exceeds 100 hours, or
+    /// the result is non-finite.
     static func formatETA(remainingBytes: Int64, bytesPerSecond: Double) -> String? {
         guard bytesPerSecond > 1_000 else { return nil }
         let seconds = Double(remainingBytes) / bytesPerSecond
         guard seconds.isFinite, seconds > 0, seconds < 360_000 else { return nil }
-        return formatDuration(seconds)
+        // The < 360_000 guard bounds this below 100h; clamp so a value rounding
+        // up at the boundary can't spill into a three-digit hour field.
+        let total = min(Int(seconds.rounded()), 359_999)
+        let hours = total / 3_600
+        let minutes = (total % 3_600) / 60
+        let secs = total % 60
+        let paddedHours = String(format: "%2d", hours)
+            .replacingOccurrences(of: " ", with: "\u{2007}")
+        return "\(paddedHours):\(String(format: "%02d", minutes)):\(String(format: "%02d", secs))"
     }
+
+    /// A same-width stand-in for an ETA (`"\u{2007}\u{2012}:\u{2012}\u{2012}:\u{2012}\u{2012}"`),
+    /// shown while a speed is displayed but ``formatETA`` returns `nil`.
+    ///
+    /// Uses figure dashes (U+2012), which render at the same advance as a digit
+    /// under the monospaced-digit font, so line 2 keeps a constant width whether
+    /// or not an ETA estimate is currently available.
+    static let etaUnknownPlaceholder = "\u{2007}\u{2012}:\u{2012}\u{2012}:\u{2012}\u{2012}"
 
     /// Formats a disk size in GB for display, using TB for sizes >= 1000 GB.
     ///
@@ -96,17 +121,5 @@ enum DataFormatters {
     /// name the VMs that share a file in the delete confirmations.
     static func quotedList(_ items: [String]) -> String {
         ListFormatter.localizedString(byJoining: items.map { "\u{201C}\($0)\u{201D}" })
-    }
-
-    private static let durationFormatter: DateComponentsFormatter = {
-        let formatter = DateComponentsFormatter()
-        formatter.allowedUnits = [.hour, .minute, .second]
-        formatter.unitsStyle = .abbreviated
-        return formatter
-    }()
-
-    /// Formats a duration in seconds into a human-readable string.
-    static func formatDuration(_ seconds: TimeInterval) -> String {
-        durationFormatter.string(from: seconds) ?? "\(Int(seconds))s"
     }
 }

--- a/Kernova/Views/Detail/MacOSInstallProgressViewController.swift
+++ b/Kernova/Views/Detail/MacOSInstallProgressViewController.swift
@@ -198,11 +198,10 @@ final class MacOSInstallProgressViewController: NSViewController {
         switch state.currentPhase {
         case .downloading(let download):
             progressBar.doubleValue = download.fraction
-            detailLabel.stringValue = downloadDetailText(download)
         case .installing(let progress):
             progressBar.doubleValue = progress
-            detailLabel.stringValue = "Installing macOS: \(Int(progress * 100))%"
         }
+        detailLabel.stringValue = Self.detailText(for: state.currentPhase)
     }
 
     private func applyStepStates(_ state: MacOSInstallState) {
@@ -264,7 +263,24 @@ final class MacOSInstallProgressViewController: NSViewController {
         return .pending
     }
 
-    private func downloadDetailText(_ download: DownloadProgress) -> String {
+    /// Builds the subtitle text for a phase.
+    ///
+    /// Both lines are assembled from fixed-width pieces (figure-space-padded
+    /// byte/percent fields and the constant-glyph `H:MM:SS` ETA) so the label
+    /// holds a stable horizontal position as values update — see #555. Pure and
+    /// `nonisolated` so it can be exercised directly by the width-stability tests.
+    nonisolated static func detailText(for phase: MacOSInstallPhase) -> String {
+        switch phase {
+        case .downloading(let download):
+            return downloadDetailText(download)
+        case .installing(let progress):
+            let pct = String(format: "%3d", Int(progress * 100))
+                .replacingOccurrences(of: " ", with: "\u{2007}")
+            return "Installing macOS:\u{2007}\(pct)%"
+        }
+    }
+
+    nonisolated static func downloadDetailText(_ download: DownloadProgress) -> String {
         let written = DataFormatters.formatBytesFixedWidth(UInt64(max(0, download.bytesWritten)))
         let total = DataFormatters.formatBytesFixedWidth(UInt64(max(0, download.totalBytes)))
         let pct = String(format: "%3d", Int(download.fraction * 100))
@@ -272,14 +288,13 @@ final class MacOSInstallProgressViewController: NSViewController {
         var text = "Downloading:\u{2007}\(written) / \(total) — \(pct)%"
         if download.bytesPerSecond > 0 {
             let speed = DataFormatters.formatSpeed(download.bytesPerSecond)
-            if let eta = DataFormatters.formatETA(
-                remainingBytes: download.totalBytes - download.bytesWritten,
-                bytesPerSecond: download.bytesPerSecond)
-            {
-                text += "\n\(speed) — \(eta)\u{2007}remaining"
-            } else {
-                text += "\n\(speed)"
-            }
+            // Fall back to a same-width dash placeholder (rather than dropping
+            // the ETA slot) so line 2 keeps a constant width while it is shown.
+            let eta =
+                DataFormatters.formatETA(
+                    remainingBytes: download.totalBytes - download.bytesWritten,
+                    bytesPerSecond: download.bytesPerSecond) ?? DataFormatters.etaUnknownPlaceholder
+            text += "\n\(speed) — \(eta)\u{2007}remaining"
         }
         return text
     }

--- a/Kernova/Views/Detail/MacOSInstallProgressViewController.swift
+++ b/Kernova/Views/Detail/MacOSInstallProgressViewController.swift
@@ -14,8 +14,18 @@ final class MacOSInstallProgressViewController: NSViewController {
     private var observation: ObservationLoop?
 
     private let progressBar = NSProgressIndicator()
-    private let detailLabel = NSTextField(wrappingLabelWithString: "")
+    // Two separate labels so the speed/ETA line can refresh on a slower cadence
+    // than the byte/percent line. Line 1 (bytes/%) and the progress bar track the
+    // smoother's ~10 Hz feed; line 2 is throttled to `line2RefreshInterval` so the
+    // ~5 s-smoothed speed/ETA doesn't flicker (#555 follow-up).
+    private let detailLine1Label = NSTextField(labelWithString: "")
+    private let detailLine2Label = NSTextField(labelWithString: "")
     private let cancelButton = NSButton()
+
+    /// Line 2 (speed/ETA) refreshes at most once a second; line 1 (bytes/%) and
+    /// the progress bar track the smoother's raw ~10 Hz feed.
+    private static let line2RefreshInterval: TimeInterval = 1.0
+    private var lastLine2Refresh: TimeInterval = 0
 
     // Step indicator (present only when the install has a download step).
     private var stepIndicator: NSStackView?
@@ -61,12 +71,23 @@ final class MacOSInstallProgressViewController: NSViewController {
         progressBar.translatesAutoresizingMaskIntoConstraints = false
         progressBar.widthAnchor.constraint(equalToConstant: 320).isActive = true
 
-        detailLabel.font = .monospacedDigitSystemFont(
+        let detailFont = NSFont.monospacedDigitSystemFont(
             ofSize: NSFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .regular)
-        detailLabel.textColor = .secondaryLabelColor
-        detailLabel.alignment = .center
-        detailLabel.maximumNumberOfLines = 0
-        detailLabel.isSelectable = false
+        for label in [detailLine1Label, detailLine2Label] {
+            label.font = detailFont
+            label.textColor = .secondaryLabelColor
+            label.alignment = .center
+            label.isSelectable = false
+        }
+        detailLine2Label.isHidden = true
+
+        // The two lines stack tightly (hairline gap), each centered on the shared
+        // centerline — every field is constant-width (#555), so neither line
+        // shifts horizontally as it updates.
+        let detailStack = NSStackView(views: [detailLine1Label, detailLine2Label])
+        detailStack.orientation = .vertical
+        detailStack.alignment = .centerX
+        detailStack.spacing = Spacing.hairline
 
         cancelButton.title = "Cancel"
         cancelButton.bezelStyle = .rounded
@@ -80,7 +101,7 @@ final class MacOSInstallProgressViewController: NSViewController {
             arranged.append(indicator)
         }
         arranged.append(progressBar)
-        arranged.append(detailLabel)
+        arranged.append(detailStack)
         arranged.append(cancelButton)
 
         let stack = NSStackView(views: arranged)
@@ -201,7 +222,27 @@ final class MacOSInstallProgressViewController: NSViewController {
         case .installing(let progress):
             progressBar.doubleValue = progress
         }
-        detailLabel.stringValue = Self.detailText(for: state.currentPhase)
+        refreshDetailLabels(for: state.currentPhase)
+    }
+
+    /// Refreshes the two subtitle labels.
+    ///
+    /// Line 1 (bytes/%) tracks the progress bar's ~10 Hz feed; line 2 (speed/ETA)
+    /// is throttled to `line2RefreshInterval` so the ~5 s-smoothed figures don't
+    /// flicker. Line 2 also refreshes the instant it starts or stops applying (the
+    /// first speed sample, or the install phase) so its appearance isn't delayed
+    /// by a throttle window.
+    private func refreshDetailLabels(for phase: MacOSInstallPhase) {
+        detailLine1Label.stringValue = Self.detailLine1(for: phase)
+
+        let line2 = Self.detailLine2(for: phase)
+        let visibilityChanged = detailLine2Label.isHidden == (line2 != nil)
+        let now = ProcessInfo.processInfo.systemUptime
+        if visibilityChanged || now - lastLine2Refresh >= Self.line2RefreshInterval {
+            detailLine2Label.stringValue = line2 ?? ""
+            detailLine2Label.isHidden = (line2 == nil)
+            lastLine2Refresh = now
+        }
     }
 
     private func applyStepStates(_ state: MacOSInstallState) {
@@ -263,16 +304,19 @@ final class MacOSInstallProgressViewController: NSViewController {
         return .pending
     }
 
-    /// Builds the subtitle text for a phase.
+    /// Builds subtitle line 1 — the byte/percent progress line.
     ///
-    /// Both lines are assembled from fixed-width pieces (figure-space-padded
-    /// byte/percent fields and the constant-glyph `H:MM:SS` ETA) so the label
-    /// holds a stable horizontal position as values update — see #555. Pure and
-    /// `nonisolated` so it can be exercised directly by the width-stability tests.
-    nonisolated static func detailText(for phase: MacOSInstallPhase) -> String {
+    /// Assembled from figure-space-padded fixed-width fields so it holds a stable
+    /// horizontal position as values update (#555). Pure and `nonisolated` so the
+    /// width-stability tests can exercise it directly.
+    nonisolated static func detailLine1(for phase: MacOSInstallPhase) -> String {
         switch phase {
         case .downloading(let download):
-            return downloadDetailText(download)
+            let written = DataFormatters.formatBytesFixedWidth(UInt64(max(0, download.bytesWritten)))
+            let total = DataFormatters.formatBytesFixedWidth(UInt64(max(0, download.totalBytes)))
+            let pct = String(format: "%3d", Int(download.fraction * 100))
+                .replacingOccurrences(of: " ", with: "\u{2007}")
+            return "Downloading:\u{2007}\(written) / \(total) — \(pct)%"
         case .installing(let progress):
             let pct = String(format: "%3d", Int(progress * 100))
                 .replacingOccurrences(of: " ", with: "\u{2007}")
@@ -280,23 +324,29 @@ final class MacOSInstallProgressViewController: NSViewController {
         }
     }
 
-    nonisolated static func downloadDetailText(_ download: DownloadProgress) -> String {
-        let written = DataFormatters.formatBytesFixedWidth(UInt64(max(0, download.bytesWritten)))
-        let total = DataFormatters.formatBytesFixedWidth(UInt64(max(0, download.totalBytes)))
-        let pct = String(format: "%3d", Int(download.fraction * 100))
-            .replacingOccurrences(of: " ", with: "\u{2007}")
-        var text = "Downloading:\u{2007}\(written) / \(total) — \(pct)%"
-        if download.bytesPerSecond > 0 {
-            let speed = DataFormatters.formatSpeed(download.bytesPerSecond)
-            // Fall back to a same-width dash placeholder (rather than dropping
-            // the ETA slot) so line 2 keeps a constant width while it is shown.
-            let eta =
-                DataFormatters.formatETA(
-                    remainingBytes: download.totalBytes - download.bytesWritten,
-                    bytesPerSecond: download.bytesPerSecond) ?? DataFormatters.etaUnknownPlaceholder
-            text += "\n\(speed) — \(eta)\u{2007}remaining"
-        }
-        return text
+    /// Builds subtitle line 2 — the speed/ETA line — or `nil` when it doesn't
+    /// apply (installing, or before the first non-zero speed sample).
+    ///
+    /// The constant-glyph `H:MM:SS` ETA falls back to a same-width dash
+    /// placeholder (rather than vanishing) so the line keeps a constant width
+    /// whenever it is shown.
+    nonisolated static func detailLine2(for phase: MacOSInstallPhase) -> String? {
+        guard case .downloading(let download) = phase, download.bytesPerSecond > 0 else { return nil }
+        let speed = DataFormatters.formatSpeed(download.bytesPerSecond)
+        let eta =
+            DataFormatters.formatETA(
+                remainingBytes: download.totalBytes - download.bytesWritten,
+                bytesPerSecond: download.bytesPerSecond) ?? DataFormatters.etaUnknownPlaceholder
+        return "\(speed) — \(eta)\u{2007}remaining"
+    }
+
+    /// Composes both subtitle lines into one newline-separated string.
+    ///
+    /// The live UI renders the lines in two independently-throttled labels; this
+    /// joined form is the single source of truth for the assembled text and backs
+    /// the width-stability tests.
+    nonisolated static func detailText(for phase: MacOSInstallPhase) -> String {
+        [detailLine1(for: phase), detailLine2(for: phase)].compactMap { $0 }.joined(separator: "\n")
     }
 
     // MARK: - Cancel

--- a/KernovaTests/DataFormattersTests.swift
+++ b/KernovaTests/DataFormattersTests.swift
@@ -125,20 +125,54 @@ struct DataFormattersTests {
         #expect(result == nil)
     }
 
-    @Test("formatETA returns formatted duration for valid inputs")
+    @Test("formatETA formats a sub-minute estimate as a padded H:MM:SS clock")
     func formatETAValid() {
         // 100 MB remaining at 10 MB/s = 10 seconds
         let result = DataFormatters.formatETA(remainingBytes: 100_000_000, bytesPerSecond: 10_000_000)
-        #expect(result != nil)
-        #expect(result!.contains("s"))
+        #expect(result == "\u{2007}0:00:10")
     }
 
-    @Test("formatETA handles large remaining time")
+    @Test("formatETA formats a multi-hour estimate, padding a single-digit hour with a figure space")
     func formatETALargeTime() {
-        // 10 GB remaining at 1 MB/s = ~10000 seconds
+        // 10 GB remaining at 1 MB/s = 10000 seconds = 2h 46m 40s
         let result = DataFormatters.formatETA(remainingBytes: 10_000_000_000, bytesPerSecond: 1_000_000)
-        #expect(result != nil)
-        #expect(result!.contains("h"))
+        #expect(result == "\u{2007}2:46:40")
+    }
+
+    @Test("formatETA keeps a two-digit hour field unpadded")
+    func formatETATwoDigitHour() {
+        // 36 GB remaining at 1 MB/s = 36000 seconds = exactly 10:00:00
+        let result = DataFormatters.formatETA(remainingBytes: 36_000_000_000, bytesPerSecond: 1_000_000)
+        #expect(result == "10:00:00")
+    }
+
+    @Test("formatETA holds a constant glyph template across unit boundaries")
+    func formatETAConstantTemplate() {
+        // Every estimate renders as [figure-space|digit][digit]:[digit][digit]:[digit][digit].
+        let template = "^[\u{2007}0-9][0-9]:[0-9]{2}:[0-9]{2}$"
+        for seconds in [9, 10, 59, 60, 90, 3599, 3600, 35_999, 36_000, 359_000] {
+            // remaining = seconds × speed, so the estimate is exactly `seconds`.
+            let result = DataFormatters.formatETA(
+                remainingBytes: Int64(seconds) * 1_000_000, bytesPerSecond: 1_000_000)
+            #expect(result != nil)
+            #expect(
+                result?.range(of: template, options: .regularExpression) != nil,
+                "ETA \(result ?? "nil") for \(seconds)s should match the fixed clock template")
+        }
+    }
+
+    @Test("formatETA pads with figure spaces, never plain spaces")
+    func formatETAFigureSpaces() {
+        // 5000 seconds = 1h 23m 20s — a single-digit hour that must be figure-space padded.
+        let result = DataFormatters.formatETA(remainingBytes: 10_000_000, bytesPerSecond: 2_000)
+        #expect(result == "\u{2007}1:23:20")
+        #expect(result?.contains(" ") == false)
+        #expect(result?.contains("\u{2007}") == true)
+    }
+
+    @Test("etaUnknownPlaceholder is a same-shape figure-dash clock")
+    func etaUnknownPlaceholder() {
+        #expect(DataFormatters.etaUnknownPlaceholder == "\u{2007}\u{2012}:\u{2012}\u{2012}:\u{2012}\u{2012}")
     }
 
     @Test("formatETA returns nil when estimate exceeds upper bound")
@@ -195,29 +229,5 @@ struct DataFormattersTests {
     @Test("formatCPUCount returns plural for multiple cores")
     func formatCPUCountPlural() {
         #expect(DataFormatters.formatCPUCount(4) == "4 cores")
-    }
-
-    // MARK: - formatDuration
-
-    @Test("formatDuration formats seconds only")
-    func formatDurationSecondsOnly() {
-        let result = DataFormatters.formatDuration(45)
-        #expect(result.contains("45"))
-        #expect(result.contains("s"))
-    }
-
-    @Test("formatDuration formats minutes and seconds")
-    func formatDurationMinutesSeconds() {
-        let result = DataFormatters.formatDuration(125)  // 2m 5s
-        #expect(result.contains("m"))
-        #expect(result.contains("s"))
-    }
-
-    @Test("formatDuration formats hours, minutes, and seconds")
-    func formatDurationHoursMinutesSeconds() {
-        let result = DataFormatters.formatDuration(3661)  // 1h 1m 1s
-        #expect(result.contains("h"))
-        #expect(result.contains("m"))
-        #expect(result.contains("s"))
     }
 }

--- a/KernovaTests/IPSWBundleTests.swift
+++ b/KernovaTests/IPSWBundleTests.swift
@@ -265,8 +265,8 @@ struct DownloadSpeedSmootherTests {
         _ = smoother.sample(totalBytes: 0, now: 1000.0)
         let steady = smoother.sample(totalBytes: 1_000_000, now: 1001.0) ?? 0
         let spiked = smoother.sample(totalBytes: 11_000_000, now: 1002.0) ?? 0
-        // After a 10x spike, EWMA(α=0.2) over a steady baseline lands between
-        // the prior value and the instantaneous value, never at the spike itself.
+        // After a 10x spike, the EWMA over a steady baseline lands between the
+        // prior value and the instantaneous value, never at the spike itself.
         #expect(spiked > steady)
         #expect(spiked < 10_000_000)
     }

--- a/KernovaTests/MacOSInstallSubtitleTests.swift
+++ b/KernovaTests/MacOSInstallSubtitleTests.swift
@@ -103,4 +103,41 @@ struct MacOSInstallSubtitleTests {
         ).components(separatedBy: "\n")
         #expect(lines.count == 1)
     }
+
+    // MARK: - Per-line builders (the labels are refreshed on separate cadences)
+
+    @Test("detailLine2 is nil for the install phase and before the first speed sample")
+    func line2NilWhenNotApplicable() {
+        #expect(MacOSInstallProgressViewController.detailLine2(for: .installing(progress: 0.5)) == nil)
+        #expect(
+            MacOSInstallProgressViewController.detailLine2(
+                for: .downloading(
+                    DownloadProgress(bytesWritten: 0, totalBytes: 1_000_000, bytesPerSecond: 0)))
+                == nil)
+    }
+
+    @Test("detailLine2 is present, with the dash placeholder, when speed is below the ETA guard")
+    func line2UsesPlaceholderBelowGuard() {
+        let line2 = MacOSInstallProgressViewController.detailLine2(
+            for: .downloading(
+                DownloadProgress(bytesWritten: 0, totalBytes: 500_000, bytesPerSecond: 500)))
+        #expect(line2 != nil)
+        #expect(line2?.contains(DataFormatters.etaUnknownPlaceholder) == true)
+    }
+
+    @Test("detailText composes exactly line 1, then line 2 when present")
+    func detailTextComposesLines() {
+        let downloading = MacOSInstallPhase.downloading(
+            DownloadProgress(bytesWritten: 0, totalBytes: 100_000_000, bytesPerSecond: 10_000_000))
+        let line1 = MacOSInstallProgressViewController.detailLine1(for: downloading)
+        let line2 = MacOSInstallProgressViewController.detailLine2(for: downloading)
+        #expect(line2 != nil)
+        #expect(MacOSInstallProgressViewController.detailText(for: downloading) == "\(line1)\n\(line2!)")
+
+        // Install phase has no line 2, so the composed text is line 1 alone.
+        let installing = MacOSInstallPhase.installing(progress: 0.42)
+        #expect(
+            MacOSInstallProgressViewController.detailText(for: installing)
+                == MacOSInstallProgressViewController.detailLine1(for: installing))
+    }
 }

--- a/KernovaTests/MacOSInstallSubtitleTests.swift
+++ b/KernovaTests/MacOSInstallSubtitleTests.swift
@@ -1,0 +1,106 @@
+import AppKit
+import Testing
+
+@testable import Kernova
+
+/// Verifies the "Installing macOS" download-progress subtitle holds a stable
+/// horizontal position as it updates (#555).
+///
+/// The subtitle is one center-aligned wrapping label, so any change in a line's
+/// *rendered width* re-centers it and reads as horizontal jitter. These tests
+/// measure the actual rendered width of the assembled lines in the label's own
+/// font and assert the structural invariants that keep it still — rather than
+/// counting characters, which a proportional unit suffix (KB vs MB) would defeat.
+@MainActor
+@Suite("macOS install subtitle width stability")
+struct MacOSInstallSubtitleTests {
+    /// The exact font `MacOSInstallProgressViewController` gives `detailLabel`.
+    private static let font = NSFont.monospacedDigitSystemFont(
+        ofSize: NSFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .regular)
+
+    private func width(_ line: String) -> CGFloat {
+        NSAttributedString(string: line, attributes: [.font: Self.font]).size().width
+    }
+
+    /// The subtitle lines for an estimate of `etaSeconds` at `bytesPerSecond`.
+    private func downloadLines(etaSeconds: Int, bytesPerSecond: Double) -> [String] {
+        let remaining = Int64((Double(etaSeconds) * bytesPerSecond).rounded())
+        let progress = DownloadProgress(
+            bytesWritten: 0, totalBytes: remaining, bytesPerSecond: bytesPerSecond)
+        return MacOSInstallProgressViewController.detailText(for: .downloading(progress))
+            .components(separatedBy: "\n")
+    }
+
+    /// ETA values spanning every unit boundary the H:MM:SS clock can cross.
+    private let etaBoundaries = [9, 10, 59, 60, 90, 3_599, 3_600, 35_999, 36_000, 359_000]
+    /// One speed per display regime: KB/s, MB/s, GB/s.
+    private let regimeSpeeds: [Double] = [500_000, 20_000_000, 2_000_000_000]
+
+    // A width move of half a point is imperceptible; a real regression from an
+    // un-normalized field jumps by several points.
+    private let tolerance: CGFloat = 0.5
+
+    @Test("Line 2 holds a constant width as the ETA crosses unit boundaries, within each speed regime")
+    func line2StableWithinRegime() {
+        for speed in regimeSpeeds {
+            let widths = etaBoundaries.map {
+                width(downloadLines(etaSeconds: $0, bytesPerSecond: speed)[1])
+            }
+            let spread = (widths.max() ?? 0) - (widths.min() ?? 0)
+            #expect(
+                spread < tolerance,
+                "line 2 width moved by \(spread)pt at \(speed) B/s as the ETA changed")
+        }
+    }
+
+    @Test("The ETA placeholder keeps line 2 width identical when speed flaps around the 1 KB/s guard")
+    func placeholderMatchesNumericWidth() {
+        // Just above the guard yields a real estimate; just below yields the
+        // placeholder. Both render the same "1.0 KB/s" speed, so line 2 must not
+        // move as the speed dips across the guard and back.
+        let numeric = MacOSInstallProgressViewController.detailText(
+            for: .downloading(
+                DownloadProgress(bytesWritten: 0, totalBytes: 100_100, bytesPerSecond: 1_001))
+        ).components(separatedBy: "\n")[1]
+        let placeholder = MacOSInstallProgressViewController.detailText(
+            for: .downloading(
+                DownloadProgress(bytesWritten: 0, totalBytes: 99_900, bytesPerSecond: 999))
+        ).components(separatedBy: "\n")[1]
+        #expect(abs(width(numeric) - width(placeholder)) < tolerance)
+    }
+
+    @Test("Line 1 always sets the label box: every line-2 width stays below every line-1 width")
+    func line1AnchorsTheBox() {
+        var line1Widths: [CGFloat] = []
+        var line2Widths: [CGFloat] = []
+        for speed in regimeSpeeds {
+            for eta in etaBoundaries {
+                let lines = downloadLines(etaSeconds: eta, bytesPerSecond: speed)
+                line1Widths.append(width(lines[0]))
+                line2Widths.append(width(lines[1]))
+            }
+        }
+        // Because line 1 is always the wider line, it fixes the centered label's
+        // width — so line 2 appearing, disappearing, or changing width never
+        // shifts line 1.
+        #expect((line2Widths.max() ?? 0) < (line1Widths.min() ?? .greatestFiniteMagnitude))
+    }
+
+    @Test("The install-phase percentage renders at a constant width across its range")
+    func installPercentStable() {
+        let widths = [0.0, 0.09, 0.10, 0.5, 0.99, 1.0].map {
+            width(MacOSInstallProgressViewController.detailText(for: .installing(progress: $0)))
+        }
+        let spread = (widths.max() ?? 0) - (widths.min() ?? 0)
+        #expect(spread < tolerance, "install percentage width moved by \(spread)pt")
+    }
+
+    @Test("Line 2 is omitted before the first speed sample")
+    func line2AbsentWithoutSpeed() {
+        let lines = MacOSInstallProgressViewController.detailText(
+            for: .downloading(
+                DownloadProgress(bytesWritten: 0, totalBytes: 1_000_000, bytesPerSecond: 0))
+        ).components(separatedBy: "\n")
+        #expect(lines.count == 1)
+    }
+}


### PR DESCRIPTION
Polishes the "Installing macOS" download-progress subtitle in two steps: first make its horizontal position rock-stable, then stop it flickering and steady the speed/ETA figures.

## 1 — Width stability (Closes #555)
The second subtitle line (`1.2 MB/s — 4h 33m 22s remaining`) jittered left/right on every tick because both lines lived in one **center-aligned** label and the ETA (`DateComponentsFormatter`, `.abbreviated`) had no width normalization, so it re-centered as the ETA crossed unit boundaries.

- **Fixed-width ETA**: `DataFormatters.formatETA` now emits a constant-glyph `H:MM:SS` clock (figure-space-padded hour, digits/colons only) — its rendered width never changes. Deleted the unused `formatDuration` + its `DateComponentsFormatter`.
- **Same-width placeholder** (`etaUnknownPlaceholder`, a `‒:‒‒:‒‒` figure-dash clock) so line 2 keeps its width when the ETA is unavailable instead of dropping the slot.
- Figure-space-padded the install-phase percentage too.

## 2 — De-flicker + steadier numbers
Even with position locked, the text repainted at the progress bar's ~10 Hz feed (flicker), and the speed/ETA jumped around because it was smoothed over only ~0.4 s.

- **Split into two independently-throttled labels**: line 1 (bytes/%) and the progress bar track the ~10 Hz feed; line 2 (speed/ETA) refreshes once per second so the smoothed figures don't flicker. Line 2 force-refreshes the instant it starts/stops applying.
- **Wider EWMA window**: `DownloadSpeedSmoother.smoothingAlpha` 0.2 → 0.02 (~49 samples ≈ 5 s at the 0.1 s reporting interval), so speed/ETA read steadily.

## Tests
- `MacOSInstallSubtitleTests` measures the assembled lines' **actual rendered widths** in the label's font and asserts stability across a byte/speed/ETA matrix (incl. unit-boundary crossings), the placeholder flap, and the line-1-anchors-the-box invariant; plus per-line builder/composition tests.
- Migrated the `formatDuration`/`formatETA` tests; the `DownloadSpeedSmoother` tests still hold under the new α.

## Notes
Presentation/tuning only — no change to the download, the progress cadence (`progressInterval` stays 0.1 s), or the EWMA mechanism beyond the α constant. Width stability is preserved by the split because both lines are constant-width.

## Test plan
- [x] `make test` (full suite) passes
- [x] `make lint` clean
- [x] Ran the built app and verified the live download subtitle

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)