### PR TITLE
fix: Give LazyPullCoordinatorTests' blocking pull its own thread

### DIFF
--- a/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
@@ -40,8 +40,21 @@ struct LazyPullCoordinatorTests {
         var isMonotonic: Bool { lock.withLock { monotonic } }
     }
 
-    /// Runs the blocking `pull` on a global queue so the test's cooperative
-    /// thread stays free to deliver/abort/failAll and `await` the outcome.
+    /// Runs the blocking `pull` on a dedicated thread so the test's
+    /// cooperative thread stays free to deliver/abort/failAll and `await` the
+    /// outcome.
+    ///
+    /// `pull` blocks its thread on a semaphore for up to `timeout`. A
+    /// dedicated `Thread` — not `DispatchQueue.global()` — draws from no
+    /// shared pool: Swift Testing runs this suite's tests in parallel, so the
+    /// suite's ~15 concurrent blocking pulls would otherwise park shared
+    /// global-pool workers at once, and GCD throttles new-worker creation
+    /// under saturation. A freshly dispatched `pull` then can't get a thread
+    /// within a sibling's `pollUntil` window, its slot never registers, and
+    /// the whole cluster times out together — a starvation cascade that
+    /// self-reinforces (each test's deliver/abort/failAll, which would free a
+    /// worker, is gated behind the very `pollUntil` that's timing out) and
+    /// survives the automatic retry (#578).
     private func runPull(
         _ coordinator: LazyPullCoordinator,
         transferID: UInt64,
@@ -49,11 +62,13 @@ struct LazyPullCoordinatorTests {
         send: @escaping @Sendable () -> Void = {}
     ) async -> LazyPullOutcome {
         await withCheckedContinuation { (cont: CheckedContinuation<LazyPullOutcome, Never>) in
-            DispatchQueue.global().async {
+            let thread = Thread {
                 cont.resume(
                     returning: coordinator.pull(
                         transferID: transferID, timeout: timeout, send: send))
             }
+            thread.name = "LazyPullCoordinatorTests.runPull(\(transferID))"
+            thread.start()
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes #578: a cluster of 9 `LazyPullCoordinatorTests` tests (`abortWakesPull`, `concurrentPullsForSameIDSupersedeCleanly`, `deliverWakesPull`, `failAllCancels`, `heartbeatNoOpWhenAbsent`, `idempotentDelivery`, `interleavedDemux`, `pullSupersedesInFlightPullForSameID`, `supersededPullCleanupDoesNotEvictSuccessor`) timed out together on CI, tripping "Build & Test" on main after PR #574 merged.

## Root cause
- Not caused by #574. That PR's only relevant hunk touched `AsyncGate`'s timeout-backstop closure in `AsyncWaits.swift`, which none of the 9 failing tests use — they fail in `pollUntil` (`StreamTestSupport.swift`, default 5s timeout, matching the CI error text exactly), not `AsyncGate.wait` (which defaults to 10s and would read differently).
- The real cause: `LazyPullCoordinatorTests`' shared `runPull` helper dispatched each blocking `pull()` call (which parks its thread on a semaphore for up to its own timeout) onto `DispatchQueue.global()`. Swift Testing runs this suite's tests in parallel, so the suite's ~15 concurrent blocking pulls could pile up competing for a throttled shared pool of GCD workers. A freshly dispatched `pull` that couldn't get a worker within a sibling's `pollUntil` window never registered its slot, so `pollUntil` timed out — and the cascade survived the automatic retry because each test's own `deliver`/`abort`/`failAll` (which would free a worker) was gated behind the very `pollUntil` that was timing out.

## Changes
- `KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift`: `runPull` now runs the blocking `pull()` call on a dedicated `Thread` instead of `DispatchQueue.global()`, so parking it never consumes a shared global-pool worker. Test-only change — no production code touched.

## Deviation from the issue
The issue frames the fix as making the affected test(s) event-driven per docs/TESTING.md (the `#if DEBUG` seam precedent from #572, which fixed a different test in the same class). This diagnosis is different: it's not an observation-side wall-clock race (a `pollUntil`→`AsyncGate` conversion wouldn't fix it, per docs/TESTING.md's note that "a wait conversion alone won't fix" a starved-executor miss), so the fix instead targets the test harness's executor — a one-line change to the shared `runPull` helper that fixes all 9 tests at once with no production-code change.

## Test plan
- [x] `make test-package` — all 251 KernovaKit tests pass, including the full `LazyPullCoordinator` suite
- [x] `make lint`
- [x] `make test` — full three-target suite (`** TEST SUCCEEDED **`)

Fixes #578