### PR TITLE
docs: Record that Finder copy-dialog progress consumption was never observed

### DIFF
--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -437,9 +437,13 @@ indicator, over two owner-side channels:
 
 **The copy dialog's consumption of the published progress is environment-sensitive** (#639).
 With publication log-proven in every live run, the dialog rendered a determinate bar in some
-sessions (single flat files in #638's runs; folder children in both #639 sessions) and stayed on
-the indeterminate "Preparing to copy…" slide in others (every flat-file paste across two later
-sessions, including from a clean host boot) — byte-identical binaries throughout. The dialog also
+runs (single flat files in #638's sessions; folder children once, with fill growth across
+observations) and stayed on the indeterminate "Preparing to copy…" slide in others (every
+flat-file paste across two later sessions — clean host boot included — and two same-boot folder
+re-runs) — byte-identical binaries throughout, varying run-to-run within one boot. Captured frame
+sequences also show the indeterminate sweep parking at the track's left edge each cycle, which
+mimics a small determinate fill in any single glance: a determinate claim needs fill growth
+across multiple observations, never one frame. The dialog also
 dismisses itself tens of seconds into a multi-GB pull while materialization continues in the
 background; the `fetchContents` `Progress` channel keeps driving the framework's own bookkeeping
 for the full pull and payloads land intact either way. This is a **documented gap**, not a defect

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -435,22 +435,23 @@ indicator, over two owner-side channels:
   for the CloudStorage URL because the domain host holds the domain root's security scope while
   the root is current.
 
-**The copy dialog's consumption of the published progress is environment-sensitive** (#639).
-With publication log-proven in every live run, the dialog rendered a determinate bar in some
-runs (single flat files in #638's sessions; folder children once, with fill growth across
-observations) and stayed on the indeterminate "Preparing to copy…" slide in others (every
-flat-file paste across two later sessions — clean host boot included — and two same-boot folder
-re-runs) — byte-identical binaries throughout, varying run-to-run within one boot. Captured frame
-sequences also show the indeterminate sweep parking at the track's left edge each cycle, which
-mimics a small determinate fill in any single glance: a determinate claim needs fill growth
-across multiple observations, never one frame. The dialog also
+**Consumption of the published progress by Finder's copy dialog has never been durably
+observed** (#639). Publication is log-proven full-duration in every live run (development- and
+Release/profile-signed builds alike), but every captured frame of the dialog — all paste shapes,
+clean host boot included — shows the indeterminate "Preparing to copy…" slide. Its sweep
+animation parks at the track's left edge each cycle and produces arbitrary-width segments, so
+one or two glances convincingly mimic a determinate fill; the determinate classifications
+recorded earlier (#638's test plan, #639's session notes) were exactly such sparse-glance
+observations, and no run ever recorded the label flip to a byte-count "Copying…" style that
+real consumption produces. Treat them as unverified: claim consumption only on a captured label
+flip or a dense, file-preserved frame sequence of slow monotonic growth. The dialog also
 dismisses itself tens of seconds into a multi-GB pull while materialization continues in the
 background; the `fetchContents` `Progress` channel keeps driving the framework's own bookkeeping
-for the full pull and payloads land intact either way. This is a **documented gap**, not a defect
-to engineer around: the publication is the API's supported shape, the degradation is only ever an
-indeterminate or absent bar (never a wrong one), and no folder-root aggregate `NSProgress` is
-warranted — per-child publications already render whenever Finder consumes published progress at
-all.
+for the full pull and payloads land intact. This is a **documented gap**, not a defect to
+engineer around: the publication is the API's supported shape (the one first-party providers'
+determinate dialogs consume), the degradation is only ever an indeterminate or absent bar
+(never a wrong one), and a folder-root aggregate `NSProgress` would not close it — no
+publication shape has been observed to render.
 
 The host clipboard window's in-app bar records the guest→host pull from the same per-chunk
 callback (`performBlockingPull`, direction `.inbound`); all indicators clear at every terminal.

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -405,9 +405,9 @@ Large transfers are streamed and take real time. Two obligations follow:
   promise on its own clock. For unbounded operations, **prefer an API with no host-OS deadline**
   (File Provider) over one where we must beat a clock we do not control.
 
-The File Provider paste path is **determinate end to end** (#426, #634), in both directions. One
-per-chunk `(bytesTransferred, totalBytes)` callback from the receiver drives every indicator, over
-two owner-side channels:
+The File Provider paste path reports **determinate progress end to end** (#426, #634), in both
+directions. One per-chunk `(bytesTransferred, totalBytes)` callback from the receiver drives every
+indicator, over two owner-side channels:
 
 - **The extension's `fetchContents` `Progress`** (#426): the extension can't see the vsock
   transfer, so the owner pushes the per-chunk counts to the sandboxed extension over the
@@ -434,6 +434,19 @@ two owner-side channels:
   same shape first-party providers use for per-file downloads. The sandboxed host app can publish
   for the CloudStorage URL because the domain host holds the domain root's security scope while
   the root is current.
+
+**The copy dialog's consumption of the published progress is environment-sensitive** (#639).
+With publication log-proven in every live run, the dialog rendered a determinate bar in some
+sessions (single flat files in #638's runs; folder children in both #639 sessions) and stayed on
+the indeterminate "Preparing to copy…" slide in others (every flat-file paste across two later
+sessions, including from a clean host boot) — byte-identical binaries throughout. The dialog also
+dismisses itself tens of seconds into a multi-GB pull while materialization continues in the
+background; the `fetchContents` `Progress` channel keeps driving the framework's own bookkeeping
+for the full pull and payloads land intact either way. This is a **documented gap**, not a defect
+to engineer around: the publication is the API's supported shape, the degradation is only ever an
+indeterminate or absent bar (never a wrong one), and no folder-root aggregate `NSProgress` is
+warranted — per-child publications already render whenever Finder consumes published progress at
+all.
 
 The host clipboard window's in-app bar records the guest→host pull from the same per-chunk
 callback (`performBlockingPull`, direction `.inbound`); all indicators clear at every terminal.


### PR DESCRIPTION
## Summary

#639's live verification ran four sessions across two days (clean host boot included), with the per-pull `NSProgress` publication log-proven full-duration in every run, from both the development-signed and Release/provisioning-profile-signed builds.

**Consumption of that publication by Finder's copy dialog was never durably observed.** Every captured dialog frame — all paste shapes, all sessions — shows the indeterminate "Preparing to copy…" slide, and no run ever recorded the label flip to a byte-count "Copying…" style that real consumption produces. File-captured frame sequences show the indeterminate sweep parks at the track's left edge each cycle and produces arbitrary-width segments, so sparse glances convincingly mimic a determinate fill — which is what the determinate classifications previously recorded in #638's test plan and #639's session notes turned out to be. Those classifications are withdrawn as unverified.

This PR records the corrected outcome in docs/CLIPBOARD.md §13:

- Scope the "determinate end to end" claim to what Kernova *reports* (publication, the in-app bar, the `fetchContents` channel).
- State that dialog consumption has never been durably observed, why the prior sightings don't count, and the proof bar for any future claim (captured label flip, or a dense file-preserved sequence of slow monotonic growth).
- Record the documented-gap disposition: the publication is the API's supported shape, the degradation is only ever an indeterminate/absent bar (never a wrong one), and a folder-root aggregate `NSProgress` would not close the gap — no publication shape has been observed to render.

The verification evidence (clean-boot matrix, Release-signed publication check, captured frame sequences) is in the #639 issue comments.

Closes #639

## Test plan
- [x] Docs-only change; content matches the corrected, log-proven verification record on #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcBMZLjpQtVsQ7gddw65Wy