### PR TITLE
fix: Kill the running File Provider extension on agent install and uninstall

### DIFF
--- a/KernovaMacOSAgent/install.command
+++ b/KernovaMacOSAgent/install.command
@@ -68,6 +68,13 @@ if [[ "${choice}" =~ ^[Yy]$ ]]; then
     # pre-rename install ran under app.kernova.agent and is booted out below).
     launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
 
+    # fileproviderd does not replace a running File Provider extension when its
+    # app bundle is replaced — the already-spawned process (the old binary) keeps
+    # serving the domain (docs/CLIPBOARD.md, Engineering practices). Kill it so
+    # the system respawns the new one on demand; a no-match (fresh install, or
+    # the extension never launched) is fine.
+    pkill -f KernovaMacOSAgentFileProvider 2>/dev/null || true
+
     # Copy the app bundle with ditto so its code signature and layout survive — a
     # flattened or re-permissioned copy would invalidate the bundle signature and
     # launchd would refuse to exec it.

--- a/KernovaMacOSAgent/uninstall.command
+++ b/KernovaMacOSAgent/uninstall.command
@@ -31,6 +31,11 @@ if [[ "${choice}" =~ ^[Yy]$ ]]; then
     # Stop the agent
     launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
 
+    # Also kill the running File Provider extension so no process lingers from
+    # the deleted bundle — fileproviderd would keep the already-spawned process
+    # serving the domain otherwise (docs/CLIPBOARD.md, Engineering practices).
+    pkill -f KernovaMacOSAgentFileProvider 2>/dev/null || true
+
     # RATIONALE: rm is used instead of trash because this runs inside a guest VM
     # where the trash CLI is not a standard macOS utility, and Finder-based trash
     # (osascript) requires a GUI session that may not be available in headless VMs.

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -417,11 +417,12 @@ These are not negotiable mechanics for *how* clipboard changes ship:
   on `app.kernova` yields a misleadingly complete-looking partial capture.
 - **A reinstalled guest agent does not replace its running File Provider extension.**
   `fileproviderd` keeps the already-spawned extension process (the old binary) serving the domain
-  across an agent reinstall + relaunch. When live-testing an extension change, kill it
-  (`pkill -f KernovaMacOSAgentFileProvider`; `fileproviderd` respawns the new binary on demand) —
-  or reboot the guest — before attributing File Provider behavior to the new build (observed in
-  #604's verification: a fixed extension appeared to still fail until the stale process was
-  killed).
+  across an agent reinstall + relaunch. `install.command` and `uninstall.command` kill it
+  (`pkill -f KernovaMacOSAgentFileProvider`; `fileproviderd` respawns the new binary on demand),
+  so a scripted reinstall is safe — but when replacing the bundle any other way (Xcode build,
+  manual copy), kill it yourself or reboot the guest before attributing File Provider behavior
+  to the new build (observed in #604's verification: a fixed extension appeared to still fail
+  until the stale process was killed).
 
 ---
 


### PR DESCRIPTION
fileproviderd does not replace a running File Provider extension when its app bundle is replaced — the already-spawned process (the old binary) keeps serving the domain, observed live in #604's verification where a fixed extension appeared to still fail until the stale process was killed. The uninstaller had the worse variant: a ghost extension process surviving the deleted bundle.

Both scripts now `pkill -f KernovaMacOSAgentFileProvider` alongside the agent bootout (`fileproviderd` respawns the new binary on demand; a no-match on fresh installs is tolerated). CLIPBOARD.md's practice note now scopes the manual kill to non-scripted bundle replacement (Xcode builds, manual copies).

No agent version bump: the agent binary is unchanged and the scripts take effect on the next install regardless of version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXnzNJJJT5uzv7KCt39aTy