### PR TITLE
fix: Capture self weakly in outer closures around weak-self Tasks

### DIFF
--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -957,7 +957,7 @@ final class VsockClipboardService: ClipboardServicing {
             receiver.awaitTransfer(
                 transferID,
                 onComplete: { pull.resume($0) },
-                onAbort: { info in
+                onAbort: { [weak self] info in
                     // Surface a mid-stream disk-full: the pre-flight above covers
                     // the up-front case; this covers a volume that fills *during*
                     // the transfer (parity with the retired eager onTransferAbort).

--- a/Kernova/Utilities/ObservationLoop.swift
+++ b/Kernova/Utilities/ObservationLoop.swift
@@ -29,7 +29,7 @@ final class ObservationLoop {
         guard !isCancelled else { return }
         withObservationTracking {
             track()
-        } onChange: {
+        } onChange: { [weak self] in
             Task { @MainActor [weak self] in
                 guard let self, !self.isCancelled else { return }
                 // Re-arm BEFORE applying: `apply()` can synchronously mutate

--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -965,7 +965,7 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
         let firstFileGate = PromiseFirstFileGate()
 
         receiver.receivePromisedFiles(atDestination: destination, options: [:], operationQueue: promiseQueue) {
-            url, error in
+            [weak self] url, error in
             Task { @MainActor [weak self] in
                 // Per-file cleanup happens even if the window closed before
                 // the promise resolved (self gone). Removing the directory


### PR DESCRIPTION
## Summary
Xcode 27 Beta 3's Swift compiler flags three sites with **'weak' ownership of capture 'self' differs from implicitly-captured strong reference in outer closure**. In each, a `Task { @MainActor [weak self] in … }` sits inside an outer escaping closure with no capture list of its own — so the outer closure implicitly captures `self` **strongly** to hand it to the Task, and the weak capture only takes effect once the outer closure runs.

The fix at every site is the same one-line change: add `[weak self]` to the outer closure so the weak semantics hold end-to-end.

## Changes
- **ObservationLoop** — the `onChange:` closure registered with `withObservationTracking` now captures weakly. Previously the Observation runtime retained the loop strongly while armed, so dropping the handle didn't release it until the next change fired (indefinitely, if the tracked state never changed again). The documented contract — "the observation runs until this handle is deallocated" — now actually holds.
- **VsockClipboardService** — `awaitTransfer`'s `onAbort:` closure now captures weakly, matching the sibling `onLiveRecord:`/`onProgress:` closures that already did.
- **ClipboardContentViewController** — the `receivePromisedFiles` per-file completion now captures weakly. The cleanup comment already documented that scratch cleanup runs "even if the window closed before the promise resolved (self gone)", but the strong outer capture retained the view controller until every promised file resolved (60+ seconds for a large Finder drop). The `defer` cleanup stays outside the `guard let self`, so per-file scratch cleanup still runs when the window closed.

A repo-wide sweep of every nested `Task { [weak self] }` confirmed these three were the only sites with a strong-capturing outer closure; all others are either directly in method bodies or inside closures that already capture weakly.

## Test plan
- [x] Full test suite passes on Xcode 27 Beta 3 (1632 tests, 0 failures)
- [x] Build log from that run shows zero 'differs from implicitly-captured' warnings
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FohgFWxGZuZZDobNkggufv