### PR TITLE
fix: Add deadline-safe size cap to the guest's host→guest paste pull

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -1012,7 +1012,7 @@
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
-				MARKETING_VERSION = 0.41.0;
+				MARKETING_VERSION = 0.42.0;
 				EXECUTABLE_NAME = KernovaMacOSAgent;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
@@ -1038,7 +1038,7 @@
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
-				MARKETING_VERSION = 0.41.0;
+				MARKETING_VERSION = 0.42.0;
 				EXECUTABLE_NAME = KernovaMacOSAgent;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
@@ -1096,7 +1096,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.41.0;
+				MARKETING_VERSION = 0.42.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent.fileprovider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1127,7 +1127,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.41.0;
+				MARKETING_VERSION = 0.42.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent.fileprovider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -726,6 +726,8 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
                 return "The guest couldn't provide the requested format"
             case "clipboard.paste.disk.full":
                 return "The guest ran out of disk space receiving the clipboard file"
+            case "clipboard.paste.too.large":
+                return "The file is too large to paste into the guest without File Provider"
             case "clipboard.paste.timeout":
                 return "The clipboard transfer to the guest timed out"
             default:

--- a/KernovaKit/Sources/KernovaKit/ClipboardFileProviderReminder.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileProviderReminder.swift
@@ -81,10 +81,13 @@ public enum ClipboardFileProviderReminder {
 
     /// Degraded-mode summary for the guest side (host→guest paste).
     ///
-    /// Deliberately makes no size promise: unlike the host direction, this
-    /// mirror-image fallback has no deadline-safe cap yet (open #561) — an
-    /// over-cap paste with the toggle off can fail without any drop message,
-    /// so this must not claim a size ceiling a user could rely on.
+    /// With the toggle off, a file paste falls back to a synchronous,
+    /// deadline-bound pull capped at `ClipboardStreamTuning
+    /// .maxDeadlineSafeFileBytes` — symmetric with the host direction (#561) —
+    /// and an over-cap file is refused with its own `clipboard.paste.too.large`
+    /// error frame, surfaced in the host's clipboard window. This summary
+    /// deliberately doesn't restate the byte figure, matching
+    /// `hostDegradedSummary`.
     public static func guestDegradedSummary() -> String {
         "Text and images paste normally. Enable File Provider to reliably paste files from your Mac."
     }

--- a/KernovaKit/Sources/KernovaKit/ClipboardFileProviderReminder.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileProviderReminder.swift
@@ -81,13 +81,12 @@ public enum ClipboardFileProviderReminder {
 
     /// Degraded-mode summary for the guest side (host→guest paste).
     ///
-    /// With the toggle off, a file paste falls back to a synchronous,
-    /// deadline-bound pull capped at `ClipboardStreamTuning
-    /// .maxDeadlineSafeFileBytes` — symmetric with the host direction (#561) —
-    /// and an over-cap file is refused with its own `clipboard.paste.too.large`
-    /// error frame, surfaced in the host's clipboard window. This summary
-    /// deliberately doesn't restate the byte figure, matching
-    /// `hostDegradedSummary`.
+    /// A file or folder paste falls back to a synchronous, deadline-bound pull
+    /// capped at `ClipboardStreamTuning.maxDeadlineSafeFileBytes` — mirroring the
+    /// host direction (#561) — and an over-cap rep is refused with its own
+    /// `clipboard.paste.too.large` error frame, surfaced in the host's clipboard
+    /// window. This summary deliberately doesn't restate the byte figure,
+    /// matching `hostDegradedSummary`.
     public static func guestDegradedSummary() -> String {
         "Text and images paste normally. Enable File Provider to reliably paste files from your Mac."
     }

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -1132,24 +1132,31 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     ) -> ClipboardContent.Representation? {
         let info = promise.reps[repIndex]
         // RATIONALE: mirrors the host's deadline-safe gate
-        // (`VsockClipboardService.isLazyEligibleFile` + `lazyFileItem`) — a
-        // non-inline, non-directory file rep over `maxDeadlineSafeFileBytes` on
-        // the synchronous provider path would block the OS paste deadline with
-        // no progress signal. Checked first (actionable-first: "enable File
-        // Provider" beats a disk-space message) and only on the deadline-bound
-        // caller — the File Provider relay has no deadline and must stay
-        // uncapped (docs/CLIPBOARD.md §2).
-        if deadlineBound, !info.isInline, !info.isDirectory,
+        // (`VsockClipboardService.isLazyEligibleFile` + `lazyFileItem`) for plain
+        // files, and additionally covers directory reps — unlike the host (whose
+        // "Copy to Mac" pulls a directory eagerly, at click time, never through a
+        // deadline-bound pasteboard-provider callback), the guest's inbound
+        // directory extraction runs through this *same* synchronous path as a
+        // plain file (D1b folder File-Provider routing hasn't shipped, so every
+        // inbound directory rep reaches here). A non-inline rep over
+        // `maxDeadlineSafeFileBytes` on the synchronous provider path would block
+        // the OS paste deadline with no progress signal, file or folder alike.
+        // Checked first (actionable-first: "enable File Provider" beats a
+        // disk-space message) and only on the deadline-bound caller — the File
+        // Provider relay has no deadline and must stay uncapped
+        // (docs/CLIPBOARD.md §2).
+        if deadlineBound, !info.isInline,
             info.byteCount > UInt64(ClipboardStreamTuning.maxDeadlineSafeFileBytes)
         {
             Self.logger.warning(
-                "Clipboard file rep '\(info.uti, privacy: .public)' is \(info.byteCount, privacy: .public) bytes — over the deadline-safe cap with the File Provider off; refusing the synchronous paste pull"
+                "Clipboard rep '\(info.uti, privacy: .public)' is \(info.byteCount, privacy: .public) bytes — over the deadline-safe cap with the File Provider off; refusing the synchronous paste pull"
             )
             // The guest has no UI; tell the host so it shows the failure.
+            let kind = info.isDirectory ? "Folder" : "File"
             sendPasteError(
                 code: "clipboard.paste.too.large",
                 message:
-                    "File too large to paste into the guest without File Provider (\(info.byteCount) bytes)",
+                    "\(kind) too large to paste into the guest without File Provider (\(info.byteCount) bytes)",
                 on: channel)
             return nil
         }

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -1098,7 +1098,8 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             }
             guard
                 let pulled = pullRepresentation(
-                    repIndex, promise: promise, channel: channel, receiver: receiver)
+                    repIndex, promise: promise, channel: channel, receiver: receiver,
+                    deadlineBound: true)
             else { return nil }
             promise.materialized[repIndex] = pulled
             representation = pulled
