### PR TITLE
refactor: Use subscript-nil dictionary removal under withLock

### DIFF
--- a/Kernova/Services/ClipboardTransferProgressTracker.swift
+++ b/Kernova/Services/ClipboardTransferProgressTracker.swift
@@ -79,7 +79,7 @@ final class ClipboardTransferProgressTracker: @unchecked Sendable {
 
     /// Drops a finished or aborted transfer.
     func finish(_ id: UInt64) {
-        lock.withLock { _ = entries.removeValue(forKey: id) }
+        lock.withLock { entries[id] = nil }
     }
 
     /// Drops every transfer (channel teardown / `stop()`).

--- a/Kernova/Services/HostClipboardFileProvider.swift
+++ b/Kernova/Services/HostClipboardFileProvider.swift
@@ -183,7 +183,7 @@ final class HostClipboardPullRouter: FileProviderPullProvider, @unchecked Sendab
             return current
         }
         guard let source else { return .failure(.noCurrentOffer) }
-        defer { lock.withLock { dispatchedSources.removeValue(forKey: key) } }
+        defer { lock.withLock { dispatchedSources[key] = nil } }
         return source.pullStagedFile(generation: generation, repIndex: repIndex)
     }
 

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
@@ -472,7 +472,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
 
     /// Deregisters a per-transfer delivery handler without firing it.
     public func cancelAwait(_ transferID: UInt64) {
-        lock.withLock { _ = awaiters.removeValue(forKey: transferID) }
+        lock.withLock { awaiters[transferID] = nil }
     }
 
     // MARK: - Private
@@ -482,7 +482,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     }
 
     private func remove(_ id: UInt64) {
-        lock.withLock { _ = transfers.removeValue(forKey: id) }
+        lock.withLock { transfers[id] = nil }
     }
 
     /// Delivers a completed representation to a registered per-transfer awaiter,

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
@@ -168,7 +168,7 @@ public final class ClipboardStreamSender: @unchecked Sendable {
     }
 
     private func remove(_ id: UInt64) {
-        lock.withLock { _ = transfers.removeValue(forKey: id) }
+        lock.withLock { transfers[id] = nil }
     }
 
     private func run(

--- a/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
@@ -147,7 +147,7 @@ public final class AsyncGate: @unchecked Sendable {
             // genuinely stuck condition fails the wait instead of hanging.
             backstop = Task {
                 try? await Task.sleep(until: deadline, clock: ContinuousClock())
-                self.lock.withLock { _ = self.waiters.removeValue(forKey: id) }
+                self.lock.withLock { self.waiters[id] = nil }
                 once.fire { cont.resume() }
             }
         }


### PR DESCRIPTION
## Summary
- Fix a "Result of call to 'withLock' is unused" compiler warning at `HostClipboardFileProvider.fetchStagedFile`'s cleanup `defer`
- Apply the same fix consistently at every other site with the same shape across the clipboard subsystem, rather than leaving a mix of patterns

## Changes
- Replace `lock.withLock { dict.removeValue(forKey: key) }` / `lock.withLock { _ = dict.removeValue(forKey: key) }` with `lock.withLock { dict[key] = nil }` in:
  - `Kernova/Services/HostClipboardFileProvider.swift`
  - `Kernova/Services/ClipboardTransferProgressTracker.swift`
  - `KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift` (x2)
  - `KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift`
  - `KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift`
- Left the three sites that bind and use the removed value (`ClipboardStreamReceiver`'s `deliverComplete`/`deliverAbort`/`deliverAbortToAwaiterOnly`) untouched — they need the result
- All touched dictionaries have non-Optional `Value` types, so `dict[key] = nil` is an unambiguous removal (no `Optional<Optional>` trap)

## Test plan
- [x] `make lint`
- [x] `make build`
- [x] `make test` (1648 tests passed)
- [x] `make test-package` (251 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)