### PR TITLE
fix: Reset agentInstallNudgeDismissed when cloning a VM

### DIFF
--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -397,6 +397,12 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         // an initial boot.
         clone.installContext = nil
 
+        // A clone is a distinct VM whose own guest-agent state the user hasn't
+        // evaluated yet, so let the sidebar install nudge surface again rather
+        // than inheriting the source VM's dismissal. (Contrast lastSeenAgentVersion,
+        // preserved deliberately because the agent binary is copied with the disk.)
+        clone.agentInstallNudgeDismissed = false
+
         return clone
     }
 

--- a/KernovaTests/VMConfigurationCloneTests.swift
+++ b/KernovaTests/VMConfigurationCloneTests.swift
@@ -166,6 +166,14 @@ struct VMConfigurationCloneTests {
         #expect(clone.lastFullscreenDisplayID == nil)
     }
 
+    @Test("Clone resets agentInstallNudgeDismissed to false")
+    func cloneResetsAgentInstallNudgeDismissed() {
+        var config = makeConfig()
+        config.agentInstallNudgeDismissed = true
+        let clone = config.clonedForNewInstance(existingNames: [])
+        #expect(clone.agentInstallNudgeDismissed == false)
+    }
+
     // MARK: - Shared Directories
 
     @Test("Clone regenerates shared directory IDs")


### PR DESCRIPTION
## Summary
- A cloned VM no longer inherits the source VM's dismissed "install guest agent" sidebar nudge. The clone is a distinct VM whose own guest-agent state the user hasn't evaluated yet, so the nudge should be able to surface again.

## Changes
- Reset `agentInstallNudgeDismissed` to `false` in `VMConfiguration.clonedForNewInstance(existingNames:)`, alongside the other explicitly-reset clone fields (`Kernova/Models/VMConfiguration.swift`)
- Add `cloneResetsAgentInstallNudgeDismissed` test following the existing reset-field pattern (`KernovaTests/VMConfigurationCloneTests.swift`)

## Test plan
- [x] `make test-suite SUITE=KernovaTests/VMConfigurationCloneTests` passes, including the new test
- [x] `make test` passes (full suite)
- [x] `make lint` passes

Closes #562