### PR TITLE
fix: Repair ghosts.sh reporting defects and the lint job's toolchain record

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Select Xcode
         run: |
           sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-          xcrun swift-format --version
+          xcodebuild -version
 
       # The macOS runner images ship shellcheck; install it only if a future
       # image drops it, so `make lint` never silently skips static analysis

--- a/Tools/ghosts.sh
+++ b/Tools/ghosts.sh
@@ -373,7 +373,7 @@ while IFS= read -r pid; do
     fi
 done < <(pgrep -f -i kernova 2>/dev/null)
 
-[ "$proc_found" -eq 0 ] && clean 'No orphaned Kernova processes found'
+[ "$proc_found" -eq 0 ] && pass 'No orphaned Kernova processes found'
 
 # ---- stale git worktrees ------------------------------------------------------
 
@@ -819,7 +819,7 @@ done
 # ---- verdicts, then one block per location ------------------------------------
 
 case "$copies_verdict_kind" in
-    clean) clean "$copies_verdict" ;;
+    clean) pass "$copies_verdict" ;;
     warn)  warn "$copies_verdict" ;;
     ghost) ghost "$copies_verdict" ;;
 esac

--- a/Tools/ghosts.sh
+++ b/Tools/ghosts.sh
@@ -43,12 +43,25 @@ FIX=0
 SWEEP=0
 EVICT=0
 EVICT_DIR=
+# No argument is the report mode, so '' is an arm rather than falling to *).
+# Printed with plain printf, not the lib's helpers: output.sh is sourced below,
+# after this dispatch, so a bad flag can be rejected before anything else runs.
+usage='Usage: Tools/ghosts.sh [--fix | --sweep | --evict <dir>]'
 case "${1:-}" in
+    '') ;;
     --fix) FIX=1 ;;
     --sweep | --sweep-ls) SWEEP=1 ;;
     --evict)
         EVICT=1
         EVICT_DIR="${2:-}"
+        ;;
+    -h | --help)
+        printf '%s\n' "$usage"
+        exit 0
+        ;;
+    *)
+        printf 'ghosts.sh: unknown option %s\n%s\n' "$1" "$usage" >&2
+        exit 2
         ;;
 esac
 
@@ -943,6 +956,10 @@ if [ "$found_count" -eq 0 ]; then
     exit 0
 fi
 
+# Findings are this script's output, not a failure, so the two report-mode arms
+# below exit 0 — `make ghosts` would otherwise stamp "Error 1" over its own
+# closing instruction. A non-zero exit is reserved for not doing the requested
+# job: `--fix` repairing less than it found, and the --evict failures above.
 if [ "$FIX" = 1 ]; then
     printf '%d issue(s) found, %d fixed.\n' "$found_count" "$fixed_count"
     [ "$manual_count" -gt 0 ] && printf '%d need the manual step noted above; --fix does not perform it.\n' "$manual_count"
@@ -951,7 +968,7 @@ if [ "$FIX" = 1 ]; then
 elif [ "$manual_count" -eq "$found_count" ]; then
     printf '%s%d issue(s) found.%s Follow the step(s) noted above — %smake clean-ghosts%s does not repair these.\n' \
         "$c_yellow" "$found_count" "$c_reset" "$c_bold" "$c_reset"
-    exit 1
+    exit 0
 else
     # `make` first, direct invocation second: this script is normally reached
     # through the Makefile, and `make ghosts --fix` does not do what leading
@@ -959,5 +976,5 @@ else
     # options and bails with "unrecognized option".
     printf '%s%d issue(s) found.%s Run %smake clean-ghosts%s (or `Tools/ghosts.sh --fix`) to clean them up.\n' \
         "$c_yellow" "$found_count" "$c_reset" "$c_bold" "$c_reset"
-    exit 1
+    exit 0
 fi


### PR DESCRIPTION
## Summary

Four defects in the ghost-report tooling, three of them silent.

`Tools/ghosts.sh` called `clean`, a function defined nowhere — not in the script, not in `Tools/lib/output.sh`. Every run printed `clean: command not found` twice on stderr and still exited 0, so two verdict lines were missing from every report while `make lint` and the required CI `lint` job both stayed green. `shellcheck` cannot diagnose a call to an unknown command, and nothing in CI executes these scripts, so it survived a full documentation zero-basing pass.

It was a slip rather than a missing helper: the comment above the script's local markers enumerates what the shared lib provides (`section`/`pass`/`warn`/`value`/`detail`/`pretty_path`) and lists no `clean`, and seven other sites already use `pass` for the same green check. Both call sites now use `pass`, so no new marker enters the shared lib.

The option dispatch had no default arm. A mistyped repair flag (`--fx`, `--Fix`) left `FIX=0` and produced output byte-identical to a normal report, closing with "Run make clean-ghosts to clean them up" — a repair command that silently did nothing, with no signal the flag was not understood. `--help` fell through the same way and paid a full `lsregister -dump` scan to answer a usage question, and the usage string existed only in the header comment and was never printed. Unknown options now exit 2 with usage on stderr, `-h`/`--help` print it on stdout and exit 0, and no-argument report mode is an explicit arm so the new default cannot catch it. This applies the rejection pattern the `--evict` guard already uses a few lines down.

Report mode exited 1 whenever it found anything, so `make ghosts` stamped `make: *** [ghosts] Error 1` over the script's own closing instruction — a report that worked reading as a tool that crashed, on every run that found something. Findings are the script's output, not a failure. Both report arms now exit 0; non-zero stays reserved for not doing the requested job, which is `--fix` repairing less than it found and the `--evict` failure paths, both unchanged.

Separately, the `lint` workflow recorded no usable toolchain identity: it probed `xcrun swift-format --version`, which prints the branch name `main`. That left the one required check whose *rule set* ships inside the toolchain as the only workflow unable to attribute a red run to a toolchain move — the other three all capture `xcodebuild -version`. `xcodebuild -version` also asserts what the preceding `xcode-select` exists to guarantee: Command Line Tools ships `swift-format` but no `xcodebuild`, so the previous probe passed under either toolchain. This is a diagnosability change only; the floating Xcode version is deliberate and unchanged.

## Changes

- `Tools/ghosts.sh` — `clean` → `pass` at the orphaned-process and on-disk-copies verdicts; `''`, `-h | --help`, and `*)` arms on the option dispatch with the usage string hoisted to a variable; report-mode `exit 1` → `exit 0` in both summary arms.
- `.github/workflows/lint.yml` — `xcrun swift-format --version` → `xcodebuild -version` in the `Select Xcode` step.

## Test plan

- [x] `Tools/ghosts.sh` writes nothing to stderr
- [x] `No orphaned Kernova processes found` renders in the report
- [x] `--help` and `-h` print usage, exit 0, no scan
- [x] `--fx` prints usage on stderr, exits 2
- [x] no-argument invocation still runs the report
- [x] `--evict` with no directory still exits 2
- [x] `make ghosts` prints no `Error 1`; report exits 0
- [x] `make lint` exits 0

`--fix`'s incomplete-repair exit 1 is unchanged and was verified by inspection rather than execution, since running it would evict a live 722M build arena.