### PR TITLE
docs: Record why the SPICE clipboard path excludes macOS guests

### DIFF
--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -511,8 +511,14 @@ struct ConfigurationBuilder: Sendable {
     /// `VZSpiceAgentPortAttachment` — the latter syncs the host `NSPasteboard`
     /// automatically, bypassing `SpiceClipboardService`'s gated UI.
     ///
-    /// Returns `nil` for macOS guests (they sync over vsock) and when clipboard
-    /// sharing is disabled.
+    /// Returns `nil` for macOS guests and when clipboard sharing is disabled.
+    ///
+    /// The macOS exclusion is load-bearing rather than routing: SPICE needs a
+    /// userspace agent inside the guest to read the port, and while Linux ships
+    /// `spice-vdagent`, macOS ships nothing comparable. Attaching the port to a
+    /// macOS guest therefore exchanges no clipboard data and leaks a
+    /// `tty.com.redhat.spice.0X` port across save/restore. Those guests reach
+    /// the clipboard over vsock through the guest agent instead.
     private func configureClipboardSharing(
         _ vzConfig: VZVirtualMachineConfiguration,
         config: VMConfiguration


### PR DESCRIPTION
## Summary

`ConfigurationBuilder.configureClipboardSharing` bails for macOS guests with a bare `guard config.guestOS == .linux else { return nil }`, and the reason is recorded nowhere in the tree. The existing summary line — "Returns `nil` for macOS guests (they sync over vsock)" — describes the behavior as routing. Read alone it invites widening the guard to cover macOS, which fails silently.

The exclusion is a platform constraint: SPICE needs a userspace agent inside the guest to read the port. Linux ships `spice-vdagent`; macOS ships nothing comparable. Attaching the port to a macOS guest exchanges no clipboard data and leaks a `tty.com.redhat.spice.0X` port across save/restore.

This states that on the symbol's `///`, which is where `AGENTS.md`'s layer table puts "the contract a caller needs, plus at most one non-obvious constraint."

## Test plan

- [x] `make lint` passes
- [x] `make test` — `** TEST SUCCEEDED **`
- [x] Diff is comment-only
- [x] Positive form, no history, no bare issue number as citation; `///` so the `//` block cap does not apply