### PR TITLE
refactor: Clear the dead-code scan findings

### DIFF
--- a/KernovaKit/Sources/KernovaKit/ClipboardFileStaging.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileStaging.swift
@@ -4,9 +4,6 @@ import Foundation
 /// `write(_:)` and finalized with `commit()` (keep) or `abort()` (delete the
 /// partial).
 public protocol StagingSink: Sendable {
-    /// The local file the bytes are being written to.
-    var url: URL { get }
-
     /// Appends a chunk to the file.
     func write(_ data: Data) throws
 
@@ -40,7 +37,7 @@ public final class ClipboardFileStaging: @unchecked Sendable {
     /// `write`/`commit`/`abort` safe.
     public final class Sink: StagingSink, @unchecked Sendable {
         /// The local file the bytes are being written to.
-        public let url: URL
+        let url: URL
 
         private let handle: FileHandle
         private let lock = NSLock()

--- a/KernovaKit/Sources/KernovaKit/FileProviderRelayService.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderRelayService.swift
@@ -164,11 +164,11 @@ public final class FileProviderRelayService: NSObject, FileProviderRelay {
 /// The final chunk (`bytes >= total`) always forwards, so a determinate readout
 /// reaches 100% rather than stalling one throttle interval short. Stateless — the
 /// caller owns the watermarks.
-public enum FetchProgressThrottle {
+enum FetchProgressThrottle {
     /// Minimum fraction of the total that must accumulate since the last push.
-    public static let minByteFraction = 0.01
+    static let minByteFraction = 0.01
     /// Minimum wall-clock gap between time-triggered pushes.
-    public static let minInterval: TimeInterval = 0.1
+    static let minInterval: TimeInterval = 0.1
 
     /// Whether `bytes`/`total` warrants a push given the last pushed byte count and
     /// the time since the last push.
@@ -194,7 +194,7 @@ public enum FetchProgressThrottle {
 /// republishes at one shared policy.
 ///
 /// `@unchecked Sendable`: every stored property is guarded by `lock`.
-public final class FetchProgressCoalescer: @unchecked Sendable {
+final class FetchProgressCoalescer: @unchecked Sendable {
     private let lock = NSLock()
     private var lastForwardedBytes: UInt64 = 0
     /// When the last update was forwarded; `nil` until the first, so the first
@@ -203,7 +203,7 @@ public final class FetchProgressCoalescer: @unchecked Sendable {
 
     /// Creates a coalescer with empty watermarks, so its first forward-progress
     /// update always passes.
-    public init() {}
+    init() {}
 
     /// Records that an update was forwarded without asking `shouldForward` —
     /// a consumer that bypasses the throttle for something the user must see
@@ -212,7 +212,7 @@ public final class FetchProgressCoalescer: @unchecked Sendable {
     /// Without it the watermarks would still describe the last *throttled*
     /// forward, so the next update would measure its delta from a byte count
     /// already on screen and sail through the policy however small it was.
-    public func markForwarded(bytesTransferred: UInt64) {
+    func markForwarded(bytesTransferred: UInt64) {
         lock.withLock {
             lastForwardedBytes = max(lastForwardedBytes, bytesTransferred)
             lastForwardAt = DispatchTime.now()
@@ -221,7 +221,7 @@ public final class FetchProgressCoalescer: @unchecked Sendable {
 
     /// Whether `(bytesTransferred, totalBytes)` should be forwarded now,
     /// advancing the watermarks when it should.
-    public func shouldForward(bytesTransferred: UInt64, totalBytes: UInt64) -> Bool {
+    func shouldForward(bytesTransferred: UInt64, totalBytes: UInt64) -> Bool {
         let now = DispatchTime.now()
         return lock.withLock {
             let elapsed =

--- a/KernovaKit/Sources/KernovaKit/TransferRateEstimator.swift
+++ b/KernovaKit/Sources/KernovaKit/TransferRateEstimator.swift
@@ -7,7 +7,7 @@ import Foundation
 /// credit stall reads as 0 B/s, the chunk after it as a burst), so this keeps an
 /// exponential moving average instead. The caller passes its own sample time;
 /// the estimator never reads the wall clock itself.
-public struct TransferRateEstimator: Equatable, Sendable {
+struct TransferRateEstimator: Equatable, Sendable {
     /// Weight of the newest instantaneous reading in the moving average.
     private static let smoothing = 0.25
 
@@ -24,17 +24,17 @@ public struct TransferRateEstimator: Equatable, Sendable {
 
     /// The moving average, or `nil` until two samples a usable interval apart
     /// have landed.
-    public private(set) var bytesPerSecond: Double?
+    private(set) var bytesPerSecond: Double?
 
     /// Creates an estimator with no samples.
-    public init() {}
+    init() {}
 
     /// Folds a cumulative byte count observed at `seconds` (any monotonic
     /// timebase) into the average.
     ///
     /// A regression in `bytes` is ignored rather than folded in as negative
     /// throughput.
-    public mutating func record(bytes: UInt64, seconds: TimeInterval) {
+    mutating func record(bytes: UInt64, seconds: TimeInterval) {
         guard let previousBytes = anchorBytes, let previousSeconds = anchorSeconds else {
             anchorBytes = bytes
             anchorSeconds = seconds
@@ -54,7 +54,7 @@ public struct TransferRateEstimator: Equatable, Sendable {
 
     /// Seconds until `total` is reached at the current rate, or `nil` when there
     /// is no rate yet, nothing left to transfer, or the total is unknown.
-    public func secondsRemaining(bytes: UInt64, total: UInt64) -> Double? {
+    func secondsRemaining(bytes: UInt64, total: UInt64) -> Double? {
         guard let rate = bytesPerSecond, rate > 0, total > bytes else { return nil }
         return Double(total - bytes) / rate
     }

--- a/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
+++ b/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
@@ -112,8 +112,6 @@ final class GatedSink: StagingSink, @unchecked Sendable {
     /// wait event-driven.
     let gate = AsyncGate()
 
-    var url: URL { wrapped.url }
-
     init(wrapping sink: ClipboardFileStaging.Sink) { wrapped = sink }
 
     /// Writes the receiver's write lane has entered — the last of them is
@@ -183,8 +181,6 @@ final class SilentlyDroppingSink: StagingSink, @unchecked Sendable {
     private let lock = NSLock()
     private var attempts = 0
 
-    var url: URL { wrapped.url }
-
     init(wrapping sink: ClipboardFileStaging.Sink, droppingWrite: Int) {
         wrapped = sink
         self.droppingWrite = droppingWrite
@@ -213,8 +209,6 @@ final class FailingSink: StagingSink, @unchecked Sendable {
     private let failingWrite: Int
     private let lock = NSLock()
     private var attempts = 0
-
-    var url: URL { wrapped.url }
 
     init(wrapping sink: ClipboardFileStaging.Sink, failingWrite: Int) {
         wrapped = sink

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -265,7 +265,6 @@ final class FakeFileProviderPublisher: FileProviderPublishing, @unchecked Sendab
     private var publishedStorage: [Published] = []
     private var publishedFoldersStorage: [FileProviderPublishFolder] = []
     private var publishCallCountStorage = 0
-    private var publishedSourceNameStorage: String?
     private var clearCountStorage = 0
     private var prepareCountStorage = 0
     private var rootToReturnStorage: URL?
@@ -302,7 +301,6 @@ final class FakeFileProviderPublisher: FileProviderPublishing, @unchecked Sendab
     ) -> [Int: URL]? {
         lock.withLock {
             publishCallCountStorage += 1
-            publishedSourceNameStorage = sourceName
             publishedStorage.append(
                 contentsOf: items.map {
                     Published(
@@ -328,8 +326,6 @@ final class FakeFileProviderPublisher: FileProviderPublishing, @unchecked Sendab
     var publishedFolders: [FileProviderPublishFolder] { lock.withLock { publishedFoldersStorage } }
     /// Number of `publishItems` calls (each may carry several items).
     var publishCallCount: Int { lock.withLock { publishCallCountStorage } }
-    /// Source name the most recent publish carried, for the paste readout.
-    var publishedSourceName: String? { lock.withLock { publishedSourceNameStorage } }
     var clearCount: Int { lock.withLock { clearCountStorage } }
     var prepareCount: Int { lock.withLock { prepareCountStorage } }
 }


### PR DESCRIPTION
Closes #662

## Summary

All 17 Periphery findings, in three groups.

**`StagingSink.url` (4 findings).** The protocol required `var url: URL { get }`, but nothing reads a sink's URL through the protocol — `commit()` returns the final URL, and `ClipboardFileStaging.Sink` uses its own `url` internally for the close-failure and abort deletes. The requirement's only effect was forcing `GatedSink`, `SilentlyDroppingSink`, and `FailingSink` to forward one, which is where the other three findings came from. Removed from the protocol and the three doubles; `Sink.url` stays (now internal, since only the staging tests read it).

**Redundant `public` (12 findings).** `FetchProgressThrottle`, `FetchProgressCoalescer`, and `TransferRateEstimator` are consumed only by `ClipboardProgressTracker`, inside KernovaKit. Their tests use `@testable import`, so internal access loses nothing. Narrowed to internal, matching `FetchProgressThrottle.shouldPush`, which was already internal.

**`publishedSourceName` (1 finding).** The guest agent's `FakeFileProviderPublisher` recorded the publish source name and exposed an accessor no test reads. The agent passes a constant (`"Mac"` — the guest can't learn the host's computer name over the control handshake), so an assertion on it would be tautological; the accessor, its storage, and the assignment are gone rather than backfilled with a test. The host-side double's identically-named accessor is asserted on and is untouched.

## Changes

- `KernovaKit/Sources/KernovaKit/ClipboardFileStaging.swift`
- `KernovaKit/Sources/KernovaKit/FileProviderRelayService.swift`
- `KernovaKit/Sources/KernovaKit/TransferRateEstimator.swift`
- `KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift`
- `KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift`

No behavior change — access levels and unused declarations only.

## Test plan

- [x] `make test` — all three test targets pass
- [x] `make lint`
- [x] `periphery scan` (3.7.4, repo `.periphery.yml`) locally — *No unused code detected*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198qgr2psXvqcpwYd8Xue8B
