### PR TITLE
feat: Explain and offer a fix for disk images Virtualization can't open

### DIFF
--- a/Kernova/App/DetailContainerViewController.swift
+++ b/Kernova/App/DetailContainerViewController.swift
@@ -267,8 +267,8 @@ extension DetailContainerViewController: VMCreationWizardViewControllerDelegate 
 // MARK: - VMLibraryPresenting
 
 extension DetailContainerViewController: VMLibraryPresenting {
-    func presentError(_ message: String) {
-        alertsPresenter.presentError(message)
+    func presentError(_ message: String, copyableCommand: String?) {
+        alertsPresenter.presentError(message, copyableCommand: copyableCommand)
     }
 
     func presentStartFailedAttachment(_ failure: StartFailedAttachment, for instance: VMInstance) {

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -721,7 +721,7 @@ struct ConfigurationBuilder: Sendable {
 
 // MARK: - Errors
 
-enum ConfigurationBuilderError: LocalizedError {
+enum ConfigurationBuilderError: LocalizedError, CommandSuggestingError {
     case invalidHardwareModel
     case invalidMachineIdentifier
     case missingKernelPath
@@ -773,7 +773,8 @@ enum ConfigurationBuilderError: LocalizedError {
         case .storageDiskNotWritable(let path, let label):
             "Storage disk '\(label)' is not writable: \(path). Change it to read-only or select a writable file."
         case .storageDiskAttachFailed(_, let path, let label, let underlying):
-            "Couldn't open storage disk '\(label)' at \(path). The file may have been moved or replaced, or Kernova may no longer have permission to read it. (\(underlying.localizedDescription))"
+            DiskImageFormatGuidance.attachFailureMessage(
+                subject: "storage disk '\(label)'", path: path, underlying: underlying)
         case .removableMediaNotFound(let path, let label):
             "Removable media '\(label)' not found at \(path)."
         case .removableMediaPathIsDirectory(let path, let label):
@@ -781,7 +782,8 @@ enum ConfigurationBuilderError: LocalizedError {
         case .removableMediaNotWritable(let path, let label):
             "Removable media '\(label)' is not writable: \(path). Change it to read-only or select a writable file."
         case .removableMediaAttachFailed(_, let path, let label, let underlying):
-            "Couldn't open removable media '\(label)' at \(path). The file may have been moved or replaced, or Kernova may no longer have permission to read it. (\(underlying.localizedDescription))"
+            DiskImageFormatGuidance.attachFailureMessage(
+                subject: "removable media '\(label)'", path: path, underlying: underlying)
         case .sharedDirectoryNotFound(let path):
             "Shared directory not found at \(path)."
         case .sharedDirectoryNotADirectory(let path):
@@ -799,6 +801,16 @@ enum ConfigurationBuilderError: LocalizedError {
         case .storageDiskAttachFailed(_, _, _, let underlying),
             .removableMediaAttachFailed(_, _, _, let underlying):
             underlying
+        default:
+            nil
+        }
+    }
+
+    var suggestedCommand: String? {
+        switch self {
+        case .storageDiskAttachFailed(_, let path, _, let underlying),
+            .removableMediaAttachFailed(_, let path, _, let underlying):
+            DiskImageFormatGuidance.suggestedCommand(forPath: path, underlying: underlying)
         default:
             nil
         }

--- a/Kernova/Services/USBDeviceService.swift
+++ b/Kernova/Services/USBDeviceService.swift
@@ -52,7 +52,7 @@ final class USBDeviceService: USBDeviceProviding {
             Self.logger.error(
                 "Failed to create disk attachment for '\(resolved.url.lastPathComponent, privacy: .public)': \(error.localizedDescription, privacy: .public)"
             )
-            throw error
+            throw USBDeviceError.diskImageAttachFailed(path: diskImagePath, underlying: error)
         }
         let usbConfig = VZUSBMassStorageDeviceConfiguration(attachment: attachment)
         if let desiredUUID {
@@ -117,12 +117,15 @@ final class USBDeviceService: USBDeviceProviding {
 
 // MARK: - Errors
 
-enum USBDeviceError: LocalizedError {
+enum USBDeviceError: LocalizedError, CommandSuggestingError {
     case noVirtualMachine
     case noUSBController
     case diskImageNotFound(String)
     case diskImageIsDirectory(String)
     case diskImageNotWritable(String)
+    /// The file exists but `VZDiskImageStorageDeviceAttachment` refused it —
+    /// the hot-attach counterpart of `ConfigurationBuilderError`'s attach cases.
+    case diskImageAttachFailed(path: String, underlying: any Error)
     case deviceNotFound
 
     var errorDescription: String? {
@@ -137,8 +140,20 @@ enum USBDeviceError: LocalizedError {
             "Path is a directory, not a file: \(path)."
         case .diskImageNotWritable(let path):
             "Disk image is not writable: \(path). Try attaching as read-only."
+        case .diskImageAttachFailed(let path, let underlying):
+            DiskImageFormatGuidance.attachFailureMessage(
+                subject: "the disk image", path: path, underlying: underlying)
         case .deviceNotFound:
             "The USB device could not be found on the controller."
+        }
+    }
+
+    var suggestedCommand: String? {
+        switch self {
+        case .diskImageAttachFailed(let path, let underlying):
+            DiskImageFormatGuidance.suggestedCommand(forPath: path, underlying: underlying)
+        default:
+            nil
         }
     }
 }

--- a/Kernova/Utilities/DetailAlertsPresenter.swift
+++ b/Kernova/Utilities/DetailAlertsPresenter.swift
@@ -112,8 +112,8 @@ final class DetailAlertsPresenter: NSObject {
 
     // MARK: - Imperative presentation
 
-    func presentError(_ message: String) {
-        enqueue { $0.present($0.errorConfig(message)) }
+    func presentError(_ message: String, copyableCommand: String?) {
+        enqueue { $0.present($0.errorConfig(message, copyableCommand)) }
     }
 
     func presentStartFailedAttachment(_ failure: StartFailedAttachment, for instance: VMInstance) {
@@ -331,25 +331,43 @@ final class DetailAlertsPresenter: NSObject {
             ])
     }
 
-    private func errorConfig(_ message: String) -> AlertConfiguration {
+    private func errorConfig(_ message: String, _ copyableCommand: String?) -> AlertConfiguration {
         AlertConfiguration(
-            title: "Error", message: message, buttons: [AlertButton("OK", role: .cancel)])
+            title: "Error",
+            message: Self.appendingConvertPrompt(to: message, command: copyableCommand),
+            buttons: [AlertButton("OK", role: .cancel)],
+            accessory: Self.commandAccessory(copyableCommand))
     }
 
     private func startFailedAttachmentConfig(
         _ failure: StartFailedAttachment, _ vm: VMInstance
     ) -> AlertConfiguration {
-        AlertConfiguration(
+        let message =
+            "\(failure.message)\n\nYou can remove “\(failure.label)” from this virtual machine and start without it. The file itself is not deleted, and you can re-attach it later in Settings."
+        return AlertConfiguration(
             title: "Couldn't Start “\(vm.name)”",
-            message:
-                "\(failure.message)\n\nYou can remove “\(failure.label)” from this virtual machine and start without it. The file itself is not deleted, and you can re-attach it later in Settings.",
+            message: Self.appendingConvertPrompt(
+                to: message, command: failure.conversionCommand),
             buttons: [
                 AlertButton("Remove and Start", role: .default) { [weak self] in
                     guard let self else { return }
                     Task { await self.viewModel.removeStartFailedAttachmentAndStart(failure, on: vm) }
                 },
                 AlertButton("Cancel", role: .cancel),
-            ])
+            ],
+            accessory: Self.commandAccessory(failure.conversionCommand))
+    }
+
+    /// Introduces the command shown in the accessory, or returns `message`
+    /// unchanged when there is no command.
+    private static func appendingConvertPrompt(to message: String, command: String?) -> String {
+        guard command != nil else { return message }
+        return "\(message)\n\n\(DiskImageFormatGuidance.convertPrompt)"
+    }
+
+    private static func commandAccessory(_ command: String?) -> (@MainActor () -> NSView)? {
+        guard let command else { return nil }
+        return { CopyableCommandView(command: command) }
     }
 
     private func installerMountedConfig(

--- a/Kernova/Utilities/DiskImageFormatGuidance.swift
+++ b/Kernova/Utilities/DiskImageFormatGuidance.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Virtualization
+
+/// An error that can name a shell command the user can run to resolve it.
+///
+/// Lets the presentation layer offer the command for copying without knowing
+/// which error type produced it.
+protocol CommandSuggestingError {
+    /// The command to offer, or `nil` when this error has no such remedy.
+    var suggestedCommand: String? { get }
+}
+
+/// Translates `VZError.Code.invalidDiskImage` into a message the user can act
+/// on, and builds the command that converts a rejected image.
+///
+/// `VZDiskImageStorageDeviceAttachment(url:readOnly:)` enforces exactly one
+/// thing: the file's size is a multiple of 512 bytes. Any 512-aligned file is
+/// accepted — random bytes and compressed disk images included — and everything
+/// else fails with `invalidDiskImage` ("The disk image format is not
+/// recognized"), whatever the actual contents. Compressed `.dmg` files are the
+/// common casualty because their size is arbitrary; converting to ASIF or RAW
+/// yields both an aligned size and contents the guest can read.
+enum DiskImageFormatGuidance {
+    /// `true` when `error` is Virtualization's invalid-disk-image error.
+    static func isInvalidDiskImage(_ error: any Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == VZError.errorDomain
+            && VZError.Code(rawValue: nsError.code) == .invalidDiskImage
+    }
+
+    /// Lead-in shown above the copyable conversion command in an alert.
+    static let convertPrompt = "To convert it, run this in Terminal:"
+
+    /// Why an attachment couldn't be opened, worded for the cause.
+    ///
+    /// `subject` names the item as the sentence's object — `"storage disk
+    /// 'Data'"`.
+    static func attachFailureMessage(
+        subject: String, path: String, underlying: any Error
+    ) -> String {
+        guard isInvalidDiskImage(underlying) else {
+            return
+                "Couldn't open \(subject) at \(path). The file may have been moved or replaced, or Kernova may no longer have permission to read it. (\(underlying.localizedDescription))"
+        }
+        return
+            "Couldn't open \(subject) at \(path). Virtualization reads only raw sector images, whose size must be a multiple of 512 bytes; most compressed disk images, including .dmg files, aren't. Convert it to ASIF — the format Kernova uses for its own disks."
+    }
+
+    /// The `diskutil` command converting the image at `path` to an ASIF copy
+    /// beside it, or `nil` when `underlying` is not the invalid-disk-image error.
+    static func suggestedCommand(forPath path: String, underlying: any Error) -> String? {
+        guard isInvalidDiskImage(underlying) else { return nil }
+        let destination =
+            URL(fileURLWithPath: path)
+            .deletingPathExtension()
+            .appendingPathExtension("asif")
+            .path(percentEncoded: false)
+        return
+            "diskutil image create from --format ASIF \(shellQuoted(path)) \(shellQuoted(destination))"
+    }
+
+    /// Wraps `value` in single quotes for pasting into a POSIX shell, ending and
+    /// reopening the quoted run around each embedded quote.
+    private static func shellQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}

--- a/Kernova/Utilities/SheetAlert.swift
+++ b/Kernova/Utilities/SheetAlert.swift
@@ -39,11 +39,23 @@ struct AlertConfiguration {
     let title: String
     let message: String
     let buttons: [AlertButton]
+    /// Builds the view shown between the message and the buttons.
+    ///
+    /// A builder rather than a stored view: configurations wait in
+    /// ``DetailAlertsPresenter``'s queue, and one shouldn't hold a live view
+    /// while it does.
+    let accessory: (@MainActor () -> NSView)?
 
-    init(title: String, message: String, buttons: [AlertButton]) {
+    init(
+        title: String,
+        message: String,
+        buttons: [AlertButton],
+        accessory: (@MainActor () -> NSView)? = nil
+    ) {
         self.title = title
         self.message = message
         self.buttons = buttons
+        self.accessory = accessory
     }
 }
 
@@ -59,6 +71,7 @@ func presentSheetAlert(
     let alert = NSAlert()
     alert.messageText = config.title
     alert.informativeText = config.message
+    alert.accessoryView = config.accessory?()
 
     for button in config.buttons {
         let nsButton = alert.addButton(withTitle: button.title)

--- a/Kernova/ViewModels/VMLibraryPresenting.swift
+++ b/Kernova/ViewModels/VMLibraryPresenting.swift
@@ -30,14 +30,26 @@ struct StartFailedAttachment: Equatable, Sendable {
     let label: String
     /// The full user-facing error description (item, path, likely cause).
     let message: String
+    /// A shell command that would make the image usable, offered for copying;
+    /// `nil` when the failure has no such remedy.
+    let conversionCommand: String?
+
+    init(kind: Kind, id: UUID, label: String, message: String, conversionCommand: String? = nil) {
+        self.kind = kind
+        self.id = id
+        self.label = label
+        self.message = message
+        self.conversionCommand = conversionCommand
+    }
 }
 
 /// Imperative presentation interface the view model calls to surface alerts,
 /// sheets, and the creation wizard.
 @MainActor
 protocol VMLibraryPresenting: AnyObject {
-    /// Show a generic error alert with `message`.
-    func presentError(_ message: String)
+    /// Show a generic error alert with `message`, offering `copyableCommand`
+    /// for copying when the failure has a command-line remedy.
+    func presentError(_ message: String, copyableCommand: String?)
     /// Show the start-failed alert for an attachment that couldn't be opened,
     /// offering to remove it from the configuration and start again.
     func presentStartFailedAttachment(_ failure: StartFailedAttachment, for instance: VMInstance)

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -34,14 +34,20 @@ final class VMLibraryViewModel {
     /// in `init`) are buffered and flushed when one is set.
     @ObservationIgnored weak var presenter: (any VMLibraryPresenting)? {
         didSet {
-            guard presenter != nil, !bufferedErrorMessages.isEmpty else { return }
-            let buffered = bufferedErrorMessages
-            bufferedErrorMessages.removeAll()
-            buffered.forEach { presenter?.presentError($0) }
+            guard presenter != nil, !bufferedErrors.isEmpty else { return }
+            let buffered = bufferedErrors
+            bufferedErrors.removeAll()
+            buffered.forEach { presenter?.presentError($0.message, copyableCommand: $0.copyableCommand) }
         }
     }
 
-    @ObservationIgnored private var bufferedErrorMessages: [String] = []
+    /// An error raised before a presenter was attached, held until one is.
+    private struct BufferedError {
+        let message: String
+        let copyableCommand: String?
+    }
+
+    @ObservationIgnored private var bufferedErrors: [BufferedError] = []
 
     /// VMs with an in-flight removable-media reconciliation Task.
     ///
@@ -355,7 +361,8 @@ final class VMLibraryViewModel {
             else { return nil }
             return StartFailedAttachment(
                 kind: .storageDisk, id: id, label: label,
-                message: builderError.localizedDescription)
+                message: builderError.localizedDescription,
+                conversionCommand: builderError.suggestedCommand)
         case .removableMediaAttachFailed(let id, _, let label, _):
             // Confirm the entry is really in the list: an offer whose action could
             // only no-op leaves a button that appears to do nothing.
@@ -363,7 +370,8 @@ final class VMLibraryViewModel {
             else { return nil }
             return StartFailedAttachment(
                 kind: .removableMedia, id: id, label: label,
-                message: builderError.localizedDescription)
+                message: builderError.localizedDescription,
+                conversionCommand: builderError.suggestedCommand)
         default:
             return nil
         }
@@ -2116,16 +2124,18 @@ final class VMLibraryViewModel {
     }
 
     func presentError(_ error: Error) {
-        surfaceError(error.localizedDescription)
+        surfaceError(
+            error.localizedDescription,
+            copyableCommand: (error as? any CommandSuggestingError)?.suggestedCommand)
     }
 
     /// Routes an error message to the presenter, buffering it if none is
     /// attached yet (e.g. during the initial `loadVMs()` in `init`).
-    private func surfaceError(_ message: String) {
+    private func surfaceError(_ message: String, copyableCommand: String? = nil) {
         if let presenter {
-            presenter.presentError(message)
+            presenter.presentError(message, copyableCommand: copyableCommand)
         } else {
-            bufferedErrorMessages.append(message)
+            bufferedErrors.append(BufferedError(message: message, copyableCommand: copyableCommand))
         }
     }
 }

--- a/Kernova/Views/Detail/CalloutStyle.swift
+++ b/Kernova/Views/Detail/CalloutStyle.swift
@@ -59,11 +59,14 @@ func makeCalloutBody(_ text: String, color: NSColor = CalloutStyle.bodyColor) ->
 
 /// Builds a monospaced, selectable `NSTextField` for code snippets (shell
 /// commands, paths, identifiers the user is expected to copy).
+///
+/// `size` defaults to the callout body size; pass the surrounding text's size
+/// where the snippet sits among prose set at a different scale.
 @MainActor
-func makeCalloutCode(_ text: String) -> NSTextField {
+func makeCalloutCode(_ text: String, size: CGFloat? = nil) -> NSTextField {
     let label = NSTextField(wrappingLabelWithString: text)
     label.font = .monospacedSystemFont(
-        ofSize: NSFont.preferredFont(forTextStyle: .callout).pointSize,
+        ofSize: size ?? NSFont.preferredFont(forTextStyle: .callout).pointSize,
         weight: .regular
     )
     label.textColor = .labelColor

--- a/Kernova/Views/Shared/CopyableCommandView.swift
+++ b/Kernova/Views/Shared/CopyableCommandView.swift
@@ -1,0 +1,85 @@
+import AppKit
+
+/// A shell command shown as selectable monospaced text beside a button that
+/// copies it to the pasteboard.
+///
+/// Built for `NSAlert.accessoryView`, which neither sizes nor lays out its
+/// accessory, so the view gives itself a concrete frame at the requested width.
+@MainActor
+final class CopyableCommandView: NSView {
+    private static let copySymbol = "doc.on.doc"
+    private static let copiedSymbol = "checkmark"
+    private static let spacing: CGFloat = 8
+    private static let buttonWidth: CGFloat = 20
+    /// How long the button shows a checkmark after a copy.
+    private static let confirmationDuration: Duration = .milliseconds(1500)
+
+    private let command: String
+    private let pasteboard: NSPasteboard
+    private let copyButton = NSButton()
+    private var revertTask: Task<Void, Never>?
+
+    init(
+        command: String,
+        width: CGFloat = CalloutStyle.width,
+        pasteboard: NSPasteboard = .general
+    ) {
+        self.command = command
+        self.pasteboard = pasteboard
+        super.init(frame: .zero)
+
+        // `NSAlert` sets its informative text at the small system size; the
+        // command reads as a peer of that prose rather than a heading.
+        let label = makeCalloutCode(command, size: NSFont.smallSystemFontSize)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.preferredMaxLayoutWidth = width - Self.buttonWidth - Self.spacing
+
+        copyButton.translatesAutoresizingMaskIntoConstraints = false
+        copyButton.bezelStyle = .accessoryBarAction
+        copyButton.isBordered = false
+        copyButton.image = .systemSymbol(Self.copySymbol, accessibilityDescription: "Copy command")
+        copyButton.contentTintColor = .secondaryLabelColor
+        copyButton.toolTip = "Copy"
+        copyButton.target = self
+        copyButton.action = #selector(copyCommand)
+
+        addSubview(label)
+        addSubview(copyButton)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor),
+            label.topAnchor.constraint(equalTo: topAnchor),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor),
+            copyButton.leadingAnchor.constraint(
+                equalTo: label.trailingAnchor, constant: Self.spacing),
+            copyButton.trailingAnchor.constraint(equalTo: trailingAnchor),
+            copyButton.widthAnchor.constraint(equalToConstant: Self.buttonWidth),
+            copyButton.firstBaselineAnchor.constraint(equalTo: label.firstBaselineAnchor),
+        ])
+
+        frame = NSRect(x: 0, y: 0, width: width, height: fittingSize.height)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Puts the command on the pasteboard and confirms it on the button.
+    @objc func copyCommand() {
+        pasteboard.clearContents()
+        pasteboard.setString(command, forType: .string)
+        revertTask?.cancel()
+        copyButton.image = .systemSymbol(
+            Self.copiedSymbol, accessibilityDescription: "Command copied")
+        revertTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.confirmationDuration)
+            guard !Task.isCancelled, let self else { return }
+            copyButton.image = .systemSymbol(
+                Self.copySymbol, accessibilityDescription: "Copy command")
+        }
+    }
+
+    #if DEBUG
+    /// The button's current symbol, so tests can observe the copy confirmation.
+    var copyButtonImageForTesting: NSImage? { copyButton.image }
+    #endif
+}

--- a/KernovaTests/CalloutStyleTests.swift
+++ b/KernovaTests/CalloutStyleTests.swift
@@ -52,5 +52,13 @@ struct CalloutStyleTests {
         let label = makeCalloutCode("mount -t virtiofs share0 /mnt/myshare")
         #expect(label.isSelectable)
         #expect(label.font?.isFixedPitch == true)
+        #expect(label.font?.pointSize == CalloutStyle.bodyFont.pointSize)
+    }
+
+    @Test("makeCalloutCode honors an explicit size and stays monospaced")
+    func codeFactoryHonorsSize() {
+        let label = makeCalloutCode("diskutil image create from", size: NSFont.smallSystemFontSize)
+        #expect(label.font?.pointSize == NSFont.smallSystemFontSize)
+        #expect(label.font?.isFixedPitch == true)
     }
 }

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -341,6 +341,39 @@ struct ConfigurationBuilderTests {
         }
     }
 
+    @Test("Attach-failure messages explain an invalid disk image and offer a conversion")
+    func attachFailureDescribesInvalidDiskImage() {
+        let invalid = NSError(
+            domain: VZError.errorDomain, code: VZError.Code.invalidDiskImage.rawValue)
+        let disk = ConfigurationBuilderError.storageDiskAttachFailed(
+            id: UUID(), path: "/tmp/bad.dmg", label: "Bad Disk", underlying: invalid)
+        let media = ConfigurationBuilderError.removableMediaAttachFailed(
+            id: UUID(), path: "/tmp/bad.iso", label: "Bad ISO", underlying: invalid)
+
+        #expect(disk.errorDescription?.contains("Bad Disk") == true)
+        #expect(disk.errorDescription?.contains("512") == true)
+        #expect(disk.suggestedCommand?.contains("'/tmp/bad.dmg' '/tmp/bad.asif'") == true)
+        #expect(media.errorDescription?.contains("Bad ISO") == true)
+        #expect(media.suggestedCommand?.contains("'/tmp/bad.iso' '/tmp/bad.asif'") == true)
+    }
+
+    @Test("Attach failures from other causes keep their message and suggest nothing")
+    func attachFailureFromOtherCauseIsUnchanged() {
+        let denied = NSError(domain: NSPOSIXErrorDomain, code: Int(ENOTSUP))
+        let error = ConfigurationBuilderError.storageDiskAttachFailed(
+            id: UUID(), path: "/tmp/gone.asif", label: "Data", underlying: denied)
+
+        #expect(error.errorDescription?.contains("moved or replaced") == true)
+        #expect(error.errorDescription?.contains("512") == false)
+        #expect(error.suggestedCommand == nil)
+    }
+
+    @Test("Errors that aren't attach failures suggest no command")
+    func nonAttachErrorsSuggestNoCommand() {
+        #expect(ConfigurationBuilderError.invalidHardwareModel.suggestedCommand == nil)
+        #expect(ConfigurationBuilderError.storageDiskNotFound("/tmp/x", "Data").suggestedCommand == nil)
+    }
+
     @Test("Attach failure for external storage disk throws typed error with item identity")
     func storageDiskAttachFailureThrowsTypedError() throws {
         let bundleURL = try makeTempBundle(withDisk: true)

--- a/KernovaTests/CopyableCommandViewTests.swift
+++ b/KernovaTests/CopyableCommandViewTests.swift
@@ -1,0 +1,56 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("CopyableCommandView Tests")
+@MainActor
+struct CopyableCommandViewTests {
+    /// A private pasteboard so tests never disturb the user's clipboard.
+    private func makePasteboard() -> NSPasteboard {
+        NSPasteboard(name: NSPasteboard.Name("kernova-test-\(UUID().uuidString)"))
+    }
+
+    private let command = "diskutil image create from --format ASIF '/tmp/a.dmg' '/tmp/a.asif'"
+
+    @Test("Copying writes the command verbatim to the pasteboard")
+    func copyWritesCommand() {
+        let pasteboard = makePasteboard()
+        let view = CopyableCommandView(command: command, pasteboard: pasteboard)
+
+        view.copyCommand()
+
+        #expect(pasteboard.string(forType: .string) == command)
+    }
+
+    @Test("Copying replaces prior pasteboard contents rather than appending")
+    func copyClearsFirst() {
+        let pasteboard = makePasteboard()
+        pasteboard.clearContents()
+        pasteboard.setString("stale", forType: .string)
+        let view = CopyableCommandView(command: command, pasteboard: pasteboard)
+
+        view.copyCommand()
+
+        #expect(pasteboard.string(forType: .string) == command)
+    }
+
+    @Test("The button confirms the copy")
+    func copyConfirmsOnButton() {
+        let view = CopyableCommandView(command: command, pasteboard: makePasteboard())
+        #expect(view.copyButtonImageForTesting?.accessibilityDescription == "Copy command")
+
+        view.copyCommand()
+
+        #expect(view.copyButtonImageForTesting?.accessibilityDescription == "Command copied")
+    }
+
+    @Test("The view sizes itself, since NSAlert does not size its accessory")
+    func viewHasConcreteFrame() {
+        let view = CopyableCommandView(
+            command: command, width: 340, pasteboard: makePasteboard())
+        #expect(view.frame.width == 340)
+        #expect(view.frame.height > 0)
+    }
+}

--- a/KernovaTests/DiskImageFormatGuidanceTests.swift
+++ b/KernovaTests/DiskImageFormatGuidanceTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+import Virtualization
+
+@testable import Kernova
+
+@Suite("DiskImageFormatGuidance Tests")
+struct DiskImageFormatGuidanceTests {
+    private func vzError(_ code: VZError.Code) -> NSError {
+        NSError(domain: VZError.errorDomain, code: code.rawValue)
+    }
+
+    private var invalidDiskImage: NSError { vzError(.invalidDiskImage) }
+
+    /// The shape of a sandbox-denied open, which shares these code paths.
+    private var operationNotSupported: NSError {
+        NSError(domain: NSPOSIXErrorDomain, code: Int(ENOTSUP))
+    }
+
+    // MARK: - isInvalidDiskImage
+
+    @Test("Virtualization's invalid-disk-image error is recognized")
+    func recognizesInvalidDiskImage() {
+        #expect(DiskImageFormatGuidance.isInvalidDiskImage(invalidDiskImage))
+    }
+
+    @Test("Other Virtualization errors are not invalid-disk-image")
+    func otherVZErrorsRejected() {
+        #expect(!DiskImageFormatGuidance.isInvalidDiskImage(vzError(.internalError)))
+        #expect(
+            !DiskImageFormatGuidance.isInvalidDiskImage(vzError(.invalidVirtualMachineConfiguration))
+        )
+    }
+
+    @Test("An error from another domain sharing the code is not invalid-disk-image")
+    func otherDomainRejected() {
+        // Same numeric code, different domain — the domain check is what
+        // separates them.
+        let posix = NSError(domain: NSPOSIXErrorDomain, code: VZError.Code.invalidDiskImage.rawValue)
+        #expect(!DiskImageFormatGuidance.isInvalidDiskImage(posix))
+        #expect(!DiskImageFormatGuidance.isInvalidDiskImage(operationNotSupported))
+    }
+
+    // MARK: - attachFailureMessage
+
+    @Test("Invalid-disk-image failures explain the format and size requirement")
+    func formatMessageForInvalidDiskImage() {
+        let message = DiskImageFormatGuidance.attachFailureMessage(
+            subject: "storage disk 'Data'", path: "/tmp/data.dmg", underlying: invalidDiskImage)
+        #expect(message.contains("storage disk 'Data'"))
+        #expect(message.contains("/tmp/data.dmg"))
+        #expect(message.contains("512"))
+        #expect(message.contains("ASIF"))
+        #expect(!message.contains("moved or replaced"))
+    }
+
+    @Test("Other attach failures keep the moved-or-permission message")
+    func movedMessageForOtherFailures() {
+        let message = DiskImageFormatGuidance.attachFailureMessage(
+            subject: "removable media 'Installer'", path: "/tmp/x.iso",
+            underlying: operationNotSupported)
+        #expect(message.contains("removable media 'Installer'"))
+        #expect(message.contains("moved or replaced"))
+        #expect(message.contains(operationNotSupported.localizedDescription))
+        #expect(!message.contains("512"))
+    }
+
+    // MARK: - suggestedCommand
+
+    @Test("No command is suggested for failures other than invalid disk image")
+    func noCommandForOtherFailures() {
+        #expect(
+            DiskImageFormatGuidance.suggestedCommand(
+                forPath: "/tmp/data.dmg", underlying: operationNotSupported) == nil)
+    }
+
+    @Test("The suggested command converts to an ASIF copy beside the source")
+    func commandTargetsASIFBesideSource() {
+        let command = DiskImageFormatGuidance.suggestedCommand(
+            forPath: "/tmp/data.dmg", underlying: invalidDiskImage)
+        #expect(
+            command == "diskutil image create from --format ASIF '/tmp/data.dmg' '/tmp/data.asif'")
+    }
+
+    @Test("An extensionless path still gets an .asif destination")
+    func commandForExtensionlessPath() {
+        let command = DiskImageFormatGuidance.suggestedCommand(
+            forPath: "/tmp/diskimage", underlying: invalidDiskImage)
+        #expect(command?.hasSuffix("'/tmp/diskimage' '/tmp/diskimage.asif'") == true)
+    }
+
+    @Test("Paths with spaces are quoted for the shell")
+    func commandQuotesSpaces() {
+        let command = DiskImageFormatGuidance.suggestedCommand(
+            forPath: "/tmp/my image.dmg", underlying: invalidDiskImage)
+        #expect(command?.hasSuffix("'/tmp/my image.dmg' '/tmp/my image.asif'") == true)
+    }
+
+    @Test("A single quote in the path is escaped by closing and reopening the quoted run")
+    func commandEscapesSingleQuote() {
+        let command = DiskImageFormatGuidance.suggestedCommand(
+            forPath: "/tmp/it's.dmg", underlying: invalidDiskImage)
+        // '/tmp/it'\''s.dmg' — the shell concatenates the three runs back into
+        // /tmp/it's.dmg.
+        #expect(command?.contains("'/tmp/it'\\''s.dmg'") == true)
+        #expect(command?.hasSuffix("'/tmp/it'\\''s.asif'") == true)
+    }
+}

--- a/KernovaTests/Mocks/MockVMLibraryPresenting.swift
+++ b/KernovaTests/Mocks/MockVMLibraryPresenting.swift
@@ -11,6 +11,8 @@ import Foundation
 @MainActor
 final class MockVMLibraryPresenting: VMLibraryPresenting {
     private(set) var errors: [String] = []
+    /// Parallel to `errors`: the copyable command offered with each, if any.
+    private(set) var errorCopyableCommands: [String?] = []
     private(set) var startFailedAttachments: [StartFailedAttachment] = []
     private(set) var startFailedAttachmentInstances: [VMInstance] = []
     private(set) var deleteSheetInstances: [VMInstance] = []
@@ -25,7 +27,10 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
     private(set) var installerMountedPurposes: [GuestAgentInstallerPurpose] = []
     private(set) var creationWizardCount = 0
 
-    func presentError(_ message: String) { errors.append(message) }
+    func presentError(_ message: String, copyableCommand: String?) {
+        errors.append(message)
+        errorCopyableCommands.append(copyableCommand)
+    }
     func presentStartFailedAttachment(_ failure: StartFailedAttachment, for instance: VMInstance) {
         startFailedAttachments.append(failure)
         startFailedAttachmentInstances.append(instance)
@@ -48,6 +53,8 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
 
     var showError: Bool { !errors.isEmpty }
     var errorMessage: String? { errors.last }
+    /// The copyable command offered with the most recent error, if any.
+    var errorCopyableCommand: String? { errorCopyableCommands.last ?? nil }
     var showDeleteSheet: Bool { !deleteSheetInstances.isEmpty }
     var instanceToDelete: VMInstance? { deleteSheetInstances.last }
     /// Whether the most recent delete-sheet request asked for immediate delete.
@@ -68,6 +75,7 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
     /// Clears all recorded requests (mirrors resetting the former flags).
     func reset() {
         errors.removeAll()
+        errorCopyableCommands.removeAll()
         startFailedAttachments.removeAll()
         startFailedAttachmentInstances.removeAll()
         deleteSheetInstances.removeAll()

--- a/KernovaTests/SheetAlertTests.swift
+++ b/KernovaTests/SheetAlertTests.swift
@@ -112,6 +112,28 @@ struct SheetAlertTests {
         #expect(config.buttons[2].role == .cancel)
     }
 
+    @Test("AlertConfiguration has no accessory unless one is supplied")
+    func configurationAccessoryDefaultsToNil() {
+        let config = AlertConfiguration(title: "Test", message: "body", buttons: [])
+        #expect(config.accessory == nil)
+    }
+
+    @Test("AlertConfiguration builds its accessory on demand")
+    func configurationBuildsAccessory() {
+        var built = 0
+        let config = AlertConfiguration(
+            title: "Test", message: "body", buttons: [],
+            accessory: {
+                built += 1
+                return NSView()
+            })
+        // The builder runs at presentation time, not construction time — a
+        // queued configuration must not hold a live view while it waits.
+        #expect(built == 0)
+        _ = config.accessory?()
+        #expect(built == 1)
+    }
+
     @Test("AlertButton init defaults to .standard role and a no-op action")
     func alertButtonDefaults() {
         let button = AlertButton("Plain")

--- a/KernovaTests/USBDeviceServiceTests.swift
+++ b/KernovaTests/USBDeviceServiceTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Virtualization
 @testable import Kernova
 
 @Suite("USBDeviceService Tests")
@@ -22,6 +23,36 @@ struct USBDeviceServiceTests {
     func usbDeviceInfoDisplayName() {
         let info = USBDeviceInfo(path: "/Users/test/disk.dmg", readOnly: true)
         #expect(info.displayName == "disk.dmg")
+    }
+
+    // MARK: - Error Messages
+
+    @Test("Hot-attach of an invalid disk image explains the format and offers a conversion")
+    func attachFailureDescribesInvalidDiskImage() {
+        let invalid = NSError(
+            domain: VZError.errorDomain, code: VZError.Code.invalidDiskImage.rawValue)
+        let error = USBDeviceError.diskImageAttachFailed(
+            path: "/tmp/bad.dmg", underlying: invalid)
+
+        #expect(error.errorDescription?.contains("/tmp/bad.dmg") == true)
+        #expect(error.errorDescription?.contains("512") == true)
+        #expect(error.suggestedCommand?.contains("'/tmp/bad.dmg' '/tmp/bad.asif'") == true)
+    }
+
+    @Test("Hot-attach failures from other causes keep their message and suggest nothing")
+    func attachFailureFromOtherCauseIsUnchanged() {
+        let denied = NSError(domain: NSPOSIXErrorDomain, code: Int(ENOTSUP))
+        let error = USBDeviceError.diskImageAttachFailed(
+            path: "/tmp/gone.asif", underlying: denied)
+
+        #expect(error.errorDescription?.contains("moved or replaced") == true)
+        #expect(error.suggestedCommand == nil)
+    }
+
+    @Test("Errors that aren't attach failures suggest no command")
+    func nonAttachErrorsSuggestNoCommand() {
+        #expect(USBDeviceError.noVirtualMachine.suggestedCommand == nil)
+        #expect(USBDeviceError.diskImageNotFound("/tmp/x").suggestedCommand == nil)
     }
 
     // MARK: - Mock Service Tests

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -183,6 +183,27 @@ struct VMLibraryViewModelTests {
         #expect(presenter.errorMessage != nil)
     }
 
+    @Test("An error buffered before a presenter attaches keeps its conversion command")
+    func bufferedErrorKeepsConversionCommand() {
+        let viewModel = VMLibraryViewModel(
+            storageService: MockVMStorageService(),
+            diskImageService: MockDiskImageService(),
+            virtualizationService: MockVirtualizationService(),
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService(),
+            preferences: preferences
+        )
+        viewModel.presentError(
+            ConfigurationBuilderError.storageDiskAttachFailed(
+                id: UUID(), path: "/tmp/compressed.dmg", label: "Data",
+                underlying: NSError(
+                    domain: VZError.errorDomain, code: VZError.Code.invalidDiskImage.rawValue)))
+
+        viewModel.presenter = presenter
+
+        #expect(presenter.errorCopyableCommand?.contains("/tmp/compressed.asif") == true)
+    }
+
     @Test("loadVMs falls back to first VM when stored ID is invalid")
     func loadVMsFallsBackWhenStoredIDInvalid() {
         let storage = MockVMStorageService()
@@ -1172,6 +1193,87 @@ struct VMLibraryViewModelTests {
         #expect(presenter.startFailedAttachments.first?.kind == .storageDisk)
         #expect(presenter.startFailedAttachments.first?.id == external.id)
         #expect(presenter.errors.isEmpty)
+    }
+
+    @Test("start's removal offer carries the conversion command for an invalid disk image")
+    func startOfferCarriesConversionCommand() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let instance = makeInstance()
+        let layout = VMBundleLayout(bundleURL: instance.bundleURL)
+        let external = StorageDisk(
+            id: UUID(), path: "/tmp/compressed.dmg", readOnly: true, label: "External",
+            isInternal: false, kind: .virtio)
+        instance.configuration.storageDisks = [
+            ConfigurationBuilder.defaultMainDisk(layout: layout), external,
+        ]
+        viewModel.instances.append(instance)
+        virtService.startError = ConfigurationBuilderError.storageDiskAttachFailed(
+            id: external.id, path: external.path, label: external.label,
+            underlying: NSError(
+                domain: VZError.errorDomain, code: VZError.Code.invalidDiskImage.rawValue))
+
+        await viewModel.start(instance)
+
+        let failure = presenter.startFailedAttachments.first
+        #expect(failure?.conversionCommand?.contains("/tmp/compressed.asif") == true)
+        #expect(failure?.message.contains("512") == true)
+    }
+
+    @Test("start's removal offer carries no command for a non-format failure")
+    func startOfferCarriesNoCommandForOtherFailures() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let instance = makeInstance()
+        let layout = VMBundleLayout(bundleURL: instance.bundleURL)
+        let external = StorageDisk(
+            id: UUID(), path: "/tmp/gone.img", readOnly: false, label: "External",
+            isInternal: false, kind: .virtio)
+        instance.configuration.storageDisks = [
+            ConfigurationBuilder.defaultMainDisk(layout: layout), external,
+        ]
+        viewModel.instances.append(instance)
+        virtService.startError = ConfigurationBuilderError.storageDiskAttachFailed(
+            id: external.id, path: external.path, label: external.label,
+            underlying: NSError(domain: NSPOSIXErrorDomain, code: Int(ENOTSUP)))
+
+        await viewModel.start(instance)
+
+        #expect(presenter.startFailedAttachments.first?.conversionCommand == nil)
+    }
+
+    @Test("The generic error alert carries the conversion command too")
+    func genericErrorCarriesConversionCommand() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let instance = makeInstance()
+        viewModel.instances.append(instance)
+        // The boot disk never qualifies for the removal offer, so a format
+        // failure on it falls through to the generic alert.
+        virtService.startError = ConfigurationBuilderError.storageDiskAttachFailed(
+            id: UUID(), path: "/tmp/compressed.dmg", label: "Main Disk",
+            underlying: NSError(
+                domain: VZError.errorDomain, code: VZError.Code.invalidDiskImage.rawValue))
+
+        await viewModel.start(instance)
+
+        #expect(presenter.startFailedAttachments.isEmpty)
+        #expect(presenter.errorCopyableCommand?.contains("/tmp/compressed.asif") == true)
+    }
+
+    @Test("Errors with no command remedy offer none")
+    func genericErrorCarriesNoCommandForOtherFailures() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let instance = makeInstance()
+        viewModel.instances.append(instance)
+        virtService.startError = VirtualizationError.invalidStateTransition(
+            from: .stopped, action: "start")
+
+        await viewModel.start(instance)
+
+        #expect(presenter.showError == true)
+        #expect(presenter.errorCopyableCommand == nil)
     }
 
     @Test("start does not offer removal for transient file-lock contention")


### PR DESCRIPTION
Closes #573

## Summary

When `VZDiskImageStorageDeviceAttachment` refuses a file, Kernova now says why in its own words and hands the user the command that fixes it, on every attach path — cold-attached storage disks and removable media, and the runtime USB hot-attach.

## What Virtualization actually checks

The issue's premise was that the framework rejects compressed disk images and that catching `VZError.Code.invalidDiskImage` would surface that. Verifying against the framework on macOS 26 (26A5388g) with a standalone probe showed otherwise: the initializer validates exactly one property — the file's size is a multiple of 512 bytes — and inspects no contents.

| File | Result |
|---|---|
| 100 bytes / 513 bytes of zeros | `VZErrorDomain` code 5 |
| 2 KiB from `/dev/urandom`, 1 MiB of zeros | accepted |
| UDZO / ULFO / UDRO `.dmg` | accepted |

Compressed `.dmg` files do fail in practice, but because their size is arbitrary rather than because of their format — the two application `.dmg` files sampled from `/Applications` had `mod512` of 335 and 11. Apple's own header ("Only RAW data disk images are supported") describes an intent the initializer does not enforce.

That changed the wording, not the shape of the fix: the message names the size requirement alongside the supported formats, and converting to ASIF resolves both. The residual case — an aligned compressed image that attaches with no error and is simply unreadable in the guest — needs content inspection and is filed as #668.

## In-app conversion

Not possible. Decompressing a UDIF `.dmg` needs `hdiutil`/`diskutil` or the private DiskImages framework, neither reachable from the sandbox, and ASIF creation has no public in-process API — already why disk images ship as bundled lzfse templates. So the failure flow offers the command instead: `diskutil image create from --format ASIF`, which is the non-deprecated spelling on macOS 26 (`hdiutil convert` is deprecated and cannot emit ASIF). Verified end to end that it converts a compressed source into an image the framework accepts.

## Route taken

`DiskImageFormatGuidance` is the single place that knows the VZ error code, both attach-failure messages, and the shell-quoted command. `CommandSuggestingError` lets `VMLibraryViewModel` ask any error for a copyable remedy without switching on error types.

Both `ConfigurationBuilder` sites already wrapped the failure in a typed error preserving the underlying `NSError`, so the message branches off that — no new plumbing, and the file-lock-contention retry that reads the same underlying error is untouched. `USBDeviceService.attach` was the outlier, rethrowing the framework error raw; it now wraps in `USBDeviceError.diskImageAttachFailed`. Nothing on that path inspects the raw error (all contention detection is start-path only), so the wrap is safe and it is what lets the hot-attach path carry a Kernova message at all.

The command surfaces as a selectable monospaced field with a copy button in the alert's accessory view, rather than a "Copy" button in the button row — copying doesn't dismiss the alert, so the start-failure case keeps its "Remove and Start" offer intact.

### Rejected alternatives

- **Pre-validating the format before attaching** — the issue rejected it to avoid an allowlist that would go stale if Apple widened support. Still right, though for a different reason than assumed: there is no format check to mirror.
- **A second `presentError` overload carrying the command** — one method with the parameter instead, so there is no parallel path. The ripple was four call sites.
- **Command in the message text only** — no way to copy it without retyping.

## Test plan

- [x] `make test` — 1815 cases, no failures
- [x] `make lint`
- [x] Probed the framework directly for which files it rejects, and that `diskutil image create from --format ASIF` produces one it accepts
- [x] Rendered the alert from the real view sources to confirm the accessory sizes correctly (`NSAlert` does not size accessory views)

New coverage: `DiskImageFormatGuidanceTests` (classification, both message branches, shell quoting for spaces and embedded quotes), `CopyableCommandViewTests` (pasteboard write against a private pasteboard, copy confirmation, self-sizing), plus message/`suggestedCommand` assertions on both error enums and command-propagation tests through the view model, including the buffered-before-presenter path.

## Notes

No `RATIONALE:` comments added.