@@ -1119,11 +1120,39 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// hopping to the main thread this call holds. The free-space pre-flight runs
     /// here, before the request, so an over-budget file rep never starts a
     /// transfer. [Safeguard 4]
+    ///
+    /// `deadlineBound` gates the deadline-safe size cap (#561): `provideData`'s
+    /// synchronous pasteboard-provider path passes `true` (it blocks the OS paste
+    /// deadline), while the File Provider relay's `fetchStagedFile` passes
+    /// `false` — that path has no deadline and must stay uncapped
+    /// (docs/CLIPBOARD.md §2), the whole reason large files route there.
     private func pullRepresentation(
         _ repIndex: Int, promise: InboundPromise, channel: VsockChannel,
-        receiver: ClipboardStreamReceiver
+        receiver: ClipboardStreamReceiver, deadlineBound: Bool
     ) -> ClipboardContent.Representation? {
         let info = promise.reps[repIndex]
+        // RATIONALE: mirrors the host's deadline-safe gate
+        // (`VsockClipboardService.isLazyEligibleFile` + `lazyFileItem`) — a
+        // non-inline, non-directory file rep over `maxDeadlineSafeFileBytes` on
+        // the synchronous provider path would block the OS paste deadline with
+        // no progress signal. Checked first (actionable-first: "enable File
+        // Provider" beats a disk-space message) and only on the deadline-bound
+        // caller — the File Provider relay has no deadline and must stay
+        // uncapped (docs/CLIPBOARD.md §2).
+        if deadlineBound, !info.isInline, !info.isDirectory,
+            info.byteCount > UInt64(ClipboardStreamTuning.maxDeadlineSafeFileBytes)
+        {
+            Self.logger.warning(
+                "Clipboard file rep '\(info.uti, privacy: .public)' is \(info.byteCount, privacy: .public) bytes — over the deadline-safe cap with the File Provider off; refusing the synchronous paste pull"
+            )
+            // The guest has no UI; tell the host so it shows the failure.
+            sendPasteError(
+                code: "clipboard.paste.too.large",
+                message:
+                    "File too large to paste into the guest without File Provider (\(info.byteCount) bytes)",
+                on: channel)
+            return nil
+        }
         if !info.isInline, !staging.hasCapacity(forByteCount: Int(clamping: info.byteCount)) {
             Self.logger.warning(
                 "Not enough disk space to receive clipboard rep '\(info.uti, privacy: .public)' (\(info.byteCount, privacy: .public) bytes)"
@@ -1474,7 +1503,7 @@ extension VsockGuestClipboardAgent: FileProviderPullProvider {
         guard
             let representation = pullRepresentation(
                 repIndex, promise: context.promise, channel: context.channel,
-                receiver: context.receiver),
+                receiver: context.receiver, deadlineBound: false),
             let url = representation.fileURL
         else { return .failure(.pullFailed) }
         return .success(url.path)

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -2152,6 +2152,180 @@ struct VsockGuestClipboardAgentTests {
         #expect(error.code == "clipboard.paste.disk.full")
     }
 
+    // MARK: - Deadline-safe size cap (#561)
+
+    @Test(
+        "deadline cap: a `.fileURL` pull for an over-cap file rep returns nil without a request")
+    func tooLargePullReturnsNilWithoutRequest() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        // Ample disk (default free-space provider) — the size cap must refuse the
+        // pull on its own, before the disk-capacity guard is even reached.
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        let txtUTI = try #require(UTType(filenameExtension: "txt")).identifier
+        let overCap = UInt64(ClipboardStreamTuning.maxDeadlineSafeFileBytes) + 1
+        try hostChannel.send(
+            makeOfferFrame(
+                generation: 21,
+                reps: [
+                    RepInfo(uti: txtUTI, byteCount: overCap, filename: "huge.bin", isInline: false)
+                ]))
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.fileURL] }
+
+        let pull = lazyPull(pasteboard, forType: .fileURL)
+        let provided = await pull.value
+        #expect(provided == nil)
+        try await expectNoRequest(from: hostChannel)
+    }
+
+    @Test(
+        "deadline cap: the guest surfaces the failure to the host as a clipboard.paste.too.large error frame"
+    )
+    func tooLargeSurfacesErrorFrame() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        let txtUTI = try #require(UTType(filenameExtension: "txt")).identifier
+        let overCap = UInt64(ClipboardStreamTuning.maxDeadlineSafeFileBytes) + 1
+        try hostChannel.send(
+            makeOfferFrame(
+                generation: 22,
+                reps: [
+                    RepInfo(uti: txtUTI, byteCount: overCap, filename: "huge.bin", isInline: false)
+                ]))
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.fileURL] }
+
+        let pull = lazyPull(pasteboard, forType: .fileURL)
+        #expect(await pull.value == nil)
+
+        let frame = try await maybeNextFrame(from: hostChannel)
+        guard case .error(let error)? = frame?.payload else {
+            Issue.record("Expected an Error frame, got \(String(describing: frame?.payload))")
+            return
+        }
+        #expect(error.code == "clipboard.paste.too.large")
+    }
+
+    @Test("deadline cap: a file rep exactly at the cap is not refused — the pull still proceeds")
+    func atCapBoundaryIsNotRefused() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        let txtUTI = try #require(UTType(filenameExtension: "txt")).identifier
+        let atCap = UInt64(ClipboardStreamTuning.maxDeadlineSafeFileBytes)
+        try hostChannel.send(
+            makeOfferFrame(
+                generation: 23,
+                reps: [
+                    RepInfo(uti: txtUTI, byteCount: atCap, filename: "atcap.bin", isInline: false)
+                ]))
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.fileURL] }
+
+        // The cap uses `>`, not `>=` — an exactly-at-cap rep must issue a real
+        // request rather than being refused pre-flight. Abort it to resolve the
+        // pull without streaming the full 256 MiB in-test.
+        let pull = lazyPull(pasteboard, forType: .fileURL)
+        let req = try await awaitRequest(on: hostChannel)
+        try hostChannel.send(
+            makeAbortFrame(transferID: req.transferID, code: "host.abort", message: "test abort"))
+        _ = await pull.value
+    }
+
+    @Test("deadline cap: an inline over-cap rep is not deadline-capped — the pull still proceeds")
+    func inlineOverCapIsNotDeadlineCapped() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        // Inline reps (§1: no Kernova-imposed size bound) are exempt from the
+        // deadline cap, which only guards non-inline, non-directory file reps —
+        // mirroring the host's `isLazyEligibleFile` gate.
+        let overCap = UInt64(ClipboardStreamTuning.maxDeadlineSafeFileBytes) + 1
+        try hostChannel.send(
+            makeOfferFrame(
+                generation: 24,
+                reps: [
+                    RepInfo(uti: ClipboardContent.utf8TextUTI, byteCount: overCap, isInline: true)
+                ]))
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.string] }
+
+        let pull = lazyPull(pasteboard, forType: .string)
+        let req = try await awaitRequest(on: hostChannel)
+        try hostChannel.send(
+            makeAbortFrame(transferID: req.transferID, code: "host.abort", message: "test abort"))
+        _ = await pull.value
+    }
+
+    @Test(
+        "deadline cap: the File Provider relay's fetchStagedFile stays uncapped — an over-cap rep still issues a request"
+    )
+    func fileProviderRelayIsNotDeadlineCapped() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        let txtUTI = try #require(UTType(filenameExtension: "txt")).identifier
+        let overCap = UInt64(ClipboardStreamTuning.maxDeadlineSafeFileBytes) + 1
+        try hostChannel.send(
+            makeOfferFrame(
+                generation: 25,
+                reps: [
+                    RepInfo(uti: txtUTI, byteCount: overCap, filename: "relay-huge.bin", isInline: false)
+                ]))
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.fileURL] }
+
+        // `fetchStagedFile` (the relay entry point, no OS paste deadline) must
+        // issue a real request for the same over-cap rep the pasteboard path
+        // above refuses — proving `deadlineBound: false` bypasses the cap.
+        let pull = Task.detached { agent.fetchStagedFile(generation: 25, repIndex: 0) }
+        let req = try await awaitRequest(on: hostChannel)
+        try hostChannel.send(
+            makeAbortFrame(transferID: req.transferID, code: "host.abort", message: "test abort"))
+        let outcome = await pull.value
+        guard case .failure(.pullFailed) = outcome else {
+            Issue.record("expected .pullFailed after abort, got \(outcome)")
+            return
+        }
+    }
+
     // MARK: - Request send failure
 
     @Test("a request-send failure resolves the lazy pull promptly with nil instead of blocking")

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -2187,6 +2187,38 @@ struct VsockGuestClipboardAgentTests {
     }
 
     @Test(
+        "deadline cap: an over-cap directory rep is refused too — a folder paste has no File Provider escape hatch yet (D1b), so it rides the same deadline-bound path as a plain file"
+    )
+    func tooLargeDirectoryPullReturnsNilWithoutRequest() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        let overCap = UInt64(ClipboardStreamTuning.maxDeadlineSafeFileBytes) + 1
+        try hostChannel.send(
+            makeOfferFrame(
+                generation: 26,
+                reps: [
+                    RepInfo(
+                        uti: UTType.folder.identifier, byteCount: overCap, filename: "HugeFolder",
+                        isInline: false, isDirectory: true)
+                ]))
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.fileURL] }
+
+        let pull = lazyPull(pasteboard, forType: .fileURL)
+        let provided = await pull.value
+        #expect(provided == nil)
+        try await expectNoRequest(from: hostChannel)
+    }
+
+    @Test(
         "deadline cap: the guest surfaces the failure to the host as a clipboard.paste.too.large error frame"
     )
     func tooLargeSurfacesErrorFrame() async throws {

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -123,10 +123,13 @@ Honest caveats this principle does **not** waive:
   entirely once the File Provider is enabled — `fetchContents` has no deadline and no size
   limit. This direction (guest→host) is unaffected by §3's advertiser caveat: host "Copy to
   Mac" has published a concrete File Provider placeholder since #434, so the advertiser's
-  offer-time fetch (§3) costs nothing here. The **mirror-image host→guest path has no
-  equivalent cap yet** — see #561. The offer-time advertiser fetch that once made that
-  uncapped pull fire with no paste at all is suppressed — the guest's promise write is
-  `.currentHostOnly` (§3, #542) — so the sync-promise pull now runs only on a real paste.
+  offer-time fetch (§3) costs nothing here. The **mirror-image host→guest path carries the
+  same cap** (#561): the guest's synchronous pull refuses a non-inline, non-directory file
+  rep over `maxDeadlineSafeFileBytes` and reports `clipboard.paste.too.large` back to the
+  host rather than pulling it, mirroring `isLazyEligibleFile`/`lazyFileItem` above. The
+  offer-time advertiser fetch that once made an uncapped pull fire with no paste at all is
+  separately suppressed — the guest's promise write is `.currentHostOnly` (§3, #542) — so
+  the sync-promise pull now runs only on a real paste, and the cap guards that real paste.
 - **Host "Copy to Mac" routes a plain-file rep lazily only when exactly one is offered (D2
   scope).** If two or more plain-file reps are present, all of them are dropped (the user sees
   "Only one file can be copied to your Mac at a time"), regardless of the toggle. Unlike the
@@ -151,8 +154,8 @@ bounded pull — see §5).
   materializes the entire file with no paste ever issued. The rule this establishes: a published
   representation is only genuinely lazy if **every** flavor it exposes is cheap to produce at
   registration time, not merely at the moment we intend it to be consumed. This bit hardest
-  on the host→guest sync-promise fallback, which has no size cap yet (§2, #561) — an
-  already-uncapped pull that the advertiser also made paste-independent, until #542 scoped the
+  on the host→guest sync-promise fallback — an uncapped pull (until #561 added the mirror-image
+  size cap, §2) that the advertiser also made paste-independent, until #542 scoped the
   guest's promise write `.currentHostOnly`: the advertiser then never processes the generation
   at all (no item-to-advertise determination, no flavor fetch — verified live: a 1.5 GiB
   toggle-off offer sat 160 s with zero bytes pulled, and a real paste still streamed
@@ -360,6 +363,7 @@ fix, not just whether to fix it. (macOS-guest issues only; Linux/Windows out of 
 | **#500** — a duplicate pull registration for the same id silently overwrites the prior one | §9 wake immediately, not a backstop stall | `LazyPullCoordinator.pull`/`ClipboardStreamReceiver.awaitTransfer` had no guard against a concurrent duplicate registration (e.g. a File Provider fetch retry after a dropped owner connection). ✓ **Resolved** — a duplicate registration supersedes the prior one, resolving it immediately via a distinct `.superseded` outcome (not `.cancelled`, which would let the displaced caller tear down the live successor's awaiter). |
 | **#560** — Copy to Mac advertises guest clipboard content to other devices over Universal Clipboard | §10 Trust boundary | `HostClipboardPublisher` prepared every write with `clearContents()`, which leaves the pasteboard cross-device-advertisable. ✓ **Resolved** — every host write now prepares with `prepareForNewContents(with: .currentHostOnly)` instead, applied unconditionally at the single inbound-publication choke point (§4) on every write, since the option does not survive a later prepare/clear. |
 | **#542** — guest pulls a host clipboard offer's full payload at offer time, with no paste (toggle-off sync path) | §3 Pay on consume, §10 Trust boundary | The guest's continuity-pasteboard advertiser fetched the promised `public.file-url` at offer time, and fulfilling it materialized the whole file (§3's advertiser caveat). ✓ **Resolved** — the guest's promise write prepares with `.currentHostOnly` (the #560 mechanism applied guest-side), which keeps the advertiser from processing the generation at all; verified live (1.5 GiB toggle-off offer idle 160 s with zero bytes moved, in-guest log shows no advertiser fetch, a real paste still streams immediately). |
+| **#561** — host→guest paste has no deadline-safe size cap, unlike guest→host | §2 Disk-as-fallback (deadline cap), §13 OS deadlines | The two directions were asymmetric: the host's synchronous fallback already refuses an over-cap file (`isLazyEligibleFile`/`lazyFileItem`), but the guest's `pullRepresentation` checked only staging disk capacity. ✓ **Resolved** — the guest's synchronous pasteboard-provider pull now refuses a non-inline, non-directory file rep over `maxDeadlineSafeFileBytes` and reports `clipboard.paste.too.large`, surfaced in the host's clipboard window; the File Provider relay (`fetchStagedFile`, no deadline) stays uncapped via a `deadlineBound` parameter on the shared `pullRepresentation`. |
 
 ---
 

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -124,12 +124,16 @@ Honest caveats this principle does **not** waive:
   limit. This direction (guest→host) is unaffected by §3's advertiser caveat: host "Copy to
   Mac" has published a concrete File Provider placeholder since #434, so the advertiser's
   offer-time fetch (§3) costs nothing here. The **mirror-image host→guest path carries the
-  same cap** (#561): the guest's synchronous pull refuses a non-inline, non-directory file
-  rep over `maxDeadlineSafeFileBytes` and reports `clipboard.paste.too.large` back to the
-  host rather than pulling it, mirroring `isLazyEligibleFile`/`lazyFileItem` above. The
-  offer-time advertiser fetch that once made an uncapped pull fire with no paste at all is
-  separately suppressed — the guest's promise write is `.currentHostOnly` (§3, #542) — so
-  the sync-promise pull now runs only on a real paste, and the cap guards that real paste.
+  same cap** (#561): the guest's synchronous pull refuses a non-inline rep (file **or**
+  directory) over `maxDeadlineSafeFileBytes` and reports `clipboard.paste.too.large` back to
+  the host rather than pulling it, mirroring `isLazyEligibleFile`/`lazyFileItem` above — and
+  going further for directories, since a folder paste has no File-Provider-routed escape hatch
+  on the guest yet (D1b), so it always rides this same synchronous path regardless of the
+  toggle, unlike the host's directory pull (eager, at "Copy to Mac" click time, never through a
+  deadline-bound pasteboard callback at all). The offer-time advertiser fetch that once made an
+  uncapped pull fire with no paste at all is separately suppressed — the guest's promise write
+  is `.currentHostOnly` (§3, #542) — so the sync-promise pull now runs only on a real paste,
+  and the cap guards that real paste.
 - **Host "Copy to Mac" routes a plain-file rep lazily only when exactly one is offered (D2
   scope).** If two or more plain-file reps are present, all of them are dropped (the user sees
   "Only one file can be copied to your Mac at a time"), regardless of the toggle. Unlike the
@@ -363,7 +367,7 @@ fix, not just whether to fix it. (macOS-guest issues only; Linux/Windows out of 
 | **#500** — a duplicate pull registration for the same id silently overwrites the prior one | §9 wake immediately, not a backstop stall | `LazyPullCoordinator.pull`/`ClipboardStreamReceiver.awaitTransfer` had no guard against a concurrent duplicate registration (e.g. a File Provider fetch retry after a dropped owner connection). ✓ **Resolved** — a duplicate registration supersedes the prior one, resolving it immediately via a distinct `.superseded` outcome (not `.cancelled`, which would let the displaced caller tear down the live successor's awaiter). |
 | **#560** — Copy to Mac advertises guest clipboard content to other devices over Universal Clipboard | §10 Trust boundary | `HostClipboardPublisher` prepared every write with `clearContents()`, which leaves the pasteboard cross-device-advertisable. ✓ **Resolved** — every host write now prepares with `prepareForNewContents(with: .currentHostOnly)` instead, applied unconditionally at the single inbound-publication choke point (§4) on every write, since the option does not survive a later prepare/clear. |
 | **#542** — guest pulls a host clipboard offer's full payload at offer time, with no paste (toggle-off sync path) | §3 Pay on consume, §10 Trust boundary | The guest's continuity-pasteboard advertiser fetched the promised `public.file-url` at offer time, and fulfilling it materialized the whole file (§3's advertiser caveat). ✓ **Resolved** — the guest's promise write prepares with `.currentHostOnly` (the #560 mechanism applied guest-side), which keeps the advertiser from processing the generation at all; verified live (1.5 GiB toggle-off offer idle 160 s with zero bytes moved, in-guest log shows no advertiser fetch, a real paste still streams immediately). |
-| **#561** — host→guest paste has no deadline-safe size cap, unlike guest→host | §2 Disk-as-fallback (deadline cap), §13 OS deadlines | The two directions were asymmetric: the host's synchronous fallback already refuses an over-cap file (`isLazyEligibleFile`/`lazyFileItem`), but the guest's `pullRepresentation` checked only staging disk capacity. ✓ **Resolved** — the guest's synchronous pasteboard-provider pull now refuses a non-inline, non-directory file rep over `maxDeadlineSafeFileBytes` and reports `clipboard.paste.too.large`, surfaced in the host's clipboard window; the File Provider relay (`fetchStagedFile`, no deadline) stays uncapped via a `deadlineBound` parameter on the shared `pullRepresentation`. |
+| **#561** — host→guest paste has no deadline-safe size cap, unlike guest→host | §2 Disk-as-fallback (deadline cap), §13 OS deadlines | The two directions were asymmetric: the host's synchronous fallback already refuses an over-cap file (`isLazyEligibleFile`/`lazyFileItem`), but the guest's `pullRepresentation` checked only staging disk capacity. ✓ **Resolved** — the guest's synchronous pasteboard-provider pull now refuses a non-inline rep (file or directory) over `maxDeadlineSafeFileBytes` and reports `clipboard.paste.too.large`, surfaced in the host's clipboard window; the File Provider relay (`fetchStagedFile`, no deadline) stays uncapped via a `deadlineBound` parameter on the shared `pullRepresentation`. Directories are covered too, going beyond the host mirror: the guest has no File-Provider escape hatch for folders yet (D1b), so every inbound directory rep rides this same deadline-bound path today, unlike the host's eager (never deadline-bound) directory pull. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Mirror the guest→host size cap on the host→guest sync-promise paste path: with the guest File Provider off (or not ready), an over-cap file or folder rep pulled by a real paste no longer blocks the OS paste deadline indefinitely — it is refused pre-flight and reported to the host instead.
- Closes #561.

## Changes
- `VsockGuestClipboardAgent.pullRepresentation` gains a `deadlineBound` parameter; when `true` (the synchronous `provideData` pasteboard-provider path) a non-inline rep (file **or** directory) over `ClipboardStreamTuning.maxDeadlineSafeFileBytes` is refused pre-flight with a `clipboard.paste.too.large` error frame, mirroring the host's `isLazyEligibleFile`/`lazyFileItem` gate for files, and going further for directories (see Deviations). The File Provider relay (`fetchStagedFile`, no OS deadline) passes `false` and stays uncapped, per docs/CLIPBOARD.md §2.
- `ClipboardContentViewController.message(for:)` maps the new `clipboard.paste.too.large` peer-reported error code to a host-facing message.
- `ClipboardFileProviderReminder.guestDegradedSummary()` doc comment updated — the fallback is no longer uncapped.
- `docs/CLIPBOARD.md` §2/§3 updated to describe the now-symmetric (and, for directories, broader-than-symmetric) cap, plus a resolved row for #561 in the issue → principle triage map.
- Bumped the guest agent's `MARKETING_VERSION` (0.41.0 → 0.42.0, all four `app.kernova.macosagent`/`app.kernova.macosagent.fileprovider` configs) since the guest's paste behavior changes.

## Deviations from the issue
The issue and its 2026-07-16 triage comment describe the eager-pull-at-offer-time failure modes from #542. Commit d6cee67 (#593, merged after the triage) eliminated that eager pull entirely via `.currentHostOnly` — bytes now move only on a real paste. That narrows #561 to the one residual risk: a **genuine paste** of an over-cap file on the sync path (guest File Provider off/not-ready) still had no size bound and could block the guest agent's main thread past the OS paste deadline. This PR adds exactly that bound; no eager-pull-suppression work was needed since #593 already did it.

The cap is gated behind a `deadlineBound` flag on the shared `pullRepresentation`, rather than applied unconditionally, because that method also serves the File Provider relay path (`fetchStagedFile`), which per docs/CLIPBOARD.md §2 must remain uncapped (no OS deadline there — that's the point of routing large files through the File Provider).

**Found during code review (`/code-review medium --fix`) and folded in:** the initial cap excluded directory reps, mirroring the host's `isLazyEligibleFile` (which also excludes directories). But the host excludes directories because its "Copy to Mac" pulls a folder *eagerly*, at click time, never through a deadline-bound pasteboard-provider callback at all — so it doesn't need a cap for them. The guest has no such escape hatch: folder File-Provider routing (D1b) hasn't shipped, so *every* inbound directory rep rides this same synchronous, deadline-bound path as a plain file, regardless of the toggle. Excluding directories from the guest's cap would have left the exact hang #561 was filed to fix, just for folders instead of files. The cap now covers both, and the refusal message distinguishes "File" vs "Folder."

## Test plan
- [x] `make build` succeeds
- [x] `make test` — full suite passes, including 6 new tests: over-cap file/directory pulls return nil without a request, over-cap surfaces a `clipboard.paste.too.large` error frame, an exactly-at-cap rep is not refused, an inline over-cap rep is not deadline-capped, and the File Provider relay stays uncapped for an over-cap rep
- [x] `make lint` passes
- [x] `/code-review medium --fix` run on the full branch diff — findings folded in (directory-cap gap, directory-aware error message); no follow-up issues filed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
