### PR TITLE
feat: Add version-catalog and pasted-URL install sources for macOS guests

### DIFF
--- a/Kernova/Models/MacOSInstallContext.swift
+++ b/Kernova/Models/MacOSInstallContext.swift
@@ -8,16 +8,29 @@ import Foundation
 struct MacOSInstallContext: Codable, Sendable, Equatable {
     enum Source: String, Codable, Sendable, Equatable {
         case downloadLatest
+        case catalogVersion
         case localFile
     }
 
     var source: Source
 
-    /// Where to write the downloaded IPSW (for `.downloadLatest`).
+    /// Where to write the downloaded IPSW (for `.downloadLatest` and
+    /// `.catalogVersion`).
     ///
     /// A sibling `.kernovadownload` bundle at this location holds in-progress
     /// download state and enables resume across app restarts.
     var downloadDestinationPath: String?
+
+    /// The exact image to download (for `.catalogVersion`).
+    ///
+    /// Pinned at wizard time from the bundled catalog, so a Start weeks later
+    /// fetches the version the user chose rather than whatever is newest.
+    var remoteURL: URL?
+
+    /// Marketing version and build of the pinned image, for display while the
+    /// install runs.
+    var version: String?
+    var build: String?
 
     /// Path to an existing IPSW file on disk (for `.localFile`).
     var localIPSWPath: String?
@@ -51,13 +64,19 @@ struct MacOSInstallContext: Codable, Sendable, Equatable {
         downloadDestinationPath: String? = nil,
         localIPSWPath: String? = nil,
         localIPSWBookmark: Data? = nil,
-        requestedFreshDownload: Bool = false
+        requestedFreshDownload: Bool = false,
+        remoteURL: URL? = nil,
+        version: String? = nil,
+        build: String? = nil
     ) {
         self.source = source
         self.downloadDestinationPath = downloadDestinationPath
         self.localIPSWPath = localIPSWPath
         self.localIPSWBookmark = localIPSWBookmark
         self.requestedFreshDownload = requestedFreshDownload
+        self.remoteURL = remoteURL
+        self.version = version
+        self.build = build
     }
 
     // Custom decoder so a context missing these keys decodes with
@@ -68,6 +87,9 @@ struct MacOSInstallContext: Codable, Sendable, Equatable {
         case localIPSWPath
         case localIPSWBookmark
         case requestedFreshDownload
+        case remoteURL
+        case version
+        case build
     }
 
     init(from decoder: any Decoder) throws {
@@ -79,5 +101,8 @@ struct MacOSInstallContext: Codable, Sendable, Equatable {
         self.localIPSWBookmark = try c.decodeIfPresent(Data.self, forKey: .localIPSWBookmark)
         self.requestedFreshDownload =
             try c.decodeIfPresent(Bool.self, forKey: .requestedFreshDownload) ?? false
+        self.remoteURL = try c.decodeIfPresent(URL.self, forKey: .remoteURL)
+        self.version = try c.decodeIfPresent(String.self, forKey: .version)
+        self.build = try c.decodeIfPresent(String.self, forKey: .build)
     }
 }

--- a/Kernova/Models/MacOSInstallContext.swift
+++ b/Kernova/Models/MacOSInstallContext.swift
@@ -9,7 +9,25 @@ struct MacOSInstallContext: Codable, Sendable, Equatable {
     enum Source: String, Codable, Sendable, Equatable {
         case downloadLatest
         case catalogVersion
+        case customURL
         case localFile
+
+        /// Whether the install downloads the image named by ``remoteURL``
+        /// rather than resolving one at Start.
+        var usesPinnedURL: Bool {
+            switch self {
+            case .catalogVersion, .customURL: true
+            case .downloadLatest, .localFile: false
+            }
+        }
+
+        /// Whether the install fetches the image over the network.
+        var downloadsImage: Bool {
+            switch self {
+            case .downloadLatest, .catalogVersion, .customURL: true
+            case .localFile: false
+            }
+        }
     }
 
     var source: Source
@@ -21,10 +39,11 @@ struct MacOSInstallContext: Codable, Sendable, Equatable {
     /// download state and enables resume across app restarts.
     var downloadDestinationPath: String?
 
-    /// The exact image to download (for `.catalogVersion`).
+    /// The exact image to download (for the sources where ``Source/usesPinnedURL``).
     ///
-    /// Pinned at wizard time from the bundled catalog, so a Start weeks later
-    /// fetches the version the user chose rather than whatever is newest.
+    /// Pinned at wizard time — from the bundled catalog, or from a URL the user
+    /// supplied and Kernova checked — so a Start weeks later fetches the image
+    /// the user chose rather than whatever is newest.
     var remoteURL: URL?
 
     /// Marketing version and build of the pinned image, for display while the

--- a/Kernova/Models/ProbedRestoreImage.swift
+++ b/Kernova/Models/ProbedRestoreImage.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// A restore image at a user-supplied URL, after the pre-download check.
+///
+/// Only ``sizeBytes`` and the fact that the image carries the virtual-machine
+/// hardware model are measured. ``version`` and ``build`` are read out of
+/// Apple's filename convention and are absent whenever the filename does not
+/// follow it, so nothing that gates the install may depend on them.
+struct ProbedRestoreImage: Sendable, Equatable {
+    var url: URL
+    var sizeBytes: UInt64
+    /// Marketing version parsed from the filename, e.g. `"15.6.1"`.
+    var version: String?
+    /// Apple build parsed from the filename, e.g. `"24G90"`.
+    var build: String?
+
+    /// The filename the download lands on, taken from the URL.
+    ///
+    /// Per-image rather than a fixed name for the same reason a catalog pick is:
+    /// a shared filename lets an already-downloaded image of a different version
+    /// satisfy the download step.
+    var suggestedFilename: String {
+        let candidate = url.lastPathComponent
+        guard candidate.lowercased().hasSuffix(".ipsw"), !candidate.hasPrefix(".") else {
+            return "RestoreImage.ipsw"
+        }
+        return candidate
+    }
+
+    /// Version and build as one phrase, or a fallback when the filename did not
+    /// follow Apple's convention.
+    var versionSummary: String {
+        switch (version, build) {
+        case (let version?, let build?): "macOS \(version) (\(build))"
+        case (let version?, nil): "macOS \(version)"
+        case (nil, let build?): "Build \(build)"
+        case (nil, nil): "Unrecognized version"
+        }
+    }
+
+    /// Whether the parsed version is at most `host`.
+    ///
+    /// `nil` when the filename yielded no version — the answer is unknown, which
+    /// is not the same as a "no". Virtualization refuses a guest newer than the
+    /// host, but it only says so once the image is on disk.
+    func isSupported(onHost host: OperatingSystemVersion) -> Bool? {
+        guard let version else { return nil }
+        let parsed = version.split(separator: ".").map { Int($0) }
+        guard !parsed.isEmpty, !parsed.contains(nil) else { return nil }
+        var components = parsed.compactMap { $0 }
+        while components.count < 3 { components.append(0) }
+        let hostComponents = [host.majorVersion, host.minorVersion, host.patchVersion]
+        for (guestPart, hostPart) in zip(components.prefix(3), hostComponents)
+        where guestPart != hostPart {
+            return guestPart < hostPart
+        }
+        return true
+    }
+
+    /// Reads version and build out of Apple's restore-image filename.
+    ///
+    /// The convention is `UniversalMac_<version>_<build>_Restore.ipsw`. Anything
+    /// else yields `(nil, nil)` rather than a guess.
+    static func parseFilename(_ filename: String) -> (version: String?, build: String?) {
+        let parts = filename.split(separator: "_", omittingEmptySubsequences: false)
+        guard parts.count == 4,
+            parts[0] == "UniversalMac",
+            parts[3].lowercased() == "restore.ipsw"
+        else { return (nil, nil) }
+
+        let version = String(parts[1])
+        let build = String(parts[2])
+        let versionIsNumeric =
+            !version.isEmpty
+            && version.split(separator: ".", omittingEmptySubsequences: false)
+                .allSatisfy { !$0.isEmpty && $0.allSatisfy(\.isNumber) }
+        let buildLooksLikeBuild =
+            !build.isEmpty && build.allSatisfy { $0.isLetter || $0.isNumber }
+        guard versionIsNumeric, buildLooksLikeBuild else { return (nil, nil) }
+        return (version, build)
+    }
+}

--- a/Kernova/Models/ProbedRestoreImage.swift
+++ b/Kernova/Models/ProbedRestoreImage.swift
@@ -14,17 +14,9 @@ struct ProbedRestoreImage: Sendable, Equatable {
     /// Apple build parsed from the filename, e.g. `"24G90"`.
     var build: String?
 
-    /// The filename the download lands on, taken from the URL.
-    ///
-    /// Per-image rather than a fixed name for the same reason a catalog pick is:
-    /// a shared filename lets an already-downloaded image of a different version
-    /// satisfy the download step.
+    /// The filename the download lands on, derived from ``url``.
     var suggestedFilename: String {
-        let candidate = url.lastPathComponent
-        guard candidate.lowercased().hasSuffix(".ipsw"), !candidate.hasPrefix(".") else {
-            return "RestoreImage.ipsw"
-        }
-        return candidate
+        RestoreImageFilename.destination(for: url)
     }
 
     /// Version and build as one phrase, or a fallback when the filename did not
@@ -41,20 +33,9 @@ struct ProbedRestoreImage: Sendable, Equatable {
     /// Whether the parsed version is at most `host`.
     ///
     /// `nil` when the filename yielded no version — the answer is unknown, which
-    /// is not the same as a "no". Virtualization refuses a guest newer than the
-    /// host, but it only says so once the image is on disk.
+    /// is not the same as a "no".
     func isSupported(onHost host: OperatingSystemVersion) -> Bool? {
-        guard let version else { return nil }
-        let parsed = version.split(separator: ".").map { Int($0) }
-        guard !parsed.isEmpty, !parsed.contains(nil) else { return nil }
-        var components = parsed.compactMap { $0 }
-        while components.count < 3 { components.append(0) }
-        let hostComponents = [host.majorVersion, host.minorVersion, host.patchVersion]
-        for (guestPart, hostPart) in zip(components.prefix(3), hostComponents)
-        where guestPart != hostPart {
-            return guestPart < hostPart
-        }
-        return true
+        version.flatMap(MacOSVersion.init)?.isSupported(onHost: host)
     }
 
     /// Reads version and build out of Apple's restore-image filename.

--- a/Kernova/Models/RestoreImageCatalogEntry.swift
+++ b/Kernova/Models/RestoreImageCatalogEntry.swift
@@ -21,11 +21,8 @@ struct RestoreImageCatalogEntry: Codable, Sendable, Identifiable, Equatable {
     var id: String { build }
 
     /// Apple's own filename for the image, e.g. `UniversalMac_15.6.1_24G90_Restore.ipsw`.
-    ///
-    /// The download destination is per-build precisely because of this: a fixed
-    /// filename would let a previously-downloaded image satisfy a different pick.
     var suggestedFilename: String {
-        url.lastPathComponent
+        RestoreImageFilename.destination(for: url)
     }
 
     /// ``lastModified`` parsed for display, or `nil` if Apple's header did not parse.
@@ -38,29 +35,15 @@ struct RestoreImageCatalogEntry: Codable, Sendable, Identifiable, Equatable {
     /// A component that is not a number yields `nil` — the entry is then
     /// unusable for host comparison and the service drops it.
     var versionComponents: [Int]? {
-        let parsed = version.split(separator: ".").map { Int($0) }
-        guard !parsed.isEmpty, !parsed.contains(nil) else { return nil }
-        var components = parsed.compactMap { $0 }
-        while components.count < 3 { components.append(0) }
-        return Array(components.prefix(3))
+        MacOSVersion(version)?.components
     }
 
     /// Whether this guest can run on the given host.
     ///
-    /// Virtualization refuses a guest newer than the host, and the framework's
-    /// own answer is only available after the image is downloaded — it comes
-    /// from `VZMacOSRestoreImage.loadFileURL`, which takes a local file.
+    /// An unparseable version answers `false`: the catalog service drops such
+    /// entries at decode time, so no pickable entry reaches this.
     func isSupported(onHost host: OperatingSystemVersion) -> Bool {
-        guard let components = versionComponents else { return false }
-        let hostComponents = [host.majorVersion, host.minorVersion, host.patchVersion]
-        for (guestPart, hostPart) in zip(components, hostComponents) where guestPart != hostPart {
-            return guestPart < hostPart
-        }
-        return true
-    }
-
-    var isSupportedOnHost: Bool {
-        isSupported(onHost: ProcessInfo.processInfo.operatingSystemVersion)
+        MacOSVersion(version)?.isSupported(onHost: host) ?? false
     }
 
     /// Newest first, comparing version components numerically so 26.10 sorts

--- a/Kernova/Models/RestoreImageCatalogEntry.swift
+++ b/Kernova/Models/RestoreImageCatalogEntry.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// One macOS restore image in the bundled catalog.
+///
+/// Identity is ``build``, not ``version``: Apple ships hardware-specific spins
+/// under one version number (15.4 exists as both `24E246` and `24E248`), so a
+/// version is not unique and cannot address an image.
+struct RestoreImageCatalogEntry: Codable, Sendable, Identifiable, Equatable {
+    /// Marketing version, two or three dot-separated components (`"26.6"`, `"12.0.1"`).
+    var version: String
+    /// Apple build identifier, unique across the catalog.
+    var build: String
+    var url: URL
+    var sizeBytes: UInt64
+    /// The `Last-Modified` Apple's CDN reports for ``url``, in RFC 1123 form.
+    var lastModified: String
+    /// Which pass of the generator found this image (`apple-live`,
+    /// `apple-archived`, `apple-indexed`).
+    var source: String
+
+    var id: String { build }
+
+    /// Apple's own filename for the image, e.g. `UniversalMac_15.6.1_24G90_Restore.ipsw`.
+    ///
+    /// The download destination is per-build precisely because of this: a fixed
+    /// filename would let a previously-downloaded image satisfy a different pick.
+    var suggestedFilename: String {
+        url.lastPathComponent
+    }
+
+    /// ``lastModified`` parsed for display, or `nil` if Apple's header did not parse.
+    var releaseDate: Date? {
+        Self.rfc1123Formatter.date(from: lastModified)
+    }
+
+    /// `version` split into numeric components, zero-padded to three.
+    ///
+    /// A component that is not a number yields `nil` — the entry is then
+    /// unusable for host comparison and the service drops it.
+    var versionComponents: [Int]? {
+        let parsed = version.split(separator: ".").map { Int($0) }
+        guard !parsed.isEmpty, !parsed.contains(nil) else { return nil }
+        var components = parsed.compactMap { $0 }
+        while components.count < 3 { components.append(0) }
+        return Array(components.prefix(3))
+    }
+
+    /// Whether this guest can run on the given host.
+    ///
+    /// Virtualization refuses a guest newer than the host, and the framework's
+    /// own answer is only available after the image is downloaded — it comes
+    /// from `VZMacOSRestoreImage.loadFileURL`, which takes a local file.
+    func isSupported(onHost host: OperatingSystemVersion) -> Bool {
+        guard let components = versionComponents else { return false }
+        let hostComponents = [host.majorVersion, host.minorVersion, host.patchVersion]
+        for (guestPart, hostPart) in zip(components, hostComponents) where guestPart != hostPart {
+            return guestPart < hostPart
+        }
+        return true
+    }
+
+    var isSupportedOnHost: Bool {
+        isSupported(onHost: ProcessInfo.processInfo.operatingSystemVersion)
+    }
+
+    /// Newest first, comparing version components numerically so 26.10 sorts
+    /// above 26.9.
+    ///
+    /// Equal versions fall back to `build` so the order is total.
+    static func isDescending(_ lhs: Self, _ rhs: Self) -> Bool {
+        let left = lhs.versionComponents ?? []
+        let right = rhs.versionComponents ?? []
+        for (leftPart, rightPart) in zip(left, right) where leftPart != rightPart {
+            return leftPart > rightPart
+        }
+        if left.count != right.count { return left.count > right.count }
+        return lhs.build > rhs.build
+    }
+
+    /// Whether the entry matches a picker search term, over version and build.
+    func matches(searchTerm: String) -> Bool {
+        let term = searchTerm.trimmingCharacters(in: .whitespaces)
+        guard !term.isEmpty else { return true }
+        return version.localizedCaseInsensitiveContains(term)
+            || build.localizedCaseInsensitiveContains(term)
+    }
+
+    /// Fixed-locale RFC 1123 parser for Apple's `Last-Modified` header.
+    ///
+    /// `en_US_POSIX` and an explicit GMT zone keep the parse independent of the
+    /// user's locale and time zone, which is what HTTP dates require.
+    private static let rfc1123Formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        return formatter
+    }()
+}
+
+/// The bundled catalog document.
+struct RestoreImageCatalog: Codable, Sendable, Equatable {
+    /// Apple's device key the images were verified against.
+    var device: String
+    /// `yyyy-MM-dd` the catalog was generated, shown in the picker footer.
+    var generatedAt: String
+    var images: [RestoreImageCatalogEntry]
+}

--- a/Kernova/Models/RestoreImageFilename.swift
+++ b/Kernova/Models/RestoreImageFilename.swift
@@ -1,0 +1,118 @@
+import CryptoKit
+import Foundation
+
+/// Turns a restore image's URL into the filename its download lands on.
+///
+/// Every source — the bundled catalog, a pasted URL, a persisted install
+/// context — resolves its destination here, so no filename a remote server or a
+/// hand-edited `config.json` controls reaches the filesystem unchecked.
+enum RestoreImageFilename {
+    /// The destination filename for an image whose URL names none.
+    static let fallback = "\(defaultStem).ipsw"
+
+    /// The download destination's filename for the image at `url`.
+    ///
+    /// Apple's `UniversalMac_<version>_<build>_Restore.ipsw` convention passes
+    /// through, because the build in such a name is the image's identity: two
+    /// picks of one build share a destination on purpose. Any other URL gets a
+    /// name unique to it, since a shared name lets an unrelated image already on
+    /// disk satisfy the download and install in place of the one chosen.
+    static func destination(for url: URL) -> String {
+        guard let sanitized = sanitized(url.lastPathComponent),
+            ProbedRestoreImage.parseFilename(sanitized).build != nil
+        else { return unique(for: url) }
+        return sanitized
+    }
+
+    /// `candidate` when it is a filename safe to append to a directory, `nil`
+    /// when the caller must generate one instead.
+    ///
+    /// `URL.lastPathComponent` percent-decodes, so a URL ending in
+    /// `a%2F..%2F..%2Fevil.ipsw` hands back `a/../../evil.ipsw` — a value that
+    /// walks out of whatever directory it is appended to. Anything empty,
+    /// hidden (`.` and `..` included), carrying a separator, or not naming an
+    /// `.ipsw` is refused.
+    static func sanitized(_ candidate: String) -> String? {
+        guard candidate.lowercased().hasSuffix(".ipsw"), isSingleComponent(candidate) else {
+            return nil
+        }
+        return candidate
+    }
+
+    /// A destination filename unique to `url`.
+    ///
+    /// The digest covers the whole absolute URL, so two images differing only in
+    /// host or query land on different files, while one URL always resolves to
+    /// the same file and stays resumable across attempts.
+    static func unique(for url: URL) -> String {
+        let digest = SHA256.hash(data: Data(url.absoluteString.utf8))
+        let discriminator =
+            digest.prefix(discriminatorBytes)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return "\(stem(of: url.lastPathComponent) ?? defaultStem)-\(discriminator).ipsw"
+    }
+
+    /// Stem of a generated filename when the URL's own last component yields none.
+    private static let defaultStem = "RestoreImage"
+
+    /// Leading bytes of the URL digest a generated filename carries.
+    private static let discriminatorBytes = 4
+
+    /// Longest stem a generated filename keeps, so a hostile URL cannot push the
+    /// name past the byte limit a path component has.
+    private static let maximumStemLength = 64
+
+    /// Whether `candidate` is one visible path component.
+    private static func isSingleComponent(_ candidate: String) -> Bool {
+        // `.` and `..` fall out of the leading-dot refusal.
+        guard !candidate.isEmpty, !candidate.hasPrefix(".") else { return false }
+        let decoded = candidate.removingPercentEncoding ?? candidate
+        return !candidate.contains(where: isSeparator)
+            && !decoded.contains(where: isSeparator)
+    }
+
+    private static func isSeparator(_ character: Character) -> Bool {
+        character == "/" || character == "\0"
+    }
+
+    /// The part of `candidate` before its extension, or `nil` when `candidate`
+    /// is not usable as a filename at all.
+    private static func stem(of candidate: String) -> String? {
+        guard isSingleComponent(candidate) else { return nil }
+        var stem = candidate
+        if let dot = stem.lastIndex(of: "."), dot != stem.startIndex {
+            stem = String(stem[stem.startIndex..<dot])
+        }
+        guard !stem.isEmpty else { return nil }
+        return String(stem.prefix(maximumStemLength))
+    }
+}
+
+/// A macOS marketing version, parsed for comparison against a host.
+struct MacOSVersion: Sendable, Equatable {
+    /// Numeric components, zero-padded to three.
+    let components: [Int]
+
+    /// `nil` when `version` is not a dot-separated run of numbers.
+    init?(_ version: String) {
+        let parsed = version.split(separator: ".").map { Int($0) }
+        guard !parsed.isEmpty, !parsed.contains(nil) else { return nil }
+        var components = parsed.compactMap { $0 }
+        while components.count < 3 { components.append(0) }
+        self.components = Array(components.prefix(3))
+    }
+
+    /// Whether a guest at this version can run on the given host.
+    ///
+    /// Virtualization refuses a guest newer than the host, and the framework's
+    /// own answer is only available after the image is downloaded — it comes
+    /// from `VZMacOSRestoreImage.loadFileURL`, which takes a local file.
+    func isSupported(onHost host: OperatingSystemVersion) -> Bool {
+        let hostComponents = [host.majorVersion, host.minorVersion, host.patchVersion]
+        for (guestPart, hostPart) in zip(components, hostComponents) where guestPart != hostPart {
+            return guestPart < hostPart
+        }
+        return true
+    }
+}

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -41,12 +41,64 @@ final class IPSWService: Sendable {
     /// ETag / Last-Modified used for `If-Range`. The bundle is preserved for a
     /// later resume on any failure, cancellation included (which throws
     /// `CancellationError`). A completed IPSW with no bundle beside it is skipped.
+    ///
+    /// Calls are serialized per destination: two VMs pinned to the same image
+    /// share one path and one bundle, so a second caller waits for the download
+    /// already streaming there and then skips over the image it finished.
+    ///
+    /// `discardsExistingDownload` honors a "Download & Replace": the image and
+    /// bundle at the destination are trashed first, inside the claim, so the
+    /// disposal cannot reach bytes another caller is streaming into them.
     func downloadRestoreImage(
         from remoteURL: URL,
         to destinationURL: URL,
+        discardsExistingDownload: Bool = false,
         progressHandler: @MainActor @Sendable @escaping (DownloadProgress) -> Void
     ) async throws {
-        Self.logger.info("Downloading restore image from \(remoteURL, privacy: .public)")
+        let key = destinationURL.standardizedFileURL.path(percentEncoded: false)
+        var discardsExisting = discardsExistingDownload
+        while true {
+            try Task.checkCancellation()
+            let discards = discardsExisting
+            let claim = await Self.claimDownload(forKey: key) { [self] in
+                try await performDownload(
+                    from: remoteURL, to: destinationURL, discardsExistingDownload: discards,
+                    progressHandler: progressHandler)
+            }
+            guard claim.isOwner else {
+                Self.logger.notice(
+                    "A download to '\(destinationURL.lastPathComponent, privacy: .public)' is already running — waiting for it to finish"
+                )
+                // That download's failure is its own caller's to report; this one
+                // loops and downloads, resuming from whatever bytes landed. What
+                // it landed is this call's image too — same destination, same
+                // pinned URL — so there is nothing stale left to replace.
+                _ = try? await claim.task.value
+                discardsExisting = false
+                continue
+            }
+            try await withTaskCancellationHandler {
+                try await claim.task.value
+            } onCancel: {
+                claim.task.cancel()
+            }
+            return
+        }
+    }
+
+    /// Runs one download, with this destination already reserved by the caller.
+    private func performDownload(
+        from remoteURL: URL,
+        to destinationURL: URL,
+        discardsExistingDownload: Bool,
+        progressHandler: @MainActor @Sendable @escaping (DownloadProgress) -> Void
+    ) async throws {
+        Self.logger.info(
+            "Downloading restore image from \(Self.loggableURL(remoteURL), privacy: .public)")
+
+        if discardsExistingDownload {
+            try discardExistingImage(at: destinationURL)
+        }
 
         let bundleURL = Self.resumeBundleURL(for: destinationURL)
         let bundle = IPSWBundle(url: bundleURL)
@@ -207,7 +259,7 @@ final class IPSWService: Sendable {
 
         if metadata.originalURL != remoteURL {
             Self.logger.notice(
-                "Bundle URL '\(metadata.originalURL, privacy: .public)' ≠ requested '\(remoteURL, privacy: .public)' — discarding stale bundle"
+                "Bundle URL '\(Self.loggableURL(metadata.originalURL), privacy: .public)' ≠ requested '\(Self.loggableURL(remoteURL), privacy: .public)' — discarding stale bundle"
             )
             try? FileManager.default.removeItem(at: bundleURL)
             return nil
@@ -217,6 +269,30 @@ final class IPSWService: Sendable {
             "Resuming prior IPSW download from bundle at '\(bundleURL.lastPathComponent, privacy: .public)' (\(bundle.partialByteCount, privacy: .public) bytes on disk)"
         )
         return metadata
+    }
+
+    /// Trashes the image at `destinationURL` and any partial bundle beside it.
+    ///
+    /// Trashing the completed image is a hard failure: the skip-existing fast
+    /// path would otherwise hand back the very file the caller asked to replace.
+    /// Losing the partial bundle is not — it goes to the Trash on a best-effort
+    /// basis, restorable by the user either way.
+    private func discardExistingImage(at destinationURL: URL) throws {
+        let path = destinationURL.path(percentEncoded: false)
+        if fileSystem.fileExists(atPath: path) {
+            do {
+                try fileSystem.trashItem(at: destinationURL)
+            } catch {
+                Self.logger.error(
+                    "Failed to trash existing IPSW at '\(path, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+                )
+                throw IPSWError.freshDownloadCleanupFailed(path: path, underlying: error)
+            }
+            Self.logger.notice(
+                "Trashed the existing IPSW at '\(destinationURL.lastPathComponent, privacy: .public)' for a fresh download"
+            )
+        }
+        discardResumeData(at: destinationURL)
     }
 
     /// Discards the `.kernovadownload` bundle for the given destination, if present.
@@ -260,7 +336,53 @@ final class IPSWService: Sendable {
         destinationURL.deletingPathExtension().appendingPathExtension("kernovadownload")
     }
 
+    // MARK: - Destination Serialization
+
+    /// Downloads currently streaming, keyed by standardized destination path.
+    ///
+    /// A destination's `.kernovadownload` bundle takes one writer at a time: the
+    /// truncate / append / move sequence produces a corrupt image when two
+    /// downloads to the same path interleave. Keyed by path rather than held per
+    /// instance because the contended resource is the file, not the service.
+    @MainActor private static var inFlightDownloads: [String: Task<Void, any Error>] = [:]
+
+    /// Hands back the download already streaming to `key`, or starts `operation`
+    /// as the one that owns it.
+    ///
+    /// Synchronous on the MainActor, so no second caller can look up an empty
+    /// slot and fill it in between. The task clears its own slot before it
+    /// finishes, so a waiter that sees it complete finds the slot free.
+    @MainActor
+    private static func claimDownload(
+        forKey key: String,
+        operation: @Sendable @escaping () async throws -> Void
+    ) -> (task: Task<Void, any Error>, isOwner: Bool) {
+        if let existing = inFlightDownloads[key] { return (existing, false) }
+        let task = Task<Void, any Error> {
+            defer { inFlightDownloads[key] = nil }
+            try await operation()
+        }
+        inFlightDownloads[key] = task
+        return (task, true)
+    }
+
     // MARK: - Helpers
+
+    /// Renders a remote URL for logging as scheme, host, port and path only.
+    ///
+    /// A user-supplied restore-image URL can carry pre-signed credentials in its
+    /// query or userinfo (S3 and CloudFront signatures), which the unified log
+    /// would otherwise persist.
+    static func loggableURL(_ url: URL) -> String {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url.lastPathComponent
+        }
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.string ?? url.lastPathComponent
+    }
 
     /// Issues a GET (with optional `Range` / `If-Range` headers) and returns the
     /// response plus a stream of `Data` chunks delivered by URLSession.

--- a/Kernova/Services/LocalRestoreImageInspector.swift
+++ b/Kernova/Services/LocalRestoreImageInspector.swift
@@ -31,7 +31,7 @@ struct LocalRestoreImageInspector: LocalRestoreImageInspecting {
             build: image.buildVersion,
             isSupportedOnThisHost: image.mostFeaturefulSupportedConfiguration != nil
         )
-        Self.logger.notice(
+        Self.logger.info(
             "Inspected local restore image: \(inspected.summary, privacy: .public), supported=\(inspected.isSupportedOnThisHost, privacy: .public)"
         )
         return inspected

--- a/Kernova/Services/LocalRestoreImageInspector.swift
+++ b/Kernova/Services/LocalRestoreImageInspector.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Virtualization
+import os
+
+/// Reads a restore image already on disk through Virtualization.
+///
+/// Used before adopting a file the wizard did not download itself, so the
+/// version shown on the Review step is the image's own rather than the one the
+/// user happened to have selected when the file was found.
+struct LocalRestoreImageInspector: LocalRestoreImageInspecting {
+    private static let logger = Logger(
+        subsystem: "app.kernova", category: "LocalRestoreImageInspector")
+
+    func inspect(_ url: URL) async throws -> InspectedRestoreImage {
+        // VZ rejects a path containing a symlink in any component and reports it
+        // as a missing file, so it is only ever handed resolved URLs.
+        let resolved = url.resolvingSymlinksInPath()
+        let image: VZMacOSRestoreImage
+        do {
+            image = try await VZMacOSRestoreImage.image(from: resolved)
+        } catch {
+            Self.logger.warning(
+                "Could not read restore image at '\(resolved.lastPathComponent, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+            throw LocalRestoreImageError.unreadable
+        }
+
+        let version = image.operatingSystemVersion
+        let inspected = InspectedRestoreImage(
+            version: Self.versionString(version),
+            build: image.buildVersion,
+            isSupportedOnThisHost: image.mostFeaturefulSupportedConfiguration != nil
+        )
+        Self.logger.notice(
+            "Inspected local restore image: \(inspected.summary, privacy: .public), supported=\(inspected.isSupportedOnThisHost, privacy: .public)"
+        )
+        return inspected
+    }
+
+    /// Renders a version, dropping a zero patch the way Apple writes it.
+    static func versionString(_ version: OperatingSystemVersion) -> String {
+        version.patchVersion == 0
+            ? "\(version.majorVersion).\(version.minorVersion)"
+            : "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
+}

--- a/Kernova/Services/Protocols/IPSWProviding.swift
+++ b/Kernova/Services/Protocols/IPSWProviding.swift
@@ -3,9 +3,17 @@ import Foundation
 /// Abstraction for IPSW (macOS restore image) fetching and downloading.
 protocol IPSWProviding: Sendable {
     func fetchLatestRestoreImageURL() async throws -> URL
+
+    /// Downloads the image at `remoteURL` to `destinationURL`, resuming a
+    /// partial download already beside it.
+    ///
+    /// `discardsExistingDownload` replaces what is at the destination instead:
+    /// the image and its partial bundle are trashed as part of this call, so
+    /// the disposal is serialized with any download already streaming there.
     func downloadRestoreImage(
         from remoteURL: URL,
         to destinationURL: URL,
+        discardsExistingDownload: Bool,
         progressHandler: @MainActor @Sendable @escaping (DownloadProgress) -> Void
     ) async throws
 

--- a/Kernova/Services/Protocols/LocalRestoreImageInspecting.swift
+++ b/Kernova/Services/Protocols/LocalRestoreImageInspecting.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// What Virtualization reports about a restore image already on disk.
+struct InspectedRestoreImage: Sendable, Equatable {
+    /// Marketing version, e.g. `"15.6.1"`.
+    var version: String
+    /// Apple build identifier, e.g. `"24G90"`.
+    var build: String
+    /// Whether the framework offers a supported configuration for it on this host.
+    var isSupportedOnThisHost: Bool
+
+    var summary: String { "macOS \(version) (\(build))" }
+}
+
+/// Why a restore image already on disk could not be adopted.
+enum LocalRestoreImageError: LocalizedError, Equatable {
+    case unreadable
+    case unsupported
+
+    var errorDescription: String? {
+        switch self {
+        case .unreadable:
+            "That file isn't a usable restore image."
+        case .unsupported:
+            "That restore image can't install into a virtual machine on this Mac."
+        }
+    }
+}
+
+/// Abstraction for reading a restore image that is already on disk.
+///
+/// Unlike a remote URL, a local file gets Virtualization's own answer:
+/// `VZMacOSRestoreImage` loads from a file URL, so the version, build and
+/// supported-configuration verdict here are the framework's, not a guess.
+protocol LocalRestoreImageInspecting: Sendable {
+    func inspect(_ url: URL) async throws -> InspectedRestoreImage
+}

--- a/Kernova/Services/Protocols/RestoreImageCatalogProviding.swift
+++ b/Kernova/Services/Protocols/RestoreImageCatalogProviding.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Abstraction for reading the bundled catalog of macOS restore images.
+protocol RestoreImageCatalogProviding: Sendable {
+    /// Every usable image, newest first.
+    ///
+    /// Empty when the catalog resource is missing or unreadable — the picker
+    /// then has nothing to offer, and the other two IPSW sources still work.
+    var entries: [RestoreImageCatalogEntry] { get }
+
+    /// `yyyy-MM-dd` the catalog was generated, or `nil` when it did not load.
+    var generatedAt: String? { get }
+}

--- a/Kernova/Services/Protocols/RestoreImageProbing.swift
+++ b/Kernova/Services/Protocols/RestoreImageProbing.swift
@@ -5,6 +5,7 @@ enum RestoreImageProbeError: LocalizedError, Equatable {
     case insecureURL
     case unreachable(statusCode: Int)
     case unknownSize
+    case rangeRequestsUnsupported
     case notAVirtualMachineImage
     case unreadableStructure
     case transportFailed(description: String)
@@ -17,6 +18,11 @@ enum RestoreImageProbeError: LocalizedError, Equatable {
             "Nothing is hosted at that URL (HTTP \(statusCode)). Check the link and try again."
         case .unknownSize:
             "That server didn't report the file's size, so the image can't be checked before downloading."
+        case .rangeRequestsUnsupported:
+            """
+            That server only sends whole files, so the image can't be checked before downloading. \
+            Download it and add it with Choose Local File.
+            """
         case .notAVirtualMachineImage:
             "This image can't run as a virtual machine. It has no VM hardware model."
         case .unreadableStructure:

--- a/Kernova/Services/Protocols/RestoreImageProbing.swift
+++ b/Kernova/Services/Protocols/RestoreImageProbing.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Why a user-supplied restore image URL was refused.
+enum RestoreImageProbeError: LocalizedError, Equatable {
+    case insecureURL
+    case unreachable(statusCode: Int)
+    case unknownSize
+    case notAVirtualMachineImage
+    case unreadableStructure
+    case transportFailed(description: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .insecureURL:
+            "That link isn't secure. Restore images must be served over HTTPS."
+        case .unreachable(let statusCode):
+            "Nothing is hosted at that URL (HTTP \(statusCode)). Check the link and try again."
+        case .unknownSize:
+            "That server didn't report the file's size, so the image can't be checked before downloading."
+        case .notAVirtualMachineImage:
+            "This image can't run as a virtual machine. It has no VM hardware model."
+        case .unreadableStructure:
+            "That file isn't a readable restore image."
+        case .transportFailed(let description):
+            "Couldn't reach that URL: \(description)"
+        }
+    }
+}
+
+/// Abstraction for checking a user-supplied restore image URL before download.
+protocol RestoreImageProbing: Sendable {
+    /// Establishes that `url` serves an image that can install into a VM, and
+    /// how large it is, without downloading it.
+    func probe(_ url: URL) async throws -> ProbedRestoreImage
+}

--- a/Kernova/Services/RestoreImageCatalogService.swift
+++ b/Kernova/Services/RestoreImageCatalogService.swift
@@ -1,0 +1,173 @@
+import Foundation
+import os
+
+/// Reads the catalog of macOS restore images bundled with the app.
+///
+/// The shipped app fetches nothing to build this list: the resource is a
+/// generation-time snapshot, so the picker opens instantly and offline. Only the
+/// chosen image's bytes come off the network, from Apple.
+struct RestoreImageCatalogService: RestoreImageCatalogProviding {
+    private static let logger = Logger(
+        subsystem: "app.kernova", category: "RestoreImageCatalogService")
+
+    private static let resourceName = "RestoreImageCatalog"
+    private static let resourceExtension = "json"
+
+    let entries: [RestoreImageCatalogEntry]
+    let generatedAt: String?
+
+    init(bundle: Bundle = .main) {
+        guard
+            let url = bundle.url(
+                forResource: Self.resourceName, withExtension: Self.resourceExtension),
+            let data = try? Data(contentsOf: url)
+        else {
+            Self.logger.fault(
+                "Bundled restore image catalog '\(Self.resourceName, privacy: .public).\(Self.resourceExtension, privacy: .public)' is missing or unreadable"
+            )
+            assertionFailure(
+                "Bundled restore image catalog is missing or unreadable: \(Self.resourceName).\(Self.resourceExtension)"
+            )
+            self.entries = []
+            self.generatedAt = nil
+            return
+        }
+
+        let result = Self.parse(data)
+        for rejection in result.rejections {
+            Self.logger.fault(
+                "Dropping restore image catalog entry: \(rejection.description, privacy: .public)")
+            assertionFailure("Dropping restore image catalog entry: \(rejection.description)")
+        }
+        self.entries = result.catalog?.images ?? []
+        self.generatedAt = result.catalog?.generatedAt
+    }
+
+    // MARK: - Parsing
+
+    /// Why one entry, or the whole document, did not survive parsing.
+    enum Rejection: Equatable, CustomStringConvertible {
+        case undecodableDocument
+        case undecodableEntry(index: Int)
+        case insecureURL(build: String, url: URL)
+        case foreignHost(build: String, url: URL)
+        case unparseableVersion(build: String, version: String)
+        case duplicateBuild(build: String)
+
+        var description: String {
+            switch self {
+            case .undecodableDocument:
+                "the document did not decode"
+            case .undecodableEntry(let index):
+                "entry at index \(index) did not decode"
+            case .insecureURL(let build, let url):
+                "\(build) has a non-HTTPS URL (\(url))"
+            case .foreignHost(let build, let url):
+                "\(build) is hosted off Apple (\(url))"
+            case .unparseableVersion(let build, let version):
+                "\(build) has a non-numeric version ('\(version)')"
+            case .duplicateBuild(let build):
+                "\(build) appears more than once"
+            }
+        }
+    }
+
+    struct ParseResult: Equatable {
+        /// `nil` only when the document itself failed to decode.
+        var catalog: RestoreImageCatalog?
+        var rejections: [Rejection]
+    }
+
+    /// Decodes and validates catalog JSON, dropping unusable entries rather than
+    /// failing the whole document.
+    ///
+    /// Pure and non-asserting so the drop paths are testable; ``init(bundle:)``
+    /// is what turns a rejection into a fault, because a rejection in the
+    /// *shipped* resource is a build-time mistake.
+    static func parse(_ data: Data) -> ParseResult {
+        guard let document = try? JSONDecoder().decode(LenientCatalog.self, from: data) else {
+            return ParseResult(catalog: nil, rejections: [.undecodableDocument])
+        }
+
+        var rejections: [Rejection] = document.undecodableIndices.map { .undecodableEntry(index: $0) }
+        var kept: [RestoreImageCatalogEntry] = []
+        var seenBuilds: Set<String> = []
+
+        for entry in document.decodedImages {
+            guard entry.url.scheme?.lowercased() == "https" else {
+                rejections.append(.insecureURL(build: entry.build, url: entry.url))
+                continue
+            }
+            guard let host = entry.url.host(), isAppleHost(host) else {
+                rejections.append(.foreignHost(build: entry.build, url: entry.url))
+                continue
+            }
+            guard entry.versionComponents != nil else {
+                rejections.append(
+                    .unparseableVersion(build: entry.build, version: entry.version))
+                continue
+            }
+            guard seenBuilds.insert(entry.build).inserted else {
+                rejections.append(.duplicateBuild(build: entry.build))
+                continue
+            }
+            kept.append(entry)
+        }
+
+        let catalog = RestoreImageCatalog(
+            device: document.device,
+            generatedAt: document.generatedAt,
+            images: kept.sorted(by: RestoreImageCatalogEntry.isDescending)
+        )
+        return ParseResult(catalog: catalog, rejections: rejections)
+    }
+
+    /// Whether a URL host belongs to Apple.
+    ///
+    /// Both domains are matched on a leading dot so a lookalike registered
+    /// elsewhere cannot pass. Restore images are served from
+    /// `updates.cdn-apple.com`, which is *not* a subdomain of `apple.com` —
+    /// the separator before `apple.com` there is a hyphen.
+    static func isAppleHost(_ host: String) -> Bool {
+        let lowered = host.lowercased()
+        for domain in ["apple.com", "cdn-apple.com"]
+        where
+            lowered == domain || lowered.hasSuffix("." + domain)
+        {
+            return true
+        }
+        return false
+    }
+
+    /// Catalog document whose `images` array tolerates a bad element.
+    ///
+    /// Each element decodes through a wrapper that never throws, so one
+    /// malformed entry costs that entry rather than the document.
+    private struct LenientCatalog: Decodable {
+        let device: String
+        let generatedAt: String
+        let decodedImages: [RestoreImageCatalogEntry]
+        let undecodableIndices: [Int]
+
+        private enum CodingKeys: String, CodingKey {
+            case device, generatedAt, images
+        }
+
+        private struct LenientEntry: Decodable {
+            let entry: RestoreImageCatalogEntry?
+
+            init(from decoder: any Decoder) throws {
+                entry = try? RestoreImageCatalogEntry(from: decoder)
+            }
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            device = try container.decode(String.self, forKey: .device)
+            generatedAt = try container.decode(String.self, forKey: .generatedAt)
+            let lenient = try container.decode([LenientEntry].self, forKey: .images)
+            decodedImages = lenient.compactMap(\.entry)
+            undecodableIndices = lenient.enumerated().compactMap { $0.element.entry == nil ? $0.offset : nil }
+        }
+    }
+}

--- a/Kernova/Services/RestoreImageProbeService.swift
+++ b/Kernova/Services/RestoreImageProbeService.swift
@@ -14,6 +14,20 @@ final class RestoreImageProbeService: RestoreImageProbing {
     /// Comfortably larger than the record plus a maximal comment.
     private static let tailWindow: Int64 = 131_072
 
+    /// How much of the zip64 end-of-directory record to read.
+    ///
+    /// Its fixed fields end at 56 bytes, and the two the probe wants — the
+    /// central directory's size and offset — are the last of them.
+    private static let zip64RecordWindow: Int64 = 64
+
+    /// The most any one ranged read pulls into memory.
+    ///
+    /// The tail and the zip64 record are fixed and small, so this bounds the one
+    /// read whose length the remote file dictates: a zip64 record can claim a
+    /// central directory of any size, while a real IPSW's runs to a few hundred
+    /// kilobytes.
+    private static let maxRangeBytes: Int64 = 16 * 1024 * 1024
+
     private let session: URLSession
 
     init(sessionConfiguration: URLSessionConfiguration? = nil) {
@@ -32,9 +46,11 @@ final class RestoreImageProbeService: RestoreImageProbing {
         }
 
         let sizeBytes = try await totalSize(of: url)
-        guard sizeBytes > 0 else { throw RestoreImageProbeError.unknownSize }
+        guard sizeBytes > 0, let totalBytes = Int64(exactly: sizeBytes) else {
+            throw RestoreImageProbeError.unknownSize
+        }
 
-        switch try await supportsVirtualMachine(url, totalBytes: Int64(sizeBytes)) {
+        switch try await supportsVirtualMachine(url, totalBytes: totalBytes) {
         case .some(true):
             break
         case .some(false):
@@ -44,7 +60,7 @@ final class RestoreImageProbeService: RestoreImageProbing {
         }
 
         let parsed = ProbedRestoreImage.parseFilename(url.lastPathComponent)
-        Self.logger.notice(
+        Self.logger.info(
             "Probed restore image at \(url.host() ?? "?", privacy: .public): \(sizeBytes, privacy: .public) bytes, VM-capable"
         )
         return ProbedRestoreImage(
@@ -55,41 +71,55 @@ final class RestoreImageProbeService: RestoreImageProbing {
 
     /// The file's length in bytes.
     ///
-    /// Read from `HEAD` where the server answers it, and from a one-byte ranged
-    /// `GET`'s `Content-Range` where it does not.
+    /// `HEAD` answers it wherever a server implements it. A server that refuses
+    /// `HEAD` — pre-signed S3 and CloudFront links answer 403, others 405 — still
+    /// serves the ranged `GET`s the rest of the probe is built from, so a
+    /// non-2xx `HEAD` is not fatal: the one-byte ranged `GET`'s `Content-Range`
+    /// settles the size, and its status settles whether the URL is live at all.
     private func totalSize(of url: URL) async throws -> UInt64 {
         var head = URLRequest(url: url)
         head.httpMethod = "HEAD"
-        if let response = try await status(for: head) {
-            guard (200..<300).contains(response.statusCode) else {
-                throw RestoreImageProbeError.unreachable(statusCode: response.statusCode)
-            }
-            if response.expectedContentLength > 0 {
-                return UInt64(response.expectedContentLength)
-            }
+        if let response = try await responseWithoutBody(for: head),
+            (200..<300).contains(response.statusCode),
+            response.expectedContentLength > 0
+        {
+            return UInt64(response.expectedContentLength)
         }
 
         var probe = URLRequest(url: url)
         probe.setValue("bytes=0-0", forHTTPHeaderField: "Range")
-        guard let response = try await status(for: probe) else {
+        guard let response = try await responseWithoutBody(for: probe) else {
             throw RestoreImageProbeError.unknownSize
         }
-        guard (200..<300).contains(response.statusCode) else {
-            throw RestoreImageProbeError.unreachable(statusCode: response.statusCode)
+        guard response.statusCode == 206 else {
+            // 2xx that isn't 206 means the Range header was ignored and the body
+            // is the whole file, which is neither a size nor something to read.
+            guard (200..<300).contains(response.statusCode) else {
+                throw RestoreImageProbeError.unreachable(statusCode: response.statusCode)
+            }
+            throw RestoreImageProbeError.rangeRequestsUnsupported
         }
         // `Content-Range: bytes 0-0/19772077142` — the total is after the slash.
-        if let range = response.value(forHTTPHeaderField: "Content-Range"),
+        guard let range = response.value(forHTTPHeaderField: "Content-Range"),
             let total = range.split(separator: "/").last,
             let bytes = UInt64(total.trimmingCharacters(in: .whitespaces))
-        {
-            return bytes
+        else {
+            throw RestoreImageProbeError.unknownSize
         }
-        throw RestoreImageProbeError.unknownSize
+        return bytes
     }
 
-    private func status(for request: URLRequest) async throws -> HTTPURLResponse? {
+    /// The response to `request`, with its body abandoned unread.
+    ///
+    /// `URLSession.bytes(for:)` surfaces the response as the body starts
+    /// arriving and streams the rest under backpressure, so cancelling here
+    /// costs one read-ahead buffer. `data(for:)` in its place buffers a server's
+    /// entire multi-gigabyte answer to a ranged request before the status can be
+    /// looked at. `nil` means the response was not HTTP.
+    private func responseWithoutBody(for request: URLRequest) async throws -> HTTPURLResponse? {
         do {
-            let (_, response) = try await session.data(for: request)
+            let (stream, response) = try await session.bytes(for: request)
+            stream.task.cancel()
             return response as? HTTPURLResponse
         } catch let error as URLError {
             throw RestoreImageProbeError.transportFailed(
@@ -97,17 +127,46 @@ final class RestoreImageProbeService: RestoreImageProbing {
         }
     }
 
-    /// Fetches a byte range, or `nil` when the server would not serve one.
-    private func range(_ url: URL, from offset: Int64, count: Int64) async -> [UInt8]? {
-        guard count > 0, offset >= 0 else { return nil }
-        var request = URLRequest(url: url)
-        request.setValue(
-            "bytes=\(offset)-\(offset + count - 1)", forHTTPHeaderField: "Range")
-        guard let (data, response) = try? await session.data(for: request),
-            let http = response as? HTTPURLResponse,
-            http.statusCode == 206 || http.statusCode == 200
+    /// Fetches a byte range, or `nil` when the server would not serve that one.
+    ///
+    /// Only 206 is accepted: a 200 means the server ignored the `Range` header
+    /// and is sending the entire file, so the response is abandoned rather than
+    /// read. The body is streamed and stopped at `count` bytes, which is what
+    /// keeps a mis-sized or hostile length from becoming an unbounded read.
+    private func range(_ url: URL, from offset: Int64, count: Int64) async throws -> [UInt8]? {
+        guard offset >= 0, count > 0, count <= Self.maxRangeBytes,
+            let limit = Int(exactly: count)
         else { return nil }
-        return [UInt8](data)
+        let (last, overflowed) = offset.addingReportingOverflow(count - 1)
+        guard !overflowed else { return nil }
+
+        var request = URLRequest(url: url)
+        request.setValue("bytes=\(offset)-\(last)", forHTTPHeaderField: "Range")
+        guard let (stream, response) = try? await session.bytes(for: request) else { return nil }
+        guard let http = response as? HTTPURLResponse else {
+            stream.task.cancel()
+            return nil
+        }
+        guard http.statusCode == 206 else {
+            stream.task.cancel()
+            // 2xx that isn't 206 means the Range header was ignored and the body
+            // is the whole file, so no read here can ever be satisfied.
+            guard (200..<300).contains(http.statusCode) else { return nil }
+            throw RestoreImageProbeError.rangeRequestsUnsupported
+        }
+
+        var buffer: [UInt8] = []
+        do {
+            for try await byte in stream {
+                buffer.append(byte)
+                if buffer.count == limit { break }
+            }
+        } catch {
+            stream.task.cancel()
+            return nil
+        }
+        stream.task.cancel()
+        return buffer
     }
 
     // MARK: - Zip directory
@@ -124,29 +183,60 @@ final class RestoreImageProbeService: RestoreImageProbing {
     /// `nil` means the structure could not be read, which is not the same as a "no".
     private func supportsVirtualMachine(_ url: URL, totalBytes: Int64) async throws -> Bool? {
         let tailStart = max(0, totalBytes - Self.tailWindow)
-        guard let tail = await range(url, from: tailStart, count: totalBytes - tailStart),
+        guard let tail = try await range(url, from: tailStart, count: totalBytes - tailStart),
             let eocd = Self.lastIndex(of: [0x50, 0x4B, 0x05, 0x06], in: tail),
             var directorySize = Self.readLE(tail, eocd + 12, UInt32.self).map(Int64.init),
             var directoryOffset = Self.readLE(tail, eocd + 16, UInt32.self).map(Int64.init)
         else { return nil }
 
-        // Restore images exceed 4 GB, so the real offsets live in the zip64
-        // record the locator points at; the 32-bit fields above are sentinels.
-        if let locator = Self.lastIndex(of: [0x50, 0x4B, 0x06, 0x07], in: tail),
-            let zip64Offset = Self.readLE(tail, locator + 8, UInt64.self),
-            let header = await range(url, from: Int64(zip64Offset), count: 64),
-            Array(header.prefix(4)) == [0x50, 0x4B, 0x06, 0x06],
-            let size = Self.readLE(header, 40, UInt64.self),
-            let offset = Self.readLE(header, 48, UInt64.self)
-        {
-            directorySize = Int64(size)
-            directoryOffset = Int64(offset)
+        // Restore images exceed 4 GB, so where a locator is present the real
+        // offsets live in the zip64 record it points at and the 32-bit fields
+        // above are sentinels — an unusable record is unreadable structure, not
+        // a reason to trust the sentinels.
+        if let locator = Self.lastIndex(of: [0x50, 0x4B, 0x06, 0x07], in: tail) {
+            guard
+                let bounds = try await zip64DirectoryBounds(
+                    url, tail: tail, locator: locator, totalBytes: totalBytes)
+            else { return nil }
+            directoryOffset = bounds.offset
+            directorySize = bounds.size
         }
 
-        guard directorySize > 0, directoryOffset >= 0,
-            let directory = await range(url, from: directoryOffset, count: directorySize)
+        guard Self.fits(offset: directoryOffset, count: directorySize, within: totalBytes),
+            let directory = try await range(
+                url, from: directoryOffset, count: min(directorySize, Self.maxRangeBytes))
         else { return nil }
         return Self.lastIndex(of: [UInt8]("vma2".utf8), in: directory) != nil
+    }
+
+    /// The central directory's offset and size, read from the zip64 record the
+    /// locator at `locator` points at.
+    ///
+    /// Every field here is remote-controlled, so each is checked to be
+    /// representable as an `Int64` and to name a read that lands inside the file
+    /// before it becomes a request. `nil` means the record is unusable.
+    private func zip64DirectoryBounds(
+        _ url: URL, tail: [UInt8], locator: Int, totalBytes: Int64
+    ) async throws -> (offset: Int64, size: Int64)? {
+        guard let recordOffset = Self.readLE(tail, locator + 8, UInt64.self),
+            let recordStart = Int64(exactly: recordOffset),
+            Self.fits(offset: recordStart, count: Self.zip64RecordWindow, within: totalBytes),
+            let record = try await range(
+                url, from: recordStart, count: Self.zip64RecordWindow),
+            Array(record.prefix(4)) == [0x50, 0x4B, 0x06, 0x06],
+            let size = Self.readLE(record, 40, UInt64.self),
+            let offset = Self.readLE(record, 48, UInt64.self),
+            let directorySize = Int64(exactly: size),
+            let directoryOffset = Int64(exactly: offset)
+        else { return nil }
+        return (directoryOffset, directorySize)
+    }
+
+    /// Whether a `count`-byte read at `offset` lands wholly inside a file of `totalBytes`.
+    private static func fits(offset: Int64, count: Int64, within totalBytes: Int64) -> Bool {
+        guard offset >= 0, count > 0 else { return false }
+        let (end, overflowed) = offset.addingReportingOverflow(count)
+        return !overflowed && end <= totalBytes
     }
 
     static func readLE<T: FixedWidthInteger>(_ bytes: [UInt8], _ offset: Int, _ type: T.Type) -> T? {

--- a/Kernova/Services/RestoreImageProbeService.swift
+++ b/Kernova/Services/RestoreImageProbeService.swift
@@ -1,0 +1,168 @@
+import Foundation
+import os
+
+/// Checks a user-supplied restore image URL before anything is downloaded.
+///
+/// A class rather than a struct so `deinit` can invalidate the `URLSession`, the
+/// same reason `IPSWService` is one.
+final class RestoreImageProbeService: RestoreImageProbing {
+    private static let logger = Logger(
+        subsystem: "app.kernova", category: "RestoreImageProbeService")
+
+    /// How much of the file's tail to read looking for the zip end-of-directory record.
+    ///
+    /// Comfortably larger than the record plus a maximal comment.
+    private static let tailWindow: Int64 = 131_072
+
+    private let session: URLSession
+
+    init(sessionConfiguration: URLSessionConfiguration? = nil) {
+        let configuration = sessionConfiguration ?? .ephemeral
+        configuration.timeoutIntervalForRequest = 30
+        self.session = URLSession(configuration: configuration)
+    }
+
+    deinit {
+        session.finishTasksAndInvalidate()
+    }
+
+    func probe(_ url: URL) async throws -> ProbedRestoreImage {
+        guard url.scheme?.lowercased() == "https" else {
+            throw RestoreImageProbeError.insecureURL
+        }
+
+        let sizeBytes = try await totalSize(of: url)
+        guard sizeBytes > 0 else { throw RestoreImageProbeError.unknownSize }
+
+        switch try await supportsVirtualMachine(url, totalBytes: Int64(sizeBytes)) {
+        case .some(true):
+            break
+        case .some(false):
+            throw RestoreImageProbeError.notAVirtualMachineImage
+        case .none:
+            throw RestoreImageProbeError.unreadableStructure
+        }
+
+        let parsed = ProbedRestoreImage.parseFilename(url.lastPathComponent)
+        Self.logger.notice(
+            "Probed restore image at \(url.host() ?? "?", privacy: .public): \(sizeBytes, privacy: .public) bytes, VM-capable"
+        )
+        return ProbedRestoreImage(
+            url: url, sizeBytes: sizeBytes, version: parsed.version, build: parsed.build)
+    }
+
+    // MARK: - HTTP
+
+    /// The file's length in bytes.
+    ///
+    /// Read from `HEAD` where the server answers it, and from a one-byte ranged
+    /// `GET`'s `Content-Range` where it does not.
+    private func totalSize(of url: URL) async throws -> UInt64 {
+        var head = URLRequest(url: url)
+        head.httpMethod = "HEAD"
+        if let response = try await status(for: head) {
+            guard (200..<300).contains(response.statusCode) else {
+                throw RestoreImageProbeError.unreachable(statusCode: response.statusCode)
+            }
+            if response.expectedContentLength > 0 {
+                return UInt64(response.expectedContentLength)
+            }
+        }
+
+        var probe = URLRequest(url: url)
+        probe.setValue("bytes=0-0", forHTTPHeaderField: "Range")
+        guard let response = try await status(for: probe) else {
+            throw RestoreImageProbeError.unknownSize
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            throw RestoreImageProbeError.unreachable(statusCode: response.statusCode)
+        }
+        // `Content-Range: bytes 0-0/19772077142` — the total is after the slash.
+        if let range = response.value(forHTTPHeaderField: "Content-Range"),
+            let total = range.split(separator: "/").last,
+            let bytes = UInt64(total.trimmingCharacters(in: .whitespaces))
+        {
+            return bytes
+        }
+        throw RestoreImageProbeError.unknownSize
+    }
+
+    private func status(for request: URLRequest) async throws -> HTTPURLResponse? {
+        do {
+            let (_, response) = try await session.data(for: request)
+            return response as? HTTPURLResponse
+        } catch let error as URLError {
+            throw RestoreImageProbeError.transportFailed(
+                description: error.localizedDescription)
+        }
+    }
+
+    /// Fetches a byte range, or `nil` when the server would not serve one.
+    private func range(_ url: URL, from offset: Int64, count: Int64) async -> [UInt8]? {
+        guard count > 0, offset >= 0 else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue(
+            "bytes=\(offset)-\(offset + count - 1)", forHTTPHeaderField: "Range")
+        guard let (data, response) = try? await session.data(for: request),
+            let http = response as? HTTPURLResponse,
+            http.statusCode == 206 || http.statusCode == 200
+        else { return nil }
+        return [UInt8](data)
+    }
+
+    // MARK: - Zip directory
+
+    /// Whether a restore image contains the virtual-machine hardware model.
+    ///
+    /// An IPSW is a zip. Its central directory lists `kernelcache.release.vma2`
+    /// and `apticket.vma2macosap.im4m` exactly when the image can install into a
+    /// VM, so reading the directory alone settles it — three ranged requests and
+    /// roughly 150 KB rather than the whole multi-gigabyte file. This is the same
+    /// check `Tools/regen-restore-image-catalog.swift` applies to every catalog
+    /// candidate, which is what makes a pasted URL as trustworthy as a catalog row.
+    ///
+    /// `nil` means the structure could not be read, which is not the same as a "no".
+    private func supportsVirtualMachine(_ url: URL, totalBytes: Int64) async throws -> Bool? {
+        let tailStart = max(0, totalBytes - Self.tailWindow)
+        guard let tail = await range(url, from: tailStart, count: totalBytes - tailStart),
+            let eocd = Self.lastIndex(of: [0x50, 0x4B, 0x05, 0x06], in: tail),
+            var directorySize = Self.readLE(tail, eocd + 12, UInt32.self).map(Int64.init),
+            var directoryOffset = Self.readLE(tail, eocd + 16, UInt32.self).map(Int64.init)
+        else { return nil }
+
+        // Restore images exceed 4 GB, so the real offsets live in the zip64
+        // record the locator points at; the 32-bit fields above are sentinels.
+        if let locator = Self.lastIndex(of: [0x50, 0x4B, 0x06, 0x07], in: tail),
+            let zip64Offset = Self.readLE(tail, locator + 8, UInt64.self),
+            let header = await range(url, from: Int64(zip64Offset), count: 64),
+            Array(header.prefix(4)) == [0x50, 0x4B, 0x06, 0x06],
+            let size = Self.readLE(header, 40, UInt64.self),
+            let offset = Self.readLE(header, 48, UInt64.self)
+        {
+            directorySize = Int64(size)
+            directoryOffset = Int64(offset)
+        }
+
+        guard directorySize > 0, directoryOffset >= 0,
+            let directory = await range(url, from: directoryOffset, count: directorySize)
+        else { return nil }
+        return Self.lastIndex(of: [UInt8]("vma2".utf8), in: directory) != nil
+    }
+
+    static func readLE<T: FixedWidthInteger>(_ bytes: [UInt8], _ offset: Int, _ type: T.Type) -> T? {
+        let width = MemoryLayout<T>.size
+        guard offset >= 0, offset + width <= bytes.count else { return nil }
+        var value: T = 0
+        for index in (0..<width).reversed() { value = (value << 8) | T(bytes[offset + index]) }
+        return value
+    }
+
+    static func lastIndex(of needle: [UInt8], in haystack: [UInt8]) -> Int? {
+        guard haystack.count >= needle.count, !needle.isEmpty else { return nil }
+        for start in stride(from: haystack.count - needle.count, through: 0, by: -1)
+        where Array(haystack[start..<start + needle.count]) == needle {
+            return start
+        }
+        return nil
+    }
+}

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -85,7 +85,8 @@ final class VMCreationViewModel {
     private(set) var pastedImage: ProbedRestoreImage?
     /// Always inside Downloads — there is no custom-destination picker.
     ///
-    /// The filename is Apple's for a catalog pick, `RestoreImage.ipsw` otherwise.
+    /// A pinned pick names the file through ``RestoreImageFilename``;
+    /// "Download Latest" keeps the fixed default.
     var ipswDownloadPath: String = VMCreationViewModel.defaultIPSWDownloadPath {
         didSet {
             if ipswDownloadPath != confirmedOverwritePath {
@@ -228,7 +229,7 @@ final class VMCreationViewModel {
     // MARK: - Defaults
 
     static var defaultIPSWDownloadPath: String {
-        downloadPath(forFilename: "RestoreImage.ipsw")
+        downloadPath(forFilename: RestoreImageFilename.fallback)
     }
 
     /// The Downloads path for a given IPSW filename.
@@ -237,6 +238,10 @@ final class VMCreationViewModel {
     /// home-relative layout: under the sandbox this resolves through the
     /// container's `Downloads` symlink, which the downloads.read-write
     /// entitlement covers — no save panel or bookmark needed.
+    ///
+    /// `filename` must be one path component: callers derive it through
+    /// ``RestoreImageFilename``, which is what keeps a URL-supplied name from
+    /// walking out of Downloads.
     static func downloadPath(forFilename filename: String) -> String {
         guard
             let downloads = FileManager.default.urls(
@@ -417,6 +422,9 @@ final class VMCreationViewModel {
         case mismatch(expected: String, found: InspectedRestoreImage)
         /// Not adoptable at all; the message is user-facing.
         case unusable(message: String)
+        /// The caller cancelled while the inspection ran; nothing was changed,
+        /// and the verdict describes a destination the wizard may have left.
+        case cancelled
     }
 
     /// Checks the file sitting at the download destination, and adopts it only
@@ -426,17 +434,23 @@ final class VMCreationViewModel {
     /// that is a *valid but different* macOS installs silently — the same
     /// wrong-image failure the per-build destination fixes for downloads, which
     /// a stale or hand-placed file reintroduces.
+    ///
+    /// Reading a multi-gigabyte image takes seconds, in which the user can pick
+    /// another source or leave the step: a cancelled call returns
+    /// ``ExistingFileVerdict/cancelled`` having changed nothing.
     func adoptExistingDownloadFile() async -> ExistingFileVerdict {
         let url = URL(fileURLWithPath: ipswDownloadPath)
         let inspected: InspectedRestoreImage
         do {
             inspected = try await localImageInspector.inspect(url)
         } catch {
+            if Task.isCancelled { return .cancelled }
             let message =
                 (error as? LocalRestoreImageError)?.errorDescription
                 ?? LocalRestoreImageError.unreadable.errorDescription
             return .unusable(message: message ?? "That file isn't a usable restore image.")
         }
+        if Task.isCancelled { return .cancelled }
 
         guard inspected.isSupportedOnThisHost else {
             return .unusable(

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -23,13 +23,14 @@ enum VMCreationStep: String, CaseIterable, Sendable {
 enum IPSWSource: Sendable {
     case downloadLatest
     case catalogVersion
+    case customURL
     case localFile
 
     /// Whether this source obtains the image over the network, and so shares
     /// the download destination, overwrite warning, and resume affordance.
     var downloadsImage: Bool {
         switch self {
-        case .downloadLatest, .catalogVersion: true
+        case .downloadLatest, .catalogVersion, .customURL: true
         case .localFile: false
         }
     }
@@ -47,8 +48,15 @@ final class VMCreationViewModel {
     /// touch it.
     let catalogService: any RestoreImageCatalogProviding
 
-    init(catalogService: any RestoreImageCatalogProviding = RestoreImageCatalogService()) {
+    /// Backs the "Paste an IPSW URL…" sheet's pre-download check.
+    let probeService: any RestoreImageProbing
+
+    init(
+        catalogService: any RestoreImageCatalogProviding = RestoreImageCatalogService(),
+        probeService: any RestoreImageProbing = RestoreImageProbeService()
+    ) {
         self.catalogService = catalogService
+        self.probeService = probeService
     }
 
     // MARK: - Wizard State
@@ -67,6 +75,9 @@ final class VMCreationViewModel {
     /// The catalog image chosen for `.catalogVersion`, set through
     /// ``selectCatalogEntry(_:)`` so the download destination moves with it.
     private(set) var selectedCatalogEntry: RestoreImageCatalogEntry?
+    /// The checked image accepted for `.customURL`, set through
+    /// ``selectPastedImage(_:)`` on the same terms.
+    private(set) var pastedImage: ProbedRestoreImage?
     /// Always inside Downloads — there is no custom-destination picker.
     ///
     /// The filename is Apple's for a catalog pick, `RestoreImage.ipsw` otherwise.
@@ -122,6 +133,9 @@ final class VMCreationViewModel {
                 case .catalogVersion:
                     if selectedCatalogEntry == nil { return "Choose a macOS version to continue." }
                     if shouldShowOverwriteWarning { return "Resolve the file conflict above to continue." }
+                case .customURL:
+                    if pastedImage == nil { return "Add a restore image URL to continue." }
+                    if shouldShowOverwriteWarning { return "Resolve the file conflict above to continue." }
                 case .localFile:
                     if ipswPath == nil { return "Select a restore image file." }
                 }
@@ -168,6 +182,7 @@ final class VMCreationViewModel {
             switch ipswSource {
             case .downloadLatest: !shouldShowOverwriteWarning
             case .catalogVersion: selectedCatalogEntry != nil && !shouldShowOverwriteWarning
+            case .customURL: pastedImage != nil && !shouldShowOverwriteWarning
             case .localFile: ipswPath != nil
             }
         case .linux:
@@ -248,11 +263,20 @@ final class VMCreationViewModel {
         ipswDownloadPath = Self.downloadPath(forFilename: entry.suggestedFilename)
     }
 
+    /// Commits a checked URL, on the same per-image destination terms as a
+    /// catalog pick.
+    func selectPastedImage(_ image: ProbedRestoreImage) {
+        ipswSource = .customURL
+        pastedImage = image
+        ipswDownloadPath = Self.downloadPath(forFilename: image.suggestedFilename)
+    }
+
     /// Commits the "Download Latest" source, returning the destination to the
     /// fixed filename that source has always resolved to at install time.
     func selectDownloadLatest() {
         ipswSource = .downloadLatest
         selectedCatalogEntry = nil
+        pastedImage = nil
         ipswDownloadPath = Self.defaultIPSWDownloadPath
     }
 
@@ -311,6 +335,24 @@ final class VMCreationViewModel {
                 remoteURL: entry.url,
                 version: entry.version,
                 build: entry.build
+            )
+        case .customURL:
+            guard let image = pastedImage else {
+                Self.logger.fault("URL source selected with no checked image")
+                assertionFailure("URL source selected with no checked image")
+                return MacOSInstallContext(
+                    source: .downloadLatest,
+                    downloadDestinationPath: Self.defaultIPSWDownloadPath
+                )
+            }
+            return MacOSInstallContext(
+                source: .customURL,
+                downloadDestinationPath: ipswDownloadPath,
+                requestedFreshDownload: confirmedOverwritePath != nil
+                    && confirmedOverwritePath == ipswDownloadPath,
+                remoteURL: image.url,
+                version: image.version,
+                build: image.build
             )
         case .localFile:
             return MacOSInstallContext(

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -22,7 +22,17 @@ enum VMCreationStep: String, CaseIterable, Sendable {
 /// IPSW source selection for macOS VM creation.
 enum IPSWSource: Sendable {
     case downloadLatest
+    case catalogVersion
     case localFile
+
+    /// Whether this source obtains the image over the network, and so shares
+    /// the download destination, overwrite warning, and resume affordance.
+    var downloadsImage: Bool {
+        switch self {
+        case .downloadLatest, .catalogVersion: true
+        case .localFile: false
+        }
+    }
 }
 
 /// State machine for the VM creation wizard.
@@ -30,6 +40,16 @@ enum IPSWSource: Sendable {
 @Observable
 final class VMCreationViewModel {
     private static let logger = Logger(subsystem: "app.kernova", category: "VMCreationViewModel")
+
+    /// Backs the "Choose a Version…" picker.
+    ///
+    /// Read only while that source is selected; the other two sources never
+    /// touch it.
+    let catalogService: any RestoreImageCatalogProviding
+
+    init(catalogService: any RestoreImageCatalogProviding = RestoreImageCatalogService()) {
+        self.catalogService = catalogService
+    }
 
     // MARK: - Wizard State
 
@@ -44,7 +64,12 @@ final class VMCreationViewModel {
     var selectedBootMode: VMBootMode = .efi
     var ipswSource: IPSWSource = .downloadLatest
     var ipswPath: String?
-    /// Always the Downloads default — there is no custom-destination picker.
+    /// The catalog image chosen for `.catalogVersion`, set through
+    /// ``selectCatalogEntry(_:)`` so the download destination moves with it.
+    private(set) var selectedCatalogEntry: RestoreImageCatalogEntry?
+    /// Always inside Downloads — there is no custom-destination picker.
+    ///
+    /// The filename is Apple's for a catalog pick, `RestoreImage.ipsw` otherwise.
     var ipswDownloadPath: String = VMCreationViewModel.defaultIPSWDownloadPath {
         didSet {
             if ipswDownloadPath != confirmedOverwritePath {
@@ -94,6 +119,9 @@ final class VMCreationViewModel {
                 switch ipswSource {
                 case .downloadLatest:
                     if shouldShowOverwriteWarning { return "Resolve the file conflict above to continue." }
+                case .catalogVersion:
+                    if selectedCatalogEntry == nil { return "Choose a macOS version to continue." }
+                    if shouldShowOverwriteWarning { return "Resolve the file conflict above to continue." }
                 case .localFile:
                     if ipswPath == nil { return "Select a restore image file." }
                 }
@@ -139,6 +167,7 @@ final class VMCreationViewModel {
         case .macOS:
             switch ipswSource {
             case .downloadLatest: !shouldShowOverwriteWarning
+            case .catalogVersion: selectedCatalogEntry != nil && !shouldShowOverwriteWarning
             case .localFile: ipswPath != nil
             }
         case .linux:
@@ -179,10 +208,16 @@ final class VMCreationViewModel {
     // MARK: - Defaults
 
     static var defaultIPSWDownloadPath: String {
-        // Ask the system for the Downloads location rather than assuming a
-        // home-relative layout: under the sandbox this resolves through the
-        // container's `Downloads` symlink, which the downloads.read-write
-        // entitlement covers — no save panel or bookmark needed.
+        downloadPath(forFilename: "RestoreImage.ipsw")
+    }
+
+    /// The Downloads path for a given IPSW filename.
+    ///
+    /// Asks the system for the Downloads location rather than assuming a
+    /// home-relative layout: under the sandbox this resolves through the
+    /// container's `Downloads` symlink, which the downloads.read-write
+    /// entitlement covers — no save panel or bookmark needed.
+    static func downloadPath(forFilename filename: String) -> String {
         guard
             let downloads = FileManager.default.urls(
                 for: .downloadsDirectory, in: .userDomainMask
@@ -191,10 +226,34 @@ final class VMCreationViewModel {
             logger.fault("No Downloads directory in userDomainMask")
             assertionFailure("FileManager returned no Downloads directory")
             return FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent("Downloads/RestoreImage.ipsw")
+                .appendingPathComponent("Downloads")
+                .appendingPathComponent(filename)
                 .path(percentEncoded: false)
         }
-        return downloads.appendingPathComponent("RestoreImage.ipsw").path(percentEncoded: false)
+        return downloads.appendingPathComponent(filename).path(percentEncoded: false)
+    }
+
+    // MARK: - Source Selection
+
+    /// Commits a catalog pick, moving the download destination to Apple's own
+    /// filename for that build.
+    ///
+    /// Per-build destinations are what keep a pick honest: a single fixed
+    /// filename would let an already-downloaded image of a *different* version
+    /// satisfy the download step, installing something other than what the
+    /// wizard shows.
+    func selectCatalogEntry(_ entry: RestoreImageCatalogEntry) {
+        ipswSource = .catalogVersion
+        selectedCatalogEntry = entry
+        ipswDownloadPath = Self.downloadPath(forFilename: entry.suggestedFilename)
+    }
+
+    /// Commits the "Download Latest" source, returning the destination to the
+    /// fixed filename that source has always resolved to at install time.
+    func selectDownloadLatest() {
+        ipswSource = .downloadLatest
+        selectedCatalogEntry = nil
+        ipswDownloadPath = Self.defaultIPSWDownloadPath
     }
 
     // MARK: - Apply Defaults
@@ -212,7 +271,7 @@ final class VMCreationViewModel {
     }
 
     var shouldShowOverwriteWarning: Bool {
-        ipswSource == .downloadLatest
+        ipswSource.downloadsImage
             && ipswDownloadPathFileExists
             && confirmedOverwritePath != ipswDownloadPath
     }
@@ -235,6 +294,24 @@ final class VMCreationViewModel {
                 requestedFreshDownload: confirmedOverwritePath != nil
                     && confirmedOverwritePath == ipswDownloadPath
             )
+        case .catalogVersion:
+            guard let entry = selectedCatalogEntry else {
+                Self.logger.fault("Catalog source selected with no chosen entry")
+                assertionFailure("Catalog source selected with no chosen entry")
+                return MacOSInstallContext(
+                    source: .downloadLatest,
+                    downloadDestinationPath: Self.defaultIPSWDownloadPath
+                )
+            }
+            return MacOSInstallContext(
+                source: .catalogVersion,
+                downloadDestinationPath: ipswDownloadPath,
+                requestedFreshDownload: confirmedOverwritePath != nil
+                    && confirmedOverwritePath == ipswDownloadPath,
+                remoteURL: entry.url,
+                version: entry.version,
+                build: entry.build
+            )
         case .localFile:
             return MacOSInstallContext(
                 source: .localFile,
@@ -254,7 +331,7 @@ final class VMCreationViewModel {
     /// The bytes check (`isResumable` rather than `exists`) keeps a husk left by
     /// a failed disposal from offering a resume with nothing behind it.
     var hasResumableDownload: Bool {
-        guard ipswSource == .downloadLatest,
+        guard ipswSource.downloadsImage,
             !ipswDownloadPathFileExists
         else { return false }
         let bundleURL = IPSWService.resumeBundleURL(for: URL(fileURLWithPath: ipswDownloadPath))

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -51,12 +51,17 @@ final class VMCreationViewModel {
     /// Backs the "Paste an IPSW URL…" sheet's pre-download check.
     let probeService: any RestoreImageProbing
 
+    /// Reads an IPSW already on disk before the wizard adopts it.
+    let localImageInspector: any LocalRestoreImageInspecting
+
     init(
         catalogService: any RestoreImageCatalogProviding = RestoreImageCatalogService(),
-        probeService: any RestoreImageProbing = RestoreImageProbeService()
+        probeService: any RestoreImageProbing = RestoreImageProbeService(),
+        localImageInspector: any LocalRestoreImageInspecting = LocalRestoreImageInspector()
     ) {
         self.catalogService = catalogService
         self.probeService = probeService
+        self.localImageInspector = localImageInspector
     }
 
     // MARK: - Wizard State
@@ -391,6 +396,60 @@ final class VMCreationViewModel {
         // Downloads location is entitlement-covered. Clearing also drops any
         // bookmark left over from an earlier local-file pick.
         ipswBookmark = nil
+    }
+
+    /// The build the wizard is currently promising, or `nil` when the source
+    /// names no particular image.
+    var pinnedBuild: String? {
+        switch ipswSource {
+        case .catalogVersion: selectedCatalogEntry?.build
+        case .customURL: pastedImage?.build
+        case .downloadLatest, .localFile: nil
+        }
+    }
+
+    /// What inspecting the file at the download destination established.
+    enum ExistingFileVerdict: Equatable {
+        /// Adopted. Carries what the file turned out to be.
+        case adopted(InspectedRestoreImage)
+        /// A different build than the one the wizard is showing; **not** adopted,
+        /// so the user decides.
+        case mismatch(expected: String, found: InspectedRestoreImage)
+        /// Not adoptable at all; the message is user-facing.
+        case unusable(message: String)
+    }
+
+    /// Checks the file sitting at the download destination, and adopts it only
+    /// if it is the image the wizard is promising.
+    ///
+    /// Without this, "Use Existing File" takes whatever is at the path. A file
+    /// that is a *valid but different* macOS installs silently — the same
+    /// wrong-image failure the per-build destination fixes for downloads, which
+    /// a stale or hand-placed file reintroduces.
+    func adoptExistingDownloadFile() async -> ExistingFileVerdict {
+        let url = URL(fileURLWithPath: ipswDownloadPath)
+        let inspected: InspectedRestoreImage
+        do {
+            inspected = try await localImageInspector.inspect(url)
+        } catch {
+            let message =
+                (error as? LocalRestoreImageError)?.errorDescription
+                ?? LocalRestoreImageError.unreadable.errorDescription
+            return .unusable(message: message ?? "That file isn't a usable restore image.")
+        }
+
+        guard inspected.isSupportedOnThisHost else {
+            return .unusable(
+                message: LocalRestoreImageError.unsupported.errorDescription
+                    ?? "That restore image can't install on this Mac.")
+        }
+
+        if let pinnedBuild, pinnedBuild != inspected.build {
+            return .mismatch(expected: pinnedBuild, found: inspected)
+        }
+
+        useExistingDownloadFile()
+        return .adopted(inspected)
     }
 
     // MARK: - Build Configuration

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -109,8 +109,7 @@ final class VMLibraryViewModel {
             virtualizationService: virtualizationService,
             installService: installService,
             ipswService: ipswService,
-            usbDeviceService: usbDeviceService,
-            fileSystem: fileSystem
+            usbDeviceService: usbDeviceService
         )
 
         loadVMs()
@@ -756,13 +755,14 @@ final class VMLibraryViewModel {
 
     /// Trashes any in-progress IPSW download bundle for a VM that's being deleted.
     ///
-    /// The `.kernovadownload` bundle holding the partial bytes and resume metadata
-    /// is discarded unconditionally (not gated on the "delete externals" toggle),
-    /// using the same disposition as the VM itself. The completed IPSW at
-    /// `downloadDestinationPath` lives at a user-known path and is left alone.
+    /// Every install source that fetches its image writes the same
+    /// `.kernovadownload` sidecar, so all of them are covered; the "delete
+    /// externals" toggle does not gate it, and the disposition matches the VM's
+    /// own. The completed IPSW at `downloadDestinationPath` lives at a user-known
+    /// path and is left alone.
     private func cleanupInstallResumeData(for instance: VMInstance, permanently: Bool) {
         guard let context = instance.configuration.installContext,
-            context.source == .downloadLatest,
+            context.source.downloadsImage,
             let destinationURL = context.downloadDestinationURL
         else { return }
         lifecycle.ipswService.discardResumeData(at: destinationURL, permanently: permanently)

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -17,7 +17,6 @@ final class VMLifecycleCoordinator {
     let installService: any MacOSInstallProviding
     let ipswService: any IPSWProviding
     let usbDeviceService: any USBDeviceProviding
-    let fileSystem: any FileSystemOperating
 
     /// The directory IPSW downloads must land in — the one location the
     /// sandbox's downloads entitlement covers.
@@ -35,7 +34,6 @@ final class VMLifecycleCoordinator {
         installService: any MacOSInstallProviding,
         ipswService: any IPSWProviding,
         usbDeviceService: any USBDeviceProviding = USBDeviceService(),
-        fileSystem: any FileSystemOperating = FileManager.default,
         downloadsDirectory: URL? = FileManager.default.urls(
             for: .downloadsDirectory, in: .userDomainMask
         ).first
@@ -44,7 +42,6 @@ final class VMLifecycleCoordinator {
         self.installService = installService
         self.ipswService = ipswService
         self.usbDeviceService = usbDeviceService
-        self.fileSystem = fileSystem
         self.downloadsDirectory = downloadsDirectory
     }
 
@@ -153,30 +150,47 @@ final class VMLifecycleCoordinator {
     // MARK: - macOS Installation
 
     /// The effective IPSW download destination for a persisted path: the path
-    /// itself when it lives in `downloadsDirectory`, otherwise `fallbackFilename`
-    /// inside Downloads (the wizard default when none is given).
+    /// itself when it names a file directly inside `downloadsDirectory`,
+    /// otherwise the destination `remoteURL` derives inside Downloads (the
+    /// wizard default when there is no pinned URL).
     ///
     /// Downloads is the only destination the app supports — the sandbox
     /// entitlement covers it, resume sidecar included, with no per-pick grant.
-    /// Comparison is symlink-resolved because the sandbox container's `Downloads`
-    /// and the real `~/Downloads` are the same directory spelled two ways.
     ///
-    /// A catalog install passes its pinned image's filename, because the shared
-    /// default name would let a stale download of another version stand in for
-    /// the chosen one.
+    /// The replacement is built from the remote URL through
+    /// ``RestoreImageFilename`` rather than from the persisted path, because
+    /// both the path and the URL come out of a `config.json` a user can edit:
+    /// only a filename this app derived is safe to append to Downloads.
     func normalizedDownloadDestination(
-        for persisted: URL, fallbackFilename: String? = nil
+        for persisted: URL, remoteURL: URL? = nil
     ) -> URL {
         guard let downloads = downloadsDirectory else { return persisted }
-        let persistedParent = persisted.deletingLastPathComponent()
-            .resolvingSymlinksInPath().standardizedFileURL
-        let downloadsResolved = downloads.resolvingSymlinksInPath().standardizedFileURL
-        guard persistedParent.path != downloadsResolved.path else { return persisted }
-        guard let fallbackFilename else {
-            return URL(fileURLWithPath: VMCreationViewModel.defaultIPSWDownloadPath)
-        }
-        return URL(
-            fileURLWithPath: VMCreationViewModel.downloadPath(forFilename: fallbackFilename))
+        guard !isInsideDownloads(persisted) else { return persisted }
+        let filename =
+            remoteURL.map(RestoreImageFilename.destination(for:))
+            ?? RestoreImageFilename.fallback
+        return downloads.appendingPathComponent(filename)
+    }
+
+    /// Whether `candidate` names a file sitting directly in the Downloads
+    /// directory, which the directory itself does not.
+    ///
+    /// Symlink-resolved because the sandbox container's `Downloads` and the real
+    /// `~/Downloads` are the same directory spelled two ways. Always `true` when
+    /// normalization is disabled.
+    private func isInsideDownloads(_ candidate: URL) -> Bool {
+        guard let downloads = downloadsDirectory else { return true }
+        let downloadsPath = Self.canonicalPath(downloads)
+        guard Self.canonicalPath(candidate) != downloadsPath else { return false }
+        return Self.canonicalPath(candidate.deletingLastPathComponent()) == downloadsPath
+    }
+
+    /// A path with symlinks resolved, `..` collapsed and any trailing separator
+    /// dropped, so two spellings of one location compare equal.
+    private static func canonicalPath(_ url: URL) -> String {
+        let path = url.resolvingSymlinksInPath().standardizedFileURL.path(percentEncoded: false)
+        guard path.count > 1, path.hasSuffix("/") else { return path }
+        return String(path.dropLast())
     }
 
     func installMacOS(
@@ -207,21 +221,19 @@ final class VMLifecycleCoordinator {
                     // config.json) can never be written and has no picker to
                     // re-point it, so the invariant is enforced at use time.
                     let downloadDestination = normalizedDownloadDestination(
-                        for: persistedDestination,
-                        fallbackFilename: context.remoteURL?.lastPathComponent)
+                        for: persistedDestination, remoteURL: context.remoteURL)
                     if downloadDestination != persistedDestination {
                         Self.logger.notice(
-                            "installMacOS: persisted download destination is outside Downloads; using the default destination instead"
+                            "installMacOS: persisted download destination is outside Downloads; using the derived destination instead"
                         )
                     }
 
-                    // Honor "Download & Replace" intent ONCE: trash the existing
-                    // IPSW plus any in-progress download bundle beside it, then
-                    // clear the flag so a retry after a partial-install failure
-                    // reuses the freshly-downloaded file. Trash failure is a hard
-                    // error — the skip-existing fast path inside
-                    // `downloadRestoreImage` would otherwise silently reuse the
-                    // stale file.
+                    // Honor "Download & Replace" intent ONCE: the download
+                    // trashes the existing IPSW and any bundle beside it while
+                    // holding its per-destination claim — trashing from out here
+                    // could delete bytes another VM is streaming into the same
+                    // bundle. The flag clears before the download so a retry
+                    // after a partial-install failure reuses what it fetched.
                     if context.requestedFreshDownload {
                         // `downloadDestinationPath` survives through `config.json`
                         // on disk, so a stray edit could otherwise have us
@@ -236,24 +248,8 @@ final class VMLifecycleCoordinator {
                         }
 
                         Self.logger.notice(
-                            "installMacOS: honoring requestedFreshDownload for '\(instance.name, privacy: .public)' — trashing existing IPSW + bundle"
+                            "installMacOS: honoring requestedFreshDownload for '\(instance.name, privacy: .public)' — the existing IPSW + bundle are trashed before the download starts"
                         )
-                        if fileSystem.fileExists(atPath: downloadDestination.path(percentEncoded: false)) {
-                            do {
-                                try fileSystem.trashItem(at: downloadDestination)
-                            } catch {
-                                Self.logger.error(
-                                    "Failed to trash existing IPSW at '\(downloadDestination.path(percentEncoded: false), privacy: .public)': \(error.localizedDescription, privacy: .public)"
-                                )
-                                throw IPSWError.freshDownloadCleanupFailed(
-                                    path: downloadDestination.path(percentEncoded: false),
-                                    underlying: error
-                                )
-                            }
-                        }
-                        // Recoverable on purpose: the stale partial goes to the
-                        // Trash so the user can restore it.
-                        ipswService.discardResumeData(at: downloadDestination, permanently: false)
                         instance.performConfigurationMutation {
                             $0.installContext?.requestedFreshDownload = false
                         }
@@ -280,7 +276,8 @@ final class VMLifecycleCoordinator {
 
                     try await ipswService.downloadRestoreImage(
                         from: remoteURL,
-                        to: downloadDestination
+                        to: downloadDestination,
+                        discardsExistingDownload: context.requestedFreshDownload
                     ) { progress in
                         instance.installState?.currentPhase = .downloading(progress)
                     }

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -153,19 +153,30 @@ final class VMLifecycleCoordinator {
     // MARK: - macOS Installation
 
     /// The effective IPSW download destination for a persisted path: the path
-    /// itself when it lives in `downloadsDirectory`, the wizard default otherwise.
+    /// itself when it lives in `downloadsDirectory`, otherwise `fallbackFilename`
+    /// inside Downloads (the wizard default when none is given).
     ///
     /// Downloads is the only destination the app supports — the sandbox
     /// entitlement covers it, resume sidecar included, with no per-pick grant.
     /// Comparison is symlink-resolved because the sandbox container's `Downloads`
     /// and the real `~/Downloads` are the same directory spelled two ways.
-    func normalizedDownloadDestination(for persisted: URL) -> URL {
+    ///
+    /// A catalog install passes its pinned image's filename, because the shared
+    /// default name would let a stale download of another version stand in for
+    /// the chosen one.
+    func normalizedDownloadDestination(
+        for persisted: URL, fallbackFilename: String? = nil
+    ) -> URL {
         guard let downloads = downloadsDirectory else { return persisted }
         let persistedParent = persisted.deletingLastPathComponent()
             .resolvingSymlinksInPath().standardizedFileURL
         let downloadsResolved = downloads.resolvingSymlinksInPath().standardizedFileURL
         guard persistedParent.path != downloadsResolved.path else { return persisted }
-        return URL(fileURLWithPath: VMCreationViewModel.defaultIPSWDownloadPath)
+        guard let fallbackFilename else {
+            return URL(fileURLWithPath: VMCreationViewModel.defaultIPSWDownloadPath)
+        }
+        return URL(
+            fileURLWithPath: VMCreationViewModel.downloadPath(forFilename: fallbackFilename))
     }
 
     func installMacOS(
@@ -188,7 +199,7 @@ final class VMLifecycleCoordinator {
                 defer { localIPSWScope?.release() }
 
                 switch context.source {
-                case .downloadLatest:
+                case .downloadLatest, .catalogVersion:
                     guard let persistedDestination = context.downloadDestinationURL else {
                         throw IPSWError.noDownloadURL
                     }
@@ -196,7 +207,8 @@ final class VMLifecycleCoordinator {
                     // config.json) can never be written and has no picker to
                     // re-point it, so the invariant is enforced at use time.
                     let downloadDestination = normalizedDownloadDestination(
-                        for: persistedDestination)
+                        for: persistedDestination,
+                        fallbackFilename: context.remoteURL?.lastPathComponent)
                     if downloadDestination != persistedDestination {
                         Self.logger.notice(
                             "installMacOS: persisted download destination is outside Downloads; using the default destination instead"
@@ -253,7 +265,19 @@ final class VMLifecycleCoordinator {
                     )
                     instance.status = .installing
 
-                    let remoteURL = try await ipswService.fetchLatestRestoreImageURL()
+                    // A catalog pick names its image at wizard time, so the
+                    // install downloads that build however long it sits
+                    // unstarted. Only "Download Latest" resolves here.
+                    let remoteURL: URL
+                    if context.source == .catalogVersion {
+                        guard let pinnedURL = context.remoteURL else {
+                            throw IPSWError.noDownloadURL
+                        }
+                        remoteURL = pinnedURL
+                    } else {
+                        remoteURL = try await ipswService.fetchLatestRestoreImageURL()
+                    }
+
                     try await ipswService.downloadRestoreImage(
                         from: remoteURL,
                         to: downloadDestination

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -199,7 +199,7 @@ final class VMLifecycleCoordinator {
                 defer { localIPSWScope?.release() }
 
                 switch context.source {
-                case .downloadLatest, .catalogVersion:
+                case .downloadLatest, .catalogVersion, .customURL:
                     guard let persistedDestination = context.downloadDestinationURL else {
                         throw IPSWError.noDownloadURL
                     }
@@ -265,11 +265,11 @@ final class VMLifecycleCoordinator {
                     )
                     instance.status = .installing
 
-                    // A catalog pick names its image at wizard time, so the
-                    // install downloads that build however long it sits
-                    // unstarted. Only "Download Latest" resolves here.
+                    // A catalog pick or a checked URL names its image at wizard
+                    // time, so the install downloads that build however long it
+                    // sits unstarted. Only "Download Latest" resolves here.
                     let remoteURL: URL
-                    if context.source == .catalogVersion {
+                    if context.source.usesPinnedURL {
                         guard let pinnedURL = context.remoteURL else {
                             throw IPSWError.noDownloadURL
                         }

--- a/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
@@ -16,6 +16,8 @@ final class IPSWSelectionContentViewController: NSViewController {
 
     /// Rebuilt by ``rebuildConditional()`` whenever the source/path/warning state changes.
     private let conditionalContainer = NSStackView()
+    /// Hosts the nested version picker.
+    private let catalogSheetPresenter = SheetPresenter()
     /// Shows the "more content below" cue while this step's content overflows the
     /// sheet; a hint only.
     private var scrollMoreIndicator: ScrollMoreIndicator?
@@ -41,14 +43,20 @@ final class IPSWSelectionContentViewController: NSViewController {
             title: "Download Latest",
             description: "Download the latest compatible macOS restore image from Apple."
         )
+        let catalogOption = makeSourceRadio(
+            for: .catalogVersion,
+            symbol: "list.bullet",
+            title: "Choose a Version…",
+            description: "Browse every macOS release Apple still hosts, including older versions."
+        )
         let localOption = makeSourceRadio(
             for: .localFile,
             symbol: "folder",
-            title: "Choose Local File",
+            title: "Choose Local File…",
             description: "Select an IPSW file already on your Mac."
         )
 
-        let options = NSStackView(views: [downloadOption, localOption])
+        let options = NSStackView(views: [downloadOption, catalogOption, localOption])
         options.orientation = .vertical
         options.alignment = .leading
         options.spacing = Spacing.large
@@ -77,6 +85,13 @@ final class IPSWSelectionContentViewController: NSViewController {
         refresh()
     }
 
+    override func viewWillDisappear() {
+        super.viewWillDisappear()
+        // The step is swapped out on navigation; a picker left attached to a
+        // window that is going away would wedge the presenter as shown.
+        catalogSheetPresenter.reset()
+    }
+
     // MARK: - Source radios
 
     private func makeSourceRadio(
@@ -92,8 +107,12 @@ final class IPSWSelectionContentViewController: NSViewController {
         guard let source = radios.first(where: { $0.value === sender })?.key else { return }
         switch source {
         case .downloadLatest:
-            creationVM.ipswSource = .downloadLatest
+            creationVM.selectDownloadLatest()
             refresh()
+        case .catalogVersion:
+            // Same deferred-commit rule as Choose Local File below.
+            updateRadioSelection()
+            selectCatalogVersion()
         case .localFile:
             // Selection only commits when the user actually picks a file. Re-sync
             // the radios to the (still-current) model so the just-clicked radio
@@ -124,39 +143,61 @@ final class IPSWSelectionContentViewController: NSViewController {
 
         switch creationVM.ipswSource {
         case .downloadLatest:
-            let path = creationVM.ipswDownloadPath
             // No "Change…" affordance: the destination is always the Downloads
             // folder, the one location the sandbox's downloads entitlement covers
             // without per-pick grants.
-            conditionalContainer.addArrangedSubview(makeWizardPathBadge(path: path))
-
-            if creationVM.shouldShowOverwriteWarning {
-                let useExisting = NSButton(
-                    title: "Use Existing File", target: self, action: #selector(useExistingTapped))
-                let replace = NSButton(
-                    title: "Download & Replace", target: self, action: #selector(confirmOverwriteTapped))
-                addFullWidthBanner(
-                    makeGroupedFormBanner(
-                        symbolName: "exclamationmark.triangle.fill",
-                        tint: .systemYellow,
-                        message:
-                            "A file already exists at this location. It will be replaced when downloading.",
-                        trailingButtons: [useExisting, replace]
-                    ))
-            } else if creationVM.hasResumableDownload {
-                addFullWidthBanner(
-                    makeGroupedFormBanner(
-                        symbolName: "arrow.clockwise.circle.fill",
-                        tint: .systemBlue,
-                        message:
-                            "A previous download was interrupted at this location. It will resume when the install starts."
-                    ))
-            }
+            conditionalContainer.addArrangedSubview(
+                makeWizardPathBadge(path: creationVM.ipswDownloadPath))
+            addDownloadBanners(version: nil)
+        case .catalogVersion:
+            guard let entry = creationVM.selectedCatalogEntry else { return }
+            let change = makeLinkButton(
+                "Change…", target: self, action: #selector(changeCatalogVersion))
+            conditionalContainer.addArrangedSubview(
+                makeWizardBadge(
+                    symbolName: "shippingbox.fill",
+                    text:
+                        "macOS \(entry.version)  ·  Build \(entry.build)  ·  \(DataFormatters.formatBytes(entry.sizeBytes))",
+                    trailingButton: change
+                ))
+            conditionalContainer.addArrangedSubview(
+                makeWizardPathBadge(path: creationVM.ipswDownloadPath))
+            addDownloadBanners(version: entry.version)
         case .localFile:
             guard let path = creationVM.ipswPath else { return }
             let change = makeLinkButton(
                 "Change…", target: self, action: #selector(changeLocalFile))
             conditionalContainer.addArrangedSubview(makeWizardPathBadge(path: path, changeButton: change))
+        }
+    }
+
+    /// Adds the overwrite or resume banner for whichever download source is
+    /// selected, naming `version` when the pick is a specific one.
+    private func addDownloadBanners(version: String?) {
+        let subject = version.map { "macOS \($0)" }
+        if creationVM.shouldShowOverwriteWarning {
+            let useExisting = NSButton(
+                title: "Use Existing File", target: self, action: #selector(useExistingTapped))
+            let replace = NSButton(
+                title: "Download & Replace", target: self, action: #selector(confirmOverwriteTapped))
+            addFullWidthBanner(
+                makeGroupedFormBanner(
+                    symbolName: "exclamationmark.triangle.fill",
+                    tint: .systemYellow,
+                    message: subject.map { "\($0) is already downloaded. It will be replaced when downloading." }
+                        ?? "A file already exists at this location. It will be replaced when downloading.",
+                    trailingButtons: [useExisting, replace]
+                ))
+        } else if creationVM.hasResumableDownload {
+            addFullWidthBanner(
+                makeGroupedFormBanner(
+                    symbolName: "arrow.clockwise.circle.fill",
+                    tint: .systemBlue,
+                    message: subject.map {
+                        "A previous download of \($0) was interrupted. It will resume when the install starts."
+                    }
+                        ?? "A previous download was interrupted at this location. It will resume when the install starts."
+                ))
         }
     }
 
@@ -171,6 +212,10 @@ final class IPSWSelectionContentViewController: NSViewController {
 
     @objc private func changeLocalFile() {
         selectIPSWFile()
+    }
+
+    @objc private func changeCatalogVersion() {
+        selectCatalogVersion()
     }
 
     @objc private func useExistingTapped() {
@@ -201,5 +246,40 @@ final class IPSWSelectionContentViewController: NSViewController {
             self.creationVM.ipswBookmark = bookmark
             self.refresh()
         }
+    }
+
+    /// Opens the nested version picker, preselecting the current pick.
+    private func selectCatalogVersion() {
+        guard let window = view.window, !catalogSheetPresenter.isShown else { return }
+        let sheet = RestoreImageCatalogSheetContentViewController(
+            entries: creationVM.catalogService.entries,
+            selectedBuild: creationVM.selectedCatalogEntry?.build,
+            generatedAt: creationVM.catalogService.generatedAt
+        )
+        sheet.delegate = self
+        catalogSheetPresenter.show(content: sheet, in: window)
+    }
+}
+
+// MARK: - RestoreImageCatalogSheetContentViewControllerDelegate
+
+extension IPSWSelectionContentViewController:
+    RestoreImageCatalogSheetContentViewControllerDelegate
+{
+    func restoreImageCatalogSheet(
+        _ vc: RestoreImageCatalogSheetContentViewController,
+        didChoose entry: RestoreImageCatalogEntry
+    ) {
+        catalogSheetPresenter.close()
+        creationVM.selectCatalogEntry(entry)
+        refresh()
+    }
+
+    func restoreImageCatalogSheetDidCancel(
+        _ vc: RestoreImageCatalogSheetContentViewController
+    ) {
+        // The model was never touched, so the radios already show the source
+        // that was selected before the picker opened.
+        catalogSheetPresenter.close()
     }
 }

--- a/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
@@ -320,9 +320,11 @@ final class IPSWSelectionContentViewController: NSViewController {
         adoptTask = Task { [weak self] in
             guard let self else { return }
             let verdict = await self.creationVM.adoptExistingDownloadFile()
-            guard !Task.isCancelled else { return }
-            self.adoptTask = nil
             switch verdict {
+            case .cancelled:
+                // The canceller dropped this task and the notice already, and a
+                // later click may own `adoptTask` by now — so touch neither.
+                return
             case .adopted:
                 self.existingFileNotice = nil
             case .mismatch(let expected, let found):
@@ -330,6 +332,7 @@ final class IPSWSelectionContentViewController: NSViewController {
             case .unusable(let message):
                 self.existingFileNotice = .unusable(message: message)
             }
+            self.adoptTask = nil
             self.refresh()
         }
     }

--- a/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
@@ -18,6 +18,22 @@ final class IPSWSelectionContentViewController: NSViewController {
     private let conditionalContainer = NSStackView()
     /// Hosts the nested version picker.
     private let catalogSheetPresenter = SheetPresenter()
+
+    /// What the last "Use Existing File" attempt turned up, replacing the
+    /// overwrite banner while it is set.
+    private enum ExistingFileNotice: Equatable {
+        case checking
+        case mismatch(expected: String, found: InspectedRestoreImage)
+        case unusable(message: String)
+    }
+    private var existingFileNotice: ExistingFileNotice?
+    /// In-flight inspection, so a second click can't race the first.
+    private var adoptTask: Task<Void, Never>?
+
+    #if DEBUG
+    /// Awaited by tests instead of polling for the verdict to land.
+    var adoptTaskForTesting: Task<Void, Never>? { adoptTask }
+    #endif
     /// Shows the "more content below" cue while this step's content overflows the
     /// sheet; a hint only.
     private var scrollMoreIndicator: ScrollMoreIndicator?
@@ -96,6 +112,8 @@ final class IPSWSelectionContentViewController: NSViewController {
         // The step is swapped out on navigation; a picker left attached to a
         // window that is going away would wedge the presenter as shown.
         catalogSheetPresenter.reset()
+        adoptTask?.cancel()
+        adoptTask = nil
     }
 
     // MARK: - Source radios
@@ -111,6 +129,8 @@ final class IPSWSelectionContentViewController: NSViewController {
 
     @objc private func sourceRadioClicked(_ sender: NSButton) {
         guard let source = radios.first(where: { $0.value === sender })?.key else { return }
+        // The verdict described the previous source's destination.
+        clearExistingFileNotice()
         switch source {
         case .downloadLatest:
             creationVM.selectDownloadLatest()
@@ -202,6 +222,12 @@ final class IPSWSelectionContentViewController: NSViewController {
     /// selected, naming `version` when the pick is a specific one.
     private func addDownloadBanners(version: String?) {
         let subject = version.map { "macOS \($0)" }
+        // A verdict on the existing file supersedes the plain overwrite
+        // warning — it says something more specific about the same file.
+        if let notice = existingFileNotice {
+            addExistingFileNotice(notice)
+            return
+        }
         if creationVM.shouldShowOverwriteWarning {
             let useExisting = NSButton(
                 title: "Use Existing File", target: self, action: #selector(useExistingTapped))
@@ -228,6 +254,42 @@ final class IPSWSelectionContentViewController: NSViewController {
         }
     }
 
+    /// Renders the outcome of checking the file already at the destination.
+    private func addExistingFileNotice(_ notice: ExistingFileNotice) {
+        switch notice {
+        case .checking:
+            addFullWidthBanner(
+                makeGroupedFormBanner(
+                    symbolName: "magnifyingglass.circle.fill",
+                    tint: .systemBlue,
+                    message: "Checking the file already at this location…"
+                ))
+        case .mismatch(let expected, let found):
+            let anyway = NSButton(
+                title: "Use It Anyway", target: self, action: #selector(useExistingAnywayTapped))
+            let replace = NSButton(
+                title: "Download & Replace", target: self, action: #selector(confirmOverwriteTapped))
+            addFullWidthBanner(
+                makeGroupedFormBanner(
+                    symbolName: "exclamationmark.triangle.fill",
+                    tint: .systemYellow,
+                    message:
+                        "The file already here is \(found.summary), not build \(expected). Using it installs \(found.summary).",
+                    trailingButtons: [anyway, replace]
+                ))
+        case .unusable(let message):
+            let replace = NSButton(
+                title: "Download & Replace", target: self, action: #selector(confirmOverwriteTapped))
+            addFullWidthBanner(
+                makeGroupedFormBanner(
+                    symbolName: "exclamationmark.triangle.fill",
+                    tint: .systemYellow,
+                    message: message,
+                    trailingButtons: [replace]
+                ))
+        }
+    }
+
     /// Adds a banner to the conditional container, pinned to the full step width
     /// so it lines up with the source options (the path badge stays content-sized).
     private func addFullWidthBanner(_ banner: NSView) {
@@ -249,14 +311,48 @@ final class IPSWSelectionContentViewController: NSViewController {
         selectPastedURL()
     }
 
+    /// Checks the existing file before adopting it, so a stale or hand-placed
+    /// IPSW can't stand in for the version the wizard is showing.
     @objc private func useExistingTapped() {
+        guard adoptTask == nil else { return }
+        existingFileNotice = .checking
+        rebuildConditional()
+        adoptTask = Task { [weak self] in
+            guard let self else { return }
+            let verdict = await self.creationVM.adoptExistingDownloadFile()
+            guard !Task.isCancelled else { return }
+            self.adoptTask = nil
+            switch verdict {
+            case .adopted:
+                self.existingFileNotice = nil
+            case .mismatch(let expected, let found):
+                self.existingFileNotice = .mismatch(expected: expected, found: found)
+            case .unusable(let message):
+                self.existingFileNotice = .unusable(message: message)
+            }
+            self.refresh()
+        }
+    }
+
+    /// Adopts the file the mismatch banner described, on the user's say-so.
+    @objc private func useExistingAnywayTapped() {
         creationVM.useExistingDownloadFile()
+        existingFileNotice = nil
         refresh()
     }
 
     @objc private func confirmOverwriteTapped() {
+        clearExistingFileNotice()
         creationVM.confirmOverwrite()
         refresh()
+    }
+
+    /// Drops any verdict about the existing file, and any inspection still
+    /// running to produce one.
+    private func clearExistingFileNotice() {
+        adoptTask?.cancel()
+        adoptTask = nil
+        existingFileNotice = nil
     }
 
     // MARK: - Panels
@@ -313,6 +409,7 @@ extension IPSWSelectionContentViewController:
         didChoose image: ProbedRestoreImage
     ) {
         catalogSheetPresenter.close()
+        clearExistingFileNotice()
         creationVM.selectPastedImage(image)
         refresh()
     }
@@ -334,6 +431,7 @@ extension IPSWSelectionContentViewController:
         didChoose entry: RestoreImageCatalogEntry
     ) {
         catalogSheetPresenter.close()
+        clearExistingFileNotice()
         creationVM.selectCatalogEntry(entry)
         refresh()
     }

--- a/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
@@ -49,6 +49,12 @@ final class IPSWSelectionContentViewController: NSViewController {
             title: "Choose a Version…",
             description: "Browse every macOS release Apple still hosts, including older versions."
         )
+        let urlOption = makeSourceRadio(
+            for: .customURL,
+            symbol: "link",
+            title: "Paste an IPSW URL…",
+            description: "Install from a restore image at a URL you supply."
+        )
         let localOption = makeSourceRadio(
             for: .localFile,
             symbol: "folder",
@@ -56,7 +62,7 @@ final class IPSWSelectionContentViewController: NSViewController {
             description: "Select an IPSW file already on your Mac."
         )
 
-        let options = NSStackView(views: [downloadOption, catalogOption, localOption])
+        let options = NSStackView(views: [downloadOption, catalogOption, urlOption, localOption])
         options.orientation = .vertical
         options.alignment = .leading
         options.spacing = Spacing.large
@@ -113,6 +119,9 @@ final class IPSWSelectionContentViewController: NSViewController {
             // Same deferred-commit rule as Choose Local File below.
             updateRadioSelection()
             selectCatalogVersion()
+        case .customURL:
+            updateRadioSelection()
+            selectPastedURL()
         case .localFile:
             // Selection only commits when the user actually picks a file. Re-sync
             // the radios to the (still-current) model so the just-clicked radio
@@ -151,24 +160,42 @@ final class IPSWSelectionContentViewController: NSViewController {
             addDownloadBanners(version: nil)
         case .catalogVersion:
             guard let entry = creationVM.selectedCatalogEntry else { return }
-            let change = makeLinkButton(
-                "Change…", target: self, action: #selector(changeCatalogVersion))
-            conditionalContainer.addArrangedSubview(
-                makeWizardBadge(
-                    symbolName: "shippingbox.fill",
-                    text:
-                        "macOS \(entry.version)  ·  Build \(entry.build)  ·  \(DataFormatters.formatBytes(entry.sizeBytes))",
-                    trailingButton: change
-                ))
-            conditionalContainer.addArrangedSubview(
-                makeWizardPathBadge(path: creationVM.ipswDownloadPath))
+            addPinnedImageBadge(
+                summary:
+                    "macOS \(entry.version)  ·  Build \(entry.build)  ·  \(DataFormatters.formatBytes(entry.sizeBytes))",
+                changeAction: #selector(changeCatalogVersion)
+            )
             addDownloadBanners(version: entry.version)
+        case .customURL:
+            guard let image = creationVM.pastedImage else { return }
+            addPinnedImageBadge(
+                summary:
+                    "\(image.versionSummary)  ·  \(DataFormatters.formatBytes(image.sizeBytes))",
+                changeAction: #selector(changePastedURL)
+            )
+            addDownloadBanners(version: image.version)
         case .localFile:
             guard let path = creationVM.ipswPath else { return }
             let change = makeLinkButton(
                 "Change…", target: self, action: #selector(changeLocalFile))
             conditionalContainer.addArrangedSubview(makeWizardPathBadge(path: path, changeButton: change))
         }
+    }
+
+    /// Adds the one badge a pinned-image source shows: what was chosen, and
+    /// where it will land.
+    ///
+    /// One two-line badge rather than two badges — with four sources listed,
+    /// two badges no longer fit the fixed-size sheet without scrolling.
+    private func addPinnedImageBadge(summary: String, changeAction: Selector) {
+        let change = makeLinkButton("Change…", target: self, action: changeAction)
+        conditionalContainer.addArrangedSubview(
+            makeWizardBadge(
+                symbolName: "shippingbox.fill",
+                text: summary,
+                secondaryText: wizardAbbreviateWithTilde(creationVM.ipswDownloadPath),
+                trailingButton: change
+            ))
     }
 
     /// Adds the overwrite or resume banner for whichever download source is
@@ -218,6 +245,10 @@ final class IPSWSelectionContentViewController: NSViewController {
         selectCatalogVersion()
     }
 
+    @objc private func changePastedURL() {
+        selectPastedURL()
+    }
+
     @objc private func useExistingTapped() {
         creationVM.useExistingDownloadFile()
         refresh()
@@ -258,6 +289,38 @@ final class IPSWSelectionContentViewController: NSViewController {
         )
         sheet.delegate = self
         catalogSheetPresenter.show(content: sheet, in: window)
+    }
+
+    /// Opens the nested URL sheet, seeded with the current pick.
+    private func selectPastedURL() {
+        guard let window = view.window, !catalogSheetPresenter.isShown else { return }
+        let sheet = RestoreImageURLSheetContentViewController(
+            probeService: creationVM.probeService,
+            initialURL: creationVM.pastedImage?.url.absoluteString
+        )
+        sheet.delegate = self
+        catalogSheetPresenter.show(content: sheet, in: window)
+    }
+}
+
+// MARK: - RestoreImageURLSheetContentViewControllerDelegate
+
+extension IPSWSelectionContentViewController:
+    RestoreImageURLSheetContentViewControllerDelegate
+{
+    func restoreImageURLSheet(
+        _ vc: RestoreImageURLSheetContentViewController,
+        didChoose image: ProbedRestoreImage
+    ) {
+        catalogSheetPresenter.close()
+        creationVM.selectPastedImage(image)
+        refresh()
+    }
+
+    func restoreImageURLSheetDidCancel(
+        _ vc: RestoreImageURLSheetContentViewController
+    ) {
+        catalogSheetPresenter.close()
     }
 }
 

--- a/Kernova/Views/Creation/RestoreImageCatalogSheetContentViewController.swift
+++ b/Kernova/Views/Creation/RestoreImageCatalogSheetContentViewController.swift
@@ -204,10 +204,10 @@ final class RestoreImageCatalogSheetContentViewController: NSViewController {
         scrollView.hasHorizontalScroller = false
         scrollView.borderType = .noBorder
         scrollView.drawsBackground = false
-        scrollView.automaticallyAdjustsContentInsets = false
-        scrollView.contentInsets = NSEdgeInsetsZero
-        scrollView.contentView.automaticallyAdjustsContentInsets = false
-        scrollView.contentView.contentInsets = NSEdgeInsetsZero
+        // Automatic content insets stay ON, unlike the header-less sheets that
+        // zero them to kill implicit padding: the reserved space at the top is
+        // what the column header occupies, and zeroing it renders the first row
+        // underneath the header instead of below it.
         scrollView.translatesAutoresizingMaskIntoConstraints = false
 
         let container = NSView()

--- a/Kernova/Views/Creation/RestoreImageCatalogSheetContentViewController.swift
+++ b/Kernova/Views/Creation/RestoreImageCatalogSheetContentViewController.swift
@@ -1,0 +1,445 @@
+import AppKit
+import Foundation
+
+/// Delegate for ``RestoreImageCatalogSheetContentViewController``.
+@MainActor
+protocol RestoreImageCatalogSheetContentViewControllerDelegate: AnyObject {
+    /// The user committed a version, by Choose or by double-click.
+    func restoreImageCatalogSheet(
+        _ vc: RestoreImageCatalogSheetContentViewController,
+        didChoose entry: RestoreImageCatalogEntry
+    )
+
+    /// The user dismissed without choosing.
+    func restoreImageCatalogSheetDidCancel(
+        _ vc: RestoreImageCatalogSheetContentViewController
+    )
+}
+
+/// Nested sheet listing every macOS restore image in the bundled catalog.
+///
+/// Rows for guests newer than this host are dimmed and unselectable:
+/// Virtualization refuses a guest above the host, and the framework's own
+/// verdict is unavailable until the image is downloaded.
+@MainActor
+final class RestoreImageCatalogSheetContentViewController: NSViewController {
+    weak var delegate: RestoreImageCatalogSheetContentViewControllerDelegate?
+
+    /// Every entry the catalog offers, newest first.
+    private let entries: [RestoreImageCatalogEntry]
+    /// The rows currently shown, after the search filter.
+    private(set) var visibleEntries: [RestoreImageCatalogEntry]
+    private let generatedAt: String?
+    private let hostVersion: OperatingSystemVersion
+    private let isDownloaded: @MainActor (RestoreImageCatalogEntry) -> Bool
+    /// Build to select once the table exists, from a previous pick.
+    private let pendingSelectedBuild: String?
+
+    private let tableView = NSTableView()
+    private let scrollView = NSScrollView()
+    private let searchField = NSSearchField()
+    private let chooseButton = NSButton()
+
+    // MARK: - Layout constants
+
+    private static let sheetWidth: CGFloat = 620
+    private static let sheetHeight: CGFloat = 440
+    private static let padding: CGFloat = 16
+    private static let rowHeight: CGFloat = 24
+
+    private enum Column {
+        static let version = NSUserInterfaceItemIdentifier("version")
+        static let build = NSUserInterfaceItemIdentifier("build")
+        static let size = NSUserInterfaceItemIdentifier("size")
+        static let released = NSUserInterfaceItemIdentifier("released")
+        static let status = NSUserInterfaceItemIdentifier("status")
+    }
+
+    /// Builds the picker over `entries`, preselecting `selectedBuild`.
+    ///
+    /// `isDownloaded` reports whether an entry's image already sits at its
+    /// download destination — the same check that drives the wizard's overwrite
+    /// banner — and defaults to a `FileManager` probe of that path.
+    init(
+        entries: [RestoreImageCatalogEntry],
+        selectedBuild: String? = nil,
+        generatedAt: String? = nil,
+        hostVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion,
+        isDownloaded: (@MainActor (RestoreImageCatalogEntry) -> Bool)? = nil
+    ) {
+        self.entries = entries
+        self.visibleEntries = entries
+        self.generatedAt = generatedAt
+        self.hostVersion = hostVersion
+        self.isDownloaded =
+            isDownloaded
+            ?? { entry in
+                FileManager.default.fileExists(
+                    atPath: VMCreationViewModel.downloadPath(forFilename: entry.suggestedFilename))
+            }
+        self.pendingSelectedBuild = selectedBuild
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("RestoreImageCatalogSheetContentViewController does not support NSCoder")
+    }
+
+    override func loadView() {
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let header = makeHeader()
+        let divider1 = makeHorizontalSeparator()
+        let body = makeTableSection()
+        let divider2 = makeHorizontalSeparator()
+        let footer = makeFooter()
+
+        for subview in [header, divider1, body, divider2, footer] {
+            subview.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview(subview)
+        }
+
+        NSLayoutConstraint.activate([
+            container.widthAnchor.constraint(equalToConstant: Self.sheetWidth),
+            container.heightAnchor.constraint(equalToConstant: Self.sheetHeight),
+
+            header.topAnchor.constraint(equalTo: container.topAnchor),
+            header.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            divider1.topAnchor.constraint(equalTo: header.bottomAnchor),
+            divider1.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            divider1.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            body.topAnchor.constraint(equalTo: divider1.bottomAnchor),
+            body.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            body.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            divider2.topAnchor.constraint(equalTo: body.bottomAnchor),
+            divider2.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            divider2.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            footer.topAnchor.constraint(equalTo: divider2.bottomAnchor),
+            footer.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            footer.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            footer.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+
+        view = container
+        selectInitialRow()
+        updateChooseEnabled()
+    }
+
+    // MARK: - Header
+
+    private func makeHeader() -> NSView {
+        let container = NSView()
+
+        let title = NSTextField(labelWithString: "Choose a macOS Version")
+        title.font = .preferredFont(forTextStyle: .headline)
+        title.isSelectable = false
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        searchField.placeholderString = "Search"
+        searchField.sendsSearchStringImmediately = true
+        searchField.sendsWholeSearchString = false
+        searchField.target = self
+        searchField.action = #selector(searchChanged)
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = NSStackView(views: [title, spacer, searchField])
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = Spacing.standard
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            searchField.widthAnchor.constraint(equalToConstant: 190),
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.padding),
+            stack.trailingAnchor.constraint(
+                equalTo: container.trailingAnchor, constant: -Self.padding),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Self.padding),
+        ])
+        return container
+    }
+
+    // MARK: - Table
+
+    private func makeTableSection() -> NSView {
+        for (identifier, title, width) in [
+            (Column.version, "Version", CGFloat(150)),
+            (Column.build, "Build", CGFloat(84)),
+            (Column.size, "Size", CGFloat(74)),
+            (Column.released, "Released", CGFloat(100)),
+            (Column.status, "Status", CGFloat(140)),
+        ] {
+            let column = NSTableColumn(identifier: identifier)
+            column.title = title
+            column.width = width
+            column.resizingMask = .autoresizingMask
+            tableView.addTableColumn(column)
+        }
+
+        tableView.allowsColumnReordering = false
+        tableView.allowsMultipleSelection = false
+        tableView.allowsEmptySelection = true
+        tableView.rowHeight = Self.rowHeight
+        tableView.usesAlternatingRowBackgroundColors = true
+        tableView.gridStyleMask = []
+        tableView.style = .inset
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.target = self
+        tableView.doubleAction = #selector(rowDoubleClicked)
+
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.contentInsets = NSEdgeInsetsZero
+        scrollView.contentView.automaticallyAdjustsContentInsets = false
+        scrollView.contentView.contentInsets = NSEdgeInsetsZero
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.addSubview(scrollView)
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: container.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+        return container
+    }
+
+    // MARK: - Footer
+
+    private func makeFooter() -> NSView {
+        let container = NSView()
+
+        let note = NSTextField(labelWithString: footerNote)
+        note.font = .preferredFont(forTextStyle: .caption1)
+        note.textColor = .secondaryLabelColor
+        note.lineBreakMode = .byTruncatingTail
+        note.isSelectable = false
+        note.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelTapped))
+        cancel.bezelStyle = .rounded
+        cancel.keyEquivalent = "\u{1b}"  // Escape
+
+        chooseButton.title = "Choose"
+        chooseButton.target = self
+        chooseButton.action = #selector(chooseTapped)
+        chooseButton.bezelStyle = .rounded
+        chooseButton.keyEquivalent = "\r"  // Return = default action
+
+        let stack = NSStackView(views: [note, spacer, cancel, chooseButton])
+        stack.orientation = .horizontal
+        stack.spacing = Spacing.standard
+        stack.alignment = .centerY
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.padding),
+            stack.trailingAnchor.constraint(
+                equalTo: container.trailingAnchor, constant: -Self.padding),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Self.padding),
+        ])
+        return container
+    }
+
+    /// Tells the user how fresh the list is, and where to go for anything newer.
+    ///
+    /// The catalog ships as a snapshot, so the newest release Apple has today
+    /// may postdate this build — "Download Latest" always resolves live.
+    private var footerNote: String {
+        guard let generatedAt, let date = Self.catalogDateFormatter.date(from: generatedAt) else {
+            return "For a newer release than this list offers, use Download Latest"
+        }
+        let month = date.formatted(.dateTime.month(.wide).year())
+        return "List current as of \(month) — for anything newer, use Download Latest"
+    }
+
+    // MARK: - Selection
+
+    private func selectInitialRow() {
+        let target =
+            pendingSelectedBuild.flatMap { build in
+                visibleEntries.firstIndex { $0.build == build }
+            } ?? visibleEntries.firstIndex { isSelectable($0) }
+        guard let target else { return }
+        tableView.selectRowIndexes([target], byExtendingSelection: false)
+        tableView.scrollRowToVisible(target)
+    }
+
+    /// The entry the user has settled on, or `nil` when nothing selectable is
+    /// selected.
+    var selectedEntry: RestoreImageCatalogEntry? {
+        let row = tableView.selectedRow
+        guard row >= 0, row < visibleEntries.count else { return nil }
+        let entry = visibleEntries[row]
+        return isSelectable(entry) ? entry : nil
+    }
+
+    private func isSelectable(_ entry: RestoreImageCatalogEntry) -> Bool {
+        entry.isSupported(onHost: hostVersion)
+    }
+
+    private func updateChooseEnabled() {
+        chooseButton.isEnabled = selectedEntry != nil
+    }
+
+    // MARK: - Actions
+
+    @objc private func searchChanged() {
+        applyFilter(searchField.stringValue)
+    }
+
+    /// Re-filters the rows, keeping the current selection when it survives.
+    func applyFilter(_ term: String) {
+        let previouslySelected = selectedEntry?.build
+        visibleEntries = entries.filter { $0.matches(searchTerm: term) }
+        tableView.reloadData()
+        if let previouslySelected,
+            let row = visibleEntries.firstIndex(where: { $0.build == previouslySelected })
+        {
+            tableView.selectRowIndexes([row], byExtendingSelection: false)
+            tableView.scrollRowToVisible(row)
+        }
+        updateChooseEnabled()
+    }
+
+    @objc private func cancelTapped() {
+        delegate?.restoreImageCatalogSheetDidCancel(self)
+    }
+
+    @objc private func chooseTapped() {
+        guard let entry = selectedEntry else { return }
+        delegate?.restoreImageCatalogSheet(self, didChoose: entry)
+    }
+
+    @objc private func rowDoubleClicked() {
+        // `clickedRow` is -1 when the double-click landed on the header or on
+        // empty space below the last row.
+        guard tableView.clickedRow >= 0 else { return }
+        chooseTapped()
+    }
+
+    // MARK: - Helpers
+
+    private func makeHorizontalSeparator() -> NSBox {
+        let box = NSBox()
+        box.boxType = .separator
+        return box
+    }
+
+    /// The catalog's `generatedAt`, in the fixed format the generator emits.
+    private static let catalogDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+}
+
+// MARK: - NSTableViewDataSource
+
+extension RestoreImageCatalogSheetContentViewController: NSTableViewDataSource {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        visibleEntries.count
+    }
+}
+
+// MARK: - NSTableViewDelegate
+
+extension RestoreImageCatalogSheetContentViewController: NSTableViewDelegate {
+    /// Blocks selection of a guest the host cannot run.
+    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+        guard row >= 0, row < visibleEntries.count else { return false }
+        return isSelectable(visibleEntries[row])
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        updateChooseEnabled()
+    }
+
+    func tableView(
+        _ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int
+    ) -> NSView? {
+        guard let tableColumn, row >= 0, row < visibleEntries.count else { return nil }
+        let entry = visibleEntries[row]
+
+        let identifier = NSUserInterfaceItemIdentifier("RestoreImageCatalogCell")
+        let cell =
+            tableView.makeView(withIdentifier: identifier, owner: nil) as? NSTableCellView
+            ?? makeCellView(identifier: identifier)
+        cell.textField?.stringValue = text(for: entry, column: tableColumn.identifier)
+        cell.textField?.textColor = isSelectable(entry) ? .labelColor : .tertiaryLabelColor
+        return cell
+    }
+
+    private func makeCellView(identifier: NSUserInterfaceItemIdentifier) -> NSTableCellView {
+        let cell = NSTableCellView()
+        cell.identifier = identifier
+
+        let label = NSTextField(labelWithString: "")
+        label.font = Typography.body
+        label.lineBreakMode = .byTruncatingTail
+        label.maximumNumberOfLines = 1
+        label.isSelectable = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        cell.addSubview(label)
+        cell.textField = label
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: Spacing.tight),
+            label.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -Spacing.tight),
+            label.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+        ])
+        return cell
+    }
+
+    private func text(
+        for entry: RestoreImageCatalogEntry, column: NSUserInterfaceItemIdentifier
+    ) -> String {
+        switch column {
+        case Column.version:
+            return "macOS \(entry.version)"
+        case Column.build:
+            return entry.build
+        case Column.size:
+            return DataFormatters.formatBytes(entry.sizeBytes)
+        case Column.released:
+            return entry.releaseDate.map { $0.formatted(.dateTime.month(.abbreviated).day().year()) }
+                ?? "—"
+        case Column.status:
+            return statusText(for: entry)
+        default:
+            return ""
+        }
+    }
+
+    private func statusText(for entry: RestoreImageCatalogEntry) -> String {
+        guard isSelectable(entry) else { return "Needs macOS \(entry.version)" }
+        if isDownloaded(entry) { return "In Downloads" }
+        if entry.build == entries.first?.build { return "Latest" }
+        return ""
+    }
+}

--- a/Kernova/Views/Creation/RestoreImageURLSheetContentViewController.swift
+++ b/Kernova/Views/Creation/RestoreImageURLSheetContentViewController.swift
@@ -1,0 +1,411 @@
+import AppKit
+import Foundation
+
+/// Delegate for ``RestoreImageURLSheetContentViewController``.
+@MainActor
+protocol RestoreImageURLSheetContentViewControllerDelegate: AnyObject {
+    /// The user accepted a checked image.
+    func restoreImageURLSheet(
+        _ vc: RestoreImageURLSheetContentViewController,
+        didChoose image: ProbedRestoreImage
+    )
+
+    /// The user dismissed without choosing.
+    func restoreImageURLSheetDidCancel(
+        _ vc: RestoreImageURLSheetContentViewController
+    )
+}
+
+/// Nested sheet that takes a restore image URL and checks it before anything is
+/// downloaded.
+///
+/// Nothing reaches the install pipeline unchecked: **Use** stays disabled until
+/// the probe confirms the URL serves an image carrying the virtual-machine
+/// hardware model, which costs about 150 KB rather than the whole file.
+@MainActor
+final class RestoreImageURLSheetContentViewController: NSViewController {
+    weak var delegate: RestoreImageURLSheetContentViewControllerDelegate?
+
+    private let probeService: any RestoreImageProbing
+    private let hostVersion: OperatingSystemVersion
+
+    /// The last successful probe, and what **Use** hands to the delegate.
+    private(set) var checkedImage: ProbedRestoreImage?
+
+    private let urlField = NSTextField()
+    private let checkButton = NSButton()
+    private let useButton = NSButton()
+    private let resultContainer = NSStackView()
+
+    /// In-flight probe, so a second Check supersedes the first rather than
+    /// racing it.
+    private var probeTask: Task<Void, Never>?
+
+    #if DEBUG
+    /// Awaited by tests instead of polling for the result to land.
+    var probeTaskForTesting: Task<Void, Never>? { probeTask }
+    #endif
+
+    // MARK: - Layout constants
+
+    private static let sheetWidth: CGFloat = 560
+    private static let sheetHeight: CGFloat = 320
+    private static let padding: CGFloat = 16
+
+    init(
+        probeService: any RestoreImageProbing,
+        initialURL: String? = nil,
+        hostVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
+    ) {
+        self.probeService = probeService
+        self.hostVersion = hostVersion
+        self.initialURL = initialURL
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    private let initialURL: String?
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("RestoreImageURLSheetContentViewController does not support NSCoder")
+    }
+
+    deinit {
+        probeTask?.cancel()
+    }
+
+    override func loadView() {
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let header = makeHeader()
+        let divider1 = makeHorizontalSeparator()
+        let body = makeBody()
+        let divider2 = makeHorizontalSeparator()
+        let footer = makeFooter()
+
+        for subview in [header, divider1, body, divider2, footer] {
+            subview.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview(subview)
+        }
+
+        NSLayoutConstraint.activate([
+            container.widthAnchor.constraint(equalToConstant: Self.sheetWidth),
+            container.heightAnchor.constraint(equalToConstant: Self.sheetHeight),
+
+            header.topAnchor.constraint(equalTo: container.topAnchor),
+            header.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            divider1.topAnchor.constraint(equalTo: header.bottomAnchor),
+            divider1.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            divider1.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            body.topAnchor.constraint(equalTo: divider1.bottomAnchor),
+            body.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            body.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            divider2.topAnchor.constraint(equalTo: body.bottomAnchor),
+            divider2.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            divider2.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            footer.topAnchor.constraint(equalTo: divider2.bottomAnchor),
+            footer.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            footer.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            footer.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+
+        view = container
+        if let initialURL { urlField.stringValue = initialURL }
+        updateControls()
+    }
+
+    // MARK: - Header
+
+    private func makeHeader() -> NSView {
+        let container = NSView()
+
+        let title = NSTextField(labelWithString: "Add a Restore Image by URL")
+        title.font = .preferredFont(forTextStyle: .headline)
+        title.isSelectable = false
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let stack = NSStackView(views: [title, spacer])
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = Spacing.small
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.padding),
+            stack.trailingAnchor.constraint(
+                equalTo: container.trailingAnchor, constant: -Self.padding),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Self.padding),
+        ])
+        return container
+    }
+
+    // MARK: - Body
+
+    private func makeBody() -> NSView {
+        let container = NSView()
+
+        let label = NSTextField(labelWithString: "Image URL")
+        label.font = .preferredFont(forTextStyle: .subheadline)
+        label.textColor = .secondaryLabelColor
+        label.isSelectable = false
+
+        urlField.placeholderString = "Paste a link to an .ipsw restore image"
+        urlField.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        urlField.lineBreakMode = .byTruncatingHead
+        urlField.target = self
+        urlField.action = #selector(checkTapped)
+        urlField.delegate = self
+        urlField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        checkButton.title = "Check"
+        checkButton.target = self
+        checkButton.action = #selector(checkTapped)
+        checkButton.bezelStyle = .rounded
+        checkButton.setContentHuggingPriority(.required, for: .horizontal)
+
+        let field = NSStackView(views: [urlField, checkButton])
+        field.orientation = .horizontal
+        field.alignment = .firstBaseline
+        field.spacing = Spacing.standard
+
+        resultContainer.orientation = .vertical
+        resultContainer.alignment = .leading
+        resultContainer.spacing = Spacing.standard
+
+        let stack = NSStackView(views: [label, field, resultContainer])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = Spacing.small
+        stack.setCustomSpacing(Spacing.medium, after: field)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.padding),
+            stack.trailingAnchor.constraint(
+                equalTo: container.trailingAnchor, constant: -Self.padding),
+            stack.bottomAnchor.constraint(
+                lessThanOrEqualTo: container.bottomAnchor, constant: -Self.padding),
+            field.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            resultContainer.widthAnchor.constraint(equalTo: stack.widthAnchor),
+        ])
+        return container
+    }
+
+    // MARK: - Footer
+
+    private func makeFooter() -> NSView {
+        let container = NSView()
+
+        let note = NSTextField(
+            labelWithString: "Checked without downloading — about 150 KB read")
+        note.font = .preferredFont(forTextStyle: .caption1)
+        note.textColor = .tertiaryLabelColor
+        note.lineBreakMode = .byTruncatingTail
+        note.isSelectable = false
+        note.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelTapped))
+        cancel.bezelStyle = .rounded
+        cancel.keyEquivalent = "\u{1b}"  // Escape
+
+        useButton.title = "Use"
+        useButton.target = self
+        useButton.action = #selector(useTapped)
+        useButton.bezelStyle = .rounded
+
+        let stack = NSStackView(views: [note, spacer, cancel, useButton])
+        stack.orientation = .horizontal
+        stack.spacing = Spacing.standard
+        stack.alignment = .centerY
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.padding),
+            stack.trailingAnchor.constraint(
+                equalTo: container.trailingAnchor, constant: -Self.padding),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Self.padding),
+        ])
+        return container
+    }
+
+    // MARK: - Result
+
+    private func setResult(_ views: [NSView]) {
+        for view in resultContainer.arrangedSubviews {
+            resultContainer.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+        for view in views {
+            resultContainer.addArrangedSubview(view)
+            view.widthAnchor.constraint(equalTo: resultContainer.widthAnchor).isActive = true
+        }
+    }
+
+    private func showChecking() {
+        let spinner = NSProgressIndicator()
+        spinner.style = .spinning
+        spinner.controlSize = .small
+        spinner.isIndeterminate = true
+        spinner.startAnimation(nil)
+        spinner.setContentHuggingPriority(.required, for: .horizontal)
+
+        let label = NSTextField(labelWithString: "Reading the image directory — about 150 KB…")
+        label.font = .preferredFont(forTextStyle: .callout)
+        label.textColor = .secondaryLabelColor
+        label.isSelectable = false
+
+        let spacer = NSView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let row = NSStackView(views: [spinner, label, spacer])
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = Spacing.small
+        setResult([row])
+    }
+
+    private func showFailure(_ message: String) {
+        setResult([
+            makeGroupedFormBanner(
+                symbolName: "exclamationmark.triangle.fill",
+                tint: .systemYellow,
+                message: message
+            )
+        ])
+    }
+
+    private func showSuccess(_ image: ProbedRestoreImage) {
+        var rows: [NSView] = [
+            makeWizardBadge(
+                symbolName: "checkmark.seal.fill",
+                text: image.version == nil
+                    ? "\(DataFormatters.formatBytes(image.sizeBytes)) · Installs in a virtual machine"
+                    : "\(image.versionSummary) · \(DataFormatters.formatBytes(image.sizeBytes)) · Installs in a virtual machine",
+                secondaryText: wizardAbbreviateWithTilde(
+                    VMCreationViewModel.downloadPath(forFilename: image.suggestedFilename))
+            )
+        ]
+
+        // The version is read out of the filename, so a "too new" answer is a
+        // hint, not a verdict — it warns without blocking Use.
+        if image.isSupported(onHost: hostVersion) == false, let version = image.version {
+            rows.append(
+                makeGroupedFormBanner(
+                    symbolName: "exclamationmark.triangle.fill",
+                    tint: .systemYellow,
+                    message:
+                        "The filename says macOS \(version), which is newer than this Mac. If that's right, the install will fail."
+                ))
+        } else if image.version == nil {
+            rows.append(
+                makeGroupedFormBanner(
+                    symbolName: "info.circle.fill",
+                    tint: .systemBlue,
+                    message:
+                        "The filename doesn't name a macOS version, so the version can't be shown before installing."
+                ))
+        }
+        setResult(rows)
+    }
+
+    // MARK: - Controls
+
+    private func updateControls() {
+        useButton.isEnabled = checkedImage != nil
+        checkButton.isEnabled =
+            !urlField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && probeTask == nil
+        // Return commits the check while unverified and the choice once verified,
+        // so the default button always does the obvious next thing.
+        useButton.keyEquivalent = checkedImage != nil ? "\r" : ""
+        checkButton.keyEquivalent = checkedImage == nil ? "\r" : ""
+    }
+
+    // MARK: - Actions
+
+    @objc private func checkTapped() {
+        let text = urlField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, probeTask == nil else { return }
+
+        guard let url = URL(string: text), url.scheme != nil, url.host() != nil else {
+            checkedImage = nil
+            showFailure("That isn't a valid URL. Paste the full link, starting with https://")
+            updateControls()
+            return
+        }
+
+        checkedImage = nil
+        showChecking()
+        probeTask = Task { [weak self, probeService] in
+            do {
+                let image = try await probeService.probe(url)
+                guard let self, !Task.isCancelled else { return }
+                self.probeTask = nil
+                self.checkedImage = image
+                self.showSuccess(image)
+                self.updateControls()
+            } catch {
+                guard let self, !Task.isCancelled else { return }
+                self.probeTask = nil
+                self.checkedImage = nil
+                self.showFailure(
+                    (error as? RestoreImageProbeError)?.errorDescription
+                        ?? error.localizedDescription)
+                self.updateControls()
+            }
+        }
+        updateControls()
+    }
+
+    @objc private func cancelTapped() {
+        probeTask?.cancel()
+        probeTask = nil
+        delegate?.restoreImageURLSheetDidCancel(self)
+    }
+
+    @objc private func useTapped() {
+        guard let image = checkedImage else { return }
+        delegate?.restoreImageURLSheet(self, didChoose: image)
+    }
+
+    // MARK: - Helpers
+
+    private func makeHorizontalSeparator() -> NSBox {
+        let box = NSBox()
+        box.boxType = .separator
+        return box
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+
+extension RestoreImageURLSheetContentViewController: NSTextFieldDelegate {
+    /// Editing the URL invalidates the previous verdict, so a stale "Use"
+    /// can't commit an image that isn't the one in the field.
+    func controlTextDidChange(_ obj: Notification) {
+        if checkedImage != nil {
+            checkedImage = nil
+            setResult([])
+        }
+        updateControls()
+    }
+}

--- a/Kernova/Views/Creation/RestoreImageURLSheetContentViewController.swift
+++ b/Kernova/Views/Creation/RestoreImageURLSheetContentViewController.swift
@@ -399,13 +399,14 @@ final class RestoreImageURLSheetContentViewController: NSViewController {
 // MARK: - NSTextFieldDelegate
 
 extension RestoreImageURLSheetContentViewController: NSTextFieldDelegate {
-    /// Editing the URL invalidates the previous verdict, so a stale "Use"
-    /// can't commit an image that isn't the one in the field.
+    /// Editing the URL invalidates the previous verdict and any probe still
+    /// running to produce one, so a stale "Use" can't commit an image that
+    /// isn't the one in the field.
     func controlTextDidChange(_ obj: Notification) {
-        if checkedImage != nil {
-            checkedImage = nil
-            setResult([])
-        }
+        probeTask?.cancel()
+        probeTask = nil
+        checkedImage = nil
+        setResult([])
         updateControls()
     }
 }

--- a/Kernova/Views/Creation/ReviewContentViewController.swift
+++ b/Kernova/Views/Creation/ReviewContentViewController.swift
@@ -75,15 +75,22 @@ final class ReviewContentViewController: NSViewController {
             rows: [valueRow("Networking", creationVM.networkEnabled ? "Enabled" : "Disabled")], to: form)
 
         if creationVM.selectedOS == .macOS {
-            var rows = [
-                valueRow(
-                    "IPSW Source",
-                    creationVM.ipswSource == .downloadLatest ? "Download Latest" : "Local File")
-            ]
+            let sourceLabel: String
+            switch creationVM.ipswSource {
+            case .downloadLatest: sourceLabel = "Download Latest"
+            case .catalogVersion: sourceLabel = "Chosen Version"
+            case .localFile: sourceLabel = "Local File"
+            }
+            var rows = [valueRow("Restore Image", sourceLabel)]
+            if creationVM.ipswSource == .catalogVersion, let entry = creationVM.selectedCatalogEntry {
+                rows.append(valueRow("macOS Version", "\(entry.version) (\(entry.build))"))
+                rows.append(
+                    valueRow("Download Size", DataFormatters.formatBytes(entry.sizeBytes)))
+            }
             if creationVM.ipswSource == .localFile, let path = creationVM.ipswPath {
                 rows.append(valueRow("File", URL(fileURLWithPath: path).lastPathComponent))
             }
-            if creationVM.ipswSource == .downloadLatest {
+            if creationVM.ipswSource.downloadsImage {
                 rows.append(
                     valueRow("Save to", wizardAbbreviateWithTilde(creationVM.ipswDownloadPath)))
             }

--- a/Kernova/Views/Creation/ReviewContentViewController.swift
+++ b/Kernova/Views/Creation/ReviewContentViewController.swift
@@ -79,6 +79,7 @@ final class ReviewContentViewController: NSViewController {
             switch creationVM.ipswSource {
             case .downloadLatest: sourceLabel = "Download Latest"
             case .catalogVersion: sourceLabel = "Chosen Version"
+            case .customURL: sourceLabel = "From URL"
             case .localFile: sourceLabel = "Local File"
             }
             var rows = [valueRow("Restore Image", sourceLabel)]
@@ -86,6 +87,11 @@ final class ReviewContentViewController: NSViewController {
                 rows.append(valueRow("macOS Version", "\(entry.version) (\(entry.build))"))
                 rows.append(
                     valueRow("Download Size", DataFormatters.formatBytes(entry.sizeBytes)))
+            }
+            if creationVM.ipswSource == .customURL, let image = creationVM.pastedImage {
+                rows.append(valueRow("macOS Version", image.versionSummary))
+                rows.append(
+                    valueRow("Download Size", DataFormatters.formatBytes(image.sizeBytes)))
             }
             if creationVM.ipswSource == .localFile, let path = creationVM.ipswPath {
                 rows.append(valueRow("File", URL(fileURLWithPath: path).lastPathComponent))

--- a/Kernova/Views/Creation/WizardStyle.swift
+++ b/Kernova/Views/Creation/WizardStyle.swift
@@ -123,12 +123,17 @@ func makeWizardPathBadge(path: String, changeButton: NSButton? = nil) -> NSView 
     )
 }
 
-/// Builds a wizard badge: a symbol, one line of caption text, and an optional
-/// trailing button, in a subtle rounded container.
+/// Builds a wizard badge: a symbol, one or two lines of caption text, and an
+/// optional trailing button, in a subtle rounded container.
+///
+/// The two-line form exists so a download source states its image and its
+/// destination in one badge. As two separate badges they cost more height than
+/// the fixed-size wizard sheet has once there are four sources to list.
 @MainActor
 func makeWizardBadge(
     symbolName: String,
     text: String,
+    secondaryText: String? = nil,
     lineBreakMode: NSLineBreakMode = .byTruncatingTail,
     trailingButton: NSButton? = nil
 ) -> NSView {
@@ -143,9 +148,28 @@ func makeWizardBadge(
     label.isSelectable = false
     label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
-    let row = NSStackView(views: [icon, label] + (trailingButton.map { [$0] } ?? []))
+    let textContent: NSView
+    if let secondaryText {
+        let secondary = NSTextField(labelWithString: secondaryText)
+        secondary.font = .preferredFont(forTextStyle: .caption2)
+        secondary.textColor = .tertiaryLabelColor
+        secondary.lineBreakMode = .byTruncatingMiddle
+        secondary.maximumNumberOfLines = 1
+        secondary.isSelectable = false
+        secondary.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let column = NSStackView(views: [label, secondary])
+        column.orientation = .vertical
+        column.alignment = .leading
+        column.spacing = Spacing.hairline
+        textContent = column
+    } else {
+        textContent = label
+    }
+
+    let row = NSStackView(views: [icon, textContent] + (trailingButton.map { [$0] } ?? []))
     row.orientation = .horizontal
-    row.alignment = .firstBaseline
+    row.alignment = secondaryText == nil ? .firstBaseline : .centerY
     row.spacing = Spacing.small
 
     return makeGroupedFormBox(

--- a/Kernova/Views/Creation/WizardStyle.swift
+++ b/Kernova/Views/Creation/WizardStyle.swift
@@ -115,18 +115,35 @@ func makeWizardRadioOption(radio: NSButton, iconSymbol: String, description desc
 /// optional trailing "Change…" button, in a subtle rounded container.
 @MainActor
 func makeWizardPathBadge(path: String, changeButton: NSButton? = nil) -> NSView {
-    let icon = NSImageView(image: .systemSymbol("doc.fill", accessibilityDescription: ""))
+    makeWizardBadge(
+        symbolName: "doc.fill",
+        text: wizardAbbreviateWithTilde(path),
+        lineBreakMode: .byTruncatingMiddle,
+        trailingButton: changeButton
+    )
+}
+
+/// Builds a wizard badge: a symbol, one line of caption text, and an optional
+/// trailing button, in a subtle rounded container.
+@MainActor
+func makeWizardBadge(
+    symbolName: String,
+    text: String,
+    lineBreakMode: NSLineBreakMode = .byTruncatingTail,
+    trailingButton: NSButton? = nil
+) -> NSView {
+    let icon = NSImageView(image: .systemSymbol(symbolName, accessibilityDescription: ""))
     icon.contentTintColor = .secondaryLabelColor
     icon.setContentHuggingPriority(.required, for: .horizontal)
 
-    let pathLabel = NSTextField(labelWithString: wizardAbbreviateWithTilde(path))
-    pathLabel.font = .preferredFont(forTextStyle: .caption1)
-    pathLabel.lineBreakMode = .byTruncatingMiddle
-    pathLabel.maximumNumberOfLines = 1
-    pathLabel.isSelectable = false
-    pathLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    let label = NSTextField(labelWithString: text)
+    label.font = .preferredFont(forTextStyle: .caption1)
+    label.lineBreakMode = lineBreakMode
+    label.maximumNumberOfLines = 1
+    label.isSelectable = false
+    label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
-    let row = NSStackView(views: [icon, pathLabel] + (changeButton.map { [$0] } ?? []))
+    let row = NSStackView(views: [icon, label] + (trailingButton.map { [$0] } ?? []))
     row.orientation = .horizontal
     row.alignment = .firstBaseline
     row.spacing = Spacing.small

--- a/Kernova/Views/Detail/InitialBootBannerView.swift
+++ b/Kernova/Views/Detail/InitialBootBannerView.swift
@@ -92,8 +92,8 @@ final class InitialBootBannerView: NSView {
                 return "An interrupted download will resume when you click Start."
             }
             return "Click Start to download the latest macOS and install."
-        case .catalogVersion:
-            let version = context.version.map { "macOS \($0)" } ?? "the chosen macOS version"
+        case .catalogVersion, .customURL:
+            let version = context.version.map { "macOS \($0)" } ?? "the chosen restore image"
             if instance.hasResumableInstallDownload {
                 return "An interrupted download of \(version) will resume when you click Start."
             }

--- a/Kernova/Views/Detail/InitialBootBannerView.swift
+++ b/Kernova/Views/Detail/InitialBootBannerView.swift
@@ -92,6 +92,12 @@ final class InitialBootBannerView: NSView {
                 return "An interrupted download will resume when you click Start."
             }
             return "Click Start to download the latest macOS and install."
+        case .catalogVersion:
+            let version = context.version.map { "macOS \($0)" } ?? "the chosen macOS version"
+            if instance.hasResumableInstallDownload {
+                return "An interrupted download of \(version) will resume when you click Start."
+            }
+            return "Click Start to download \(version) and install."
         case .localFile:
             let name = context.localIPSWURL?.lastPathComponent ?? "the selected IPSW"
             return "Click Start to install from \(name)."

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -72,15 +72,15 @@ extension VMInstance {
         isColdPaused ? "Discard Saved State" : "Stop"
     }
 
-    /// `true` when this VM has a `.downloadLatest` install context, a
-    /// `.kernovadownload` bundle still holding partial bytes at the chosen path,
-    /// and no completed IPSW yet at the same path.
+    /// `true` when this VM's install fetches its image, a `.kernovadownload`
+    /// bundle still holds partial bytes at the chosen path, and no completed IPSW
+    /// sits at that path yet.
     ///
     /// The bytes check (`isResumable` rather than `exists`) keeps a husk left by a
     /// failed disposal from labelling a from-scratch download as a resume.
     var hasResumableInstallDownload: Bool {
         guard let context = configuration.installContext,
-            context.source == .downloadLatest,
+            context.source.downloadsImage,
             let destinationURL = context.downloadDestinationURL
         else { return false }
         let bundle = IPSWBundle(url: IPSWService.resumeBundleURL(for: destinationURL))

--- a/KernovaTests/IPSWSelectionContentViewControllerTests.swift
+++ b/KernovaTests/IPSWSelectionContentViewControllerTests.swift
@@ -13,7 +13,8 @@ struct IPSWSelectionContentViewControllerTests {
         vc.loadViewIfNeeded()
 
         #expect(radio(titled: "Download Latest", in: vc.view)?.state == .on)
-        #expect(radio(titled: "Choose Local File", in: vc.view)?.state == .off)
+        #expect(radio(titled: "Choose a Version…", in: vc.view)?.state == .off)
+        #expect(radio(titled: "Choose Local File…", in: vc.view)?.state == .off)
         #expect(
             findLabel(withText: wizardAbbreviateWithTilde(vm.ipswDownloadPath), in: vc.view) != nil)
     }

--- a/KernovaTests/IPSWSelectionContentViewControllerTests.swift
+++ b/KernovaTests/IPSWSelectionContentViewControllerTests.swift
@@ -20,11 +20,12 @@ struct IPSWSelectionContentViewControllerTests {
     }
 
     @Test("Overwrite warning shows when a file exists; Use Existing switches to local file")
-    func overwriteUseExisting() {
+    func overwriteUseExisting() async {
         let path = makeTempIPSW()
         defer { try? FileManager.default.removeItem(atPath: path) }
 
-        let vm = VMCreationViewModel()
+        let inspector = MockLocalRestoreImageInspector()
+        let vm = VMCreationViewModel(localImageInspector: inspector)
         vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = path
         #expect(vm.shouldShowOverwriteWarning == true)
@@ -34,8 +35,67 @@ struct IPSWSelectionContentViewControllerTests {
         #expect(findButton(titled: "Use Existing File", in: vc.view) != nil)
 
         findButton(titled: "Use Existing File", in: vc.view)?.performClick(nil)
+        await vc.adoptTaskForTesting?.value
+
         #expect(vm.ipswSource == .localFile)
         #expect(vm.ipswPath == path)
+    }
+
+    @Test("A file of a different build is named, and not adopted until confirmed")
+    func mismatchedExistingFileIsNotAdopted() async {
+        let path = makeTempIPSW()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let inspector = MockLocalRestoreImageInspector()
+        inspector.inspectResult = InspectedRestoreImage(
+            version: "14.2", build: "23C64", isSupportedOnThisHost: true)
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
+        vm.ipswDownloadPath = path
+
+        let vc = IPSWSelectionContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+        findButton(titled: "Use Existing File", in: vc.view)?.performClick(nil)
+        await vc.adoptTaskForTesting?.value
+
+        #expect(vm.ipswSource == .catalogVersion)
+        #expect(vm.ipswPath == nil)
+        #expect(findLabelContaining("macOS 14.2 (23C64)", in: vc.view) != nil)
+
+        // The user can still override, which is what "Use It Anyway" is for.
+        findButton(titled: "Use It Anyway", in: vc.view)?.performClick(nil)
+        #expect(vm.ipswSource == .localFile)
+        #expect(vm.ipswPath == path)
+    }
+
+    @Test("An unreadable file offers only a re-download")
+    func unreadableExistingFileOffersReplace() async {
+        let path = makeTempIPSW()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let inspector = MockLocalRestoreImageInspector()
+        inspector.inspectError = LocalRestoreImageError.unreadable
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        vm.ipswSource = .downloadLatest
+        vm.ipswDownloadPath = path
+
+        let vc = IPSWSelectionContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+        findButton(titled: "Use Existing File", in: vc.view)?.performClick(nil)
+        await vc.adoptTaskForTesting?.value
+
+        #expect(vm.ipswSource == .downloadLatest)
+        #expect(findLabelContaining("isn't a usable restore image", in: vc.view) != nil)
+        #expect(findButton(titled: "Use It Anyway", in: vc.view) == nil)
+        #expect(findButton(titled: "Download & Replace", in: vc.view) != nil)
+    }
+
+    private func findLabelContaining(_ text: String, in view: NSView) -> NSTextField? {
+        if let field = view as? NSTextField, field.stringValue.contains(text) { return field }
+        for subview in view.subviews {
+            if let found = findLabelContaining(text, in: subview) { return found }
+        }
+        return nil
     }
 
     @Test("Download & Replace confirms the overwrite and dismisses the banner")

--- a/KernovaTests/IPSWSelectionContentViewControllerTests.swift
+++ b/KernovaTests/IPSWSelectionContentViewControllerTests.swift
@@ -90,6 +90,32 @@ struct IPSWSelectionContentViewControllerTests {
         #expect(findButton(titled: "Download & Replace", in: vc.view) != nil)
     }
 
+    @Test("Leaving the step mid-check adopts nothing")
+    func cancelledInspectionCommitsNothing() async throws {
+        let path = makeTempIPSW()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let inspector = SuspendingMockLocalRestoreImageInspector()
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        vm.ipswSource = .downloadLatest
+        vm.ipswDownloadPath = path
+
+        let vc = IPSWSelectionContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+        findButton(titled: "Use Existing File", in: vc.view)?.performClick(nil)
+        let inFlight = try #require(vc.adoptTaskForTesting)
+        try await inspector.waitUntilInspecting()
+
+        // Navigating back off the step cancels the inspection under way.
+        vc.viewWillDisappear()
+        inspector.release()
+        await inFlight.value
+
+        // Adopting here would leave the radios and the model disagreeing.
+        #expect(vm.ipswSource == .downloadLatest)
+        #expect(vm.ipswPath == nil)
+    }
+
     private func findLabelContaining(_ text: String, in view: NSView) -> NSTextField? {
         if let field = view as? NSTextField, field.stringValue.contains(text) { return field }
         for subview in view.subviews {

--- a/KernovaTests/IPSWServiceDownloadTests.swift
+++ b/KernovaTests/IPSWServiceDownloadTests.swift
@@ -908,9 +908,145 @@ struct IPSWServiceDownloadTests {
             #expect(samples[i] >= samples[i - 1])
         }
     }
+
+    @Test("Concurrent downloads to one destination issue a single request")
+    func concurrentDownloadsToSameDestinationIssueOneRequest() async throws {
+        // Two VMs pinned to the same build share a destination and its bundle.
+        // Whichever call claims the destination does the transfer; the other
+        // waits and then skips over the finished image, so exactly one GET goes
+        // out however the two interleave — and only one writer ever touches the
+        // bundle's truncate / append / move sequence.
+        let temp = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let destination = temp.appendingPathComponent("RestoreImage.ipsw")
+
+        let payload = Data(repeating: 0xAB, count: 2 * 1024 * 1024)
+        let requests = RequestCounter()
+        StubURLProtocol.handler = { request in
+            requests.increment()
+            return .fullResponse(
+                url: request.url ?? Self.remoteURL, body: payload, etag: "\"v1\"")
+        }
+        defer { StubURLProtocol.handler = nil }
+
+        let service = Self.makeServiceWithStub()
+        let first = Task {
+            try await service.downloadRestoreImage(
+                from: Self.remoteURL, to: destination, progressHandler: { _ in })
+        }
+        let second = Task {
+            try await service.downloadRestoreImage(
+                from: Self.remoteURL, to: destination, progressHandler: { _ in })
+        }
+        try await first.value
+        try await second.value
+
+        #expect(requests.value == 1)
+        let written = try Data(contentsOf: destination)
+        #expect(written == payload)
+    }
+
+    @Test("Download & Replace trashes the existing image first and issues a fresh GET")
+    func discardExistingDownloadTrashesThenDownloads() async throws {
+        let temp = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let destination = temp.appendingPathComponent("RestoreImage.ipsw")
+
+        let payload = Data(repeating: 0xCD, count: 4096)
+        StubURLProtocol.handler = { request in
+            #expect(request.value(forHTTPHeaderField: "Range") == nil)
+            return .fullResponse(url: request.url ?? Self.remoteURL, body: payload, etag: "\"v2\"")
+        }
+        defer { StubURLProtocol.handler = nil }
+
+        // `fileExistsResult` defaults to true, so the discard sees an image at
+        // the destination; the recording mock leaves the real path absent, so
+        // the skip-existing fast path (a real-FileManager check) stays out of
+        // the way and the GET below is the replacement download.
+        let fileSystem = MockFileSystem()
+        let service = Self.makeServiceWithStub(fileSystem: fileSystem)
+        try await service.downloadRestoreImage(
+            from: Self.remoteURL,
+            to: destination,
+            discardsExistingDownload: true,
+            progressHandler: { _ in }
+        )
+
+        #expect(fileSystem.trashedURLs.first == destination)
+        let written = try Data(contentsOf: destination)
+        #expect(written == payload)
+    }
+
+    @Test("Download & Replace surfaces a trash failure and never contacts the server")
+    func discardExistingDownloadCleanupFailureThrows() async throws {
+        let temp = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let destination = temp.appendingPathComponent("RestoreImage.ipsw")
+
+        let requests = RequestCounter()
+        StubURLProtocol.handler = { request in
+            requests.increment()
+            return .fullResponse(url: request.url ?? Self.remoteURL, body: Data(), etag: "\"v1\"")
+        }
+        defer { StubURLProtocol.handler = nil }
+
+        let fileSystem = MockFileSystem()
+        fileSystem.trashError = CocoaError(.fileWriteNoPermission)
+        let service = Self.makeServiceWithStub(fileSystem: fileSystem)
+
+        do {
+            try await service.downloadRestoreImage(
+                from: Self.remoteURL,
+                to: destination,
+                discardsExistingDownload: true,
+                progressHandler: { _ in }
+            )
+            Issue.record("Expected downloadRestoreImage to throw when the image can't be trashed")
+        } catch IPSWError.freshDownloadCleanupFailed {
+            // Expected
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(requests.value == 0)
+    }
+
+    @Test("A logged URL keeps scheme, host and path but drops credentials")
+    func loggableURLDropsQueryAndUserInfo() {
+        // A custom restore-image URL can be pre-signed: the signature rides in
+        // the query, and it must not reach the unified log.
+        let signed = Self.mustParseURL(
+            "https://user:secret@cdn.example.com/builds/RestoreImage.ipsw?X-Amz-Signature=abc123&Expires=99#part"
+        )
+        #expect(
+            IPSWService.loggableURL(signed)
+                == "https://cdn.example.com/builds/RestoreImage.ipsw"
+        )
+
+        let plain = Self.mustParseURL("https://updates.example.com/2026/UniversalMac.ipsw")
+        #expect(IPSWService.loggableURL(plain) == plain.absoluteString)
+    }
 }
 
 // MARK: - Helpers
+
+/// Counts stub requests from URLSession's own queue, where the handler runs.
+final class RequestCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}
 
 /// Records progress samples on the MainActor so we can read them back after
 /// the download completes.

--- a/KernovaTests/MacOSInstallContextTests.swift
+++ b/KernovaTests/MacOSInstallContextTests.swift
@@ -120,6 +120,40 @@ struct MacOSInstallContextTests {
         #expect(decoded.build == "24G90")
     }
 
+    @Test("A custom-URL context round-trips its pinned image")
+    func customURLContextRoundTrips() throws {
+        let url = try #require(URL(string: "https://mirror.example.com/R.ipsw"))
+        let original = MacOSInstallContext(
+            source: .customURL,
+            downloadDestinationPath: "/Users/me/Downloads/R.ipsw",
+            remoteURL: url,
+            version: "15.6.1",
+            build: "24G90"
+        )
+        let decoded = try JSONDecoder().decode(
+            MacOSInstallContext.self, from: try JSONEncoder().encode(original))
+
+        #expect(decoded == original)
+        #expect(decoded.source == .customURL)
+        #expect(decoded.remoteURL == url)
+    }
+
+    @Test("Only the pinned sources skip resolving the latest image")
+    func usesPinnedURLCoversPinnedSourcesOnly() {
+        #expect(MacOSInstallContext.Source.catalogVersion.usesPinnedURL)
+        #expect(MacOSInstallContext.Source.customURL.usesPinnedURL)
+        #expect(!MacOSInstallContext.Source.downloadLatest.usesPinnedURL)
+        #expect(!MacOSInstallContext.Source.localFile.usesPinnedURL)
+    }
+
+    @Test("Only the network sources own a download destination")
+    func downloadsImageCoversNetworkSourcesOnly() {
+        #expect(MacOSInstallContext.Source.downloadLatest.downloadsImage)
+        #expect(MacOSInstallContext.Source.catalogVersion.downloadsImage)
+        #expect(MacOSInstallContext.Source.customURL.downloadsImage)
+        #expect(!MacOSInstallContext.Source.localFile.downloadsImage)
+    }
+
     @Test("A context written without the pinning fields still decodes")
     func decodeWithoutPinningFields() throws {
         let json = """

--- a/KernovaTests/MacOSInstallContextTests.swift
+++ b/KernovaTests/MacOSInstallContextTests.swift
@@ -96,4 +96,45 @@ struct MacOSInstallContextTests {
         )
         #expect(a != b)
     }
+
+    // MARK: - Catalog Version Source
+
+    @Test("A catalog context round-trips its pinned image")
+    func catalogContextRoundTrips() throws {
+        let url = try #require(
+            URL(string: "https://updates.cdn-apple.com/x/UniversalMac_15.6.1_24G90_Restore.ipsw"))
+        let original = MacOSInstallContext(
+            source: .catalogVersion,
+            downloadDestinationPath: "/Users/me/Downloads/UniversalMac_15.6.1_24G90_Restore.ipsw",
+            remoteURL: url,
+            version: "15.6.1",
+            build: "24G90"
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MacOSInstallContext.self, from: data)
+
+        #expect(decoded == original)
+        #expect(decoded.source == .catalogVersion)
+        #expect(decoded.remoteURL == url)
+        #expect(decoded.version == "15.6.1")
+        #expect(decoded.build == "24G90")
+    }
+
+    @Test("A context written without the pinning fields still decodes")
+    func decodeWithoutPinningFields() throws {
+        let json = """
+            {
+                "source": "downloadLatest",
+                "downloadDestinationPath": "/Users/me/Downloads/RestoreImage.ipsw",
+                "requestedFreshDownload": true
+            }
+            """
+        let ctx = try JSONDecoder().decode(MacOSInstallContext.self, from: Data(json.utf8))
+
+        #expect(ctx.source == .downloadLatest)
+        #expect(ctx.remoteURL == nil)
+        #expect(ctx.version == nil)
+        #expect(ctx.build == nil)
+        #expect(ctx.requestedFreshDownload)
+    }
 }

--- a/KernovaTests/Mocks/MockIPSWService.swift
+++ b/KernovaTests/Mocks/MockIPSWService.swift
@@ -5,6 +5,7 @@ import Foundation
 final class MockIPSWService: IPSWProviding, @unchecked Sendable {
     var fetchCallCount = 0
     var downloadCallCount = 0
+    var lastDownloadRemoteURL: URL?
     var discardResumeDataCallCount = 0
     var lastDiscardResumeDataURL: URL?
     var lastDiscardResumeDataPermanently: Bool?
@@ -32,6 +33,7 @@ final class MockIPSWService: IPSWProviding, @unchecked Sendable {
         progressHandler: @MainActor @Sendable @escaping (DownloadProgress) -> Void
     ) async throws {
         downloadCallCount += 1
+        lastDownloadRemoteURL = remoteURL
         if let error = downloadError { throw error }
     }
 

--- a/KernovaTests/Mocks/MockIPSWService.swift
+++ b/KernovaTests/Mocks/MockIPSWService.swift
@@ -6,6 +6,8 @@ final class MockIPSWService: IPSWProviding, @unchecked Sendable {
     var fetchCallCount = 0
     var downloadCallCount = 0
     var lastDownloadRemoteURL: URL?
+    var lastDownloadDestinationURL: URL?
+    var lastDownloadDiscardsExisting: Bool?
     var discardResumeDataCallCount = 0
     var lastDiscardResumeDataURL: URL?
     var lastDiscardResumeDataPermanently: Bool?
@@ -30,10 +32,13 @@ final class MockIPSWService: IPSWProviding, @unchecked Sendable {
     func downloadRestoreImage(
         from remoteURL: URL,
         to destinationURL: URL,
+        discardsExistingDownload: Bool,
         progressHandler: @MainActor @Sendable @escaping (DownloadProgress) -> Void
     ) async throws {
         downloadCallCount += 1
         lastDownloadRemoteURL = remoteURL
+        lastDownloadDestinationURL = destinationURL
+        lastDownloadDiscardsExisting = discardsExistingDownload
         if let error = downloadError { throw error }
     }
 

--- a/KernovaTests/Mocks/MockLocalRestoreImageInspector.swift
+++ b/KernovaTests/Mocks/MockLocalRestoreImageInspector.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@testable import Kernova
+
+/// Scripted stand-in for `LocalRestoreImageInspecting`.
+final class MockLocalRestoreImageInspector: LocalRestoreImageInspecting, @unchecked Sendable {
+    var inspectCallCount = 0
+    var lastInspectedURL: URL?
+
+    /// Thrown instead of returning, per the per-method `<method>Error` convention.
+    var inspectError: (any Error)?
+    /// Returned on success; defaults to a supported image.
+    var inspectResult = InspectedRestoreImage(
+        version: "15.6.1", build: "24G90", isSupportedOnThisHost: true)
+
+    func inspect(_ url: URL) async throws -> InspectedRestoreImage {
+        inspectCallCount += 1
+        lastInspectedURL = url
+        if let error = inspectError { throw error }
+        return inspectResult
+    }
+}

--- a/KernovaTests/Mocks/MockRestoreImageCatalogService.swift
+++ b/KernovaTests/Mocks/MockRestoreImageCatalogService.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+@testable import Kernova
+
+/// In-memory stand-in for `RestoreImageCatalogProviding`.
+struct MockRestoreImageCatalogService: RestoreImageCatalogProviding {
+    var entries: [RestoreImageCatalogEntry]
+    var generatedAt: String?
+
+    init(entries: [RestoreImageCatalogEntry] = [], generatedAt: String? = "2026-07-28") {
+        self.entries = entries
+        self.generatedAt = generatedAt
+    }
+}
+
+/// Builds a catalog entry, defaulted so a test only names what it cares about.
+func makeCatalogEntry(
+    version: String = "15.6.1",
+    build: String = "24G90",
+    urlString: String? = nil,
+    sizeBytes: UInt64 = 16_808_427_372,
+    lastModified: String = "Mon, 18 Aug 2025 12:00:00 GMT",
+    source: String = "apple-live"
+) -> RestoreImageCatalogEntry {
+    let resolved =
+        urlString
+        ?? "https://updates.cdn-apple.com/fullrestores/UniversalMac_\(version)_\(build)_Restore.ipsw"
+    return RestoreImageCatalogEntry(
+        version: version,
+        build: build,
+        url: URL(string: resolved) ?? URL(fileURLWithPath: "/"),
+        sizeBytes: sizeBytes,
+        lastModified: lastModified,
+        source: source
+    )
+}

--- a/KernovaTests/Mocks/MockRestoreImageProbeService.swift
+++ b/KernovaTests/Mocks/MockRestoreImageProbeService.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+@testable import Kernova
+
+/// Scripted stand-in for `RestoreImageProbing`.
+final class MockRestoreImageProbeService: RestoreImageProbing, @unchecked Sendable {
+    var probeCallCount = 0
+    var lastProbedURL: URL?
+
+    /// Thrown instead of returning, per the per-method `<method>Error` convention.
+    var probeError: (any Error)?
+    /// Returned on success; defaults to a well-formed Apple image.
+    var probeResult: ProbedRestoreImage = makeProbedImage()
+
+    func probe(_ url: URL) async throws -> ProbedRestoreImage {
+        probeCallCount += 1
+        lastProbedURL = url
+        if let error = probeError { throw error }
+        return probeResult
+    }
+}
+
+/// Builds a probed image, defaulted so a test names only what it cares about.
+func makeProbedImage(
+    urlString: String =
+        "https://updates.cdn-apple.com/x/UniversalMac_15.6.1_24G90_Restore.ipsw",
+    sizeBytes: UInt64 = 16_808_427_372,
+    version: String? = "15.6.1",
+    build: String? = "24G90"
+) -> ProbedRestoreImage {
+    ProbedRestoreImage(
+        url: URL(string: urlString) ?? URL(fileURLWithPath: "/"),
+        sizeBytes: sizeBytes,
+        version: version,
+        build: build
+    )
+}

--- a/KernovaTests/RestoreImageCatalogSheetContentViewControllerTests.swift
+++ b/KernovaTests/RestoreImageCatalogSheetContentViewControllerTests.swift
@@ -1,0 +1,162 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("RestoreImageCatalogSheetContentViewController Tests")
+@MainActor
+struct RestoreImageCatalogSheetContentViewControllerTests {
+    private func host(_ major: Int, _ minor: Int, _ patch: Int) -> OperatingSystemVersion {
+        OperatingSystemVersion(majorVersion: major, minorVersion: minor, patchVersion: patch)
+    }
+
+    private var entries: [RestoreImageCatalogEntry] {
+        [
+            makeCatalogEntry(version: "26.6", build: "25G72"),
+            makeCatalogEntry(version: "15.6.1", build: "24G90"),
+            makeCatalogEntry(version: "12.0.1", build: "21A559"),
+        ]
+    }
+
+    private func makeSheet(
+        selectedBuild: String? = nil,
+        hostVersion: OperatingSystemVersion? = nil,
+        downloadedBuilds: Set<String> = []
+    ) -> RestoreImageCatalogSheetContentViewController {
+        let vc = RestoreImageCatalogSheetContentViewController(
+            entries: entries,
+            selectedBuild: selectedBuild,
+            generatedAt: "2026-07-28",
+            hostVersion: hostVersion ?? host(26, 6, 0),
+            isDownloaded: { downloadedBuilds.contains($0.build) }
+        )
+        vc.loadViewIfNeeded()
+        return vc
+    }
+
+    @Test("Opens with the newest supported version selected")
+    func selectsNewestSupportedByDefault() {
+        let vc = makeSheet()
+        #expect(vc.selectedEntry?.build == "25G72")
+    }
+
+    @Test("A previous pick is preselected")
+    func preselectsPreviousPick() {
+        let vc = makeSheet(selectedBuild: "24G90")
+        #expect(vc.selectedEntry?.build == "24G90")
+    }
+
+    @Test("A guest newer than the host cannot be selected")
+    func guestNewerThanHostIsUnselectable() throws {
+        // Host below 26.6, so the newest entry is out of reach.
+        let vc = makeSheet(hostVersion: host(15, 6, 1))
+        #expect(vc.selectedEntry?.build == "24G90")
+
+        let table = try #require(findTableView(in: vc.view))
+        #expect(vc.tableView(table, shouldSelectRow: 0) == false)
+        #expect(vc.tableView(table, shouldSelectRow: 1) == true)
+    }
+
+    @Test("Search filters on version and build")
+    func searchFiltersRows() {
+        let vc = makeSheet()
+
+        vc.applyFilter("15.6")
+        #expect(vc.visibleEntries.map(\.build) == ["24G90"])
+
+        vc.applyFilter("21A559")
+        #expect(vc.visibleEntries.map(\.build) == ["21A559"])
+
+        vc.applyFilter("")
+        #expect(vc.visibleEntries.count == 3)
+    }
+
+    @Test("A selection surviving the filter is kept")
+    func filterKeepsSurvivingSelection() {
+        let vc = makeSheet(selectedBuild: "24G90")
+        vc.applyFilter("15")
+        #expect(vc.selectedEntry?.build == "24G90")
+    }
+
+    @Test("A filter that hides the selection clears it")
+    func filterDroppingSelectionClearsIt() {
+        let vc = makeSheet(selectedBuild: "24G90")
+        vc.applyFilter("26.6")
+        #expect(vc.selectedEntry == nil)
+    }
+
+    @Test("Choosing reports the entry to the delegate")
+    func choosingReportsToDelegate() {
+        let vc = makeSheet(selectedBuild: "24G90")
+        let delegate = RecordingDelegate()
+        vc.delegate = delegate
+
+        findButton(titled: "Choose", in: vc.view)?.performClick(nil)
+
+        #expect(delegate.chosen?.build == "24G90")
+        #expect(delegate.cancelCount == 0)
+    }
+
+    @Test("Cancel reports a dismissal and no choice")
+    func cancelReportsToDelegate() {
+        let vc = makeSheet()
+        let delegate = RecordingDelegate()
+        vc.delegate = delegate
+
+        findButton(titled: "Cancel", in: vc.view)?.performClick(nil)
+
+        #expect(delegate.chosen == nil)
+        #expect(delegate.cancelCount == 1)
+    }
+
+    @Test("Choose is disabled while nothing selectable is selected")
+    func chooseDisabledWithoutSelection() {
+        let vc = makeSheet()
+        vc.applyFilter("nothing matches this")
+        #expect(findButton(titled: "Choose", in: vc.view)?.isEnabled == false)
+    }
+
+    @Test("The footer dates the list and points at Download Latest for newer releases")
+    func footerNamesTheSnapshotDate() {
+        let vc = makeSheet()
+        #expect(findLabel(containing: "July 2026", in: vc.view) != nil)
+        #expect(findLabel(containing: "Download Latest", in: vc.view) != nil)
+    }
+
+    // MARK: - Helpers
+
+    private final class RecordingDelegate: RestoreImageCatalogSheetContentViewControllerDelegate {
+        var chosen: RestoreImageCatalogEntry?
+        var cancelCount = 0
+
+        func restoreImageCatalogSheet(
+            _ vc: RestoreImageCatalogSheetContentViewController,
+            didChoose entry: RestoreImageCatalogEntry
+        ) {
+            chosen = entry
+        }
+
+        func restoreImageCatalogSheetDidCancel(
+            _ vc: RestoreImageCatalogSheetContentViewController
+        ) {
+            cancelCount += 1
+        }
+    }
+
+    private func findTableView(in view: NSView) -> NSTableView? {
+        if let table = view as? NSTableView { return table }
+        for subview in view.subviews {
+            if let found = findTableView(in: subview) { return found }
+        }
+        return nil
+    }
+
+    private func findLabel(containing text: String, in view: NSView) -> NSTextField? {
+        if let field = view as? NSTextField, field.stringValue.contains(text) { return field }
+        for subview in view.subviews {
+            if let found = findLabel(containing: text, in: subview) { return found }
+        }
+        return nil
+    }
+}

--- a/KernovaTests/RestoreImageCatalogTests.swift
+++ b/KernovaTests/RestoreImageCatalogTests.swift
@@ -1,0 +1,245 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("RestoreImageCatalogEntry Tests")
+struct RestoreImageCatalogEntryTests {
+    private func host(_ major: Int, _ minor: Int, _ patch: Int) -> OperatingSystemVersion {
+        OperatingSystemVersion(majorVersion: major, minorVersion: minor, patchVersion: patch)
+    }
+
+    @Test("Identity is the build, so two spins of one version stay distinct")
+    func buildIsIdentity() {
+        // Apple shipped macOS 15.4 as both of these.
+        let first = makeCatalogEntry(version: "15.4", build: "24E246")
+        let second = makeCatalogEntry(version: "15.4", build: "24E248")
+        #expect(first.id == "24E246")
+        #expect(second.id == "24E248")
+        #expect(first != second)
+        #expect(Set([first.id, second.id]).count == 2)
+    }
+
+    @Test("suggestedFilename is Apple's own filename")
+    func suggestedFilenameFromURL() {
+        let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
+        #expect(entry.suggestedFilename == "UniversalMac_15.6.1_24G90_Restore.ipsw")
+    }
+
+    @Test("A guest equal to the host is supported; one below is, one above is not")
+    func hostSupportBoundary() {
+        let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
+        #expect(entry.isSupported(onHost: host(15, 6, 1)))
+        #expect(entry.isSupported(onHost: host(15, 6, 2)))
+        #expect(entry.isSupported(onHost: host(26, 0, 0)))
+        #expect(!entry.isSupported(onHost: host(15, 6, 0)))
+        #expect(!entry.isSupported(onHost: host(15, 5, 9)))
+        #expect(!entry.isSupported(onHost: host(14, 9, 9)))
+    }
+
+    @Test("A two-component version compares as though padded with zeroes")
+    func hostSupportPadsMissingComponents() {
+        let entry = makeCatalogEntry(version: "26.6", build: "25G72")
+        #expect(entry.isSupported(onHost: host(26, 6, 0)))
+        #expect(entry.isSupported(onHost: host(26, 6, 1)))
+        #expect(!entry.isSupported(onHost: host(26, 5, 9)))
+    }
+
+    @Test("A non-numeric version has no components and cannot be host-checked")
+    func unparseableVersion() {
+        let entry = makeCatalogEntry(version: "Sequoia", build: "24G90")
+        #expect(entry.versionComponents == nil)
+        #expect(!entry.isSupported(onHost: host(26, 0, 0)))
+    }
+
+    @Test("Sorting is newest first and numeric per component")
+    func sortsNumericallyDescending() {
+        let entries = [
+            makeCatalogEntry(version: "26.9", build: "B"),
+            makeCatalogEntry(version: "12.0.1", build: "D"),
+            makeCatalogEntry(version: "26.10", build: "A"),
+            makeCatalogEntry(version: "15.6.1", build: "C"),
+        ]
+        let sorted = entries.sorted(by: RestoreImageCatalogEntry.isDescending)
+        // 26.10 above 26.9 — a lexicographic sort would invert these.
+        #expect(sorted.map(\.build) == ["A", "B", "C", "D"])
+    }
+
+    @Test("Equal versions sort by build so the order is total")
+    func sortIsTotalForEqualVersions() {
+        let first = makeCatalogEntry(version: "15.4", build: "24E248")
+        let second = makeCatalogEntry(version: "15.4", build: "24E246")
+        let sorted = [second, first].sorted(by: RestoreImageCatalogEntry.isDescending)
+        #expect(sorted.map(\.build) == ["24E248", "24E246"])
+    }
+
+    @Test("Search matches version and build, case-insensitively")
+    func searchMatchesVersionAndBuild() {
+        let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
+        #expect(entry.matches(searchTerm: "15.6"))
+        #expect(entry.matches(searchTerm: "24g90"))
+        #expect(entry.matches(searchTerm: "  "))
+        #expect(entry.matches(searchTerm: ""))
+        #expect(!entry.matches(searchTerm: "14.0"))
+        #expect(!entry.matches(searchTerm: "23A344"))
+    }
+
+    @Test("releaseDate parses Apple's RFC 1123 Last-Modified header")
+    func releaseDateParses() throws {
+        let entry = makeCatalogEntry(lastModified: "Fri, 24 Jul 2026 02:16:52 GMT")
+        let date = try #require(entry.releaseDate)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let parts = calendar.dateComponents([.year, .month, .day], from: date)
+        #expect(parts.year == 2026)
+        #expect(parts.month == 7)
+        #expect(parts.day == 24)
+    }
+
+    @Test("An unparseable Last-Modified yields no date rather than a wrong one")
+    func releaseDateRejectsGarbage() {
+        #expect(makeCatalogEntry(lastModified: "not a date").releaseDate == nil)
+    }
+}
+
+@Suite("RestoreImageCatalogService Tests")
+struct RestoreImageCatalogServiceTests {
+    private func json(images: String) -> Data {
+        Data(
+            """
+            {
+              "device": "VirtualMac2,1",
+              "generatedAt": "2026-07-28",
+              "imageCount": 1,
+              "images": [\(images)]
+            }
+            """.utf8)
+    }
+
+    private let goodEntry = """
+        {
+          "build": "24G90",
+          "version": "15.6.1",
+          "url": "https://updates.cdn-apple.com/x/UniversalMac_15.6.1_24G90_Restore.ipsw",
+          "sizeBytes": 16808427372,
+          "lastModified": "Mon, 18 Aug 2025 12:00:00 GMT",
+          "source": "apple-live"
+        }
+        """
+
+    @Test("A well-formed catalog decodes with no rejections")
+    func decodesCleanCatalog() throws {
+        let result = RestoreImageCatalogService.parse(json(images: goodEntry))
+        let catalog = try #require(result.catalog)
+        #expect(result.rejections.isEmpty)
+        #expect(catalog.generatedAt == "2026-07-28")
+        #expect(catalog.images.map(\.build) == ["24G90"])
+    }
+
+    @Test("A malformed entry is dropped rather than failing the whole decode")
+    func dropsMalformedEntry() throws {
+        let malformed = """
+            { "build": "BAD" }
+            """
+        let result = RestoreImageCatalogService.parse(
+            json(images: "\(malformed), \(goodEntry)"))
+        let catalog = try #require(result.catalog)
+        #expect(catalog.images.map(\.build) == ["24G90"])
+        #expect(result.rejections == [.undecodableEntry(index: 0)])
+    }
+
+    @Test("An undecodable document yields no catalog")
+    func rejectsUndecodableDocument() {
+        let result = RestoreImageCatalogService.parse(Data("not json".utf8))
+        #expect(result.catalog == nil)
+        #expect(result.rejections == [.undecodableDocument])
+    }
+
+    @Test("A non-HTTPS URL is rejected")
+    func rejectsInsecureURL() throws {
+        let insecure = goodEntry.replacingOccurrences(of: "https://", with: "http://")
+        let result = RestoreImageCatalogService.parse(json(images: insecure))
+        let catalog = try #require(result.catalog)
+        #expect(catalog.images.isEmpty)
+        #expect(result.rejections.count == 1)
+        if case .insecureURL(let build, _) = result.rejections[0] {
+            #expect(build == "24G90")
+        } else {
+            Issue.record("Expected an insecureURL rejection, got \(result.rejections[0])")
+        }
+    }
+
+    @Test("A non-Apple host is rejected")
+    func rejectsForeignHost() throws {
+        let foreign = goodEntry.replacingOccurrences(
+            of: "updates.cdn-apple.com", with: "mirrors.example.com")
+        let result = RestoreImageCatalogService.parse(json(images: foreign))
+        let catalog = try #require(result.catalog)
+        #expect(catalog.images.isEmpty)
+        #expect(result.rejections.count == 1)
+        if case .foreignHost(let build, _) = result.rejections[0] {
+            #expect(build == "24G90")
+        } else {
+            Issue.record("Expected a foreignHost rejection, got \(result.rejections[0])")
+        }
+    }
+
+    @Test("A non-numeric version is rejected")
+    func rejectsUnparseableVersion() throws {
+        let bad = goodEntry.replacingOccurrences(of: "\"15.6.1\"", with: "\"Sequoia\"")
+        let result = RestoreImageCatalogService.parse(json(images: bad))
+        let catalog = try #require(result.catalog)
+        #expect(catalog.images.isEmpty)
+        #expect(result.rejections == [.unparseableVersion(build: "24G90", version: "Sequoia")])
+    }
+
+    @Test("A repeated build is kept once")
+    func rejectsDuplicateBuild() throws {
+        let result = RestoreImageCatalogService.parse(json(images: "\(goodEntry), \(goodEntry)"))
+        let catalog = try #require(result.catalog)
+        #expect(catalog.images.count == 1)
+        #expect(result.rejections == [.duplicateBuild(build: "24G90")])
+    }
+
+    @Test("Parsed entries come back newest first regardless of input order")
+    func sortsParsedEntries() throws {
+        let older =
+            goodEntry
+            .replacingOccurrences(of: "\"15.6.1\"", with: "\"12.0.1\"")
+            .replacingOccurrences(of: "\"24G90\"", with: "\"21A559\"")
+        let result = RestoreImageCatalogService.parse(json(images: "\(older), \(goodEntry)"))
+        let catalog = try #require(result.catalog)
+        #expect(catalog.images.map(\.build) == ["24G90", "21A559"])
+    }
+
+    @Test("Apple hosts are matched on a dot boundary, hyphenated CDN included")
+    func appleHostMatching() {
+        #expect(RestoreImageCatalogService.isAppleHost("apple.com"))
+        #expect(RestoreImageCatalogService.isAppleHost("swcdn.apple.com"))
+        #expect(RestoreImageCatalogService.isAppleHost("UPDATES.CDN-APPLE.COM"))
+        // `updates.cdn-apple.com` is not a subdomain of `apple.com`.
+        #expect(RestoreImageCatalogService.isAppleHost("updates.cdn-apple.com"))
+        #expect(!RestoreImageCatalogService.isAppleHost("notapple.com"))
+        #expect(!RestoreImageCatalogService.isAppleHost("apple.com.example.net"))
+        #expect(!RestoreImageCatalogService.isAppleHost("evilcdn-apple.com"))
+    }
+
+    @Test("The catalog shipped in the app bundle parses clean")
+    func bundledCatalogIsValid() throws {
+        let service = RestoreImageCatalogService()
+        #expect(!service.entries.isEmpty)
+        #expect(service.generatedAt != nil)
+
+        // Every shipped invariant the parser enforces, asserted against the real
+        // resource rather than a fixture. Counts are deliberately absent: the
+        // catalog is regenerated on Apple's schedule.
+        #expect(Set(service.entries.map(\.build)).count == service.entries.count)
+        for entry in service.entries {
+            #expect(entry.url.scheme == "https")
+            #expect(entry.suggestedFilename.hasSuffix(".ipsw"))
+            #expect(entry.versionComponents != nil)
+        }
+        let sorted = service.entries.sorted(by: RestoreImageCatalogEntry.isDescending)
+        #expect(sorted.map(\.build) == service.entries.map(\.build))
+    }
+}

--- a/KernovaTests/RestoreImageCatalogTests.swift
+++ b/KernovaTests/RestoreImageCatalogTests.swift
@@ -26,6 +26,14 @@ struct RestoreImageCatalogEntryTests {
         #expect(entry.suggestedFilename == "UniversalMac_15.6.1_24G90_Restore.ipsw")
     }
 
+    @Test("A URL whose filename would escape Downloads yields a generated one")
+    func suggestedFilenameRefusesTraversal() {
+        let entry = makeCatalogEntry(
+            urlString: "https://updates.cdn-apple.com/x/a%2F..%2F..%2Fevil.ipsw")
+        #expect(!entry.suggestedFilename.contains("/"))
+        #expect(entry.suggestedFilename.hasSuffix(".ipsw"))
+    }
+
     @Test("A guest equal to the host is supported; one below is, one above is not")
     func hostSupportBoundary() {
         let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")

--- a/KernovaTests/RestoreImageProbeTests.swift
+++ b/KernovaTests/RestoreImageProbeTests.swift
@@ -1,0 +1,272 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("ProbedRestoreImage Tests")
+struct ProbedRestoreImageTests {
+    private func host(_ major: Int, _ minor: Int, _ patch: Int) -> OperatingSystemVersion {
+        OperatingSystemVersion(majorVersion: major, minorVersion: minor, patchVersion: patch)
+    }
+
+    @Test("Apple's filename convention yields version and build")
+    func parsesAppleFilename() {
+        let parsed = ProbedRestoreImage.parseFilename("UniversalMac_15.6.1_24G90_Restore.ipsw")
+        #expect(parsed.version == "15.6.1")
+        #expect(parsed.build == "24G90")
+    }
+
+    @Test("A two-component version parses too")
+    func parsesTwoComponentVersion() {
+        let parsed = ProbedRestoreImage.parseFilename("UniversalMac_26.6_25G72_Restore.ipsw")
+        #expect(parsed.version == "26.6")
+        #expect(parsed.build == "25G72")
+    }
+
+    @Test("Anything off-convention yields no guess")
+    func rejectsOffConventionFilenames() {
+        for filename in [
+            "restore.ipsw",
+            "UniversalMac_15.6.1_Restore.ipsw",
+            "UniversalMac_15.6.1_24G90_Restore.zip",
+            "SomethingElse_15.6.1_24G90_Restore.ipsw",
+            "UniversalMac_Sequoia_24G90_Restore.ipsw",
+            "UniversalMac__24G90_Restore.ipsw",
+            "UniversalMac_15.6.1_24-G90_Restore.ipsw",
+        ] {
+            let parsed = ProbedRestoreImage.parseFilename(filename)
+            #expect(parsed.version == nil, "expected no version from '\(filename)'")
+            #expect(parsed.build == nil, "expected no build from '\(filename)'")
+        }
+    }
+
+    @Test("The destination is Apple's filename, and falls back when the URL has none")
+    func suggestedFilename() {
+        #expect(
+            makeProbedImage().suggestedFilename == "UniversalMac_15.6.1_24G90_Restore.ipsw")
+        #expect(
+            makeProbedImage(urlString: "https://example.com/downloads/")
+                .suggestedFilename == "RestoreImage.ipsw")
+        #expect(
+            makeProbedImage(urlString: "https://example.com/image.zip")
+                .suggestedFilename == "RestoreImage.ipsw")
+    }
+
+    @Test("Two different images never resolve to the same destination")
+    func destinationsAreDistinct() {
+        let first = makeProbedImage(
+            urlString: "https://a.example.com/UniversalMac_15.6.1_24G90_Restore.ipsw")
+        let second = makeProbedImage(
+            urlString: "https://b.example.com/UniversalMac_26.6_25G72_Restore.ipsw")
+        #expect(first.suggestedFilename != second.suggestedFilename)
+    }
+
+    @Test("Host support is unknown when the filename named no version")
+    func hostSupportUnknownWithoutVersion() {
+        let image = makeProbedImage(version: nil, build: nil)
+        #expect(image.isSupported(onHost: host(26, 0, 0)) == nil)
+    }
+
+    @Test("Host support compares numerically at the boundary")
+    func hostSupportBoundary() {
+        let image = makeProbedImage(version: "15.6.1")
+        #expect(image.isSupported(onHost: host(15, 6, 1)) == true)
+        #expect(image.isSupported(onHost: host(15, 6, 0)) == false)
+        #expect(image.isSupported(onHost: host(26, 0, 0)) == true)
+    }
+
+    @Test("The version summary degrades to what is actually known")
+    func versionSummaryDegrades() {
+        #expect(makeProbedImage().versionSummary == "macOS 15.6.1 (24G90)")
+        #expect(makeProbedImage(build: nil).versionSummary == "macOS 15.6.1")
+        #expect(makeProbedImage(version: nil).versionSummary == "Build 24G90")
+        #expect(
+            makeProbedImage(version: nil, build: nil).versionSummary == "Unrecognized version")
+    }
+}
+
+/// Stub for the probe's requests.
+///
+/// Deliberately its own class rather than `StubURLProtocol`: that one's handler
+/// is a global, and Swift Testing runs suites in parallel, so sharing it lets
+/// this suite and `IPSWServiceDownloadTests` clobber each other's handler.
+/// `.serialized` orders tests *within* a suite and does not prevent that.
+final class ProbeStubURLProtocol: URLProtocol, @unchecked Sendable {
+    struct Reply {
+        var statusCode: Int
+        var body: Data
+        var headers: [String: String]
+    }
+
+    nonisolated(unsafe) static var handler: ((URLRequest) -> Reply)?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler, let url = request.url else {
+            client?.urlProtocol(
+                self,
+                didFailWithError: NSError(
+                    domain: "ProbeStubURLProtocol", code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "No handler set"]))
+            return
+        }
+        let reply = handler(request)
+        var headers = reply.headers
+        if headers["Content-Length"] == nil { headers["Content-Length"] = "\(reply.body.count)" }
+        guard
+            let response = HTTPURLResponse(
+                url: url, statusCode: reply.statusCode, httpVersion: "HTTP/1.1",
+                headerFields: headers)
+        else {
+            preconditionFailure("ProbeStubURLProtocol: could not build a response")
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if !reply.body.isEmpty { client?.urlProtocol(self, didLoad: reply.body) }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@Suite("RestoreImageProbeService Tests", .serialized)
+struct RestoreImageProbeServiceTests {
+    private func makeService() -> RestoreImageProbeService {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses =
+            [ProbeStubURLProtocol.self] + (configuration.protocolClasses ?? [])
+        return RestoreImageProbeService(sessionConfiguration: configuration)
+    }
+
+    private var imageURL: URL {
+        URL(string: "https://updates.cdn-apple.com/x/UniversalMac_15.6.1_24G90_Restore.ipsw")
+            ?? URL(fileURLWithPath: "/")
+    }
+
+    /// Builds the tail of a zip whose central directory does or doesn't name a
+    /// `vma2` member — the only thing the probe reads.
+    ///
+    /// Laid out so the directory sits immediately before the end-of-directory
+    /// record, and the whole thing is served as one blob: the probe's tail read
+    /// covers it, and the zip64 locator is deliberately absent so the 32-bit
+    /// fields are authoritative.
+    private func makeZipTail(containsVMA2: Bool) -> Data {
+        var directory = Data()
+        directory.append(contentsOf: [0x50, 0x4B, 0x01, 0x02])  // central file header
+        let name = containsVMA2 ? "kernelcache.release.vma2" : "kernelcache.release.im4p"
+        directory.append(contentsOf: Array(name.utf8))
+
+        var blob = Data()
+        blob.append(directory)
+
+        var eocd = Data()
+        eocd.append(contentsOf: [0x50, 0x4B, 0x05, 0x06])  // EOCD signature
+        eocd.append(contentsOf: [0, 0, 0, 0])  // disk numbers
+        eocd.append(contentsOf: [1, 0, 1, 0])  // entry counts
+        withUnsafeBytes(of: UInt32(directory.count).littleEndian) { eocd.append(contentsOf: $0) }
+        withUnsafeBytes(of: UInt32(0).littleEndian) { eocd.append(contentsOf: $0) }  // offset
+        eocd.append(contentsOf: [0, 0])  // comment length
+        blob.append(eocd)
+        return blob
+    }
+
+    /// Serves `body` for every request, answering HEAD with the declared total
+    /// and range requests out of the same bytes.
+    private func serve(total: Int, body: Data, headStatus: Int = 200) {
+        ProbeStubURLProtocol.handler = { request in
+            if request.httpMethod == "HEAD" {
+                return ProbeStubURLProtocol.Reply(
+                    statusCode: headStatus, body: Data(),
+                    headers: ["Content-Length": "\(total)"])
+            }
+            guard let header = request.value(forHTTPHeaderField: "Range"),
+                let spec = header.split(separator: "=").last
+            else {
+                return ProbeStubURLProtocol.Reply(statusCode: 200, body: body, headers: [:])
+            }
+            let bounds = spec.split(separator: "-")
+            let start = Int(bounds.first ?? "0") ?? 0
+            let end = bounds.count > 1 ? (Int(bounds[1]) ?? total - 1) : total - 1
+            // The stub's body represents the file's tail, so a range that starts
+            // inside it is served from the corresponding offset.
+            let bodyStart = total - body.count
+            let lower = max(0, start - bodyStart)
+            let upper = min(body.count, end - bodyStart + 1)
+            let slice = lower < upper ? body.subdata(in: lower..<upper) : Data()
+            return ProbeStubURLProtocol.Reply(
+                statusCode: 206, body: slice,
+                headers: ["Content-Range": "bytes \(start)-\(end)/\(total)"])
+        }
+    }
+
+    @Test("An image carrying the VM hardware model is accepted")
+    func acceptsVirtualMachineImage() async throws {
+        let tail = makeZipTail(containsVMA2: true)
+        serve(total: tail.count, body: tail)
+        defer { ProbeStubURLProtocol.handler = nil }
+
+        let image = try await makeService().probe(imageURL)
+
+        #expect(image.sizeBytes == UInt64(tail.count))
+        #expect(image.version == "15.6.1")
+        #expect(image.build == "24G90")
+        #expect(image.url == imageURL)
+    }
+
+    @Test("An image with no VM hardware model is refused")
+    func refusesImageWithoutVirtualMachineModel() async {
+        let tail = makeZipTail(containsVMA2: false)
+        serve(total: tail.count, body: tail)
+        defer { ProbeStubURLProtocol.handler = nil }
+
+        await #expect(throws: RestoreImageProbeError.notAVirtualMachineImage) {
+            _ = try await makeService().probe(imageURL)
+        }
+    }
+
+    @Test("A non-HTTPS URL is refused before any request")
+    func refusesInsecureURL() async throws {
+        let http = try #require(URL(string: "http://updates.cdn-apple.com/x/R.ipsw"))
+        ProbeStubURLProtocol.handler = { _ in
+            Issue.record("The probe issued a request for a non-HTTPS URL")
+            return ProbeStubURLProtocol.Reply(statusCode: 200, body: Data(), headers: [:])
+        }
+        defer { ProbeStubURLProtocol.handler = nil }
+
+        await #expect(throws: RestoreImageProbeError.insecureURL) {
+            _ = try await makeService().probe(http)
+        }
+    }
+
+    @Test("A URL that 404s is refused with its status")
+    func refusesMissingImage() async {
+        serve(total: 0, body: Data(), headStatus: 404)
+        defer { ProbeStubURLProtocol.handler = nil }
+
+        await #expect(throws: RestoreImageProbeError.unreachable(statusCode: 404)) {
+            _ = try await makeService().probe(imageURL)
+        }
+    }
+
+    @Test("A file with no zip structure is refused as unreadable")
+    func refusesUnreadableStructure() async {
+        let junk = Data(repeating: 0x41, count: 4096)
+        serve(total: junk.count, body: junk)
+        defer { ProbeStubURLProtocol.handler = nil }
+
+        await #expect(throws: RestoreImageProbeError.unreadableStructure) {
+            _ = try await makeService().probe(imageURL)
+        }
+    }
+
+    @Test("Byte-order and search helpers behave at the edges")
+    func binaryHelpers() {
+        #expect(RestoreImageProbeService.readLE([0x01, 0x00, 0x00, 0x00], 0, UInt32.self) == 1)
+        #expect(RestoreImageProbeService.readLE([0xFF, 0xFF], 0, UInt32.self) == nil)
+        #expect(RestoreImageProbeService.readLE([0x01, 0x02], -1, UInt16.self) == nil)
+        #expect(RestoreImageProbeService.lastIndex(of: [0x02], in: [0x02, 0x01, 0x02]) == 2)
+        #expect(RestoreImageProbeService.lastIndex(of: [0x03], in: [0x02, 0x01]) == nil)
+        #expect(RestoreImageProbeService.lastIndex(of: [], in: [0x01]) == nil)
+    }
+}

--- a/KernovaTests/RestoreImageProbeTests.swift
+++ b/KernovaTests/RestoreImageProbeTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KernovaTestSupport
 import Testing
 
 @testable import Kernova
@@ -40,16 +41,25 @@ struct ProbedRestoreImageTests {
         }
     }
 
-    @Test("The destination is Apple's filename, and falls back when the URL has none")
+    @Test("The destination is Apple's filename when the URL follows the convention")
     func suggestedFilename() {
         #expect(
             makeProbedImage().suggestedFilename == "UniversalMac_15.6.1_24G90_Restore.ipsw")
-        #expect(
-            makeProbedImage(urlString: "https://example.com/downloads/")
-                .suggestedFilename == "RestoreImage.ipsw")
-        #expect(
-            makeProbedImage(urlString: "https://example.com/image.zip")
-                .suggestedFilename == "RestoreImage.ipsw")
+    }
+
+    @Test("An off-convention URL gets a generated name, never the shared default")
+    func suggestedFilenameForOffConventionURL() {
+        for urlString in [
+            "https://example.com/downloads/",
+            "https://example.com/image.zip",
+            "https://example.com/restore.ipsw",
+        ] {
+            let filename = makeProbedImage(urlString: urlString).suggestedFilename
+            #expect(filename.hasSuffix(".ipsw"), "expected an .ipsw name from '\(urlString)'")
+            // "Download Latest" owns that name; sharing it would let its image
+            // satisfy this one's download.
+            #expect(filename != RestoreImageFilename.fallback)
+        }
     }
 
     @Test("Two different images never resolve to the same destination")
@@ -61,10 +71,37 @@ struct ProbedRestoreImageTests {
         #expect(first.suggestedFilename != second.suggestedFilename)
     }
 
+    @Test("Two URLs sharing a basename resolve to different destinations")
+    func offConventionDestinationsAreDistinctPerURL() {
+        let first = makeProbedImage(urlString: "https://a.example.com/restore.ipsw")
+        let second = makeProbedImage(urlString: "https://b.example.com/restore.ipsw")
+        #expect(first.suggestedFilename != second.suggestedFilename)
+        // Stable, so the same URL resumes into the file it started.
+        #expect(
+            first.suggestedFilename
+                == makeProbedImage(urlString: "https://a.example.com/restore.ipsw")
+                .suggestedFilename)
+    }
+
+    @Test("A URL whose filename escapes its directory is never used as one")
+    func suggestedFilenameRefusesTraversal() {
+        // `lastPathComponent` percent-decodes, so this arrives as
+        // `a/../../evil.ipsw` and would land two directories above Downloads.
+        let image = makeProbedImage(urlString: "https://host/a%2F..%2F..%2Fevil.ipsw")
+        #expect(image.url.lastPathComponent == "a/../../evil.ipsw")
+        #expect(!image.suggestedFilename.contains("/"))
+        #expect(!image.suggestedFilename.contains(".."))
+    }
+
     @Test("Host support is unknown when the filename named no version")
     func hostSupportUnknownWithoutVersion() {
         let image = makeProbedImage(version: nil, build: nil)
         #expect(image.isSupported(onHost: host(26, 0, 0)) == nil)
+    }
+
+    @Test("An unparseable version is unknown too, not a refusal")
+    func hostSupportUnknownForUnparseableVersion() {
+        #expect(makeProbedImage(version: "Sequoia").isSupported(onHost: host(26, 0, 0)) == nil)
     }
 
     @Test("Host support compares numerically at the boundary")
@@ -85,6 +122,52 @@ struct ProbedRestoreImageTests {
     }
 }
 
+@Suite("RestoreImageFilename Tests")
+struct RestoreImageFilenameTests {
+    @Test("A plain .ipsw filename passes through")
+    func acceptsPlainFilename() {
+        #expect(
+            RestoreImageFilename.sanitized("UniversalMac_15.6.1_24G90_Restore.ipsw")
+                == "UniversalMac_15.6.1_24G90_Restore.ipsw")
+        #expect(RestoreImageFilename.sanitized("restore.IPSW") == "restore.IPSW")
+    }
+
+    @Test(
+        "Anything that is not one visible .ipsw component is refused",
+        arguments: [
+            "",
+            ".",
+            "..",
+            "/",
+            "a/../../evil.ipsw",
+            "../evil.ipsw",
+            "sub/dir/image.ipsw",
+            ".hidden.ipsw",
+            ".ipsw",
+            "image.zip",
+            "a%2F..%2Fevil.ipsw",
+        ])
+    func refusesUnsafeCandidates(candidate: String) {
+        #expect(RestoreImageFilename.sanitized(candidate) == nil)
+    }
+
+    @Test("A generated name is one visible .ipsw component, whatever the URL")
+    func generatedNamesAreSafeComponents() throws {
+        for urlString in [
+            "https://host/a%2F..%2F..%2Fevil.ipsw",
+            "https://host/",
+            "https://host",
+            "https://host/.hidden.ipsw",
+            "https://host/\(String(repeating: "n", count: 400)).ipsw",
+        ] {
+            let url = try #require(URL(string: urlString))
+            let generated = RestoreImageFilename.unique(for: url)
+            #expect(RestoreImageFilename.sanitized(generated) == generated, "from '\(urlString)'")
+            #expect(generated.utf8.count < 255)
+        }
+    }
+}
+
 /// Stub for the probe's requests.
 ///
 /// Deliberately its own class rather than `StubURLProtocol`: that one's handler
@@ -96,9 +179,43 @@ final class ProbeStubURLProtocol: URLProtocol, @unchecked Sendable {
         var statusCode: Int
         var body: Data
         var headers: [String: String]
+        /// Delivers `bodyPrimerBytes` and holds the rest back until the client
+        /// cancels, separating a client that read only the status from one that
+        /// consumed the response.
+        ///
+        /// The primer is not optional: CFNetwork surfaces a response only once
+        /// its body starts arriving, so a wholly withheld body means the client
+        /// never sees a status to react to. A client that never cancels gets the
+        /// rest once `testWaitBackstop` elapses, and `deliveredBodyBytes`
+        /// records every byte handed over either way.
+        var withholdsBodyUntilCancelled = false
     }
 
+    /// How much of a withheld body is delivered to surface the response.
+    static let bodyPrimerBytes = 1024
+
     nonisolated(unsafe) static var handler: ((URLRequest) -> Reply)?
+
+    private static let recordLock = NSLock()
+    nonisolated(unsafe) private static var deliveredBodyBytesStorage = 0
+    nonisolated(unsafe) private static var requestedRangesStorage: [String] = []
+
+    /// Body bytes handed to a client since the last `reset()`.
+    static var deliveredBodyBytes: Int { recordLock.withLock { deliveredBodyBytesStorage } }
+
+    /// Every `Range` header value the stub was asked for since the last `reset()`.
+    static var requestedRanges: [String] { recordLock.withLock { requestedRangesStorage } }
+
+    /// Clears the handler and everything recorded about the requests it served.
+    static func reset() {
+        handler = nil
+        recordLock.withLock {
+            deliveredBodyBytesStorage = 0
+            requestedRangesStorage = []
+        }
+    }
+
+    private let cancelled = DispatchSemaphore(value: 0)
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -112,6 +229,9 @@ final class ProbeStubURLProtocol: URLProtocol, @unchecked Sendable {
                     userInfo: [NSLocalizedDescriptionKey: "No handler set"]))
             return
         }
+        if let range = request.value(forHTTPHeaderField: "Range") {
+            Self.recordLock.withLock { Self.requestedRangesStorage.append(range) }
+        }
         let reply = handler(request)
         var headers = reply.headers
         if headers["Content-Length"] == nil { headers["Content-Length"] = "\(reply.body.count)" }
@@ -123,11 +243,42 @@ final class ProbeStubURLProtocol: URLProtocol, @unchecked Sendable {
             preconditionFailure("ProbeStubURLProtocol: could not build a response")
         }
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        if !reply.body.isEmpty { client?.urlProtocol(self, didLoad: reply.body) }
-        client?.urlProtocolDidFinishLoading(self)
+        guard reply.withholdsBodyUntilCancelled else {
+            deliver(reply.body)
+            return
+        }
+        // On a GCD thread, never the cooperative pool: this parks until the
+        // client cancels, and `stopLoading` has to be free to run meanwhile.
+        // The primer belongs here rather than above because nothing handed to
+        // the client reaches it until `startLoading` has returned.
+        DispatchQueue.global().async { [self] in
+            deliver(reply.body.prefix(Self.bodyPrimerBytes), finishing: false)
+            let backstop =
+                DispatchTime.now() + .seconds(Int(testWaitBackstop.components.seconds))
+            guard cancelled.wait(timeout: backstop) == .timedOut else { return }
+            deliver(reply.body.dropFirst(Self.bodyPrimerBytes))
+        }
     }
 
-    override func stopLoading() {}
+    override func stopLoading() {
+        cancelled.signal()
+    }
+
+    private func deliver(_ body: Data, finishing: Bool = true) {
+        if !body.isEmpty {
+            Self.recordLock.withLock { Self.deliveredBodyBytesStorage += body.count }
+            client?.urlProtocol(self, didLoad: body)
+        }
+        if finishing { client?.urlProtocolDidFinishLoading(self) }
+    }
+}
+
+/// Which remote-controlled zip64 value a test poisons.
+enum PoisonedZip64Field: Sendable {
+    case locatorOffset
+    case unrepresentableSize
+    case unrepresentableOffset
+    case sizeBeyondEndOfFile
 }
 
 @Suite("RestoreImageProbeService Tests", .serialized)
@@ -144,36 +295,107 @@ struct RestoreImageProbeServiceTests {
             ?? URL(fileURLWithPath: "/")
     }
 
+    private func appendLE<T: FixedWidthInteger>(_ value: T, to data: inout Data) {
+        withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    /// A central directory naming one member, `vma2` or not — the only thing the
+    /// probe reads out of it.
+    private func makeCentralDirectory(containsVMA2: Bool) -> Data {
+        var directory = Data()
+        directory.append(contentsOf: [0x50, 0x4B, 0x01, 0x02])  // central file header
+        let name = containsVMA2 ? "kernelcache.release.vma2" : "kernelcache.release.im4p"
+        directory.append(contentsOf: Array(name.utf8))
+        return directory
+    }
+
     /// Builds the tail of a zip whose central directory does or doesn't name a
-    /// `vma2` member — the only thing the probe reads.
+    /// `vma2` member.
     ///
     /// Laid out so the directory sits immediately before the end-of-directory
     /// record, and the whole thing is served as one blob: the probe's tail read
     /// covers it, and the zip64 locator is deliberately absent so the 32-bit
     /// fields are authoritative.
     private func makeZipTail(containsVMA2: Bool) -> Data {
-        var directory = Data()
-        directory.append(contentsOf: [0x50, 0x4B, 0x01, 0x02])  // central file header
-        let name = containsVMA2 ? "kernelcache.release.vma2" : "kernelcache.release.im4p"
-        directory.append(contentsOf: Array(name.utf8))
-
-        var blob = Data()
-        blob.append(directory)
+        let directory = makeCentralDirectory(containsVMA2: containsVMA2)
+        var blob = directory
 
         var eocd = Data()
         eocd.append(contentsOf: [0x50, 0x4B, 0x05, 0x06])  // EOCD signature
         eocd.append(contentsOf: [0, 0, 0, 0])  // disk numbers
         eocd.append(contentsOf: [1, 0, 1, 0])  // entry counts
-        withUnsafeBytes(of: UInt32(directory.count).littleEndian) { eocd.append(contentsOf: $0) }
-        withUnsafeBytes(of: UInt32(0).littleEndian) { eocd.append(contentsOf: $0) }  // offset
+        appendLE(UInt32(directory.count), to: &eocd)
+        appendLE(UInt32(0), to: &eocd)  // offset
         eocd.append(contentsOf: [0, 0])  // comment length
         blob.append(eocd)
         return blob
     }
 
+    /// Builds the tail of a zip64, where the locator and the record it points at
+    /// carry the authoritative central-directory bounds.
+    ///
+    /// Every parameter overriding a value the record would otherwise state
+    /// honestly stands in for a hostile or broken server. `totalBytes` is the
+    /// length of the file the tail belongs to, which is what the recorded
+    /// offsets are relative to; it defaults to the tail standing alone.
+    private func makeZip64Tail(
+        containsVMA2: Bool = true,
+        totalBytes: Int? = nil,
+        directorySize: UInt64? = nil,
+        directoryOffset: UInt64? = nil,
+        locatorOffset: UInt64? = nil
+    ) -> Data {
+        let directory = makeCentralDirectory(containsVMA2: containsVMA2)
+        // Fixed lengths: zip64 EOCD record, zip64 locator, EOCD.
+        let blobLength = directory.count + 56 + 20 + 22
+        let blobStart = UInt64((totalBytes ?? blobLength) - blobLength)
+        let recordStart = blobStart + UInt64(directory.count)
+
+        var record = Data()
+        record.append(contentsOf: [0x50, 0x4B, 0x06, 0x06])  // zip64 EOCD signature
+        appendLE(UInt64(44), to: &record)  // record size, excluding these 12 bytes
+        appendLE(UInt16(45), to: &record)  // version made by
+        appendLE(UInt16(45), to: &record)  // version needed
+        appendLE(UInt32(0), to: &record)  // this disk
+        appendLE(UInt32(0), to: &record)  // disk with the directory
+        appendLE(UInt64(1), to: &record)  // entries on this disk
+        appendLE(UInt64(1), to: &record)  // entries total
+        appendLE(directorySize ?? UInt64(directory.count), to: &record)
+        appendLE(directoryOffset ?? blobStart, to: &record)
+
+        var locator = Data()
+        locator.append(contentsOf: [0x50, 0x4B, 0x06, 0x07])  // zip64 locator signature
+        appendLE(UInt32(0), to: &locator)  // disk with the zip64 EOCD
+        appendLE(locatorOffset ?? recordStart, to: &locator)
+        appendLE(UInt32(1), to: &locator)  // disks total
+
+        var eocd = Data()
+        eocd.append(contentsOf: [0x50, 0x4B, 0x05, 0x06])  // EOCD signature
+        eocd.append(contentsOf: [0, 0, 0, 0])  // disk numbers
+        eocd.append(contentsOf: [1, 0, 1, 0])  // entry counts
+        appendLE(UInt32.max, to: &eocd)  // size: zip64 sentinel
+        appendLE(UInt32.max, to: &eocd)  // offset: zip64 sentinel
+        eocd.append(contentsOf: [0, 0])  // comment length
+
+        let blob = directory + record + locator + eocd
+        #expect(blob.count == blobLength, "zip64 tail layout drifted from its declared lengths")
+        return blob
+    }
+
+    /// The number of bytes a `bytes=first-last` header asks for.
+    private func rangeLength(_ header: String) -> Int? {
+        guard let spec = header.split(separator: "=").last else { return nil }
+        let bounds = spec.split(separator: "-")
+        guard bounds.count == 2, let first = Int(bounds[0]), let last = Int(bounds[1]) else {
+            return nil
+        }
+        return last - first + 1
+    }
+
     /// Serves `body` for every request, answering HEAD with the declared total
     /// and range requests out of the same bytes.
     private func serve(total: Int, body: Data, headStatus: Int = 200) {
+        ProbeStubURLProtocol.reset()
         ProbeStubURLProtocol.handler = { request in
             if request.httpMethod == "HEAD" {
                 return ProbeStubURLProtocol.Reply(
@@ -204,7 +426,7 @@ struct RestoreImageProbeServiceTests {
     func acceptsVirtualMachineImage() async throws {
         let tail = makeZipTail(containsVMA2: true)
         serve(total: tail.count, body: tail)
-        defer { ProbeStubURLProtocol.handler = nil }
+        defer { ProbeStubURLProtocol.reset() }
 
         let image = try await makeService().probe(imageURL)
 
@@ -218,7 +440,7 @@ struct RestoreImageProbeServiceTests {
     func refusesImageWithoutVirtualMachineModel() async {
         let tail = makeZipTail(containsVMA2: false)
         serve(total: tail.count, body: tail)
-        defer { ProbeStubURLProtocol.handler = nil }
+        defer { ProbeStubURLProtocol.reset() }
 
         await #expect(throws: RestoreImageProbeError.notAVirtualMachineImage) {
             _ = try await makeService().probe(imageURL)
@@ -232,28 +454,138 @@ struct RestoreImageProbeServiceTests {
             Issue.record("The probe issued a request for a non-HTTPS URL")
             return ProbeStubURLProtocol.Reply(statusCode: 200, body: Data(), headers: [:])
         }
-        defer { ProbeStubURLProtocol.handler = nil }
+        defer { ProbeStubURLProtocol.reset() }
 
         await #expect(throws: RestoreImageProbeError.insecureURL) {
             _ = try await makeService().probe(http)
         }
     }
 
-    @Test("A URL that 404s is refused with its status")
+    @Test("A URL that answers nothing but 404 is refused with its status")
     func refusesMissingImage() async {
-        serve(total: 0, body: Data(), headStatus: 404)
-        defer { ProbeStubURLProtocol.handler = nil }
+        ProbeStubURLProtocol.reset()
+        ProbeStubURLProtocol.handler = { _ in
+            ProbeStubURLProtocol.Reply(statusCode: 404, body: Data(), headers: [:])
+        }
+        defer { ProbeStubURLProtocol.reset() }
 
         await #expect(throws: RestoreImageProbeError.unreachable(statusCode: 404)) {
             _ = try await makeService().probe(imageURL)
         }
     }
 
+    @Test(
+        "A server that refuses HEAD is probed with ranged GETs instead",
+        arguments: [403, 405, 501])
+    func fallsBackToRangedGetWhenHeadIsRefused(headStatus: Int) async throws {
+        let tail = makeZipTail(containsVMA2: true)
+        serve(total: tail.count, body: tail, headStatus: headStatus)
+        defer { ProbeStubURLProtocol.reset() }
+
+        let image = try await makeService().probe(imageURL)
+
+        #expect(image.sizeBytes == UInt64(tail.count))
+        #expect(image.version == "15.6.1")
+    }
+
+    @Test("A server that answers a ranged read with the whole file is abandoned unread")
+    func abandonsRangeIgnoringServer() async {
+        ProbeStubURLProtocol.reset()
+        ProbeStubURLProtocol.handler = { request in
+            if request.httpMethod == "HEAD" {
+                return ProbeStubURLProtocol.Reply(
+                    statusCode: 200, body: Data(),
+                    headers: ["Content-Length": "\(16 * 1024 * 1024 * 1024)"])
+            }
+            // The Range header is ignored: 200, and the body is the whole image.
+            return ProbeStubURLProtocol.Reply(
+                statusCode: 200, body: Data(repeating: 0x41, count: 1 << 20), headers: [:],
+                withholdsBodyUntilCancelled: true)
+        }
+        defer { ProbeStubURLProtocol.reset() }
+
+        await #expect(throws: RestoreImageProbeError.rangeRequestsUnsupported) {
+            _ = try await makeService().probe(imageURL)
+        }
+        #expect(ProbeStubURLProtocol.deliveredBodyBytes == ProbeStubURLProtocol.bodyPrimerBytes)
+    }
+
+    @Test("A range-ignoring server is refused while its size is still being read")
+    func abandonsRangeIgnoringServerWithoutHead() async {
+        ProbeStubURLProtocol.reset()
+        ProbeStubURLProtocol.handler = { request in
+            if request.httpMethod == "HEAD" {
+                return ProbeStubURLProtocol.Reply(statusCode: 405, body: Data(), headers: [:])
+            }
+            return ProbeStubURLProtocol.Reply(
+                statusCode: 200, body: Data(repeating: 0x41, count: 1 << 20), headers: [:],
+                withholdsBodyUntilCancelled: true)
+        }
+        defer { ProbeStubURLProtocol.reset() }
+
+        await #expect(throws: RestoreImageProbeError.rangeRequestsUnsupported) {
+            _ = try await makeService().probe(imageURL)
+        }
+        #expect(ProbeStubURLProtocol.deliveredBodyBytes == ProbeStubURLProtocol.bodyPrimerBytes)
+    }
+
+    @Test("A zip64 image is accepted through the record its locator points at")
+    func acceptsZip64Image() async throws {
+        let tail = makeZip64Tail(containsVMA2: true)
+        serve(total: tail.count, body: tail)
+        defer { ProbeStubURLProtocol.reset() }
+
+        let image = try await makeService().probe(imageURL)
+
+        #expect(image.sizeBytes == UInt64(tail.count))
+    }
+
+    @Test(
+        "Hostile zip64 metadata is refused, not trapped",
+        arguments: [
+            PoisonedZip64Field.locatorOffset, .unrepresentableSize, .unrepresentableOffset,
+            .sizeBeyondEndOfFile,
+        ])
+    func refusesHostileZip64Metadata(field: PoisonedZip64Field) async {
+        let tail =
+            switch field {
+            case .locatorOffset: makeZip64Tail(locatorOffset: 1 << 40)
+            case .unrepresentableSize: makeZip64Tail(directorySize: .max)
+            case .unrepresentableOffset: makeZip64Tail(directoryOffset: .max)
+            case .sizeBeyondEndOfFile: makeZip64Tail(directorySize: 1 << 30)
+            }
+        serve(total: tail.count, body: tail)
+        defer { ProbeStubURLProtocol.reset() }
+
+        await #expect(throws: RestoreImageProbeError.unreadableStructure) {
+            _ = try await makeService().probe(imageURL)
+        }
+    }
+
+    @Test("A central directory larger than the cap is read only up to the cap")
+    func clampsOversizedCentralDirectory() async {
+        // A 64 GiB file, so a claimed 1 GiB directory sits inside it and nothing
+        // but the cap keeps the read down.
+        let total = 64 * 1024 * 1024 * 1024
+        let tail = makeZip64Tail(
+            containsVMA2: false, totalBytes: total, directorySize: 1 << 30, directoryOffset: 0)
+        serve(total: total, body: tail)
+        defer { ProbeStubURLProtocol.reset() }
+
+        await #expect(throws: RestoreImageProbeError.notAVirtualMachineImage) {
+            _ = try await makeService().probe(imageURL)
+        }
+        let lengths = ProbeStubURLProtocol.requestedRanges.compactMap(rangeLength)
+        #expect(lengths.count == ProbeStubURLProtocol.requestedRanges.count)
+        #expect(lengths.allSatisfy { $0 <= 16 * 1024 * 1024 })
+        #expect(lengths.contains(16 * 1024 * 1024))
+    }
+
     @Test("A file with no zip structure is refused as unreadable")
     func refusesUnreadableStructure() async {
         let junk = Data(repeating: 0x41, count: 4096)
         serve(total: junk.count, body: junk)
-        defer { ProbeStubURLProtocol.handler = nil }
+        defer { ProbeStubURLProtocol.reset() }
 
         await #expect(throws: RestoreImageProbeError.unreadableStructure) {
             _ = try await makeService().probe(imageURL)

--- a/KernovaTests/RestoreImageURLSheetContentViewControllerTests.swift
+++ b/KernovaTests/RestoreImageURLSheetContentViewControllerTests.swift
@@ -1,0 +1,188 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("RestoreImageURLSheetContentViewController Tests")
+@MainActor
+struct RestoreImageURLSheetContentViewControllerTests {
+    private func makeSheet(
+        probe: MockRestoreImageProbeService,
+        initialURL: String? = nil,
+        hostMajor: Int = 26
+    ) -> RestoreImageURLSheetContentViewController {
+        let vc = RestoreImageURLSheetContentViewController(
+            probeService: probe,
+            initialURL: initialURL,
+            hostVersion: OperatingSystemVersion(
+                majorVersion: hostMajor, minorVersion: 0, patchVersion: 0)
+        )
+        vc.loadViewIfNeeded()
+        return vc
+    }
+
+    /// Runs Check and awaits the production task rather than polling for it.
+    private func check(_ vc: RestoreImageURLSheetContentViewController) async {
+        findButton(titled: "Check", in: vc.view)?.performClick(nil)
+        await vc.probeTaskForTesting?.value
+    }
+
+    @Test("Use is disabled until a URL has been checked")
+    func useDisabledBeforeCheck() {
+        let vc = makeSheet(probe: MockRestoreImageProbeService())
+        #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == false)
+        #expect(vc.checkedImage == nil)
+    }
+
+    @Test("Check with an empty field does nothing")
+    func checkIgnoresEmptyField() async {
+        let probe = MockRestoreImageProbeService()
+        let vc = makeSheet(probe: probe)
+        await check(vc)
+        #expect(probe.probeCallCount == 0)
+    }
+
+    @Test("A successful check enables Use and records the image")
+    func successfulCheckEnablesUse() async {
+        let probe = MockRestoreImageProbeService()
+        let vc = makeSheet(
+            probe: probe,
+            initialURL: "https://updates.cdn-apple.com/x/UniversalMac_15.6.1_24G90_Restore.ipsw")
+
+        await check(vc)
+
+        #expect(probe.probeCallCount == 1)
+        #expect(vc.checkedImage == probe.probeResult)
+        #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == true)
+    }
+
+    @Test("A failed check leaves Use disabled and shows the reason")
+    func failedCheckKeepsUseDisabled() async {
+        let probe = MockRestoreImageProbeService()
+        probe.probeError = RestoreImageProbeError.notAVirtualMachineImage
+        let vc = makeSheet(probe: probe, initialURL: "https://example.com/R.ipsw")
+
+        await check(vc)
+
+        #expect(vc.checkedImage == nil)
+        #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == false)
+        #expect(findLabel(containing: "can't run as a virtual machine", in: vc.view) != nil)
+    }
+
+    @Test("A malformed URL is refused without reaching the probe")
+    func malformedURLNeverProbes() async {
+        let probe = MockRestoreImageProbeService()
+        let vc = makeSheet(probe: probe, initialURL: "not a url")
+
+        await check(vc)
+
+        #expect(probe.probeCallCount == 0)
+        #expect(vc.checkedImage == nil)
+        #expect(findLabel(containing: "isn't a valid URL", in: vc.view) != nil)
+    }
+
+    @Test("Choosing hands the checked image to the delegate")
+    func chooseReportsToDelegate() async {
+        let probe = MockRestoreImageProbeService()
+        let vc = makeSheet(probe: probe, initialURL: "https://example.com/R.ipsw")
+        let delegate = RecordingDelegate()
+        vc.delegate = delegate
+
+        await check(vc)
+        findButton(titled: "Use", in: vc.view)?.performClick(nil)
+
+        #expect(delegate.chosen == probe.probeResult)
+        #expect(delegate.cancelCount == 0)
+    }
+
+    @Test("Cancel reports a dismissal and no choice")
+    func cancelReportsToDelegate() {
+        let vc = makeSheet(probe: MockRestoreImageProbeService())
+        let delegate = RecordingDelegate()
+        vc.delegate = delegate
+
+        findButton(titled: "Cancel", in: vc.view)?.performClick(nil)
+
+        #expect(delegate.chosen == nil)
+        #expect(delegate.cancelCount == 1)
+    }
+
+    @Test("An image newer than the host warns without blocking Use")
+    func tooNewImageWarnsButDoesNotBlock() async {
+        let probe = MockRestoreImageProbeService()
+        probe.probeResult = makeProbedImage(version: "27.0", build: "26A100")
+        let vc = makeSheet(
+            probe: probe, initialURL: "https://example.com/R.ipsw", hostMajor: 26)
+
+        await check(vc)
+
+        // The version came from the filename, so it is a hint, not a verdict.
+        #expect(vc.checkedImage != nil)
+        #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == true)
+        #expect(findLabel(containing: "newer than this Mac", in: vc.view) != nil)
+    }
+
+    @Test("An unrecognized filename says the version is unknown")
+    func unknownVersionIsCalledOut() async {
+        let probe = MockRestoreImageProbeService()
+        probe.probeResult = makeProbedImage(
+            urlString: "https://example.com/image.ipsw", version: nil, build: nil)
+        let vc = makeSheet(probe: probe, initialURL: "https://example.com/image.ipsw")
+
+        await check(vc)
+
+        #expect(vc.checkedImage != nil)
+        #expect(findLabel(containing: "doesn't name a macOS version", in: vc.view) != nil)
+    }
+
+    @Test("Editing the URL invalidates the previous verdict")
+    func editingClearsTheVerdict() async throws {
+        let probe = MockRestoreImageProbeService()
+        let vc = makeSheet(probe: probe, initialURL: "https://example.com/R.ipsw")
+        await check(vc)
+        #expect(vc.checkedImage != nil)
+
+        let field = try #require(findTextField(in: vc.view))
+        field.stringValue = "https://example.com/other.ipsw"
+        vc.controlTextDidChange(Notification(name: NSControl.textDidChangeNotification))
+
+        #expect(vc.checkedImage == nil)
+        #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == false)
+    }
+
+    // MARK: - Helpers
+
+    private final class RecordingDelegate: RestoreImageURLSheetContentViewControllerDelegate {
+        var chosen: ProbedRestoreImage?
+        var cancelCount = 0
+
+        func restoreImageURLSheet(
+            _ vc: RestoreImageURLSheetContentViewController,
+            didChoose image: ProbedRestoreImage
+        ) {
+            chosen = image
+        }
+
+        func restoreImageURLSheetDidCancel(_ vc: RestoreImageURLSheetContentViewController) {
+            cancelCount += 1
+        }
+    }
+
+    private func findLabel(containing text: String, in view: NSView) -> NSTextField? {
+        if let field = view as? NSTextField, field.stringValue.contains(text) { return field }
+        for subview in view.subviews {
+            if let found = findLabel(containing: text, in: subview) { return found }
+        }
+        return nil
+    }
+
+    /// The one editable field in the sheet.
+    private func findTextField(in view: NSView) -> NSTextField? {
+        if let field = view as? NSTextField, field.isEditable { return field }
+        for subview in view.subviews {
+            if let found = findTextField(in: subview) { return found }
+        }
+        return nil
+    }
+}

--- a/KernovaTests/RestoreImageURLSheetContentViewControllerTests.swift
+++ b/KernovaTests/RestoreImageURLSheetContentViewControllerTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import KernovaTestSupport
 import Testing
 
 @testable import Kernova
@@ -8,7 +9,7 @@ import Testing
 @MainActor
 struct RestoreImageURLSheetContentViewControllerTests {
     private func makeSheet(
-        probe: MockRestoreImageProbeService,
+        probe: any RestoreImageProbing,
         initialURL: String? = nil,
         hostMajor: Int = 26
     ) -> RestoreImageURLSheetContentViewController {
@@ -151,6 +152,30 @@ struct RestoreImageURLSheetContentViewControllerTests {
         #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == false)
     }
 
+    @Test("Editing the URL invalidates a probe still in flight")
+    func editingCancelsTheInFlightProbe() async throws {
+        let probe = SuspendingProbeService()
+        let vc = makeSheet(probe: probe, initialURL: "https://example.com/A.ipsw")
+
+        findButton(titled: "Check", in: vc.view)?.performClick(nil)
+        let inFlight = try #require(vc.probeTaskForTesting)
+        try await probe.waitUntilProbing()
+
+        let field = try #require(findTextField(in: vc.view))
+        field.stringValue = "https://example.com/B.ipsw"
+        vc.controlTextDidChange(Notification(name: NSControl.textDidChangeNotification))
+        probe.release()
+        await inFlight.value
+
+        // A's answer must not become B's verdict.
+        #expect(vc.checkedImage == nil)
+        #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == false)
+        #expect(findLabel(containing: "Installs in a virtual machine", in: vc.view) == nil)
+        // Back to idle, so the edited URL can be checked in turn.
+        #expect(findLabel(containing: "Reading the image directory", in: vc.view) == nil)
+        #expect(findButton(titled: "Check", in: vc.view)?.isEnabled == true)
+    }
+
     // MARK: - Helpers
 
     private final class RecordingDelegate: RestoreImageURLSheetContentViewControllerDelegate {
@@ -184,5 +209,33 @@ struct RestoreImageURLSheetContentViewControllerTests {
             if let found = findTextField(in: subview) { return found }
         }
         return nil
+    }
+}
+
+/// Probe stand-in that stays inside `probe` until the test releases it, the way
+/// the real one stays busy across several round trips.
+private final class SuspendingProbeService: RestoreImageProbing, @unchecked Sendable {
+    private let probeResult = makeProbedImage()
+    private let gate = AsyncGate()
+    private let lock = NSLock()
+    private var isProbing = false
+    private var isReleased = false
+
+    func probe(_ url: URL) async throws -> ProbedRestoreImage {
+        lock.withLock { self.isProbing = true }
+        gate.notify()
+        try? await gate.wait(until: { self.lock.withLock { self.isReleased } })
+        return probeResult
+    }
+
+    /// Suspends until `probe` is in flight.
+    func waitUntilProbing() async throws {
+        try await gate.wait(until: { self.lock.withLock { self.isProbing } })
+    }
+
+    /// Lets the in-flight probe finish.
+    func release() {
+        lock.withLock { self.isReleased = true }
+        gate.notify()
     }
 }

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -1,10 +1,22 @@
 import Testing
 import Foundation
+import KernovaTestSupport
 @testable import Kernova
 
 @Suite("VMCreationViewModel Tests")
 @MainActor
 struct VMCreationViewModelTests {
+    /// The standardized directory a path sits in.
+    private func parentPath(of path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.deletingLastPathComponent()
+            .path(percentEncoded: false)
+    }
+
+    /// The Downloads directory every download destination must stay inside.
+    private var downloadsPath: String {
+        parentPath(of: VMCreationViewModel.defaultIPSWDownloadPath)
+    }
+
     // MARK: - Navigation
 
     @Test("goNext advances through all steps in order")
@@ -790,13 +802,43 @@ struct VMCreationViewModelTests {
         #expect(vm.ipswDownloadPath != VMCreationViewModel.defaultIPSWDownloadPath)
     }
 
-    @Test("An off-convention URL still lands on a real filename")
-    func pastedImageWithoutIPSWNameFallsBack() {
+    @Test("An off-convention URL lands on its own filename, not the shared default")
+    func pastedImageWithoutIPSWNameGetsItsOwnDestination() {
         let vm = VMCreationViewModel()
         vm.selectPastedImage(
             makeProbedImage(urlString: "https://example.com/d/", version: nil, build: nil))
 
-        #expect(vm.ipswDownloadPath == VMCreationViewModel.defaultIPSWDownloadPath)
+        #expect(vm.ipswDownloadPath.hasSuffix(".ipsw"))
+        // Sharing "Download Latest"'s destination would let its image satisfy
+        // this URL's download — a different macOS than the one pinned.
+        #expect(vm.ipswDownloadPath != VMCreationViewModel.defaultIPSWDownloadPath)
+        #expect(parentPath(of: vm.ipswDownloadPath) == downloadsPath)
+    }
+
+    @Test("Two off-convention URLs sharing a basename get different destinations")
+    func pastedImagesWithOneBasenameGetDistinctDestinations() {
+        let vm = VMCreationViewModel()
+        vm.selectPastedImage(
+            makeProbedImage(
+                urlString: "https://a.example.com/restore.ipsw", version: nil, build: nil))
+        let first = vm.ipswDownloadPath
+        vm.selectPastedImage(
+            makeProbedImage(
+                urlString: "https://b.example.com/restore.ipsw", version: nil, build: nil))
+
+        #expect(first != vm.ipswDownloadPath)
+    }
+
+    @Test("A URL whose filename walks out of Downloads cannot move the destination")
+    func pastedImageWithTraversalStaysInDownloads() {
+        let vm = VMCreationViewModel()
+        // Decodes to `a/../../evil.ipsw`, which appended verbatim would
+        // standardize to a path two directories above Downloads.
+        vm.selectPastedImage(
+            makeProbedImage(
+                urlString: "https://host/a%2F..%2F..%2Fevil.ipsw", version: nil, build: nil))
+
+        #expect(parentPath(of: vm.ipswDownloadPath) == downloadsPath)
     }
 
     @Test("The URL source cannot advance until a URL is checked")
@@ -937,6 +979,23 @@ struct VMCreationViewModelTests {
         #expect(await vm.adoptExistingDownloadFile() == .adopted(inspector.inspectResult))
     }
 
+    @Test("An inspection cancelled mid-flight adopts nothing")
+    func cancelledInspectionAdoptsNothing() async throws {
+        let inspector = SuspendingMockLocalRestoreImageInspector()
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        // The build matches, so only the cancellation keeps this from adopting.
+        vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
+
+        let adopt = Task { await vm.adoptExistingDownloadFile() }
+        try await inspector.waitUntilInspecting()
+        adopt.cancel()
+        inspector.release()
+
+        #expect(await adopt.value == .cancelled)
+        #expect(vm.ipswSource == .catalogVersion)
+        #expect(vm.ipswPath == nil)
+    }
+
     @Test("pinnedBuild names the build each source is promising")
     func pinnedBuildTracksTheSource() {
         let vm = VMCreationViewModel()
@@ -952,8 +1011,8 @@ struct VMCreationViewModelTests {
         #expect(vm.pinnedBuild == nil)
     }
 
-    @Test("Switching between pinned sources clears the other one's pick")
-    func switchingPinnedSourcesClearsTheOther() {
+    @Test("Switching between pinned sources keeps both picks; Download Latest clears them")
+    func downloadLatestClearsBothPinnedPicks() {
         let vm = VMCreationViewModel()
         vm.selectCatalogEntry(makeCatalogEntry())
         vm.selectPastedImage(makeProbedImage())
@@ -964,5 +1023,34 @@ struct VMCreationViewModelTests {
         vm.selectDownloadLatest()
         #expect(vm.selectedCatalogEntry == nil)
         #expect(vm.pastedImage == nil)
+    }
+}
+
+/// Inspector stand-in that stays inside `inspect` until the test releases it,
+/// the way a multi-gigabyte image keeps the real one busy for seconds.
+final class SuspendingMockLocalRestoreImageInspector: LocalRestoreImageInspecting, @unchecked Sendable {
+    private let inspectResult = InspectedRestoreImage(
+        version: "15.6.1", build: "24G90", isSupportedOnThisHost: true)
+    private let gate = AsyncGate()
+    private let lock = NSLock()
+    private var isInspecting = false
+    private var isReleased = false
+
+    func inspect(_ url: URL) async throws -> InspectedRestoreImage {
+        lock.withLock { self.isInspecting = true }
+        gate.notify()
+        try? await gate.wait(until: { self.lock.withLock { self.isReleased } })
+        return inspectResult
+    }
+
+    /// Suspends until `inspect` is in flight.
+    func waitUntilInspecting() async throws {
+        try await gate.wait(until: { self.lock.withLock { self.isInspecting } })
+    }
+
+    /// Lets the in-flight inspection finish.
+    func release() {
+        lock.withLock { self.isReleased = true }
+        gate.notify()
     }
 }

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -842,6 +842,116 @@ struct VMCreationViewModelTests {
         #expect(context.downloadDestinationPath == vm.ipswDownloadPath)
     }
 
+    // MARK: - Adopting an Existing File
+
+    @Test("An existing file matching the pinned build is adopted")
+    func adoptsMatchingExistingFile() async {
+        let inspector = MockLocalRestoreImageInspector()
+        inspector.inspectResult = InspectedRestoreImage(
+            version: "15.6.1", build: "24G90", isSupportedOnThisHost: true)
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
+        let destination = vm.ipswDownloadPath
+
+        let verdict = await vm.adoptExistingDownloadFile()
+
+        #expect(verdict == .adopted(inspector.inspectResult))
+        #expect(vm.ipswSource == .localFile)
+        #expect(vm.ipswPath == destination)
+        #expect(inspector.lastInspectedURL?.path(percentEncoded: false) == destination)
+    }
+
+    @Test("An existing file of a different build is reported, not adopted")
+    func refusesMismatchedExistingFile() async {
+        let inspector = MockLocalRestoreImageInspector()
+        inspector.inspectResult = InspectedRestoreImage(
+            version: "14.2", build: "23C64", isSupportedOnThisHost: true)
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
+
+        let verdict = await vm.adoptExistingDownloadFile()
+
+        #expect(verdict == .mismatch(expected: "24G90", found: inspector.inspectResult))
+        // The wrong-image install this exists to prevent.
+        #expect(vm.ipswSource == .catalogVersion)
+        #expect(vm.ipswPath == nil)
+    }
+
+    @Test("An unreadable file is refused with a reason")
+    func refusesUnreadableExistingFile() async {
+        let inspector = MockLocalRestoreImageInspector()
+        inspector.inspectError = LocalRestoreImageError.unreadable
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        vm.selectCatalogEntry(makeCatalogEntry())
+
+        let verdict = await vm.adoptExistingDownloadFile()
+
+        #expect(
+            verdict
+                == .unusable(
+                    message: LocalRestoreImageError.unreadable.errorDescription ?? ""))
+        #expect(vm.ipswSource == .catalogVersion)
+    }
+
+    @Test("An image the host can't run is refused even when the build matches")
+    func refusesUnsupportedExistingFile() async {
+        let inspector = MockLocalRestoreImageInspector()
+        inspector.inspectResult = InspectedRestoreImage(
+            version: "15.6.1", build: "24G90", isSupportedOnThisHost: false)
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
+
+        let verdict = await vm.adoptExistingDownloadFile()
+
+        #expect(
+            verdict
+                == .unusable(
+                    message: LocalRestoreImageError.unsupported.errorDescription ?? ""))
+        #expect(vm.ipswSource == .catalogVersion)
+    }
+
+    @Test("Download Latest pins no build, so any usable image is adopted")
+    func downloadLatestAdoptsAnyUsableImage() async {
+        let inspector = MockLocalRestoreImageInspector()
+        inspector.inspectResult = InspectedRestoreImage(
+            version: "14.2", build: "23C64", isSupportedOnThisHost: true)
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        vm.selectDownloadLatest()
+
+        #expect(vm.pinnedBuild == nil)
+        let verdict = await vm.adoptExistingDownloadFile()
+
+        #expect(verdict == .adopted(inspector.inspectResult))
+        #expect(vm.ipswSource == .localFile)
+    }
+
+    @Test("A URL pick with no parsed build pins nothing to compare against")
+    func customURLWithoutBuildPinsNothing() async {
+        let inspector = MockLocalRestoreImageInspector()
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        vm.selectPastedImage(
+            makeProbedImage(
+                urlString: "https://example.com/image.ipsw", version: nil, build: nil))
+
+        #expect(vm.pinnedBuild == nil)
+        #expect(await vm.adoptExistingDownloadFile() == .adopted(inspector.inspectResult))
+    }
+
+    @Test("pinnedBuild names the build each source is promising")
+    func pinnedBuildTracksTheSource() {
+        let vm = VMCreationViewModel()
+        #expect(vm.pinnedBuild == nil)
+
+        vm.selectCatalogEntry(makeCatalogEntry(build: "24G90"))
+        #expect(vm.pinnedBuild == "24G90")
+
+        vm.selectPastedImage(makeProbedImage(build: "25G72"))
+        #expect(vm.pinnedBuild == "25G72")
+
+        vm.selectDownloadLatest()
+        #expect(vm.pinnedBuild == nil)
+    }
+
     @Test("Switching between pinned sources clears the other one's pick")
     func switchingPinnedSourcesClearsTheOther() {
         let vm = VMCreationViewModel()

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -769,6 +769,90 @@ struct VMCreationViewModelTests {
     func downloadsImageCoversBothDownloadSources() {
         #expect(IPSWSource.downloadLatest.downloadsImage)
         #expect(IPSWSource.catalogVersion.downloadsImage)
+        #expect(IPSWSource.customURL.downloadsImage)
         #expect(!IPSWSource.localFile.downloadsImage)
+    }
+
+    // MARK: - Custom URL Source
+
+    @Test("A checked URL moves the destination to that image's filename")
+    func pastedImageUsesPerImageDestination() {
+        let vm = VMCreationViewModel()
+        let image = makeProbedImage()
+        vm.selectPastedImage(image)
+
+        #expect(vm.ipswSource == .customURL)
+        #expect(vm.pastedImage == image)
+        #expect(
+            vm.ipswDownloadPath
+                == VMCreationViewModel.downloadPath(
+                    forFilename: "UniversalMac_15.6.1_24G90_Restore.ipsw"))
+        #expect(vm.ipswDownloadPath != VMCreationViewModel.defaultIPSWDownloadPath)
+    }
+
+    @Test("An off-convention URL still lands on a real filename")
+    func pastedImageWithoutIPSWNameFallsBack() {
+        let vm = VMCreationViewModel()
+        vm.selectPastedImage(
+            makeProbedImage(urlString: "https://example.com/d/", version: nil, build: nil))
+
+        #expect(vm.ipswDownloadPath == VMCreationViewModel.defaultIPSWDownloadPath)
+    }
+
+    @Test("The URL source cannot advance until a URL is checked")
+    func customURLSourceRequiresACheckedImage() {
+        let vm = VMCreationViewModel()
+        vm.currentStep = .bootConfig
+        vm.ipswSource = .customURL
+
+        #expect(!vm.canAdvance)
+        #expect(vm.validationMessage == "Add a restore image URL to continue.")
+
+        vm.selectPastedImage(makeProbedImage())
+        #expect(vm.canAdvance)
+        #expect(vm.validationMessage == nil)
+    }
+
+    @Test("The URL source shares the overwrite warning")
+    func customURLSourceSharesDownloadWarnings() {
+        let vm = VMCreationViewModel()
+        vm.currentStep = .bootConfig
+        vm.selectPastedImage(makeProbedImage())
+        vm.ipswDownloadPath = "/usr/bin/true"  // exists on disk
+        #expect(vm.shouldShowOverwriteWarning)
+        #expect(!vm.canAdvance)
+
+        vm.confirmOverwrite()
+        #expect(!vm.shouldShowOverwriteWarning)
+        #expect(vm.canAdvance)
+    }
+
+    @Test("A URL install context pins the checked URL, version, and build")
+    func customURLInstallContextPinsTheImage() {
+        let vm = VMCreationViewModel()
+        let image = makeProbedImage()
+        vm.selectPastedImage(image)
+
+        let context = vm.buildInstallContext()
+
+        #expect(context.source == .customURL)
+        #expect(context.remoteURL == image.url)
+        #expect(context.version == "15.6.1")
+        #expect(context.build == "24G90")
+        #expect(context.downloadDestinationPath == vm.ipswDownloadPath)
+    }
+
+    @Test("Switching between pinned sources clears the other one's pick")
+    func switchingPinnedSourcesClearsTheOther() {
+        let vm = VMCreationViewModel()
+        vm.selectCatalogEntry(makeCatalogEntry())
+        vm.selectPastedImage(makeProbedImage())
+        #expect(vm.selectedCatalogEntry != nil)
+        #expect(vm.pastedImage != nil)
+
+        // Download Latest is the one source that owns neither pick.
+        vm.selectDownloadLatest()
+        #expect(vm.selectedCatalogEntry == nil)
+        #expect(vm.pastedImage == nil)
     }
 }

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -644,4 +644,131 @@ struct VMCreationViewModelTests {
         let vm = VMCreationViewModel()
         #expect(vm.startAfterCreate == true)
     }
+
+    // MARK: - Catalog Version Source
+
+    @Test("Choosing a catalog version moves the destination to Apple's filename")
+    func catalogPickUsesPerBuildDestination() {
+        let vm = VMCreationViewModel()
+        let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
+        vm.selectCatalogEntry(entry)
+
+        #expect(vm.ipswSource == .catalogVersion)
+        #expect(vm.selectedCatalogEntry == entry)
+        #expect(
+            vm.ipswDownloadPath
+                == VMCreationViewModel.downloadPath(
+                    forFilename: "UniversalMac_15.6.1_24G90_Restore.ipsw"))
+        #expect(vm.ipswDownloadPath != VMCreationViewModel.defaultIPSWDownloadPath)
+    }
+
+    @Test("Two different picks never resolve to the same destination")
+    func distinctPicksGetDistinctDestinations() {
+        let vm = VMCreationViewModel()
+        vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
+        let first = vm.ipswDownloadPath
+        vm.selectCatalogEntry(makeCatalogEntry(version: "26.6", build: "25G72"))
+
+        #expect(first != vm.ipswDownloadPath)
+    }
+
+    @Test("Two spins of one version get distinct destinations")
+    func sameVersionDifferentBuildsGetDistinctDestinations() {
+        let vm = VMCreationViewModel()
+        vm.selectCatalogEntry(
+            makeCatalogEntry(
+                version: "15.4", build: "24E246",
+                urlString:
+                    "https://updates.cdn-apple.com/a/UniversalMac_15.4_24E246_Restore.ipsw"))
+        let first = vm.ipswDownloadPath
+        vm.selectCatalogEntry(
+            makeCatalogEntry(
+                version: "15.4", build: "24E248",
+                urlString:
+                    "https://updates.cdn-apple.com/b/UniversalMac_15.4_24E248_Restore.ipsw"))
+
+        #expect(first != vm.ipswDownloadPath)
+    }
+
+    @Test("Returning to Download Latest restores the fixed destination")
+    func downloadLatestRestoresDefaultDestination() {
+        let vm = VMCreationViewModel()
+        vm.selectCatalogEntry(makeCatalogEntry())
+        vm.selectDownloadLatest()
+
+        #expect(vm.ipswSource == .downloadLatest)
+        #expect(vm.selectedCatalogEntry == nil)
+        #expect(vm.ipswDownloadPath == VMCreationViewModel.defaultIPSWDownloadPath)
+    }
+
+    @Test("The catalog source cannot advance until a version is chosen")
+    func catalogSourceRequiresAPick() {
+        let vm = VMCreationViewModel()
+        vm.currentStep = .bootConfig
+        vm.ipswSource = .catalogVersion
+
+        #expect(!vm.canAdvance)
+        #expect(vm.validationMessage == "Choose a macOS version to continue.")
+
+        vm.selectCatalogEntry(makeCatalogEntry())
+        #expect(vm.canAdvance)
+        #expect(vm.validationMessage == nil)
+    }
+
+    @Test("The overwrite warning and resume check cover the catalog source")
+    func catalogSourceSharesDownloadWarnings() {
+        let vm = VMCreationViewModel()
+        vm.currentStep = .bootConfig
+        vm.selectCatalogEntry(makeCatalogEntry())
+        vm.ipswDownloadPath = "/usr/bin/true"  // exists on disk
+        #expect(vm.shouldShowOverwriteWarning)
+        #expect(!vm.canAdvance)
+
+        vm.confirmOverwrite()
+        #expect(!vm.shouldShowOverwriteWarning)
+        #expect(vm.canAdvance)
+    }
+
+    @Test("A catalog install context pins the URL, version, and build")
+    func catalogInstallContextPinsTheImage() {
+        let vm = VMCreationViewModel()
+        let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
+        vm.selectCatalogEntry(entry)
+
+        let context = vm.buildInstallContext()
+
+        #expect(context.source == .catalogVersion)
+        #expect(context.remoteURL == entry.url)
+        #expect(context.version == "15.6.1")
+        #expect(context.build == "24G90")
+        #expect(context.downloadDestinationPath == vm.ipswDownloadPath)
+        #expect(!context.requestedFreshDownload)
+    }
+
+    @Test("Download & Replace carries into the catalog install context")
+    func catalogInstallContextCarriesFreshDownload() {
+        let vm = VMCreationViewModel()
+        vm.selectCatalogEntry(makeCatalogEntry())
+        vm.confirmOverwrite()
+
+        #expect(vm.buildInstallContext().requestedFreshDownload)
+    }
+
+    @Test("Use Existing File adopts the per-build download as a local file")
+    func useExistingAdoptsPerBuildPath() {
+        let vm = VMCreationViewModel()
+        vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
+        let destination = vm.ipswDownloadPath
+        vm.useExistingDownloadFile()
+
+        #expect(vm.ipswSource == .localFile)
+        #expect(vm.ipswPath == destination)
+    }
+
+    @Test("Only download sources own the destination")
+    func downloadsImageCoversBothDownloadSources() {
+        #expect(IPSWSource.downloadLatest.downloadsImage)
+        #expect(IPSWSource.catalogVersion.downloadsImage)
+        #expect(!IPSWSource.localFile.downloadsImage)
+    }
 }

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -391,15 +391,16 @@ struct VMInstanceTests {
         #expect(instance.startAction.label == "Install")
     }
 
-    /// Builds a stopped VM with a `.downloadLatest` install context whose download
-    /// destination has a sibling `.kernovadownload` bundle seeded on disk.
+    /// Builds a stopped VM with an install context whose download destination has
+    /// a sibling `.kernovadownload` bundle seeded on disk.
     ///
     /// `partialBytes` is what the bundle's `data` file holds: pass `nil` for the
     /// husk a finalize leaves when its disposal fails (directory and metadata
     /// present, `data` already moved to the destination). Returns the temp
     /// directory so the caller can clean it up.
     private func makeInstanceWithSeededDownloadBundle(
-        partialBytes: Data?
+        partialBytes: Data?,
+        source: MacOSInstallContext.Source = .downloadLatest
     ) throws -> (instance: VMInstance, temp: URL) {
         let temp = FileManager.default.temporaryDirectory
             .appendingPathComponent("VMInstanceTests-\(UUID().uuidString)", isDirectory: true)
@@ -427,7 +428,7 @@ struct VMInstanceTests {
 
         let instance = makeInstance(status: .stopped)
         instance.configuration.installContext = MacOSInstallContext(
-            source: .downloadLatest,
+            source: source,
             downloadDestinationPath: destination.path(percentEncoded: false)
         )
         return (instance, temp)
@@ -446,16 +447,38 @@ struct VMInstanceTests {
         #expect(instance.startAction.label == "Install")
     }
 
-    @Test("startAction is .resumeInstall when the bundle still holds partial bytes")
-    func startActionResumeInstallWithPartialBytes() throws {
+    @Test(
+        "startAction is .resumeInstall when the bundle still holds partial bytes",
+        arguments: [
+            MacOSInstallContext.Source.downloadLatest, .catalogVersion, .customURL,
+        ]
+    )
+    func startActionResumeInstallWithPartialBytes(source: MacOSInstallContext.Source) throws {
+        // Every downloading source writes the same sidecar and resumes through
+        // the same path, so all three offer "Resume Install".
         let (instance, temp) = try makeInstanceWithSeededDownloadBundle(
-            partialBytes: Data(repeating: 0x11, count: 1024)
+            partialBytes: Data(repeating: 0x11, count: 1024),
+            source: source
         )
         defer { try? FileManager.default.removeItem(at: temp) }
 
         #expect(instance.hasResumableInstallDownload == true)
         #expect(instance.startAction == .resumeInstall)
         #expect(instance.startAction.label == "Resume Install")
+    }
+
+    @Test("startAction is .install for a local-file install beside a partial bundle")
+    func startActionInstallForLocalFileSource() throws {
+        // A local-file install never downloads, so a bundle left at the same
+        // path by an earlier attempt says nothing about what Start will do.
+        let (instance, temp) = try makeInstanceWithSeededDownloadBundle(
+            partialBytes: Data(repeating: 0x11, count: 1024),
+            source: .localFile
+        )
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        #expect(instance.hasResumableInstallDownload == false)
+        #expect(instance.startAction == .install)
     }
 
     @Test("StartAction labels match what each variant performs")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -834,8 +834,15 @@ struct VMLibraryViewModelTests {
         return vm
     }
 
-    @Test("deleteConfirmed discards the IPSW resume-data sidecar")
-    func deleteConfirmedDiscardsResumeData() {
+    @Test(
+        "deleteConfirmed discards the IPSW resume-data sidecar",
+        arguments: [
+            MacOSInstallContext.Source.downloadLatest, .catalogVersion, .customURL,
+        ]
+    )
+    func deleteConfirmedDiscardsResumeData(source: MacOSInstallContext.Source) {
+        // Every source that downloads its image leaves a partial bundle at
+        // `downloadDestinationPath`, so deleting the VM has to discard it.
         let ipswService = MockIPSWService()
         let storage = MockVMStorageService()
         let viewModel = makeViewModelWithIPSW(ipswService: ipswService, storage: storage)
@@ -844,7 +851,7 @@ struct VMLibraryViewModelTests {
         let destination = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(UUID().uuidString)-RestoreImage.ipsw")
         instance.configuration.installContext = MacOSInstallContext(
-            source: .downloadLatest,
+            source: source,
             downloadDestinationPath: destination.path(percentEncoded: false)
         )
         viewModel.instances.append(instance)
@@ -886,6 +893,30 @@ struct VMLibraryViewModelTests {
         #expect(ipswService.lastDiscardResumeDataPermanently == true)
         #expect(storage.permanentlyDeleteVMBundleCallCount == 1)
         #expect(viewModel.instances.isEmpty)
+    }
+
+    @Test("deleteConfirmed leaves resume-data alone for a local-file install")
+    func deleteConfirmedNoResumeDataForLocalFileSource() {
+        let ipswService = MockIPSWService()
+        let storage = MockVMStorageService()
+        let viewModel = makeViewModelWithIPSW(ipswService: ipswService, storage: storage)
+
+        let instance = makeInstance()
+        // A destination path is set so the source — not a nil destination — is
+        // what keeps the cleanup from firing.
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-RestoreImage.ipsw")
+        instance.configuration.installContext = MacOSInstallContext(
+            source: .localFile,
+            downloadDestinationPath: destination.path(percentEncoded: false),
+            localIPSWPath: "/tmp/UserPicked.ipsw"
+        )
+        viewModel.instances.append(instance)
+        storage.bundles[instance.bundleURL] = instance.configuration
+
+        viewModel.deleteConfirmed(instance)
+
+        #expect(ipswService.discardResumeDataCallCount == 0)
     }
 
     @Test("deleteConfirmed leaves resume-data alone when VM has no install context")

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -403,6 +403,60 @@ struct VMLifecycleCoordinatorTests {
         #expect(installService.installCallCount == 1)
     }
 
+    @Test("installMacOS with a catalog context downloads the pinned URL, never the latest")
+    func installMacOSCatalogUsesPinnedURL() async throws {
+        let (coordinator, _, installService, ipswService, _) = makeCoordinator()
+        let instance = makeInstance()
+        let pinned = try #require(
+            URL(string: "https://updates.cdn-apple.com/x/UniversalMac_15.6.1_24G90_Restore.ipsw"))
+        let context = MacOSInstallContext(
+            source: .catalogVersion,
+            downloadDestinationPath: FileManager.default.temporaryDirectory
+                .appendingPathComponent("UniversalMac_15.6.1_24G90_Restore.ipsw")
+                .path(percentEncoded: false),
+            remoteURL: pinned,
+            version: "15.6.1",
+            build: "24G90"
+        )
+
+        try await coordinator.installMacOS(on: instance, context: context)
+
+        #expect(ipswService.fetchCallCount == 0)
+        #expect(ipswService.downloadCallCount == 1)
+        #expect(ipswService.lastDownloadRemoteURL == pinned)
+        #expect(installService.installCallCount == 1)
+    }
+
+    @Test("installMacOS rejects a catalog context with no pinned URL")
+    func installMacOSCatalogWithoutURLThrows() async {
+        let (coordinator, _, _, ipswService, _) = makeCoordinator()
+        let instance = makeInstance()
+        let context = MacOSInstallContext(
+            source: .catalogVersion,
+            downloadDestinationPath: FileManager.default.temporaryDirectory
+                .appendingPathComponent("test-restore.ipsw").path(percentEncoded: false)
+        )
+
+        await #expect(throws: IPSWError.self) {
+            try await coordinator.installMacOS(on: instance, context: context)
+        }
+        // Never silently falls back to resolving the latest image.
+        #expect(ipswService.fetchCallCount == 0)
+    }
+
+    @Test("A catalog destination outside Downloads falls back to the pinned filename")
+    func normalizedDestinationKeepsPinnedFilename() throws {
+        let (coordinator, _, _, _, _) = makeCoordinator()
+        let elsewhere = URL(fileURLWithPath: "/Users/Shared/UniversalMac_15.6.1_24G90_Restore.ipsw")
+
+        let normalized = coordinator.normalizedDownloadDestination(
+            for: elsewhere, fallbackFilename: "UniversalMac_15.6.1_24G90_Restore.ipsw")
+
+        #expect(normalized.lastPathComponent == "UniversalMac_15.6.1_24G90_Restore.ipsw")
+        #expect(
+            normalized.path(percentEncoded: false) != VMCreationViewModel.defaultIPSWDownloadPath)
+    }
+
     @Test("installMacOS sets status to error on service failure")
     func installMacOSError() async {
         let (coordinator, _, installService, _, _) = makeCoordinator()

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -5,12 +5,11 @@ import Foundation
 @Suite("VMLifecycleCoordinator Tests")
 @MainActor
 struct VMLifecycleCoordinatorTests {
-    /// `downloadsDirectory` widens the coordinator's Downloads-only
-    /// destination invariant to a test-owned directory so fresh-download
-    /// tests can stage real files without touching the user's Downloads.
+    /// `downloadsDirectory` moves the coordinator's Downloads-only destination
+    /// invariant to a test-owned directory, so destination tests can name paths
+    /// that must be honored without touching the user's Downloads.
     private func makeCoordinator(
-        downloadsDirectory: URL? = nil,
-        fileSystem: any FileSystemOperating = MockFileSystem()
+        downloadsDirectory: URL? = nil
     ) -> (
         VMLifecycleCoordinator,
         MockVirtualizationService,
@@ -27,7 +26,6 @@ struct VMLifecycleCoordinatorTests {
             installService: installService,
             ipswService: ipswService,
             usbDeviceService: usbService,
-            fileSystem: fileSystem,
             downloadsDirectory: downloadsDirectory
                 ?? FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first
         )
@@ -444,13 +442,15 @@ struct VMLifecycleCoordinatorTests {
         #expect(ipswService.fetchCallCount == 0)
     }
 
-    @Test("A catalog destination outside Downloads falls back to the pinned filename")
+    @Test("A catalog destination outside Downloads falls back to the pinned image's filename")
     func normalizedDestinationKeepsPinnedFilename() throws {
         let (coordinator, _, _, _, _) = makeCoordinator()
         let elsewhere = URL(fileURLWithPath: "/Users/Shared/UniversalMac_15.6.1_24G90_Restore.ipsw")
+        let pinned = try #require(
+            URL(string: "https://updates.cdn-apple.com/x/UniversalMac_15.6.1_24G90_Restore.ipsw"))
 
         let normalized = coordinator.normalizedDownloadDestination(
-            for: elsewhere, fallbackFilename: "UniversalMac_15.6.1_24G90_Restore.ipsw")
+            for: elsewhere, remoteURL: pinned)
 
         #expect(normalized.lastPathComponent == "UniversalMac_15.6.1_24G90_Restore.ipsw")
         #expect(
@@ -510,17 +510,14 @@ struct VMLifecycleCoordinatorTests {
         #expect(instance.configuration.installContext == originalContext)
     }
 
-    @Test("installMacOS with requestedFreshDownload trashes existing file and clears the flag")
-    func installMacOSFreshDownloadTrashesAndClears() async throws {
-        // The mock reports the destination as existing and records the trash
-        // request, so no real file (or real Trash write) is involved. The
-        // Downloads-invariant root is a unique temp path so the destination
-        // passes normalization without touching the user's Downloads.
+    @Test("installMacOS asks the download to replace what is at the destination")
+    func installMacOSFreshDownloadDelegatesTheDiscard() async throws {
+        // The disposal belongs to the download, which holds the destination's
+        // claim while it runs — trashing from the coordinator could reach a
+        // bundle another VM is streaming into.
         let temp = FileManager.default.temporaryDirectory
             .appendingPathComponent("freshDownloadTrash-\(UUID().uuidString)", isDirectory: true)
-        let fileSystem = MockFileSystem()
-        let (coordinator, _, _, ipswService, _) = makeCoordinator(
-            downloadsDirectory: temp, fileSystem: fileSystem)
+        let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: temp)
         let instance = makeInstance()
 
         let destination = temp.appendingPathComponent("RestoreImage.ipsw")
@@ -535,74 +532,53 @@ struct VMLifecycleCoordinatorTests {
 
         try await coordinator.installMacOS(on: instance, context: context)
 
-        // The existing IPSW must have been trashed, the bundle cleanup must
-        // have been invoked exactly once, and on success the installContext
-        // is cleared by the post-install path — so we can't observe the
-        // cleared `requestedFreshDownload` directly, but the
-        // discardResumeData call count is the proxy that proves the
-        // honor-and-clear branch ran.
-        #expect(fileSystem.trashedURLs == [destination])
-        #expect(ipswService.discardResumeDataCallCount == 1)
-        #expect(ipswService.lastDiscardResumeDataURL == destination)
+        #expect(ipswService.lastDownloadDiscardsExisting == true)
+        #expect(ipswService.lastDownloadDestinationURL == destination)
+        // Nothing is trashed outside the download's claim.
+        #expect(ipswService.discardResumeDataCallCount == 0)
     }
 
-    @Test("installMacOS with requestedFreshDownload skips trash when the file is absent")
-    func installMacOSFreshDownloadSkipsTrashWhenAbsent() async throws {
-        // The file-absent counterpart of the test above: the mock reports the
-        // destination as *not* existing, so the fresh-download cleanup must skip
-        // the trash entirely — but still discard any resume data and clear the
-        // flag, since that cleanup runs unconditionally within the honor branch.
+    @Test("installMacOS clears requestedFreshDownload before the download runs")
+    func installMacOSFreshDownloadClearsTheFlagOnce() async {
+        // A download that fails leaves the context for the retry Start — with
+        // the flag already spent, so the retry resumes the partial rather than
+        // trashing it and starting over.
         let temp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("freshDownloadAbsent-\(UUID().uuidString)", isDirectory: true)
-        let fileSystem = MockFileSystem()
-        fileSystem.fileExistsResult = false
-        let (coordinator, _, _, ipswService, _) = makeCoordinator(
-            downloadsDirectory: temp, fileSystem: fileSystem)
+            .appendingPathComponent("freshDownloadOnce-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: temp)
+        ipswService.downloadError = IPSWError.downloadFailed(URLError(.notConnectedToInternet))
         let instance = makeInstance()
-
-        let destination = temp.appendingPathComponent("RestoreImage.ipsw")
 
         let context = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: destination.path(percentEncoded: false),
+            downloadDestinationPath: temp.appendingPathComponent("RestoreImage.ipsw")
+                .path(percentEncoded: false),
             requestedFreshDownload: true
         )
         instance.configuration.installContext = context
         instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
 
-        try await coordinator.installMacOS(on: instance, context: context)
+        await #expect(throws: IPSWError.self) {
+            try await coordinator.installMacOS(on: instance, context: context)
+        }
 
-        // Nothing existed to trash, but the honor-and-clear branch still ran:
-        // resume data was discarded exactly once for the destination.
-        #expect(fileSystem.trashedURLs.isEmpty)
-        #expect(ipswService.discardResumeDataCallCount == 1)
-        #expect(ipswService.lastDiscardResumeDataURL == destination)
+        #expect(ipswService.lastDownloadDiscardsExisting == true)
+        #expect(instance.configuration.installContext?.requestedFreshDownload == false)
     }
 
-    @Test("installMacOS surfaces freshDownloadCleanupFailed when the trash operation throws")
-    func installMacOSFreshDownloadSurfacesTrashFailure() async throws {
-        // Inject a FileSystemOperating that always throws from `trashItem`.
-        // This exercises the catch path that wraps the error in
-        // `IPSWError.freshDownloadCleanupFailed` and proves the failure is
-        // surfaced rather than swallowed.
-        let trashError = NSError(
-            domain: NSCocoaErrorDomain,
-            code: NSFileWriteNoPermissionError,
-            userInfo: [NSLocalizedDescriptionKey: "denied"]
-        )
-        let throwingFS = MockFileSystem()
-        throwingFS.trashError = trashError
-
-        let virtService = MockVirtualizationService()
-        let installService = MockMacOSInstallService()
-        let ipswService = MockIPSWService()
-        let usbService = MockUSBDeviceService()
-        let coordinator = VMLifecycleCoordinator(
-            virtualizationService: virtService,
-            installService: installService,
-            ipswService: ipswService,
-            usbDeviceService: usbService,
-            fileSystem: throwingFS
+    @Test("installMacOS surfaces a cleanup failure raised by the download")
+    func installMacOSFreshDownloadSurfacesTrashFailure() async {
+        // The download reports that it could not clear the way for the
+        // replacement; the install must fail rather than install the file the
+        // user asked to replace.
+        let (coordinator, _, installService, ipswService, _) = makeCoordinator()
+        ipswService.downloadError = IPSWError.freshDownloadCleanupFailed(
+            path: "/tmp/cannot-trash.ipsw",
+            underlying: NSError(
+                domain: NSCocoaErrorDomain,
+                code: NSFileWriteNoPermissionError,
+                userInfo: [NSLocalizedDescriptionKey: "denied"]
+            )
         )
 
         let instance = makeInstance()
@@ -618,9 +594,8 @@ struct VMLifecycleCoordinatorTests {
             try await coordinator.installMacOS(on: instance, context: context)
             Issue.record("Expected freshDownloadCleanupFailed")
         } catch IPSWError.freshDownloadCleanupFailed {
-            // Expected — the trash failure was surfaced.
             #expect(instance.status == .error)
-            #expect(ipswService.downloadCallCount == 0, "Download must not start when cleanup fails")
+            #expect(installService.installCallCount == 0, "Install must not run on a failed download")
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
@@ -659,25 +634,24 @@ struct VMLifecycleCoordinatorTests {
 
     @Test("installMacOS without requestedFreshDownload leaves existing file alone")
     func installMacOSWithoutFreshDownloadDoesNotTrash() async throws {
-        let fileSystem = MockFileSystem()
-        let (coordinator, _, _, ipswService, _) = makeCoordinator(fileSystem: fileSystem)
-        let instance = makeInstance()
-
-        let destination = FileManager.default.temporaryDirectory
+        let temp = FileManager.default.temporaryDirectory
             .appendingPathComponent("noFreshDownload-\(UUID().uuidString)", isDirectory: true)
-            .appendingPathComponent("RestoreImage.ipsw")
+        let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: temp)
+        let instance = makeInstance()
 
         let context = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: destination.path(percentEncoded: false)
+            downloadDestinationPath: temp.appendingPathComponent("RestoreImage.ipsw")
+                .path(percentEncoded: false)
         )
         instance.configuration.installContext = context
         instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
 
         try await coordinator.installMacOS(on: instance, context: context)
 
-        // No requestedFreshDownload, so no trash, no discardResumeData call.
-        #expect(fileSystem.trashedURLs.isEmpty)
+        // Nothing at the destination is disturbed: the download resumes or
+        // skips over whatever is already there.
+        #expect(ipswService.lastDownloadDiscardsExisting == false)
         #expect(ipswService.discardResumeDataCallCount == 0)
     }
 
@@ -859,5 +833,52 @@ struct VMLifecycleCoordinatorTests {
         let normalized = coordinator.normalizedDownloadDestination(for: elsewhere)
         #expect(
             normalized.path(percentEncoded: false) == VMCreationViewModel.defaultIPSWDownloadPath)
+    }
+
+    @Test("Every destination a hand-edited config can name lands inside Downloads")
+    func normalizedDownloadDestinationContainsEveryCandidate() throws {
+        let downloads = FileManager.default.temporaryDirectory
+            .appendingPathComponent("normalizedDestination-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, _, _, _) = makeCoordinator(downloadsDirectory: downloads)
+
+        // Traversal out of Downloads, the directory itself spelled two ways,
+        // and a path that was never in Downloads at all.
+        let persistedSpellings = [
+            downloads.appendingPathComponent("../../evil.ipsw"),
+            downloads.appendingPathComponent("sub/../evil.ipsw"),
+            downloads,
+            downloads.appendingPathComponent(""),
+            URL(fileURLWithPath: "/Users/Shared/RestoreImage.ipsw"),
+        ]
+        // A remote URL is no safer: it comes out of the same `config.json`.
+        // The last names nothing at all, which appended verbatim resolves to
+        // the Downloads directory itself.
+        let traversal = try #require(URL(string: "https://host/a%2F..%2F..%2Fevil.ipsw"))
+        let pathless = try #require(URL(string: "https://example.com"))
+        let remoteSpellings: [URL?] = [nil, traversal, pathless]
+
+        for persisted in persistedSpellings {
+            for remote in remoteSpellings {
+                let normalized = coordinator.normalizedDownloadDestination(
+                    for: persisted, remoteURL: remote)
+                let context =
+                    "persisted '\(persisted.path(percentEncoded: false))', remote '\(remote?.absoluteString ?? "none")'"
+                #expect(
+                    canonicalPath(normalized.deletingLastPathComponent())
+                        == canonicalPath(downloads), "escaped Downloads for \(context)")
+                #expect(
+                    canonicalPath(normalized) != canonicalPath(downloads),
+                    "named Downloads itself for \(context)")
+                #expect(normalized.pathExtension.lowercased() == "ipsw", "not an IPSW for \(context)")
+            }
+        }
+    }
+
+    /// A path with `..` collapsed and any trailing separator dropped, so a
+    /// directory and the same directory named as a parent compare equal.
+    private func canonicalPath(_ url: URL) -> String {
+        let path = url.standardizedFileURL.path(percentEncoded: false)
+        guard path.count > 1, path.hasSuffix("/") else { return path }
+        return String(path.dropLast())
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,8 +83,11 @@ substitute mocks. Services split by concurrency: those that touch
   `~/Library/Application Support/Kernova/VMs/`. Deletion has two dispositions, `deleteVMBundle`
   (Trash) and `permanentlyDeleteVMBundle` (the user-confirmed bypass).
 - `DiskImageService` — creates ASIF disk images by decompressing bundled templates in-process.
-- `IPSWService` (a `final class`, for `URLSession` lifetime) — fetches Apple's restore-image catalog
-  and streams IPSW downloads into a resumable `.kernovadownload` bundle.
+- `IPSWService` (a `final class`, for `URLSession` lifetime) — resolves the latest supported restore
+  image through VZ and streams IPSW downloads into a resumable `.kernovadownload` bundle.
+- `RestoreImageCatalogService` — decodes the bundled snapshot of selectable macOS restore images,
+  `Kernova/Resources/RestoreImageCatalog.json`, backing the wizard's "Choose a Version…" source. It
+  reaches no network; only the image the user picks is fetched, by `IPSWService`.
 
 `ConfigurationBuilder` translates a `VMConfiguration` into a `VZVirtualMachineConfiguration` — the
 single VZ-facing translation point, covering boot loader, CPU, memory, storage, network, display,
@@ -171,7 +174,7 @@ calls `applyLiveRemovableMediaChange(for:target:)`.
   flows such as a macOS install. It serializes lifecycle operations per VM; `stop` and `forceStop`
   deliberately bypass that serialization so a hung operation can always be cancelled.
 - `VMCreationViewModel` — a pure `@Observable` state machine for the creation wizard, with no
-  UI-framework dependency.
+  UI-framework dependency. Injects `RestoreImageCatalogProviding` for the version picker.
 - `VMDirectoryWatcher` — a `DispatchSource` on the VMs directory that triggers reconciliation in
   `VMLibraryViewModel` when the library changes on disk.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,9 +93,7 @@ substitute mocks. Services split by concurrency: those that touch
   framework's own. Consulted before the wizard adopts a file it did not download itself.
 - `RestoreImageProbeService` (a `final class`, for `URLSession` lifetime) — establishes that a
   user-supplied URL serves an installable restore image, and how large it is, before any download.
-  An IPSW is a zip whose central directory names `kernelcache.release.vma2` exactly when the image
-  carries the virtual-machine hardware model, so ranged reads of the directory settle it in about
-  150 KB. `Tools/regen-restore-image-catalog.swift` applies the same check to every catalog
+  `Tools/regen-restore-image-catalog.swift` applies the same installability check to every catalog
   candidate, which is what puts a pasted URL on the same footing as a catalog row.
 
 `ConfigurationBuilder` translates a `VMConfiguration` into a `VZVirtualMachineConfiguration` — the
@@ -179,9 +177,9 @@ calls `applyLiveRemovableMediaChange(for:target:)`.
   `await`** — that is what reserves the destination atomically on the MainActor, so overlapping
   imports and clones cannot claim the same bundle URL.
 - `VMLifecycleCoordinator` — `@MainActor`; owns `VirtualizationService`, `MacOSInstallService`,
-  `IPSWService`, `USBDeviceService` and the `FileSystemOperating` seam, and orchestrates multi-step
-  flows such as a macOS install. It serializes lifecycle operations per VM; `stop` and `forceStop`
-  deliberately bypass that serialization so a hung operation can always be cancelled.
+  `IPSWService` and `USBDeviceService`, and orchestrates multi-step flows such as a macOS install.
+  It serializes lifecycle operations per VM; `stop` and `forceStop` deliberately bypass that
+  serialization so a hung operation can always be cancelled.
 - `VMCreationViewModel` — a pure `@Observable` state machine for the creation wizard, with no
   UI-framework dependency. Injects `RestoreImageCatalogProviding` for the version picker and
   `RestoreImageProbing` for the paste-a-URL sheet.
@@ -241,7 +239,7 @@ AppDelegate
     │                 ├── VMStorageService
     │                 ├── DiskImageService
     │                 ├── VMDirectoryWatcher, SystemSleepWatcher
-    │                 └── FileSystemOperating (trash/remove seam; shared with the coordinator)
+    │                 └── FileSystemOperating (trash/remove seam; also held by IPSWService)
     ├── creates → VMLifecycleCoordinator
     │                 ├── VirtualizationService
     │                 ├── MacOSInstallService

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,6 +88,12 @@ substitute mocks. Services split by concurrency: those that touch
 - `RestoreImageCatalogService` — decodes the bundled snapshot of selectable macOS restore images,
   `Kernova/Resources/RestoreImageCatalog.json`, backing the wizard's "Choose a Version…" source. It
   reaches no network; only the image the user picks is fetched, by `IPSWService`.
+- `RestoreImageProbeService` (a `final class`, for `URLSession` lifetime) — establishes that a
+  user-supplied URL serves an installable restore image, and how large it is, before any download.
+  An IPSW is a zip whose central directory names `kernelcache.release.vma2` exactly when the image
+  carries the virtual-machine hardware model, so ranged reads of the directory settle it in about
+  150 KB. `Tools/regen-restore-image-catalog.swift` applies the same check to every catalog
+  candidate, which is what puts a pasted URL on the same footing as a catalog row.
 
 `ConfigurationBuilder` translates a `VMConfiguration` into a `VZVirtualMachineConfiguration` — the
 single VZ-facing translation point, covering boot loader, CPU, memory, storage, network, display,
@@ -174,7 +180,8 @@ calls `applyLiveRemovableMediaChange(for:target:)`.
   flows such as a macOS install. It serializes lifecycle operations per VM; `stop` and `forceStop`
   deliberately bypass that serialization so a hung operation can always be cancelled.
 - `VMCreationViewModel` — a pure `@Observable` state machine for the creation wizard, with no
-  UI-framework dependency. Injects `RestoreImageCatalogProviding` for the version picker.
+  UI-framework dependency. Injects `RestoreImageCatalogProviding` for the version picker and
+  `RestoreImageProbing` for the paste-a-URL sheet.
 - `VMDirectoryWatcher` — a `DispatchSource` on the VMs directory that triggers reconciliation in
   `VMLibraryViewModel` when the library changes on disk.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,6 +88,9 @@ substitute mocks. Services split by concurrency: those that touch
 - `RestoreImageCatalogService` — decodes the bundled snapshot of selectable macOS restore images,
   `Kernova/Resources/RestoreImageCatalog.json`, backing the wizard's "Choose a Version…" source. It
   reaches no network; only the image the user picks is fetched, by `IPSWService`.
+- `LocalRestoreImageInspector` — reads a restore image already on disk through `VZMacOSRestoreImage`,
+  which loads from a file URL, so the version, build and supported-configuration verdict are the
+  framework's own. Consulted before the wizard adopts a file it did not download itself.
 - `RestoreImageProbeService` (a `final class`, for `URLSession` lifetime) — establishes that a
   user-supplied URL serves an installable restore image, and how large it is, before any download.
   An IPSW is a zip whose central directory names `kernelcache.release.vma2` exactly when the image

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -112,12 +112,25 @@ install.)
    agent has its **own** version — bump it only when agent behavior changed, per
    the guest-agent versioning conventions in [BUILD.md](BUILD.md).
    `CFBundleVersion` is derived from git and needs no manual edit.
-2. **Archive.** In Xcode, select the **Kernova** scheme, then **Product →
+2. **Restore image catalog.** Regenerate the snapshot the wizard's version
+   picker ships, so the release offers what Apple hosts today:
+
+   ```bash
+   swift Tools/regen-restore-image-catalog.swift
+   ```
+
+   It verifies every candidate against Apple's CDN, so it takes a few minutes;
+   set `KERNOVA_CATALOG_CACHE` to a directory to keep repeat runs off the
+   Internet Archive. Commit the result when it changes — an unchanged input
+   reproduces the file byte for byte, so a no-op diff means there is nothing
+   new. There is deliberately no CI drift check: Apple ships on its own
+   schedule, so the file is expected to age between releases.
+3. **Archive.** In Xcode, select the **Kernova** scheme, then **Product →
    Archive** (archiving builds Release).
-3. **Confirm the archive type.** In the Organizer, verify the new archive
+4. **Confirm the archive type.** In the Organizer, verify the new archive
    appears as a **macOS app** archive, not *Other Items*. If it's *Other
    Items*, a `SKIP_INSTALL` regressed on the agent or `KernovaRelaunchHelper`.
-4. **Distribute.** **Distribute App → Direct Distribution → Automatically
+5. **Distribute.** **Distribute App → Direct Distribution → Automatically
    manage signing.** Xcode re-signs the app and its nested code with Developer
    ID, submits to the notary service, staples the ticket on success, and
    enables **Export** (usually within minutes).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -123,8 +123,7 @@ install.)
    set `KERNOVA_CATALOG_CACHE` to a directory to keep repeat runs off the
    Internet Archive. Commit the result when it changes — an unchanged input
    reproduces the file byte for byte, so a no-op diff means there is nothing
-   new. There is deliberately no CI drift check: Apple ships on its own
-   schedule, so the file is expected to age between releases.
+   new.
 3. **Archive.** In Xcode, select the **Kernova** scheme, then **Product →
    Archive** (archiving builds Release).
 4. **Confirm the archive type.** In the Organizer, verify the new archive

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -11,7 +11,7 @@ Everything `Kernova/Resources/Kernova.entitlements` claims:
 | Entitlement | Why it is needed |
 |---|---|
 | `com.apple.security.app-sandbox` | Mac App Store eligibility |
-| `com.apple.security.network.client` | Sole network use: `IPSWService`'s macOS restore-image downloads from Apple's CDN |
+| `com.apple.security.network.client` | Sole network use: macOS restore-image traffic — `IPSWService` downloads and `RestoreImageProbeService`'s ranged probe of a user-supplied URL |
 | `com.apple.security.files.user-selected.read-write` | Powerbox grants from open/save panels — disk images, ISOs, shared folders, Linux kernel/initrd, local IPSWs |
 | `com.apple.security.files.downloads.read-write` | The fixed IPSW download destination in `~/Downloads` and its `.kernovadownload` resume sidecar |
 | `com.apple.security.files.bookmarks.app-scope` | Persisting those panel grants across launches |


### PR DESCRIPTION
Closes #280

Two new IPSW sources for the macOS creation wizard, in two commits:

| Commit | What |
|---|---|
| `697a815` | **Choose a Version…** — the Apple-sourced catalog merged in #671, 73 builds from macOS 12.0.1 to 26.6 |
| `f7b9882` | **Paste an IPSW URL…** — a ~150 KB pre-download check of any HTTPS URL |
| `8473b34` | Verify an existing IPSW before **Use Existing File** adopts it |
| `8ab97fb` | Stop the version picker's first row hiding behind its column header |

Both sources pin the chosen image into `MacOSInstallContext` and hand it to the existing download / resume / finalize pipeline unchanged. #673 was the second commit as a stacked PR; it is folded in here.

## The bug this would otherwise have shipped

Every download today lands on `~/Downloads/RestoreImage.ipsw`, and `downloadRestoreImage` **skips the download entirely** when a complete file already sits at the destination. The moment a second version is selectable, picking 15.6.1 after having downloaded 26.6 would silently install **26.6** while the wizard showed 15.6.1.

So both new sources download to the image's own filename, from the URL's last path component. The destination stays inside Downloads, which is all `normalizedDownloadDestination` checks, so the sandbox story is unchanged. That function gained a fallback-filename parameter so a persisted destination outside Downloads still normalizes per-image rather than collapsing back onto the shared name.

## Choosing a version: a bundled snapshot, no runtime fetch

The shipped app talks to nobody but Apple, and only for the image the user picked. The picker opens instantly and works offline — no cache, TTL, retry, or degraded state to build or test. #280 asks for a "cached/refreshable" catalog that "degrades gracefully offline"; a bundled snapshot is the strongest form of that, at the cost of freshness between releases. The picker footer says how old the list is and points at Download Latest for anything newer, and RELEASING.md gains a regeneration step beside the `MARKETING_VERSION` decision.

**Identity is `build`, not `version`.** Apple ships hardware-specific spins under one version number — 15.4 exists as both `24E246` and `24E248` — so a version cannot address an image. Sorting compares version components numerically (26.10 above 26.9) and falls back to build so the order is total.

**Host support is a version comparison, not a framework answer.** VZ refuses a guest newer than the host, but `VZMacOSRestoreImage.loadFileURL` takes a *local file*, so the framework has no opinion until after the download. Rows above `ProcessInfo.processInfo.operatingSystemVersion` are dimmed and unselectable, labelled with what they need.

**Validation drops rather than throws.** A malformed entry, a non-HTTPS URL, a non-Apple host, a non-numeric version, or a repeated build is dropped with `logger.fault` + `assertionFailure`. `RestoreImageCatalogService.parse` is pure and non-asserting so every drop path is testable; the initializer is what escalates a rejection to a fault, because a rejection in the *shipped* resource is a build-time mistake.

The Apple-host check is an explicit allowlist anchored on a dot: `apple.com` and `cdn-apple.com`. Restore images are served from `updates.cdn-apple.com`, which is **not** a subdomain of `apple.com` — the separator is a hyphen, so a plain `.apple.com` suffix test would reject every real entry.

## Pasting a URL: the feature is the check

The catalog cannot cover a seed, a build newer than the bundled snapshot, or an image someone was handed a link to. And it inverts the catalog's central property: every catalog entry was verified at generation time, so the app can trust it, while a pasted URL has been verified by nobody.

So the sheet points the generator's own zip-central-directory read at the URL. An IPSW is a zip whose directory names `kernelcache.release.vma2` exactly when the image carries the virtual-machine hardware model, which settles it in **about 150 KB** rather than a 16 GB download that only fails at install. **Use** stays disabled until it passes, so nothing unchecked reaches the install pipeline.

### Any host, because the image is signed

A restore image carries `apticket.vma2macosap.im4m`, an Apple-signed IMG4 manifest that the restore validates. An image Apple did not sign cannot install, whoever served the bytes — so a host allowlist would not be the integrity boundary, only a guess at where Apple's files live, and a wrong one the day someone has a legitimate mirror. **HTTPS is the only requirement.**

Two consequences worth stating rather than discovering:

- The signature bites at *install*, after the download. The pre-download check catches the ordinary failure — not an installable image at all — for 150 KB; a well-formed image with a bad signature still surfaces at restore.
- **This does not change the catalog's host check.** The two look alike and do opposite jobs: the catalog validates data *we* generated and shipped, where an off-Apple host means the generator misbehaved and the assertion should fire. The URL source validates a string the user typed, where an unfamiliar host means nothing.

### One fact is a guess, and is treated like one

Version and build are parsed from Apple's `UniversalMac_<version>_<build>_Restore.ipsw` convention; size and VM-capability are measured. The parse yields `nil` rather than a guess for anything off-convention, and nothing gating the install depends on it. A filename-derived version above the host **warns without blocking** — blocking on a guess would be wrong — and an unrecognized filename says so plainly instead of showing a blank.

## A fixed sheet, four options

The wizard is fixed at 720×540 (`WizardStyle.width` / `.height`), leaving the step about **371 pt** of content after the step indicator, navigation bar and padding. Three options plus the two chips is ~333 pt; a fourth option costs ~56 pt, taking it to ~390 pt.

Nothing breaks at 390 pt — the step already lives in `makeGroupedFormScrollView` with a `ScrollMoreIndicator`, so it would simply scroll. But scrolling a four-item radio list to reach the last option is a regression, and the fix is cheap: the image chip and the destination chip are two halves of one statement, so they collapse into **one two-line badge for every download source**, bringing it to ~346 pt. Uniform across sources rather than special-cased.

## The file that was already there

Per-image destinations stop a stale `RestoreImage.ipsw` standing in for a version the user didn't pick. That fixes the *download*; it doesn't fix **Use Existing File**, the button on the overwrite banner, which took whatever sat at the path without establishing what it was. A filename is not a fingerprint — a truncated download, a hand-placed file or a rename all produce a path that looks right and holds something else, and a *valid but different* macOS then installs silently.

A local file is the one place the framework will answer. Fact 6 is normally a limitation — `VZMacOSRestoreImage.loadFileURL` takes a local file, so a remote image can't be validated — but here the image *is* local, so version, build and the supported-configuration verdict all come from Virtualization rather than from a filename or a size.

| What the file turns out to be | What happens |
|---|---|
| The build the wizard is showing | Adopted silently |
| **A different build** | Named in the banner, both builds spelled out, **not** adopted; "Use It Anyway" and "Download & Replace" both offered |
| Unreadable, or no supported configuration on this host | Refused, only "Download & Replace" offered |
| Anything, under Download Latest | Adopted if usable — that source names no image, so there's nothing to contradict |

The override survives, so someone who knows what they have can still take it; it just stops being the default.

## Rejected alternatives

- **A CI drift check on the catalog, like `proto-drift`.** This file is *supposed* to drift; Apple ships builds on their own schedule. A drift check would fail on main every few weeks and train everyone to ignore it. Regeneration belongs in the release flow.
- **An *Include betas* checkbox.** Betas are out of scope here, and shipping the control disabled with an explanatory label would put a limitation into the UI that nothing would trigger a re-check of. The generator filters seeds by build-number pattern and says nothing about why.
- **A host allowlist on the URL source.** See above — the signature is the boundary, not the hostname.
- **Comparing the existing file's size instead of loading it.** Cheap and synchronous, and it catches a truncated download, but it answers "is this the same number of bytes", not "which build is this" — which is the question that matters. The framework's answer was available for the cost of an async call.

## Changes

**Models** — `RestoreImageCatalogEntry` / `RestoreImageCatalog` (`Identifiable` by build, `suggestedFilename`, `isSupported(onHost:)`, numeric sort, search). `ProbedRestoreImage` (measured facts plus the best-effort filename parse, and a tri-state `isSupported(onHost:)` whose `nil` means "unknown", not "no").

**Services** — `RestoreImageCatalogProviding` / `RestoreImageCatalogService` decoding the bundled JSON; `RestoreImageProbing` / `RestoreImageProbeService` doing `HEAD` for size (falling back to a one-byte ranged `GET`'s `Content-Range` for servers that don't answer HEAD) then the zip64-aware directory read.

**`VMCreationViewModel`** — `IPSWSource.catalogVersion` and `.customURL` with `selectedCatalogEntry` / `pastedImage`. The overwrite warning, resume check, boot-config validity and validation message key on `IPSWSource.downloadsImage` rather than on Download Latest specifically.

**`MacOSInstallContext`** — both source cases plus optional `remoteURL`, `version`, `build`, and `usesPinnedURL` / `downloadsImage` computed properties replacing the case lists that were starting to spread through the coordinator and wizard. Existing contexts decode unchanged via `decodeIfPresent`; no migration code.

**`VMLifecycleCoordinator.installMacOS`** — uses the pinned URL for both pinned sources and never calls `fetchLatestRestoreImageURL` for them. Everything downstream is untouched.

**`LocalRestoreImageInspecting` / `LocalRestoreImageInspector`** — reads an on-disk IPSW through `VZMacOSRestoreImage`. `VMCreationViewModel.adoptExistingDownloadFile()` returns an `ExistingFileVerdict` (adopted / mismatch / unusable) and `pinnedBuild` names the build the current source promises — nil for Download Latest, and for a pasted URL whose filename yielded no build.

**Views** — `RestoreImageCatalogSheetContentViewController` (620×440) and `RestoreImageURLSheetContentViewController` (560×320), both modelled on the Boot Order sheet. Two new radios; Review renames "IPSW Source" to "Restore Image" and adds version and size; the initial-boot banner names the pinned image. `Choose Local File` gains the ellipsis it should always have had, and `makeWizardPathBadge` became one case of a general `makeWizardBadge` rather than a second copy of the same container.

`Kernova/Resources/RestoreImageCatalog.json` needed no project-file change: `Kernova/` is a `PBXFileSystemSynchronizedRootGroup` whose only membership exception is `App/Info.plist`, so the resource was already an app-target member. Verified in the built bundle.

## Test plan

- [x] `make test` — 1874 tests, exit 0
- [x] `make lint` — clean
- [x] Catalog decodes from a fixture; a malformed entry is dropped rather than failing the whole decode
- [x] Non-HTTPS URL, non-Apple host, non-numeric version and duplicate build all rejected; `updates.cdn-apple.com` accepted
- [x] `isSupportedOnHost` at the boundary — equal to host, one below, one above
- [x] Two builds sharing a version stay distinct (`24E246`/`24E248`), and resolve to different destinations
- [x] Sorting is newest-first and numeric per component; search matches version and build
- [x] The catalog shipped in the app bundle parses clean, with no count assertions that would break on regeneration
- [x] Probe accepts a synthetic zip naming `vma2`, refuses one that doesn't, a 404, a non-HTTPS URL (without issuing a request), and a file with no zip structure
- [x] Filename parse yields nil for every off-convention shape tried
- [x] `MacOSInstallContext` round-trips both new cases; a context written before this change still decodes; `usesPinnedURL` covers exactly the two pinned sources
- [x] `VMLifecycleCoordinator` uses the pinned URL and never calls `fetchLatestRestoreImageURL`; a pinned context with no URL throws rather than falling back
- [x] Both sheets: selection/gating, host dimming, search, delegate callbacks, too-new warning, edit-invalidates-verdict
- [x] Existing-file adoption: matching build adopts, mismatched build reports without adopting, unreadable and host-unsupported both refuse, and a source that pins no build adopts any usable image
- [x] **Driven on screen.** Four options, the collapsed badge and the overwrite banner all fit the fixed 720 × 540 sheet with no scrolling. The picker lists 26.6 at the top with the "Latest" pill, search narrows to two rows on `15.6`, and the URL sheet checked a real Apple CDN URL end to end — `macOS 15.6.1 (24G90) · 16.81 GB · Installs in a virtual machine` — with Review showing *From URL / macOS 15.6.1 (24G90) / 16.81 GB*. That pass is what found `8ab97fb`.

## Notes

No `RATIONALE:` comments are added by this PR.

`ProbeStubURLProtocol` is a second stub `URLProtocol` rather than a reuse of `StubURLProtocol`. That one's handler is a global and Swift Testing runs suites in parallel, so sharing it made the probe suite and `IPSWServiceDownloadTests` clobber each other — both failed, then passed on retry. `.serialized` orders tests *within* a suite and does not prevent it. Caught before pushing; the isolated stub removes the flake.

The branch keeps its original `feat/macos-restore-image-catalog-ui` name even though it now carries both sources: renaming a branch on GitHub after a PR exists closes the PR instead of retargeting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KeE8mfWnzrawSP8x3nV1JN
