### PR TITLE
docs: Annotate the Settings window's construction and frame autosave

### DIFF
--- a/Kernova/App/SettingsWindowController.swift
+++ b/Kernova/App/SettingsWindowController.swift
@@ -8,6 +8,14 @@ import AppKit
 @MainActor
 final class SettingsWindowController: NSWindowController {
     convenience init(viewModel: VMLibraryViewModel) {
+        // RATIONALE: deliberately *not* `NSWindow.withStableContentSize`, which the
+        // main and clipboard windows use. That factory pins a fixed initial content
+        // size, and this window has no single correct one — it is non-resizable and
+        // its height is whatever the selected pane publishes as `preferredContentSize`,
+        // re-applied by `SettingsTabViewController` on appear and on every tab switch.
+        // The plain initializer's fitting-size behavior is what we want here; the
+        // factory's flexible-content collapse (a split view's minimum thicknesses) has
+        // no analogue in a fixed-width settings pane.
         let window = NSWindow(
             contentViewController: SettingsTabViewController(viewModel: viewModel))
         window.title = "Settings"
@@ -15,6 +23,12 @@ final class SettingsWindowController: NSWindowController {
         // The controller is a singleton reused across opens, so the window must
         // survive being closed (don't deallocate it out from under the reference).
         window.isReleasedWhenClosed = false
+        // RATIONALE: the autosaved frame is kept for its *position* only — a saved
+        // frame also restores a height, which for this non-resizable window is stale
+        // the moment the pane list or a pane's content changes (#629: it stretched the
+        // first pane's cards over the excess). AppKit has no position-only autosave, so
+        // `SettingsTabViewController` re-asserts the height on appear instead; losing
+        // the remembered position would be the worse trade.
         window.setFrameAutosaveName("KernovaSettings")
         self.init(window: window)
     }


### PR DESCRIPTION
Follow-up to #629 (Annotate, per AGENTS.md's review triage).

Reviewing #629 surfaced two deviations in `SettingsWindowController` that a reviewer — human or automated — would reasonably flag without project context, and that were undocumented enough that they had to be re-derived from the other window controllers:

1. **It is the only window built with the plain `NSWindow(contentViewController:)`.** `MainWindowController:60` and `ClipboardWindowController:39` both use the shared `NSWindow.withStableContentSize` factory. The divergence is correct: that factory pins a *fixed* initial content size, and this window has no single right one — it is non-resizable and its height is whatever the selected pane publishes as `preferredContentSize`. The factory's actual purpose (stopping flexible content, e.g. a split view's minimum thicknesses, from collapsing the window below the intended size) has no analogue in a fixed-width settings pane.

2. **It keeps `setFrameAutosaveName` for a window whose height it overrides.** The saved frame is wanted for its *position*; its restored *height* is the stale value that stretched the first pane's cards in #629. AppKit has no position-only autosave, so `SettingsTabViewController` re-asserts the height on appear rather than dropping autosave and losing the remembered position — the worse trade.

Neither is a behavior change. Comment-only, so the deviations stop being re-derived (or re-flagged) each review.

## Test plan
- [x] `make lint` clean
- [x] `make build` succeeds
- [x] Comment-only — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2Z9ptmAF2FgDjxNS9LsQT