### PR TITLE
fix: Refresh the sidebar row when a preparing VM settles

### DIFF
--- a/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
+++ b/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
@@ -399,13 +399,6 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
         nameField.currentEditor()?.selectAll(nil)
     }
 
-    #if DEBUG
-    /// Whether the guest-agent badge is currently hidden on the live view —
-    /// exposed so tests can assert the actual rendered state converges after an
-    /// async model change, not just the underlying `visibleAgentStatus` data.
-    var agentAccessoryHiddenForTesting: Bool { agentButton.isHidden }
-    #endif
-
     // MARK: - Reuse
 
     override func prepareForReuse() {

--- a/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
+++ b/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
@@ -399,6 +399,13 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
         nameField.currentEditor()?.selectAll(nil)
     }
 
+    #if DEBUG
+    /// Whether the guest-agent badge is currently hidden on the live view —
+    /// exposed so tests can assert the actual rendered state converges after an
+    /// async model change, not just the underlying `visibleAgentStatus` data.
+    var agentAccessoryHiddenForTesting: Bool { agentButton.isHidden }
+    #endif
+
     // MARK: - Reuse
 
     override func prepareForReuse() {

--- a/Kernova/Views/Sidebar/SidebarViewController.swift
+++ b/Kernova/Views/Sidebar/SidebarViewController.swift
@@ -141,7 +141,18 @@ final class SidebarViewController: NSViewController {
     private func startObservations() {
         if instancesObservation == nil {
             instancesObservation = observeRecurring(
-                track: { [weak self] in _ = self?.viewModel.instances.map(\.id) },
+                track: { [weak self] in
+                    guard let self else { return }
+                    _ = self.viewModel.instances.map(\.id)
+                    // A phantom clone/import registers before its background copy
+                    // starts (`isPreparing` still false) and its row settles to
+                    // "real" later without any id-list change — tracking this too
+                    // routes that settle through `reloadInstances()`, the same
+                    // proven-correct cycle that renders every row on initial load,
+                    // instead of relying solely on the row's own live-view mutation
+                    // to get flushed to screen (#575).
+                    _ = self.viewModel.instances.map(\.isPreparing)
+                },
                 apply: { [weak self] in self?.reloadInstances() }
             )
         }
@@ -168,7 +179,19 @@ final class SidebarViewController: NSViewController {
         renameObservation = nil
     }
 
+    #if DEBUG
+    /// Number of times `reloadInstances()` has run — exposed so tests can
+    /// assert a specific model change (e.g. a preparing row settling) actually
+    /// routed through the outline view's reload cycle, without depending on
+    /// off-screen `NSOutlineView` row-view realization (rendering itself is
+    /// verified manually, per this file's top-level doc comment).
+    private(set) var reloadInstancesCallCountForTesting = 0
+    #endif
+
     private func reloadInstances() {
+        #if DEBUG
+        reloadInstancesCallCountForTesting += 1
+        #endif
         // Commit any in-flight rename first: a reload tears the field editor
         // down underneath the user, which would otherwise drop keyboard focus
         // and race a partial-text commit. Resigning first responder ends

--- a/Kernova/Views/Sidebar/SidebarViewController.swift
+++ b/Kernova/Views/Sidebar/SidebarViewController.swift
@@ -150,7 +150,11 @@ final class SidebarViewController: NSViewController {
                     // routes that settle through `reloadInstances()`, the same
                     // proven-correct cycle that renders every row on initial load,
                     // instead of relying solely on the row's own live-view mutation
-                    // to get flushed to screen (#575).
+                    // to get flushed to screen (#575). This is deliberately in
+                    // addition to (not a replacement for) `SidebarVMRowCellView`'s
+                    // own per-row `rowObservation`, which still owns cheap in-place
+                    // updates (name/status/agent-status changes) that don't need a
+                    // full-table reload.
                     _ = self.viewModel.instances.map(\.isPreparing)
                 },
                 apply: { [weak self] in self?.reloadInstances() }

--- a/KernovaTests/Mocks/MockVMStorageService.swift
+++ b/KernovaTests/Mocks/MockVMStorageService.swift
@@ -93,6 +93,10 @@ final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
         cloneVMBundleCallCount += 1
         if let error = cloneVMBundleError { throw error }
         let url = try bundleURL(for: newConfiguration)
+        // Mirrors the real service actually creating the bundle directory on disk:
+        // a macOS clone's `copyWork` writes a regenerated MachineIdentifier file
+        // straight into this URL afterward, which needs the directory to exist.
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         bundles[url] = newConfiguration
         return url
     }

--- a/KernovaTests/Mocks/MockVMStorageService.swift
+++ b/KernovaTests/Mocks/MockVMStorageService.swift
@@ -4,9 +4,17 @@ import Foundation
 /// In-memory mock for `VMStorageProviding` that tracks operations without touching disk —
 /// except `vmsDirectory`, which import/clone tests need as a real, writable directory since
 /// `VMLibraryViewModel.reserveAndImport(from:)` does a raw `FileManager.copyItem` into it rather than
-/// going through this protocol. `baseDirectory` is unique per instance (suffixed with a UUID) so
+/// going through this protocol, and `cloneVMBundle`, which creates its returned URL for the same
+/// reason (see below). `baseDirectory` is unique per instance (suffixed with a UUID) so
 /// parallel/`.serialized` tests copying real bundles into it can't collide or leak state into
 /// each other.
+///
+/// Because `vmsDirectory`/`cloneVMBundle` are real, on-disk paths, and every `VMLibraryViewModel`
+/// starts a real `VMDirectoryWatcher` against `vmsDirectory` in `init`, a test driving an async
+/// clone/import to completion should register every other in-memory instance's `bundleURL` in
+/// `bundles` too (as the existing clone tests do) — otherwise a watcher-triggered
+/// `reconcileWithDisk()` racing the test could mistake an unregistered resting-state instance for a
+/// bundle that vanished from disk and evict it.
 final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
     // MARK: - Storage
 

--- a/KernovaTests/SidebarViewControllerTests.swift
+++ b/KernovaTests/SidebarViewControllerTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import KernovaTestSupport
 import Testing
 
 @testable import Kernova
@@ -26,9 +27,11 @@ struct SidebarViewControllerTests {
         self.preferences = makeEphemeralPreferences(suiteName: "test.kernova.sidebar")
     }
 
-    private func makeViewModel() -> VMLibraryViewModel {
+    private func makeViewModel(storageService: MockVMStorageService = MockVMStorageService())
+        -> VMLibraryViewModel
+    {
         VMLibraryViewModel(
-            storageService: MockVMStorageService(),
+            storageService: storageService,
             diskImageService: MockDiskImageService(),
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
@@ -382,5 +385,66 @@ struct SidebarViewControllerTests {
         #expect(outline.numberOfRows == 3)
         #expect(outline.item(atRow: 0) is SidebarSection)
         #expect(outline.item(atRow: 1) is VMInstance)
+    }
+
+    // MARK: - Clone completion refresh (#575)
+
+    @Test("A cloned VM's preparing row settling routes through the sidebar's reload cycle")
+    func clonedRowSettlingTriggersReload() async throws {
+        let storage = MockVMStorageService()
+        let viewModel = makeViewModel(storageService: storage)
+        let source = makeInstance(name: "Source", guestOS: .macOS)
+        // Registered with the mock storage so the view model's real
+        // `VMDirectoryWatcher` — which fires on the clone's directory actually
+        // landing on disk (the mock now creates it, matching production) —
+        // doesn't mistake the never-persisted source for a bundle that vanished
+        // and reconcile it away, confounding the reload count below.
+        storage.bundles[source.bundleURL] = source.configuration
+        viewModel.instances.append(source)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
+        controller.loadViewIfNeeded()
+        controller.viewDidAppear()
+
+        let reloadsBeforeClone = controller.reloadInstancesCallCountForTesting
+        viewModel.cloneVM(source)
+        guard let phantom = viewModel.instances.first(where: { $0.id != source.id }) else {
+            Issue.record("Expected a cloned phantom instance")
+            return
+        }
+
+        // Await the production Task the row's preparing state is held on, per
+        // docs/TESTING.md's "await the production Task" seam, rather than
+        // polling the flag it flips. (The mock's copy settles fast enough that
+        // polling for an intermediate "still preparing" reload count would
+        // race it — the two reloads below can both have landed by the first
+        // poll tick.)
+        await phantom.preparingState?.task.value
+        #expect(!phantom.isPreparing)
+
+        // Two reloads are expected end to end: one for the phantom's initial
+        // registration (an id-list change) and one for its `isPreparing`
+        // settle — the fix under test (#575). The settle's reload has no
+        // dedicated Observable signal at the controller layer to hang a
+        // `waitForChange` off of (it fires through an internal
+        // `ObservationLoop` cascade), so poll the counter per docs/TESTING.md's
+        // no-signal exception (asserting end-state, not per-iteration).
+        try await waitUntil {
+            controller.reloadInstancesCallCountForTesting >= reloadsBeforeClone + 2
+        }
+
+        // Best-effort: when the row happens to be realized off-screen, confirm
+        // the badge itself reads visible. Pure rendering is otherwise verified
+        // manually (see this file's top-level doc comment).
+        guard let outline = findOutlineView(in: controller.view) else {
+            Issue.record("Expected an NSOutlineView in the sidebar view tree")
+            return
+        }
+        let row = outline.row(forItem: phantom)
+        if row >= 0,
+            let cell = outline.view(atColumn: 0, row: row, makeIfNecessary: false)
+                as? SidebarVMRowCellView
+        {
+            #expect(cell.agentAccessoryHiddenForTesting == false)
+        }
     }
 }

--- a/KernovaTests/SidebarViewControllerTests.swift
+++ b/KernovaTests/SidebarViewControllerTests.swift
@@ -421,30 +421,27 @@ struct SidebarViewControllerTests {
         await phantom.preparingState?.task.value
         #expect(!phantom.isPreparing)
 
-        // Two reloads are expected end to end: one for the phantom's initial
-        // registration (an id-list change) and one for its `isPreparing`
-        // settle — the fix under test (#575). The settle's reload has no
-        // dedicated Observable signal at the controller layer to hang a
-        // `waitForChange` off of (it fires through an internal
-        // `ObservationLoop` cascade), so poll the counter per docs/TESTING.md's
-        // no-signal exception (asserting end-state, not per-iteration).
+        // Exactly two reloads are expected end to end: one for the phantom's
+        // initial registration (an id-list change) and one for its
+        // `isPreparing` settle — the fix under test (#575). The settle's
+        // reload has no dedicated Observable signal at the controller layer to
+        // hang a `waitForChange` off of (it fires through an internal
+        // `ObservationLoop` cascade), so poll the counter.
+        //
+        // RATIONALE: genuine no-signal predicate (docs/TESTING.md) — the
+        // reload count is driven by an internal `ObservationLoop` cascade with
+        // no test-facing signal to await; `==`, not `>=`, so a stray extra
+        // reload (e.g. an unrelated `VMDirectoryWatcher` reconciliation) fails
+        // the test instead of being silently masked by a looser bound.
         try await waitUntil {
-            controller.reloadInstancesCallCountForTesting >= reloadsBeforeClone + 2
+            controller.reloadInstancesCallCountForTesting == reloadsBeforeClone + 2
         }
 
-        // Best-effort: when the row happens to be realized off-screen, confirm
-        // the badge itself reads visible. Pure rendering is otherwise verified
-        // manually (see this file's top-level doc comment).
-        guard let outline = findOutlineView(in: controller.view) else {
-            Issue.record("Expected an NSOutlineView in the sidebar view tree")
-            return
-        }
-        let row = outline.row(forItem: phantom)
-        if row >= 0,
-            let cell = outline.view(atColumn: 0, row: row, makeIfNecessary: false)
-                as? SidebarVMRowCellView
-        {
-            #expect(cell.agentAccessoryHiddenForTesting == false)
-        }
+        // The reload count above is the regression guard; the row's actual
+        // rendered badge is left to manual verification, per this file's
+        // top-level doc comment — `NSOutlineView` never realizes a row's cell
+        // view in this off-screen test harness (confirmed: `view(atColumn:
+        // row:makeIfNecessary: false)` is always nil here), so an assertion on
+        // it would silently never execute.
     }
 }


### PR DESCRIPTION
## Summary
- A cloned (or imported) VM's sidebar row stopped reflecting its final state (e.g. the guest-agent-not-installed badge) until an unrelated interaction — like selecting a different row — forced a redisplay.
- Closes #575.

## Root cause
`SidebarViewController`'s `instancesObservation` only tracked each instance's `id`, so it reloaded the outline view when a phantom row was added/removed but not when a preparing phantom settled to "real" (`isPreparing` flipping to `false`). That settle only updated the row's own `rowObservation`-driven live view mutation directly, with no guaranteed flush through the outline view's own (proven-correct) reload cycle.

## Fix
Widen `instancesObservation`'s tracked state to include each instance's `isPreparing`, so the settle now also routes through `reloadInstances()` — the same cycle that already renders every row correctly on initial load.

## Deviation from the issue's proposed fix
The issue's hypothesis pointed at the per-row `rowObservation`/`applyLiveState()` path, suggesting a missing `setNeedsDisplay`/`reloadItem` call there. Investigation showed `applyLiveState()` already computes the correct badge state (`visibleAgentStatus` doesn't even depend on `isPreparing`); the actual gap was that the sidebar's *own* reload cycle never re-ran for a preparing→settled transition. Routing through the existing `reloadInstances()` cycle is more robust than patching the per-cell mutation path.

## Changes
- `Kernova/Views/Sidebar/SidebarViewController.swift`: track `isPreparing` in `instancesObservation`; add a `#if DEBUG` `reloadInstancesCallCountForTesting` counter for regression testing.
- `Kernova/Views/Sidebar/SidebarVMRowCellView.swift`: add a `#if DEBUG` `agentAccessoryHiddenForTesting` accessor for best-effort assertion of the live rendered badge state.
- `KernovaTests/Mocks/MockVMStorageService.swift`: `cloneVMBundle` now creates the destination bundle directory (matching the real service), needed for a macOS-guest clone to survive the regenerated-MachineIdentifier file write in tests.
- `KernovaTests/SidebarViewControllerTests.swift`: new regression test exercising the real clone → settle → reload flow.

## Test plan
- [x] `make test` — full suite passes
- [x] `make lint`
- [x] Verified the new test fails (times out) with the observation-tracking fix reverted, and passes with it restored