### PR TITLE
docs: Resolve the primary checkout at runtime in post-merge cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,10 +62,12 @@ inside the worktree:
   now-stale `origin/<type>/<short-description>` remote-tracking ref — all without
   leaving the worktree. A plain `git fetch --prune` from inside the worktree
   would only update the shared `origin/main` ref, not the local `main` branch
-  pointer, which is why this targets the primary checkout. (For this repo the
-  primary is `/Users/nlonsinger/Developer/GitHub/nicholas-lonsinger/kernova`;
-  resolve it at runtime via `git worktree list` if unsure.) The worktree and its
-  scratch branch are left in place for continued or follow-up work.
+  pointer, which is why this targets the primary checkout. Resolve
+  `<primary-checkout-path>` at runtime — it is the first entry of
+  `git worktree list` (the one with no `.claude/worktrees/` segment), e.g.
+  `git -C "$(git worktree list --porcelain | head -1 | cut -d' ' -f2)" pull --prune --ff-only`.
+  The worktree and its scratch branch are left in place for continued or
+  follow-up work.
 
 Working directly in a checkout (no `EnterWorktree` session), follow the
 tool-neutral post-merge steps in AGENTS.md instead.


### PR DESCRIPTION
## Summary
- CLAUDE.md's post-merge cleanup step hardcoded `/Users/nlonsinger/Developer/GitHub/nicholas-lonsinger/kernova` as the primary checkout. That path no longer exists — the repo lives under `Developer/Anthropic/GitHub/…` — so following the documented `git -C <path> pull --prune --ff-only` fails with `fatal: cannot change to … No such file or directory`. Hit live while cleaning up after #565.
- Fixed by resolving the path at runtime off `git worktree list` rather than swapping in the current absolute path: this doc is checked in, and a machine-specific absolute path drifts on every move or fresh clone. The doc already said "resolve it at runtime via `git worktree list` if unsure" — this makes that the instruction instead of the fallback.

## Changes
- `CLAUDE.md`: post-merge cleanup resolves `<primary-checkout-path>` via `git worktree list --porcelain`, with a copy-pasteable one-liner

## Test plan
- [x] Resolution command verified against this worktree — returns the real primary checkout, and the `git -C` pull it feeds succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)