### PR TITLE
fix: Make LazyPullCoordinator's heartbeat test deterministic

### DIFF
--- a/KernovaKit/Sources/KernovaKit/LazyPullCoordinator.swift
+++ b/KernovaKit/Sources/KernovaKit/LazyPullCoordinator.swift
@@ -52,6 +52,18 @@ public final class LazyPullCoordinator: @unchecked Sendable {
         var progressed = false
     }
 
+    #if DEBUG
+    /// Test seam: replaces the real timed semaphore wait at each window boundary in `pull`.
+    ///
+    /// Lets a test control precisely when a window "elapses" instead of
+    /// racing real wall-clock scheduling. Defaults to a real timed wait
+    /// identical to the Release-only path below; tests override it to make
+    /// window-boundary re-arming deterministic. Test-only.
+    var windowWaitForTesting: (@Sendable (DispatchSemaphore, Duration) -> Void) = { semaphore, timeout in
+        _ = semaphore.wait(timeout: .now() + timeout.timeInterval)
+    }
+    #endif
+
     private let lock = NSLock()
     private var slots: [UInt64: Slot] = [:]
     /// Transfer ids cancelled (#464) before `pull` registered a slot for them.
@@ -132,7 +144,11 @@ public final class LazyPullCoordinator: @unchecked Sendable {
             // The wait blocks one window; the slot's flags — not the wait result —
             // decide the outcome, so a signal that races the deadline is still
             // honored via `resolved` below.
+            #if DEBUG
+            windowWaitForTesting(slot.semaphore, timeout)
+            #else
             _ = slot.semaphore.wait(timeout: .now() + timeout.timeInterval)
+            #endif
             let outcome: LazyPullOutcome? = lock.withLock {
                 // A terminal resolve (deliver/abort/cancel) sets `resolved` before
                 // signaling, so it's observed here whether the wait was signaled or

--- a/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
@@ -128,35 +128,42 @@ struct LazyPullCoordinatorTests {
         let window1Entered = AsyncGate()
         let window2Entered = AsyncGate()
         let releaseWindow1 = DispatchSemaphore(value: 0)
-        let windowCallCount = Box(0)
+        let releaseWindow2 = DispatchSemaphore(value: 0)
+        let sawFirstWindow = Box(false)
+        let sawSecondWindow = Box(false)
 
-        coordinator.windowWaitForTesting = { semaphore, timeout in
-            let call = windowCallCount.value
-            windowCallCount.value = call + 1
-            if call == 0 {
-                // First boundary: park here (instead of a real timed wait)
-                // until the test has delivered a heartbeat, so `progressed`
-                // is guaranteed set before `pull` evaluates this boundary.
+        // Neither branch touches the real semaphore/timeout: `pull`'s outcome
+        // is decided purely by `slot.resolved`/`slot.outcome` under its lock
+        // once this closure returns, so parking on a test-owned semaphore
+        // instead is enough to control both boundaries with no wall-clock
+        // dependency anywhere in the test.
+        coordinator.windowWaitForTesting = { _, _ in
+            if !sawFirstWindow.value {
+                sawFirstWindow.value = true
                 window1Entered.notify()
                 releaseWindow1.wait()
             } else {
                 // Second boundary reached: the first window re-armed rather
                 // than resolving `.timedOut` — the invariant under test
-                // (#500 — a slow-but-live transfer must not time out). Wait
-                // for real so `deliver`'s signal wakes it as usual.
+                // (#500 — a slow-but-live transfer must not time out).
+                sawSecondWindow.value = true
                 window2Entered.notify()
-                _ = semaphore.wait(timeout: .now() + timeout.timeInterval)
+                releaseWindow2.wait()
             }
         }
         // The window value itself is moot here — `windowWaitForTesting`
         // controls boundary timing directly — but 300 ms documents the real
         // production window this test stands in for.
         async let outcome = runPull(coordinator, transferID: 11, timeout: .milliseconds(300))
-        try await window1Entered.wait { windowCallCount.value >= 1 }
+        try await window1Entered.wait { sawFirstWindow.value }
         coordinator.heartbeat(11)
         releaseWindow1.signal()
-        try await window2Entered.wait { windowCallCount.value >= 2 }
+        try await window2Entered.wait { sawSecondWindow.value }
+        // `deliver` must run before `releaseWindow2.signal()` lets `pull`'s
+        // loop past this boundary, so `slot.resolved` is already true by the
+        // time it re-checks — no race with the real semaphore's signal.
         coordinator.deliver(11, inlineRep("slow but alive"))
+        releaseWindow2.signal()
 
         guard case .delivered(let rep) = await outcome else {
             Issue.record("Expected .delivered — heartbeats should have prevented the timeout")

--- a/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
@@ -119,16 +119,43 @@ struct LazyPullCoordinatorTests {
 
     @Test("heartbeats re-arm the inactivity window so a slow-but-live pull is not timed out")
     func heartbeatExtendsTimeout() async throws {
+        // Drives the window boundary via `windowWaitForTesting` instead of a
+        // real wall-clock wait, so the test proves the re-arm branch in `pull`
+        // fires deterministically — not that a `Task.sleep` producer happens
+        // to beat a real semaphore timeout on a shared CI runner (#571: the
+        // prior version raced real time and flaked under scheduler jitter).
         let coordinator = LazyPullCoordinator()
-        // A short window: an absolute deadline would fire long before delivery.
-        async let outcome = runPull(coordinator, transferID: 11, timeout: .milliseconds(300))
-        try await pollUntil { coordinator.pendingSlotCountForTesting == 1 }
-        // Beat far faster than the window for well over a window's worth of
-        // wall-clock, so an un-reset (absolute) backstop would have fired by now.
-        for _ in 0..<24 {
-            try await Task.sleep(for: .milliseconds(25))
-            coordinator.heartbeat(11)
+        let window1Entered = AsyncGate()
+        let window2Entered = AsyncGate()
+        let releaseWindow1 = DispatchSemaphore(value: 0)
+        let windowCallCount = Box(0)
+
+        coordinator.windowWaitForTesting = { semaphore, timeout in
+            let call = windowCallCount.value
+            windowCallCount.value = call + 1
+            if call == 0 {
+                // First boundary: park here (instead of a real timed wait)
+                // until the test has delivered a heartbeat, so `progressed`
+                // is guaranteed set before `pull` evaluates this boundary.
+                window1Entered.notify()
+                releaseWindow1.wait()
+            } else {
+                // Second boundary reached: the first window re-armed rather
+                // than resolving `.timedOut` — the invariant under test
+                // (#500 — a slow-but-live transfer must not time out). Wait
+                // for real so `deliver`'s signal wakes it as usual.
+                window2Entered.notify()
+                _ = semaphore.wait(timeout: .now() + timeout.timeInterval)
+            }
         }
+        // The window value itself is moot here — `windowWaitForTesting`
+        // controls boundary timing directly — but 300 ms documents the real
+        // production window this test stands in for.
+        async let outcome = runPull(coordinator, transferID: 11, timeout: .milliseconds(300))
+        try await window1Entered.wait { windowCallCount.value >= 1 }
+        coordinator.heartbeat(11)
+        releaseWindow1.signal()
+        try await window2Entered.wait { windowCallCount.value >= 2 }
         coordinator.deliver(11, inlineRep("slow but alive"))
 
         guard case .delivered(let rep) = await outcome else {


### PR DESCRIPTION
## Summary
- `heartbeatExtendsTimeout` raced real wall-clock timing (a 300 ms inactivity window vs. 24 `Task.sleep`-paced heartbeats), flaking under CI scheduler jitter and hard-failing Build & Test on both the first run and the retry, dragging 11 sibling `LazyPullCoordinator` tests down as collateral.
- The 300 ms window is the behavior under test, so it can't simply be widened past scheduler stall per docs/TESTING.md's injected-timeout rule.

Fixes #571

## Changes
- `KernovaKit/Sources/KernovaKit/LazyPullCoordinator.swift`: add a `#if DEBUG`-gated `windowWaitForTesting` seam (same pattern as `VsockClipboardService.afterInboundPullForTesting`) that replaces the real timed semaphore wait at each window boundary in `pull`. Defaults to the real wait, so production and non-DEBUG behavior is unchanged.
- `KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift`: rewrite `heartbeatExtendsTimeout` to drive the window boundary directly via the new seam — parking at the first boundary until a heartbeat lands, then asserting a second boundary is reached (proving the re-arm branch fired) before delivering. No `Task.sleep`, no real inactivity window, no wall-clock race remains.

## Deviation from the issue
The issue reported the problem and requirements but proposed no specific fix. The chosen fix does touch production code (a `#if DEBUG`-only seam) because the re-arm branch in `pull` is reachable only through a real semaphore timeout — there is no way to exercise it deterministically purely from the test side. This is zero production behavior change (both real call sites use the default seam value) and follows the existing `…ForTesting` seam precedent in `VsockClipboardService`/`VsockGuestClipboardAgent` documented in docs/TESTING.md.

## Test plan
- [x] `make lint` passes
- [x] `make test-package` — all 251 KernovaKit tests pass, including the rewritten test (0.083s, down from the reported 3.978s/7.826s)
- [x] `make test` — full three-target suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)