### PR TITLE
fix: Mark host clipboard writes .currentHostOnly to stop Universal Clipboard leaks

### DIFF
--- a/Kernova/Services/HostClipboardPublisher.swift
+++ b/Kernova/Services/HostClipboardPublisher.swift
@@ -18,6 +18,10 @@ import os
 /// destination pastes. The providers outlive this object — a paste can land long
 /// after the window (or the VM) is gone — so they are handed to the app-scoped
 /// `LazyClipboardProviderRegistry` on a successful write.
+///
+/// Every write is marked `.currentHostOnly` (CLIPBOARD.md §10): guest content
+/// becomes host-owned data on arrival, so it must not be re-advertised to the
+/// user's other Apple-Account-linked devices over Universal Clipboard.
 @MainActor
 final class HostClipboardPublisher {
     /// Label for the host-side clipboard staging root.
@@ -141,7 +145,15 @@ final class HostClipboardPublisher {
         }
 
         let pasteboard = writePasteboard
-        pasteboard.clearContents()
+        // RATIONALE: Guest clipboard content crosses the guest→host trust
+        // boundary here (CLIPBOARD.md §10) and becomes host-owned data, not the
+        // user's own cross-device clipboard content — so it must not be
+        // re-advertised to the user's other Apple-Account-linked devices over
+        // Universal Clipboard. `.currentHostOnly` is reset by the next
+        // `prepareForNewContents`/`clearContents`, so it has to be (re)applied
+        // at this single inbound-publication choke point on every write, not
+        // once at init.
+        pasteboard.prepareForNewContents(with: .currentHostOnly)
         guard pasteboard.writeObjects(items) else {
             // The write failed, so the providers were never retained — the local
             // array drops them and no finish callback fires.

--- a/Kernova/Services/HostClipboardPublisher.swift
+++ b/Kernova/Services/HostClipboardPublisher.swift
@@ -145,14 +145,10 @@ final class HostClipboardPublisher {
         }
 
         let pasteboard = writePasteboard
-        // RATIONALE: Guest clipboard content crosses the guest→host trust
-        // boundary here (CLIPBOARD.md §10) and becomes host-owned data, not the
-        // user's own cross-device clipboard content — so it must not be
-        // re-advertised to the user's other Apple-Account-linked devices over
-        // Universal Clipboard. `.currentHostOnly` is reset by the next
-        // `prepareForNewContents`/`clearContents`, so it has to be (re)applied
-        // at this single inbound-publication choke point on every write, not
-        // once at init.
+        // RATIONALE: `.currentHostOnly` (see class doc) is reset by the next
+        // `prepareForNewContents`/`clearContents`, so it must be (re)applied at
+        // this single inbound-publication choke point on every write, not once
+        // at init.
         pasteboard.prepareForNewContents(with: .currentHostOnly)
         guard pasteboard.writeObjects(items) else {
             // The write failed, so the providers were never retained — the local

--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -1102,7 +1102,7 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
 ///
 /// `NSPasteboard` is a class cluster with no public initializer and can't be
 /// subclassed, so its write can't be made to fail from a test. This write-only
-/// seam (clear, an objects-write returning `Bool`, and the post-write
+/// seam (prepare, an objects-write returning `Bool`, and the post-write
 /// `changeCount` the passthrough coordinator reads for echo suppression) is
 /// deliberately separate from the guest agent's richer `Pasteboard` protocol,
 /// which also carries poll/read members the host write path never uses.
@@ -1112,7 +1112,7 @@ protocol HostWritePasteboard: AnyObject {
     /// after a write identifies that write to a coordinator polling the same
     /// pasteboard.
     var changeCount: Int { get }
-    @discardableResult func clearContents() -> Int
+    @discardableResult func prepareForNewContents(with options: NSPasteboard.ContentsOptions) -> Int
     func writeObjects(_ objects: [any NSPasteboardWriting]) -> Bool
 }
 

--- a/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
+++ b/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
@@ -164,30 +164,8 @@ struct ClipboardContentViewControllerRetentionTests {
         // observable via this seam.
         #expect(pasteboard.prepareCount == 1)
         // Marked host-only even though the write went on to fail — the option is
-        // applied unconditionally up front, before writeObjects is attempted.
-        #expect(pasteboard.lastPrepareOptions == .currentHostOnly)
-    }
-
-    @Test("copyToMac marks the host pasteboard write .currentHostOnly (#560)")
-    func copyToMacMarksHostOnly() async throws {
-        let registry = LazyClipboardProviderRegistry()
-        defer { registry.releaseAllForTesting() }
-        let pasteboard = FakeWritePasteboard()
-        let wrote = AsyncGate()
-        pasteboard.onWrite = { wrote.notify() }
-
-        let service = FakeClipboardService(content: ClipboardContent(text: "host only"))
-        let instance = makeInstance()
-        instance.clipboardService = service
-        let vc = ClipboardContentViewController(
-            instance: instance, viewModel: makeViewModel(),
-            writePasteboard: pasteboard, providerRegistry: registry)
-
-        vc.copy(nil)
-        try await wrote.wait { pasteboard.writeAttempts == 1 }
-
-        // Guest clipboard content must never be re-advertised to the user's other
-        // Apple-Account-linked devices over Universal Clipboard (#560).
+        // applied unconditionally up front, before writeObjects is attempted, so
+        // this failure-path write already proves every write is marked (#560).
         #expect(pasteboard.lastPrepareOptions == .currentHostOnly)
     }
 }

--- a/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
+++ b/KernovaTests/ClipboardContentViewControllerRetentionTests.swift
@@ -151,7 +151,7 @@ struct ClipboardContentViewControllerRetentionTests {
             writePasteboard: pasteboard, providerRegistry: registry)
 
         #expect(registry.countForTesting == 0)
-        // → copyToMac → finishCopyToMac → clearContents() then writeObjects(→ false).
+        // → copyToMac → finishCopyToMac → prepareForNewContents(with:) then writeObjects(→ false).
         vc.copy(nil)
         try await wrote.wait { pasteboard.writeAttempts == 1 }
 
@@ -159,9 +159,36 @@ struct ClipboardContentViewControllerRetentionTests {
         // leaves the registry empty — the providers deallocate with the copy Task's
         // local array, never getting a finish callback (so no rollback is needed).
         #expect(registry.countForTesting == 0)
-        // clearContents ran before the failed write — a latent wipe-on-failure of
-        // the real clipboard, tracked as a follow-up and observable via this seam.
-        #expect(pasteboard.clearCount == 1)
+        // prepareForNewContents ran before the failed write — a latent
+        // wipe-on-failure of the real clipboard, tracked as a follow-up and
+        // observable via this seam.
+        #expect(pasteboard.prepareCount == 1)
+        // Marked host-only even though the write went on to fail — the option is
+        // applied unconditionally up front, before writeObjects is attempted.
+        #expect(pasteboard.lastPrepareOptions == .currentHostOnly)
+    }
+
+    @Test("copyToMac marks the host pasteboard write .currentHostOnly (#560)")
+    func copyToMacMarksHostOnly() async throws {
+        let registry = LazyClipboardProviderRegistry()
+        defer { registry.releaseAllForTesting() }
+        let pasteboard = FakeWritePasteboard()
+        let wrote = AsyncGate()
+        pasteboard.onWrite = { wrote.notify() }
+
+        let service = FakeClipboardService(content: ClipboardContent(text: "host only"))
+        let instance = makeInstance()
+        instance.clipboardService = service
+        let vc = ClipboardContentViewController(
+            instance: instance, viewModel: makeViewModel(),
+            writePasteboard: pasteboard, providerRegistry: registry)
+
+        vc.copy(nil)
+        try await wrote.wait { pasteboard.writeAttempts == 1 }
+
+        // Guest clipboard content must never be re-advertised to the user's other
+        // Apple-Account-linked devices over Universal Clipboard (#560).
+        #expect(pasteboard.lastPrepareOptions == .currentHostOnly)
     }
 }
 
@@ -293,7 +320,8 @@ private final class FakeClipboardService: ClipboardServicing {
 /// fires inside `writeObjects` so a test can await the write attempt event-driven
 /// rather than polling.
 private final class FakeWritePasteboard: HostWritePasteboard {
-    private(set) var clearCount = 0
+    private(set) var prepareCount = 0
+    private(set) var lastPrepareOptions: NSPasteboard.ContentsOptions?
     private(set) var writeAttempts = 0
     var failNextWrite = false
     var onWrite: (() -> Void)?
@@ -301,9 +329,10 @@ private final class FakeWritePasteboard: HostWritePasteboard {
     /// Bumped on every successful write so it mirrors `NSPasteboard.changeCount`.
     private(set) var changeCount = 0
 
-    @discardableResult func clearContents() -> Int {
-        clearCount += 1
-        return clearCount
+    @discardableResult func prepareForNewContents(with options: NSPasteboard.ContentsOptions) -> Int {
+        prepareCount += 1
+        lastPrepareOptions = options
+        return prepareCount
     }
 
     func writeObjects(_ objects: [any NSPasteboardWriting]) -> Bool {

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -221,6 +221,10 @@ toggle and (in gated mode) explicit user intent.
 - **Honor pasteboard privacy markers.** Transient / auto-generated snapshots
   (`org.nspasteboard.*`) are not synced. Concealed (password) content may sync but its bytes
   must never reach a view — only its presence is shown (§5).
+- **Guest→host writes never leave the host.** `HostClipboardPublisher` marks every "Copy to Mac"
+  pasteboard write `.currentHostOnly`, unconditionally — guest content becomes host-owned data on
+  arrival and must not be re-advertised to the user's other Apple-Account-linked devices over
+  Universal Clipboard (#560).
 - Before non-trusted guest workloads are supported, the vsock listener must authenticate per VM.
 
 ### 11. Sandbox-forward by construction
@@ -319,6 +323,7 @@ fix, not just whether to fix it. (macOS-guest issues only; Linux/Windows out of 
 | **#330** — preference to disable the guest-agent install prompt | §10 (consent/UX) | Peripheral to transport; a consent/UX affordance, not a data-path change. |
 | **#499** — a stale cancel/abort for one pull attempt can land on a same-id retry instead | §9 idempotent/bidirectional abort | The `transfer_id`'s determinism from `(generation, repIndex, direction)` is load-bearing (cancel re-derives it; `cancelPull`'s race guard depends on it) — an id-format change to disambiguate attempts was rejected as disproportionate. ✓ **Resolved as documented-benign** — the residual (a spurious re-abort/retry, never corruption) is pinned by a regression test and the invariant is documented on `ClipboardTransferID` itself. |
 | **#500** — a duplicate pull registration for the same id silently overwrites the prior one | §9 wake immediately, not a backstop stall | `LazyPullCoordinator.pull`/`ClipboardStreamReceiver.awaitTransfer` had no guard against a concurrent duplicate registration (e.g. a File Provider fetch retry after a dropped owner connection). ✓ **Resolved** — a duplicate registration supersedes the prior one, resolving it immediately via a distinct `.superseded` outcome (not `.cancelled`, which would let the displaced caller tear down the live successor's awaiter). |
+| **#560** — Copy to Mac advertises guest clipboard content to other devices over Universal Clipboard | §10 Trust boundary | `HostClipboardPublisher` prepared every write with `clearContents()`, which leaves the pasteboard cross-device-advertisable. ✓ **Resolved** — every host write now prepares with `prepareForNewContents(with: .currentHostOnly)` instead, applied unconditionally at the single inbound-publication choke point (§4) on every write, since the option does not survive a later prepare/clear. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Guest clipboard content written to the host pasteboard ("Copy to Mac") was never marked host-local, so macOS could advertise it over Universal Clipboard to a nearby device signed into the same Apple Account.
- Every host pasteboard write is now prepared with `.currentHostOnly`, so guest clipboard content never leaves the host machine.

Closes #560

## Changes
- `Kernova/Services/HostClipboardPublisher.swift` — replace `clearContents()` with `prepareForNewContents(with: .currentHostOnly)` at the single inbound-publication choke point (`publish(from:)`), since the option resets on every prepare/clear and must be reapplied on each write, not once.
- `Kernova/Views/Clipboard/ClipboardContentViewController.swift` — update the `HostWritePasteboard` test seam's protocol requirement from `clearContents()` to `prepareForNewContents(with:)` (`NSPasteboard` already conforms via its native method).
- `KernovaTests/ClipboardContentViewControllerRetentionTests.swift` — update `FakeWritePasteboard` to implement the new requirement and capture the passed options; add a regression test asserting every write is marked `.currentHostOnly`, including on a write that goes on to fail.
- `docs/CLIPBOARD.md` — document the new host-only guarantee under §10 Trust boundary and privacy, and record #560 in the issue → principle triage map.

## Deviations from the issue's proposed fix
The issue described this as a single-line swap of `clearContents()`. The planning pass found that `clearContents()` is reached through the `HostWritePasteboard` protocol seam (used to make the write-failure path testable, since concrete `NSPasteboard` can't be subclassed), so the protocol requirement itself needed to change too, along with the one test fake that implements it. Still a small, localized change.

The issue also raised whether host-only should be unconditional or a user-facing preference. This PR applies it unconditionally to every "Copy to Mac" write, with no toggle — justified by CLIPBOARD.md §10 (guest content becomes host-owned data on arrival and crosses a trust boundary), Kernova's existing settings model (clipboard settings are per-VM only; there's no natural home for a global toggle), and the fact that this closes a leak rather than removing a capability anyone has asked for.

## Test plan
- [x] `make build` succeeds
- [x] `make test-suite SUITE=KernovaTests/ClipboardContentViewControllerRetentionTests` — all 4 tests pass, including the new regression test
- [x] `make test` — full suite passes (1540 tests, 0 failures)
- [x] `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)