### PR TITLE
docs: Log-subsystem inventory and stale File Provider extension gotcha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,19 @@ When adding new functionality or modifying existing behavior, include unit tests
 
 ### Logging
 
-The app uses Apple's `os.Logger` (subsystem `app.kernova`) with per-component categories. Each service, view model, or model that logs declares a `private static let logger`. When adding or modifying functionality, include log calls at appropriate levels:
+The app uses Apple's `os.Logger` with per-component categories. Each service, view model, or model that logs declares a `private static let logger`. Subsystems are per-target:
+
+| Subsystem | Who logs there |
+|-----------|----------------|
+| `app.kernova` | The host app and all `KernovaKit` shared code — including KernovaKit types running *inside* the guest agent's processes |
+| `app.kernova.fileprovider` | The host clipboard File Provider extension |
+| `app.kernova.macosagent` | The guest agent's own components |
+| `app.kernova.macosagent.fileprovider` | The guest agent's File Provider extension |
+| `app.kernova.guest` | Host-side re-logging of forwarded guest records (the log-forwarding toggle; category = VM name) |
+
+When capturing logs with `log stream`/`log show`, filter with `subsystem BEGINSWITH "app.kernova"`. An exact `subsystem == "app.kernova"` match silently drops the agent's and both extensions' records — and because KernovaKit code inside those processes still matches, the truncated capture *looks* complete.
+
+When adding or modifying functionality, include log calls at appropriate levels:
 
 | Level | When to use | Persistence |
 |-------|-------------|-------------|

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -412,6 +412,16 @@ These are not negotiable mechanics for *how* clipboard changes ship:
   not exist.
 - **Log at the right level.** Lifecycle transitions (transfer started/completed/aborted) at
   `.notice`; recoverable degradations at `.warning`; failures at `.error`. No `print`/`NSLog`.
+  When capturing, filter `subsystem BEGINSWITH "app.kernova"` — the agent and the File Provider
+  extensions log under their own subsystems (see AGENTS.md's Logging table), and an exact match
+  on `app.kernova` yields a misleadingly complete-looking partial capture.
+- **A reinstalled guest agent does not replace its running File Provider extension.**
+  `fileproviderd` keeps the already-spawned extension process (the old binary) serving the domain
+  across an agent reinstall + relaunch. When live-testing an extension change, kill it
+  (`pkill -f KernovaMacOSAgentFileProvider`; `fileproviderd` respawns the new binary on demand) —
+  or reboot the guest — before attributing File Provider behavior to the new build (observed in
+  #604's verification: a fixed extension appeared to still fail until the stale process was
+  killed).
 
 ---
 


### PR DESCRIPTION
Two facts surfaced by #604's live verification, recorded where future debugging will look:

- **Log capture**: the guest agent and both File Provider extensions log under their own subsystems (`app.kernova.macosagent`, `app.kernova[.macosagent].fileprovider`), and forwarded guest records land under `app.kernova.guest` — an exact `subsystem == "app.kernova"` predicate silently drops all of them while the capture still looks complete. AGENTS.md's Logging section now carries the subsystem table and the `BEGINSWITH` guidance.
- **Live-testing**: `fileproviderd` keeps a reinstalled guest agent's old extension process serving the domain; CLIPBOARD.md's engineering practices now note the `pkill`-before-attributing step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXnzNJJJT5uzv7KCt39aTy