### PR TITLE
fix: Build the pinned protoc-gen-swift in regen-proto.sh instead of trusting PATH

### DIFF
--- a/.github/workflows/proto-drift.yml
+++ b/.github/workflows/proto-drift.yml
@@ -85,6 +85,9 @@ jobs:
           brew install protobuf
           protoc --version
 
+      # Tools/regen-proto.sh resolves the pin and builds the generator into this
+      # directory, so caching it is what keeps the drift check from paying a
+      # release build of swift-protobuf on every run.
       - name: Cache SwiftPM build for protoc-gen-swift
         if: steps.filter.outputs.changed == 'true'
         uses: actions/cache@v5
@@ -92,29 +95,10 @@ jobs:
           path: KernovaKit/.build
           key: ${{ runner.os }}-proto-drift-${{ env.XCODE_BUILD }}-${{ hashFiles('Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
 
-      - name: Build protoc-gen-swift from resolved swift-protobuf
-        if: steps.filter.outputs.changed == 'true'
-        run: |
-          set -euo pipefail
-          # Mirror the xcworkspace's Package.resolved into the SwiftPM
-          # package so `swift package resolve` honors the exact revision
-          # Kernova.app links against, rather than recomputing against
-          # the `from:` constraint in Package.swift (which could pick a
-          # newer minor). This is what makes the drift check stable: the
-          # generator is built from the same source tree as the runtime.
-          cp \
-            Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved \
-            KernovaKit/Package.resolved
-          swift package --package-path KernovaKit resolve
-          CHECKOUT="KernovaKit/.build/checkouts/swift-protobuf"
-          swift build \
-            --package-path "$CHECKOUT" \
-            -c release \
-            --product protoc-gen-swift
-          BIN_DIR="$GITHUB_WORKSPACE/$CHECKOUT/.build/release"
-          echo "$BIN_DIR" >> "$GITHUB_PATH"
-          "$BIN_DIR/protoc-gen-swift" --version || true
-
+      # The script owns the whole generation environment — mirroring
+      # Package.resolved, building protoc-gen-swift from that revision, and
+      # naming it via --plugin. CI adds nothing, which is what makes this check
+      # meaningful: it runs exactly what a developer runs.
       - name: Regenerate Swift bindings
         if: steps.filter.outputs.changed == 'true'
         run: Tools/regen-proto.sh
@@ -124,7 +108,7 @@ jobs:
         run: |
           set -euo pipefail
           if ! git diff --quiet KernovaKit/Sources/KernovaKit/Generated; then
-            echo "::error::Generated Swift bindings are out of sync with kernova.proto and/or the pinned swift-protobuf version. Run 'Tools/regen-proto.sh' locally with swift-protobuf installed at the version pinned in Package.resolved, then commit the result."
+            echo "::error::Generated Swift bindings are out of sync with kernova.proto. Run 'make regen-proto' and commit the result — it builds the same pinned generator this job does, so the output will match."
             echo
             echo "--- Diff ---"
             git diff KernovaKit/Sources/KernovaKit/Generated

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ SWIFT_SOURCE_DIRS := $(shell git ls-files '*.swift' | cut -d/ -f1 | sort -u)
 SHELL_SOURCES     := $(shell git ls-files '*.sh' '*.command' .githooks)
 
 .DEFAULT_GOAL := help
-.PHONY: help build test test-suite test-package clean format lint install-hooks check-hooks bootstrap doctor ghosts clean-ghosts fp-reset
+.PHONY: help build test test-suite test-package clean format lint regen-proto install-hooks check-hooks bootstrap doctor ghosts clean-ghosts fp-reset
 
 # Generated from the `## ` annotation on each target line below — annotate new
 # targets there and this listing (and its ordering) follows automatically.
@@ -162,6 +162,13 @@ lint: ## Lint Swift sources (swift-format --strict), shell scripts, and docs
 	@test -n '$(strip $(SWIFT_SOURCE_DIRS))' || { echo 'No tracked Swift sources found — not a git checkout?' >&2; exit 1; }
 	$(SWIFT_FORMAT) lint --strict --recursive $(SWIFT_SOURCE_DIRS)
 	@bash Tools/check-docs.sh
+
+# Regenerates the checked-in Swift bindings from KernovaKit/Proto/kernova.proto.
+# The script builds its own protoc-gen-swift from the revision pinned in the
+# xcworkspace's Package.resolved, so this and .github/workflows/proto-drift.yml
+# generate with the same version; a generator taken from PATH would not.
+regen-proto: ## Regenerate the Swift protobuf bindings from kernova.proto
+	@Tools/regen-proto.sh
 
 # Environment sanity check: verifies the local toolchain (macOS, Xcode, Swift,
 # swift-format) and repo setup (git hooks, .worktreeinclude) match what Kernova

--- a/Tools/regen-proto.sh
+++ b/Tools/regen-proto.sh
@@ -1,35 +1,90 @@
 #!/usr/bin/env bash
-# Regenerate Swift bindings for kernova.proto.
+# Regenerate Swift bindings for kernova.proto. Run via `make regen-proto` after
+# any edit to KernovaKit/Proto/kernova.proto; the generated files are checked in
+# so the SPM package builds with no external tooling step in the normal dev loop.
 #
-# Run this after any edit to KernovaKit/Proto/kernova.proto. The generated
-# files are checked into the repo so the SPM package builds with no external
-# tooling step in the normal dev loop.
+# The generator is built here from the swift-protobuf revision pinned in the
+# xcworkspace's Package.resolved rather than taken from PATH. Its output varies
+# by version, so a generator picked up from PATH emits bindings that
+# .github/workflows/proto-drift.yml — which builds from the pin — rejects, and
+# the committed artifact records no version, so the mismatch stays invisible
+# until CI regenerates. Building it makes the two generators identical by
+# construction, and mirroring Package.resolved into the package keeps the
+# generator on the same source tree as the runtime the app links.
 #
-# Requires: protoc + protoc-gen-swift on PATH (`brew install protobuf swift-protobuf`).
+# The first run pays a release build of swift-protobuf; later runs reuse
+# KernovaKit/.build.
+#
+# protoc is Homebrew's (`brew install protobuf`). Homebrew offers no supported
+# way to install a given version, so protoc's version is verified rather than
+# acquired: PROTOC_VERSION is the one the committed bindings were generated
+# with, and changing it means regenerating and committing in the same change.
 
 set -euo pipefail
+
+PROTOC_VERSION=35.1
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROTO_DIR="${REPO_ROOT}/KernovaKit/Proto"
 OUT_DIR="${REPO_ROOT}/KernovaKit/Sources/KernovaKit/Generated"
+PACKAGE_DIR="${REPO_ROOT}/KernovaKit"
+WORKSPACE_RESOLVED="${REPO_ROOT}/Kernova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+PROTOBUF_CHECKOUT="${PACKAGE_DIR}/.build/checkouts/swift-protobuf"
 
 if ! command -v protoc >/dev/null 2>&1; then
     echo "ERROR: protoc not found on PATH. Run 'brew install protobuf'." >&2
     exit 1
 fi
 
-if ! command -v protoc-gen-swift >/dev/null 2>&1; then
-    echo "ERROR: protoc-gen-swift not found on PATH. Run 'brew install swift-protobuf'." >&2
+# `protoc --version` prints e.g. `libprotoc 35.1`.
+found_protoc="$(protoc --version | awk '{print $2}')"
+if [ "$found_protoc" != "$PROTOC_VERSION" ]; then
+    echo "ERROR: protoc ${found_protoc} is not the ${PROTOC_VERSION} the committed bindings were generated with." >&2
+    echo "       A different protoc can change the output, which proto-drift then rejects." >&2
+    echo "       If the new version is intended, set PROTOC_VERSION=${found_protoc} in this script," >&2
+    echo "       re-run it, and commit the regenerated bindings in the same change." >&2
+    exit 1
+fi
+
+if [ ! -f "$WORKSPACE_RESOLVED" ]; then
+    echo "ERROR: no Package.resolved at ${WORKSPACE_RESOLVED}." >&2
+    exit 1
+fi
+
+# Resolve against the xcworkspace's pin rather than Package.swift's `from:`
+# constraint, which permits a newer minor than the app actually links.
+#
+# Conditional because `swift package resolve` re-verifies the checkout and
+# invalidates its build cache even when nothing changed: measured here, a
+# generator rebuild costs ~2s on its own and ~31s when a resolve precedes it.
+# A changed pin still takes the slow path, which is when it is warranted.
+if ! cmp -s "$WORKSPACE_RESOLVED" "${PACKAGE_DIR}/Package.resolved" \
+    || [ ! -d "$PROTOBUF_CHECKOUT" ]; then
+    cp "$WORKSPACE_RESOLVED" "${PACKAGE_DIR}/Package.resolved"
+    swift package --package-path "$PACKAGE_DIR" resolve
+fi
+
+swift build --package-path "$PROTOBUF_CHECKOUT" -c release --product protoc-gen-swift
+PROTOC_GEN_SWIFT="${PROTOBUF_CHECKOUT}/.build/release/protoc-gen-swift"
+
+if [ ! -x "$PROTOC_GEN_SWIFT" ]; then
+    echo "ERROR: protoc-gen-swift was not built at ${PROTOC_GEN_SWIFT}." >&2
     exit 1
 fi
 
 mkdir -p "${OUT_DIR}"
 
+# --plugin names the binary explicitly; without it protoc searches PATH, where
+# any Homebrew-installed copy would take precedence over the build above.
 protoc \
+    --plugin=protoc-gen-swift="${PROTOC_GEN_SWIFT}" \
     --proto_path="${PROTO_DIR}" \
     --swift_out="${OUT_DIR}" \
     --swift_opt=Visibility=Public \
     --swift_opt=FileNaming=DropPath \
     "${PROTO_DIR}/kernova.proto"
 
+# Named on the way out so a drift failure can be attributed without re-running.
 echo "Regenerated Swift bindings in ${OUT_DIR}"
+echo "  protoc           ${found_protoc}"
+echo "  protoc-gen-swift $("$PROTOC_GEN_SWIFT" --version | awk '{print $2}') (pinned in Package.resolved)"


### PR DESCRIPTION
## Summary

`Tools/regen-proto.sh` checked only that `protoc-gen-swift` was present on `PATH`, never which version, and its header instructed developers to obtain it with `brew install swift-protobuf`. `proto-drift.yml` meanwhile built the generator from the swift-protobuf revision pinned in the xcworkspace's `Package.resolved` and prepended it to `$GITHUB_PATH`. The documented local workflow and CI therefore generated with different versions — **1.38.0 pinned versus 1.38.1 from Homebrew today** — and `kernova.pb.swift` carries no version stamp, so the mismatch was invisible until CI regenerated and diffed.

Recovery was close to impossible. The drift error told you to install swift-protobuf "at the version pinned in Package.resolved", which Homebrew has no supported way to do, and neither the script nor the message named the version you had or the version you needed.

The architecture was already right — CI calls the script rather than reimplementing it — so the fix is to move the environment into the script rather than restructure anything. It now mirrors `Package.resolved` into the package, builds `protoc-gen-swift` from that revision, and names the binary via `--plugin=` so a Homebrew copy on `PATH` cannot take precedence. The two generators are identical by construction, and CI's build step is **deleted** rather than duplicated: the job now runs exactly what a developer runs.

`swift package resolve` turned out to re-verify the checkout and invalidate its build cache even when nothing changed — measured here, that takes a ~2s generator rebuild to ~31s. It is now conditional on the pin actually differing, so a warm regeneration is ~3s while a changed pin still takes the full path.

protoc comes from Homebrew and cannot be version-pinned there, so its version is **verified rather than acquired**: `PROTOC_VERSION` records what the committed bindings were generated with, and a mismatch fails with the exact edit to make. This deliberately differs from the floating Xcode selection, which is intentional and unchanged — the distinction is that Xcode's output is evaluated as a normal build result, whereas protoc feeds a **committed artifact**, so a silent change there alters checked-in code.

Finally, `make regen-proto` puts the script in `make help`. It was previously reachable only by reading CI or grepping, which is why a stale invocation could persist unnoticed.

## Changes

- `Tools/regen-proto.sh` — build the pinned generator; `--plugin` instead of PATH lookup; conditional resolve; `PROTOC_VERSION` guard; report both versions on success.
- `Makefile` — `regen-proto` target and `.PHONY` entry.
- `.github/workflows/proto-drift.yml` — drop the generator-build step the script now performs; retarget the cache comment; rewrite the drift error to point at `make regen-proto`.

## Test plan

- [x] Regenerated output is byte-identical to the committed bindings, before and after the change
- [x] `make regen-proto` runs and appears in `make help`
- [x] Warm run ~3s; mutating `Package.resolved` correctly takes the resolve path
- [x] A mismatched `PROTOC_VERSION` exits 1 naming both versions
- [x] `make lint` exits 0 — shellcheck now covers logic that previously lived in YAML

This PR touches `Tools/regen-proto.sh` and `proto-drift.yml`, both in the workflow's relevance pattern, so the full drift check runs on it and exercises the new script end to end.

## Notes

Homebrew's protobuf formula is 35.1, matching `PROTOC_VERSION`, so the guard passes on CI as written. A future formula bump will fail the job until the literal is updated and the bindings regenerated in the same change — deliberate, and the failure names the edit.

The stronger form of the protoc pin is downloading a pinned release binary from `protocolbuffers/protobuf` instead of using Homebrew's. That is a genuine pin rather than a verification, at the cost of a URL and checksum to maintain; the version literal is already in one place if you want to go there later.