### PR TITLE
docs: Record why the lint job probes xcodebuild, not swift-format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Select Xcode
         run: |
           sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          # xcodebuild, not the linter itself: `swift-format --version` reports
+          # the branch name `main`, which names no toolchain, while this records
+          # the Xcode whose bundled rule set decides the run. It doubles as the
+          # full-Xcode assert — Command Line Tools carries swift-format alone.
           xcodebuild -version
 
       # The macOS runner images ship shellcheck; install it only if a future


### PR DESCRIPTION
## Summary

Follow-up to #665, which swapped the `Select Xcode` step's probe from `xcrun swift-format --version` to `xcodebuild -version`. The reasoning landed only in the squash commit body, leaving the step reading as an oddity in the tree: a lint job recording the *build tool's* version, which is the natural thing for a later reader to "fix" back to the linter's own version.

The two facts that make the current probe the right one are external and revealed nowhere in the code — `swift-format --version` reports the branch name `main`, so it identifies no toolchain, and a successful `xcodebuild` asserts a full Xcode is selected, which Command Line Tools (shipping swift-format but no xcodebuild) would not satisfy. Under AGENTS.md's routing test 0 that is keep-and-stop material, so it belongs on the step rather than in `git blame`.

## Changes

- `.github/workflows/lint.yml`: four-line comment on the `Select Xcode` step's version line

## Test plan

- [x] `make lint` passes locally
- [ ] The `lint` required check runs green here, exercising the annotated step