### PR TITLE
feat: Add a "Paste an IPSW URL…" install source for macOS guests

### DIFF
--- a/Kernova/Models/MacOSInstallContext.swift
+++ b/Kernova/Models/MacOSInstallContext.swift
@@ -9,7 +9,25 @@ struct MacOSInstallContext: Codable, Sendable, Equatable {
     enum Source: String, Codable, Sendable, Equatable {
         case downloadLatest
         case catalogVersion
+        case customURL
         case localFile
+
+        /// Whether the install downloads the image named by ``remoteURL``
+        /// rather than resolving one at Start.
+        var usesPinnedURL: Bool {
+            switch self {
+            case .catalogVersion, .customURL: true
+            case .downloadLatest, .localFile: false
+            }
+        }
+
+        /// Whether the install fetches the image over the network.
+        var downloadsImage: Bool {
+            switch self {
+            case .downloadLatest, .catalogVersion, .customURL: true
+            case .localFile: false
+            }
+        }
     }
 
     var source: Source
@@ -21,10 +39,11 @@ struct MacOSInstallContext: Codable, Sendable, Equatable {
     /// download state and enables resume across app restarts.
     var downloadDestinationPath: String?
 
-    /// The exact image to download (for `.catalogVersion`).
+    /// The exact image to download (for the sources where ``Source/usesPinnedURL``).
     ///
-    /// Pinned at wizard time from the bundled catalog, so a Start weeks later
-    /// fetches the version the user chose rather than whatever is newest.
+    /// Pinned at wizard time — from the bundled catalog, or from a URL the user
+    /// supplied and Kernova checked — so a Start weeks later fetches the image
+    /// the user chose rather than whatever is newest.
     var remoteURL: URL?
 
     /// Marketing version and build of the pinned image, for display while the

--- a/Kernova/Models/ProbedRestoreImage.swift
+++ b/Kernova/Models/ProbedRestoreImage.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// A restore image at a user-supplied URL, after the pre-download check.
+///
+/// Only ``sizeBytes`` and the fact that the image carries the virtual-machine
+/// hardware model are measured. ``version`` and ``build`` are read out of
+/// Apple's filename convention and are absent whenever the filename does not
+/// follow it, so nothing that gates the install may depend on them.
+struct ProbedRestoreImage: Sendable, Equatable {
+    var url: URL
+    var sizeBytes: UInt64
+    /// Marketing version parsed from the filename, e.g. `"15.6.1"`.
+    var version: String?
+    /// Apple build parsed from the filename, e.g. `"24G90"`.
+    var build: String?
+
+    /// The filename the download lands on, taken from the URL.
+    ///
+    /// Per-image rather than a fixed name for the same reason a catalog pick is:
+    /// a shared filename lets an already-downloaded image of a different version
+    /// satisfy the download step.
+    var suggestedFilename: String {
+        let candidate = url.lastPathComponent
+        guard candidate.lowercased().hasSuffix(".ipsw"), !candidate.hasPrefix(".") else {
+            return "RestoreImage.ipsw"
+        }
+        return candidate
+    }
+
+    /// Version and build as one phrase, or a fallback when the filename did not
+    /// follow Apple's convention.
+    var versionSummary: String {
+        switch (version, build) {
+        case (let version?, let build?): "macOS \(version) (\(build))"
+        case (let version?, nil): "macOS \(version)"
+        case (nil, let build?): "Build \(build)"
+        case (nil, nil): "Unrecognized version"
+        }
+    }
+
+    /// Whether the parsed version is at most `host`.
+    ///
+    /// `nil` when the filename yielded no version — the answer is unknown, which
+    /// is not the same as a "no". Virtualization refuses a guest newer than the
+    /// host, but it only says so once the image is on disk.
+    func isSupported(onHost host: OperatingSystemVersion) -> Bool? {
+        guard let version else { return nil }
+        let parsed = version.split(separator: ".").map { Int($0) }
+        guard !parsed.isEmpty, !parsed.contains(nil) else { return nil }
+        var components = parsed.compactMap { $0 }
+        while components.count < 3 { components.append(0) }
+        let hostComponents = [host.majorVersion, host.minorVersion, host.patchVersion]
+        for (guestPart, hostPart) in zip(components.prefix(3), hostComponents)
+        where guestPart != hostPart {
+            return guestPart < hostPart
+        }
+        return true
+    }
+
+    /// Reads version and build out of Apple's restore-image filename.
+    ///
+    /// The convention is `UniversalMac_<version>_<build>_Restore.ipsw`. Anything
+    /// else yields `(nil, nil)` rather than a guess.
+    static func parseFilename(_ filename: String) -> (version: String?, build: String?) {
+        let parts = filename.split(separator: "_", omittingEmptySubsequences: false)
+        guard parts.count == 4,
+            parts[0] == "UniversalMac",
+            parts[3].lowercased() == "restore.ipsw"
+        else { return (nil, nil) }
+
+        let version = String(parts[1])
+        let build = String(parts[2])
+        let versionIsNumeric =
+            !version.isEmpty
+            && version.split(separator: ".", omittingEmptySubsequences: false)
+                .allSatisfy { !$0.isEmpty && $0.allSatisfy(\.isNumber) }
+        let buildLooksLikeBuild =
+            !build.isEmpty && build.allSatisfy { $0.isLetter || $0.isNumber }
+        guard versionIsNumeric, buildLooksLikeBuild else { return (nil, nil) }
+        return (version, build)
+    }
+}

--- a/Kernova/Services/Protocols/RestoreImageProbing.swift
+++ b/Kernova/Services/Protocols/RestoreImageProbing.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Why a user-supplied restore image URL was refused.
+enum RestoreImageProbeError: LocalizedError, Equatable {
+    case insecureURL
+    case unreachable(statusCode: Int)
+    case unknownSize
+    case notAVirtualMachineImage
+    case unreadableStructure
+    case transportFailed(description: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .insecureURL:
+            "That link isn't secure. Restore images must be served over HTTPS."
+        case .unreachable(let statusCode):
+            "Nothing is hosted at that URL (HTTP \(statusCode)). Check the link and try again."
+        case .unknownSize:
+            "That server didn't report the file's size, so the image can't be checked before downloading."
+        case .notAVirtualMachineImage:
+            "This image can't run as a virtual machine. It has no VM hardware model."
+        case .unreadableStructure:
+            "That file isn't a readable restore image."
+        case .transportFailed(let description):
+            "Couldn't reach that URL: \(description)"
+        }
+    }
+}
+
+/// Abstraction for checking a user-supplied restore image URL before download.
+protocol RestoreImageProbing: Sendable {
+    /// Establishes that `url` serves an image that can install into a VM, and
+    /// how large it is, without downloading it.
+    func probe(_ url: URL) async throws -> ProbedRestoreImage
+}

--- a/Kernova/Services/RestoreImageProbeService.swift
+++ b/Kernova/Services/RestoreImageProbeService.swift
@@ -1,0 +1,168 @@
+import Foundation
+import os
+
+/// Checks a user-supplied restore image URL before anything is downloaded.
+///
+/// A class rather than a struct so `deinit` can invalidate the `URLSession`, the
+/// same reason `IPSWService` is one.
+final class RestoreImageProbeService: RestoreImageProbing {
+    private static let logger = Logger(
+        subsystem: "app.kernova", category: "RestoreImageProbeService")
+
+    /// How much of the file's tail to read looking for the zip end-of-directory record.
+    ///
+    /// Comfortably larger than the record plus a maximal comment.
+    private static let tailWindow: Int64 = 131_072
+
+    private let session: URLSession
+
+    init(sessionConfiguration: URLSessionConfiguration? = nil) {
+        let configuration = sessionConfiguration ?? .ephemeral
+        configuration.timeoutIntervalForRequest = 30
+        self.session = URLSession(configuration: configuration)
+    }
+
+    deinit {
+        session.finishTasksAndInvalidate()
+    }
+
+    func probe(_ url: URL) async throws -> ProbedRestoreImage {
+        guard url.scheme?.lowercased() == "https" else {
+            throw RestoreImageProbeError.insecureURL
+        }
+
+        let sizeBytes = try await totalSize(of: url)
+        guard sizeBytes > 0 else { throw RestoreImageProbeError.unknownSize }
+
+        switch try await supportsVirtualMachine(url, totalBytes: Int64(sizeBytes)) {
+        case .some(true):
+            break
+        case .some(false):
+            throw RestoreImageProbeError.notAVirtualMachineImage
+        case .none:
+            throw RestoreImageProbeError.unreadableStructure
+        }
+
+        let parsed = ProbedRestoreImage.parseFilename(url.lastPathComponent)
+        Self.logger.notice(
+            "Probed restore image at \(url.host() ?? "?", privacy: .public): \(sizeBytes, privacy: .public) bytes, VM-capable"
+        )
+        return ProbedRestoreImage(
+            url: url, sizeBytes: sizeBytes, version: parsed.version, build: parsed.build)
+    }
+
+    // MARK: - HTTP
+
+    /// The file's length in bytes.
+    ///
+    /// Read from `HEAD` where the server answers it, and from a one-byte ranged
+    /// `GET`'s `Content-Range` where it does not.
+    private func totalSize(of url: URL) async throws -> UInt64 {
+        var head = URLRequest(url: url)
+        head.httpMethod = "HEAD"
+        if let response = try await status(for: head) {
+            guard (200..<300).contains(response.statusCode) else {
+                throw RestoreImageProbeError.unreachable(statusCode: response.statusCode)
+            }
+            if response.expectedContentLength > 0 {
+                return UInt64(response.expectedContentLength)
+            }
+        }
+
+        var probe = URLRequest(url: url)
+        probe.setValue("bytes=0-0", forHTTPHeaderField: "Range")
+        guard let response = try await status(for: probe) else {
+            throw RestoreImageProbeError.unknownSize
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            throw RestoreImageProbeError.unreachable(statusCode: response.statusCode)
+        }
+        // `Content-Range: bytes 0-0/19772077142` — the total is after the slash.
+        if let range = response.value(forHTTPHeaderField: "Content-Range"),
+            let total = range.split(separator: "/").last,
+            let bytes = UInt64(total.trimmingCharacters(in: .whitespaces))
+        {
+            return bytes
+        }
+        throw RestoreImageProbeError.unknownSize
+    }
+
+    private func status(for request: URLRequest) async throws -> HTTPURLResponse? {
+        do {
+            let (_, response) = try await session.data(for: request)
+            return response as? HTTPURLResponse
+        } catch let error as URLError {
+            throw RestoreImageProbeError.transportFailed(
+                description: error.localizedDescription)
+        }
+    }
+
+    /// Fetches a byte range, or `nil` when the server would not serve one.
+    private func range(_ url: URL, from offset: Int64, count: Int64) async -> [UInt8]? {
+        guard count > 0, offset >= 0 else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue(
+            "bytes=\(offset)-\(offset + count - 1)", forHTTPHeaderField: "Range")
+        guard let (data, response) = try? await session.data(for: request),
+            let http = response as? HTTPURLResponse,
+            http.statusCode == 206 || http.statusCode == 200
+        else { return nil }
+        return [UInt8](data)
+    }
+
+    // MARK: - Zip directory
+
+    /// Whether a restore image contains the virtual-machine hardware model.
+    ///
+    /// An IPSW is a zip. Its central directory lists `kernelcache.release.vma2`
+    /// and `apticket.vma2macosap.im4m` exactly when the image can install into a
+    /// VM, so reading the directory alone settles it — three ranged requests and
+    /// roughly 150 KB rather than the whole multi-gigabyte file. This is the same
+    /// check `Tools/regen-restore-image-catalog.swift` applies to every catalog
+    /// candidate, which is what makes a pasted URL as trustworthy as a catalog row.
+    ///
+    /// `nil` means the structure could not be read, which is not the same as a "no".
+    private func supportsVirtualMachine(_ url: URL, totalBytes: Int64) async throws -> Bool? {
+        let tailStart = max(0, totalBytes - Self.tailWindow)
+        guard let tail = await range(url, from: tailStart, count: totalBytes - tailStart),
+            let eocd = Self.lastIndex(of: [0x50, 0x4B, 0x05, 0x06], in: tail),
+            var directorySize = Self.readLE(tail, eocd + 12, UInt32.self).map(Int64.init),
+            var directoryOffset = Self.readLE(tail, eocd + 16, UInt32.self).map(Int64.init)
+        else { return nil }
+
+        // Restore images exceed 4 GB, so the real offsets live in the zip64
+        // record the locator points at; the 32-bit fields above are sentinels.
+        if let locator = Self.lastIndex(of: [0x50, 0x4B, 0x06, 0x07], in: tail),
+            let zip64Offset = Self.readLE(tail, locator + 8, UInt64.self),
+            let header = await range(url, from: Int64(zip64Offset), count: 64),
+            Array(header.prefix(4)) == [0x50, 0x4B, 0x06, 0x06],
+            let size = Self.readLE(header, 40, UInt64.self),
+            let offset = Self.readLE(header, 48, UInt64.self)
+        {
+            directorySize = Int64(size)
+            directoryOffset = Int64(offset)
+        }
+
+        guard directorySize > 0, directoryOffset >= 0,
+            let directory = await range(url, from: directoryOffset, count: directorySize)
+        else { return nil }
+        return Self.lastIndex(of: [UInt8]("vma2".utf8), in: directory) != nil
+    }
+
+    static func readLE<T: FixedWidthInteger>(_ bytes: [UInt8], _ offset: Int, _ type: T.Type) -> T? {
+        let width = MemoryLayout<T>.size
+        guard offset >= 0, offset + width <= bytes.count else { return nil }
+        var value: T = 0
+        for index in (0..<width).reversed() { value = (value << 8) | T(bytes[offset + index]) }
+        return value
+    }
+
+    static func lastIndex(of needle: [UInt8], in haystack: [UInt8]) -> Int? {
+        guard haystack.count >= needle.count, !needle.isEmpty else { return nil }
+        for start in stride(from: haystack.count - needle.count, through: 0, by: -1)
+        where Array(haystack[start..<start + needle.count]) == needle {
+            return start
+        }
+        return nil
+    }
+}

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -23,13 +23,14 @@ enum VMCreationStep: String, CaseIterable, Sendable {
 enum IPSWSource: Sendable {
     case downloadLatest
     case catalogVersion
+    case customURL
     case localFile
 
     /// Whether this source obtains the image over the network, and so shares
     /// the download destination, overwrite warning, and resume affordance.
     var downloadsImage: Bool {
         switch self {
-        case .downloadLatest, .catalogVersion: true
+        case .downloadLatest, .catalogVersion, .customURL: true
         case .localFile: false
         }
     }
@@ -47,8 +48,15 @@ final class VMCreationViewModel {
     /// touch it.
     let catalogService: any RestoreImageCatalogProviding
 
-    init(catalogService: any RestoreImageCatalogProviding = RestoreImageCatalogService()) {
+    /// Backs the "Paste an IPSW URL…" sheet's pre-download check.
+    let probeService: any RestoreImageProbing
+
+    init(
+        catalogService: any RestoreImageCatalogProviding = RestoreImageCatalogService(),
+        probeService: any RestoreImageProbing = RestoreImageProbeService()
+    ) {
         self.catalogService = catalogService
+        self.probeService = probeService
     }
 
     // MARK: - Wizard State
@@ -67,6 +75,9 @@ final class VMCreationViewModel {
     /// The catalog image chosen for `.catalogVersion`, set through
     /// ``selectCatalogEntry(_:)`` so the download destination moves with it.
     private(set) var selectedCatalogEntry: RestoreImageCatalogEntry?
+    /// The checked image accepted for `.customURL`, set through
+    /// ``selectPastedImage(_:)`` on the same terms.
+    private(set) var pastedImage: ProbedRestoreImage?
     /// Always inside Downloads — there is no custom-destination picker.
     ///
     /// The filename is Apple's for a catalog pick, `RestoreImage.ipsw` otherwise.
@@ -122,6 +133,9 @@ final class VMCreationViewModel {
                 case .catalogVersion:
                     if selectedCatalogEntry == nil { return "Choose a macOS version to continue." }
                     if shouldShowOverwriteWarning { return "Resolve the file conflict above to continue." }
+                case .customURL:
+                    if pastedImage == nil { return "Add a restore image URL to continue." }
+                    if shouldShowOverwriteWarning { return "Resolve the file conflict above to continue." }
                 case .localFile:
                     if ipswPath == nil { return "Select a restore image file." }
                 }
@@ -168,6 +182,7 @@ final class VMCreationViewModel {
             switch ipswSource {
             case .downloadLatest: !shouldShowOverwriteWarning
             case .catalogVersion: selectedCatalogEntry != nil && !shouldShowOverwriteWarning
+            case .customURL: pastedImage != nil && !shouldShowOverwriteWarning
             case .localFile: ipswPath != nil
             }
         case .linux:
@@ -248,11 +263,20 @@ final class VMCreationViewModel {
         ipswDownloadPath = Self.downloadPath(forFilename: entry.suggestedFilename)
     }
 
+    /// Commits a checked URL, on the same per-image destination terms as a
+    /// catalog pick.
+    func selectPastedImage(_ image: ProbedRestoreImage) {
+        ipswSource = .customURL
+        pastedImage = image
+        ipswDownloadPath = Self.downloadPath(forFilename: image.suggestedFilename)
+    }
+
     /// Commits the "Download Latest" source, returning the destination to the
     /// fixed filename that source has always resolved to at install time.
     func selectDownloadLatest() {
         ipswSource = .downloadLatest
         selectedCatalogEntry = nil
+        pastedImage = nil
         ipswDownloadPath = Self.defaultIPSWDownloadPath
     }
 
@@ -311,6 +335,24 @@ final class VMCreationViewModel {
                 remoteURL: entry.url,
                 version: entry.version,
                 build: entry.build
+            )
+        case .customURL:
+            guard let image = pastedImage else {
+                Self.logger.fault("URL source selected with no checked image")
+                assertionFailure("URL source selected with no checked image")
+                return MacOSInstallContext(
+                    source: .downloadLatest,
+                    downloadDestinationPath: Self.defaultIPSWDownloadPath
+                )
+            }
+            return MacOSInstallContext(
+                source: .customURL,
+                downloadDestinationPath: ipswDownloadPath,
+                requestedFreshDownload: confirmedOverwritePath != nil
+                    && confirmedOverwritePath == ipswDownloadPath,
+                remoteURL: image.url,
+                version: image.version,
+                build: image.build
             )
         case .localFile:
             return MacOSInstallContext(

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -199,7 +199,7 @@ final class VMLifecycleCoordinator {
                 defer { localIPSWScope?.release() }
 
                 switch context.source {
-                case .downloadLatest, .catalogVersion:
+                case .downloadLatest, .catalogVersion, .customURL:
                     guard let persistedDestination = context.downloadDestinationURL else {
                         throw IPSWError.noDownloadURL
                     }
@@ -265,11 +265,11 @@ final class VMLifecycleCoordinator {
                     )
                     instance.status = .installing
 
-                    // A catalog pick names its image at wizard time, so the
-                    // install downloads that build however long it sits
-                    // unstarted. Only "Download Latest" resolves here.
+                    // A catalog pick or a checked URL names its image at wizard
+                    // time, so the install downloads that build however long it
+                    // sits unstarted. Only "Download Latest" resolves here.
                     let remoteURL: URL
-                    if context.source == .catalogVersion {
+                    if context.source.usesPinnedURL {
                         guard let pinnedURL = context.remoteURL else {
                             throw IPSWError.noDownloadURL
                         }

--- a/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
@@ -49,6 +49,12 @@ final class IPSWSelectionContentViewController: NSViewController {
             title: "Choose a Version…",
             description: "Browse every macOS release Apple still hosts, including older versions."
         )
+        let urlOption = makeSourceRadio(
+            for: .customURL,
+            symbol: "link",
+            title: "Paste an IPSW URL…",
+            description: "Install from a restore image at a URL you supply."
+        )
         let localOption = makeSourceRadio(
             for: .localFile,
             symbol: "folder",
@@ -56,7 +62,7 @@ final class IPSWSelectionContentViewController: NSViewController {
             description: "Select an IPSW file already on your Mac."
         )
 
-        let options = NSStackView(views: [downloadOption, catalogOption, localOption])
+        let options = NSStackView(views: [downloadOption, catalogOption, urlOption, localOption])
         options.orientation = .vertical
         options.alignment = .leading
         options.spacing = Spacing.large
@@ -113,6 +119,9 @@ final class IPSWSelectionContentViewController: NSViewController {
             // Same deferred-commit rule as Choose Local File below.
             updateRadioSelection()
             selectCatalogVersion()
+        case .customURL:
+            updateRadioSelection()
+            selectPastedURL()
         case .localFile:
             // Selection only commits when the user actually picks a file. Re-sync
             // the radios to the (still-current) model so the just-clicked radio
@@ -151,24 +160,42 @@ final class IPSWSelectionContentViewController: NSViewController {
             addDownloadBanners(version: nil)
         case .catalogVersion:
             guard let entry = creationVM.selectedCatalogEntry else { return }
-            let change = makeLinkButton(
-                "Change…", target: self, action: #selector(changeCatalogVersion))
-            conditionalContainer.addArrangedSubview(
-                makeWizardBadge(
-                    symbolName: "shippingbox.fill",
-                    text:
-                        "macOS \(entry.version)  ·  Build \(entry.build)  ·  \(DataFormatters.formatBytes(entry.sizeBytes))",
-                    trailingButton: change
-                ))
-            conditionalContainer.addArrangedSubview(
-                makeWizardPathBadge(path: creationVM.ipswDownloadPath))
+            addPinnedImageBadge(
+                summary:
+                    "macOS \(entry.version)  ·  Build \(entry.build)  ·  \(DataFormatters.formatBytes(entry.sizeBytes))",
+                changeAction: #selector(changeCatalogVersion)
+            )
             addDownloadBanners(version: entry.version)
+        case .customURL:
+            guard let image = creationVM.pastedImage else { return }
+            addPinnedImageBadge(
+                summary:
+                    "\(image.versionSummary)  ·  \(DataFormatters.formatBytes(image.sizeBytes))",
+                changeAction: #selector(changePastedURL)
+            )
+            addDownloadBanners(version: image.version)
         case .localFile:
             guard let path = creationVM.ipswPath else { return }
             let change = makeLinkButton(
                 "Change…", target: self, action: #selector(changeLocalFile))
             conditionalContainer.addArrangedSubview(makeWizardPathBadge(path: path, changeButton: change))
         }
+    }
+
+    /// Adds the one badge a pinned-image source shows: what was chosen, and
+    /// where it will land.
+    ///
+    /// One two-line badge rather than two badges — with four sources listed,
+    /// two badges no longer fit the fixed-size sheet without scrolling.
+    private func addPinnedImageBadge(summary: String, changeAction: Selector) {
+        let change = makeLinkButton("Change…", target: self, action: changeAction)
+        conditionalContainer.addArrangedSubview(
+            makeWizardBadge(
+                symbolName: "shippingbox.fill",
+                text: summary,
+                secondaryText: wizardAbbreviateWithTilde(creationVM.ipswDownloadPath),
+                trailingButton: change
+            ))
     }
 
     /// Adds the overwrite or resume banner for whichever download source is
@@ -218,6 +245,10 @@ final class IPSWSelectionContentViewController: NSViewController {
         selectCatalogVersion()
     }
 
+    @objc private func changePastedURL() {
+        selectPastedURL()
+    }
+
     @objc private func useExistingTapped() {
         creationVM.useExistingDownloadFile()
         refresh()
@@ -258,6 +289,38 @@ final class IPSWSelectionContentViewController: NSViewController {
         )
         sheet.delegate = self
         catalogSheetPresenter.show(content: sheet, in: window)
+    }
+
+    /// Opens the nested URL sheet, seeded with the current pick.
+    private func selectPastedURL() {
+        guard let window = view.window, !catalogSheetPresenter.isShown else { return }
+        let sheet = RestoreImageURLSheetContentViewController(
+            probeService: creationVM.probeService,
+            initialURL: creationVM.pastedImage?.url.absoluteString
+        )
+        sheet.delegate = self
+        catalogSheetPresenter.show(content: sheet, in: window)
+    }
+}
+
+// MARK: - RestoreImageURLSheetContentViewControllerDelegate
+
+extension IPSWSelectionContentViewController:
+    RestoreImageURLSheetContentViewControllerDelegate
+{
+    func restoreImageURLSheet(
+        _ vc: RestoreImageURLSheetContentViewController,
+        didChoose image: ProbedRestoreImage
+    ) {
+        catalogSheetPresenter.close()
+        creationVM.selectPastedImage(image)
+        refresh()
+    }
+
+    func restoreImageURLSheetDidCancel(
+        _ vc: RestoreImageURLSheetContentViewController
+    ) {
+        catalogSheetPresenter.close()
     }
 }
 

--- a/Kernova/Views/Creation/RestoreImageURLSheetContentViewController.swift
+++ b/Kernova/Views/Creation/RestoreImageURLSheetContentViewController.swift
@@ -1,0 +1,411 @@
+import AppKit
+import Foundation
+
+/// Delegate for ``RestoreImageURLSheetContentViewController``.
+@MainActor
+protocol RestoreImageURLSheetContentViewControllerDelegate: AnyObject {
+    /// The user accepted a checked image.
+    func restoreImageURLSheet(
+        _ vc: RestoreImageURLSheetContentViewController,
+        didChoose image: ProbedRestoreImage
+    )
+
+    /// The user dismissed without choosing.
+    func restoreImageURLSheetDidCancel(
+        _ vc: RestoreImageURLSheetContentViewController
+    )
+}
+
+/// Nested sheet that takes a restore image URL and checks it before anything is
+/// downloaded.
+///
+/// Nothing reaches the install pipeline unchecked: **Use** stays disabled until
+/// the probe confirms the URL serves an image carrying the virtual-machine
+/// hardware model, which costs about 150 KB rather than the whole file.
+@MainActor
+final class RestoreImageURLSheetContentViewController: NSViewController {
+    weak var delegate: RestoreImageURLSheetContentViewControllerDelegate?
+
+    private let probeService: any RestoreImageProbing
+    private let hostVersion: OperatingSystemVersion
+
+    /// The last successful probe, and what **Use** hands to the delegate.
+    private(set) var checkedImage: ProbedRestoreImage?
+
+    private let urlField = NSTextField()
+    private let checkButton = NSButton()
+    private let useButton = NSButton()
+    private let resultContainer = NSStackView()
+
+    /// In-flight probe, so a second Check supersedes the first rather than
+    /// racing it.
+    private var probeTask: Task<Void, Never>?
+
+    #if DEBUG
+    /// Awaited by tests instead of polling for the result to land.
+    var probeTaskForTesting: Task<Void, Never>? { probeTask }
+    #endif
+
+    // MARK: - Layout constants
+
+    private static let sheetWidth: CGFloat = 560
+    private static let sheetHeight: CGFloat = 320
+    private static let padding: CGFloat = 16
+
+    init(
+        probeService: any RestoreImageProbing,
+        initialURL: String? = nil,
+        hostVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
+    ) {
+        self.probeService = probeService
+        self.hostVersion = hostVersion
+        self.initialURL = initialURL
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    private let initialURL: String?
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("RestoreImageURLSheetContentViewController does not support NSCoder")
+    }
+
+    deinit {
+        probeTask?.cancel()
+    }
+
+    override func loadView() {
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let header = makeHeader()
+        let divider1 = makeHorizontalSeparator()
+        let body = makeBody()
+        let divider2 = makeHorizontalSeparator()
+        let footer = makeFooter()
+
+        for subview in [header, divider1, body, divider2, footer] {
+            subview.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview(subview)
+        }
+
+        NSLayoutConstraint.activate([
+            container.widthAnchor.constraint(equalToConstant: Self.sheetWidth),
+            container.heightAnchor.constraint(equalToConstant: Self.sheetHeight),
+
+            header.topAnchor.constraint(equalTo: container.topAnchor),
+            header.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            divider1.topAnchor.constraint(equalTo: header.bottomAnchor),
+            divider1.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            divider1.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            body.topAnchor.constraint(equalTo: divider1.bottomAnchor),
+            body.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            body.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            divider2.topAnchor.constraint(equalTo: body.bottomAnchor),
+            divider2.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            divider2.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            footer.topAnchor.constraint(equalTo: divider2.bottomAnchor),
+            footer.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            footer.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            footer.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+
+        view = container
+        if let initialURL { urlField.stringValue = initialURL }
+        updateControls()
+    }
+
+    // MARK: - Header
+
+    private func makeHeader() -> NSView {
+        let container = NSView()
+
+        let title = NSTextField(labelWithString: "Add a Restore Image by URL")
+        title.font = .preferredFont(forTextStyle: .headline)
+        title.isSelectable = false
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let stack = NSStackView(views: [title, spacer])
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = Spacing.small
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.padding),
+            stack.trailingAnchor.constraint(
+                equalTo: container.trailingAnchor, constant: -Self.padding),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Self.padding),
+        ])
+        return container
+    }
+
+    // MARK: - Body
+
+    private func makeBody() -> NSView {
+        let container = NSView()
+
+        let label = NSTextField(labelWithString: "Image URL")
+        label.font = .preferredFont(forTextStyle: .subheadline)
+        label.textColor = .secondaryLabelColor
+        label.isSelectable = false
+
+        urlField.placeholderString = "Paste a link to an .ipsw restore image"
+        urlField.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        urlField.lineBreakMode = .byTruncatingHead
+        urlField.target = self
+        urlField.action = #selector(checkTapped)
+        urlField.delegate = self
+        urlField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        checkButton.title = "Check"
+        checkButton.target = self
+        checkButton.action = #selector(checkTapped)
+        checkButton.bezelStyle = .rounded
+        checkButton.setContentHuggingPriority(.required, for: .horizontal)
+
+        let field = NSStackView(views: [urlField, checkButton])
+        field.orientation = .horizontal
+        field.alignment = .firstBaseline
+        field.spacing = Spacing.standard
+
+        resultContainer.orientation = .vertical
+        resultContainer.alignment = .leading
+        resultContainer.spacing = Spacing.standard
+
+        let stack = NSStackView(views: [label, field, resultContainer])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = Spacing.small
+        stack.setCustomSpacing(Spacing.medium, after: field)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.padding),
+            stack.trailingAnchor.constraint(
+                equalTo: container.trailingAnchor, constant: -Self.padding),
+            stack.bottomAnchor.constraint(
+                lessThanOrEqualTo: container.bottomAnchor, constant: -Self.padding),
+            field.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            resultContainer.widthAnchor.constraint(equalTo: stack.widthAnchor),
+        ])
+        return container
+    }
+
+    // MARK: - Footer
+
+    private func makeFooter() -> NSView {
+        let container = NSView()
+
+        let note = NSTextField(
+            labelWithString: "Checked without downloading — about 150 KB read")
+        note.font = .preferredFont(forTextStyle: .caption1)
+        note.textColor = .tertiaryLabelColor
+        note.lineBreakMode = .byTruncatingTail
+        note.isSelectable = false
+        note.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelTapped))
+        cancel.bezelStyle = .rounded
+        cancel.keyEquivalent = "\u{1b}"  // Escape
+
+        useButton.title = "Use"
+        useButton.target = self
+        useButton.action = #selector(useTapped)
+        useButton.bezelStyle = .rounded
+
+        let stack = NSStackView(views: [note, spacer, cancel, useButton])
+        stack.orientation = .horizontal
+        stack.spacing = Spacing.standard
+        stack.alignment = .centerY
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.padding),
+            stack.trailingAnchor.constraint(
+                equalTo: container.trailingAnchor, constant: -Self.padding),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Self.padding),
+        ])
+        return container
+    }
+
+    // MARK: - Result
+
+    private func setResult(_ views: [NSView]) {
+        for view in resultContainer.arrangedSubviews {
+            resultContainer.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+        for view in views {
+            resultContainer.addArrangedSubview(view)
+            view.widthAnchor.constraint(equalTo: resultContainer.widthAnchor).isActive = true
+        }
+    }
+
+    private func showChecking() {
+        let spinner = NSProgressIndicator()
+        spinner.style = .spinning
+        spinner.controlSize = .small
+        spinner.isIndeterminate = true
+        spinner.startAnimation(nil)
+        spinner.setContentHuggingPriority(.required, for: .horizontal)
+
+        let label = NSTextField(labelWithString: "Reading the image directory — about 150 KB…")
+        label.font = .preferredFont(forTextStyle: .callout)
+        label.textColor = .secondaryLabelColor
+        label.isSelectable = false
+
+        let spacer = NSView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let row = NSStackView(views: [spinner, label, spacer])
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = Spacing.small
+        setResult([row])
+    }
+
+    private func showFailure(_ message: String) {
+        setResult([
+            makeGroupedFormBanner(
+                symbolName: "exclamationmark.triangle.fill",
+                tint: .systemYellow,
+                message: message
+            )
+        ])
+    }
+
+    private func showSuccess(_ image: ProbedRestoreImage) {
+        var rows: [NSView] = [
+            makeWizardBadge(
+                symbolName: "checkmark.seal.fill",
+                text: image.version == nil
+                    ? "\(DataFormatters.formatBytes(image.sizeBytes)) · Installs in a virtual machine"
+                    : "\(image.versionSummary) · \(DataFormatters.formatBytes(image.sizeBytes)) · Installs in a virtual machine",
+                secondaryText: wizardAbbreviateWithTilde(
+                    VMCreationViewModel.downloadPath(forFilename: image.suggestedFilename))
+            )
+        ]
+
+        // The version is read out of the filename, so a "too new" answer is a
+        // hint, not a verdict — it warns without blocking Use.
+        if image.isSupported(onHost: hostVersion) == false, let version = image.version {
+            rows.append(
+                makeGroupedFormBanner(
+                    symbolName: "exclamationmark.triangle.fill",
+                    tint: .systemYellow,
+                    message:
+                        "The filename says macOS \(version), which is newer than this Mac. If that's right, the install will fail."
+                ))
+        } else if image.version == nil {
+            rows.append(
+                makeGroupedFormBanner(
+                    symbolName: "info.circle.fill",
+                    tint: .systemBlue,
+                    message:
+                        "The filename doesn't name a macOS version, so the version can't be shown before installing."
+                ))
+        }
+        setResult(rows)
+    }
+
+    // MARK: - Controls
+
+    private func updateControls() {
+        useButton.isEnabled = checkedImage != nil
+        checkButton.isEnabled =
+            !urlField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && probeTask == nil
+        // Return commits the check while unverified and the choice once verified,
+        // so the default button always does the obvious next thing.
+        useButton.keyEquivalent = checkedImage != nil ? "\r" : ""
+        checkButton.keyEquivalent = checkedImage == nil ? "\r" : ""
+    }
+
+    // MARK: - Actions
+
+    @objc private func checkTapped() {
+        let text = urlField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, probeTask == nil else { return }
+
+        guard let url = URL(string: text), url.scheme != nil, url.host() != nil else {
+            checkedImage = nil
+            showFailure("That isn't a valid URL. Paste the full link, starting with https://")
+            updateControls()
+            return
+        }
+
+        checkedImage = nil
+        showChecking()
+        probeTask = Task { [weak self, probeService] in
+            do {
+                let image = try await probeService.probe(url)
+                guard let self, !Task.isCancelled else { return }
+                self.probeTask = nil
+                self.checkedImage = image
+                self.showSuccess(image)
+                self.updateControls()
+            } catch {
+                guard let self, !Task.isCancelled else { return }
+                self.probeTask = nil
+                self.checkedImage = nil
+                self.showFailure(
+                    (error as? RestoreImageProbeError)?.errorDescription
+                        ?? error.localizedDescription)
+                self.updateControls()
+            }
+        }
+        updateControls()
+    }
+
+    @objc private func cancelTapped() {
+        probeTask?.cancel()
+        probeTask = nil
+        delegate?.restoreImageURLSheetDidCancel(self)
+    }
+
+    @objc private func useTapped() {
+        guard let image = checkedImage else { return }
+        delegate?.restoreImageURLSheet(self, didChoose: image)
+    }
+
+    // MARK: - Helpers
+
+    private func makeHorizontalSeparator() -> NSBox {
+        let box = NSBox()
+        box.boxType = .separator
+        return box
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+
+extension RestoreImageURLSheetContentViewController: NSTextFieldDelegate {
+    /// Editing the URL invalidates the previous verdict, so a stale "Use"
+    /// can't commit an image that isn't the one in the field.
+    func controlTextDidChange(_ obj: Notification) {
+        if checkedImage != nil {
+            checkedImage = nil
+            setResult([])
+        }
+        updateControls()
+    }
+}

--- a/Kernova/Views/Creation/ReviewContentViewController.swift
+++ b/Kernova/Views/Creation/ReviewContentViewController.swift
@@ -79,6 +79,7 @@ final class ReviewContentViewController: NSViewController {
             switch creationVM.ipswSource {
             case .downloadLatest: sourceLabel = "Download Latest"
             case .catalogVersion: sourceLabel = "Chosen Version"
+            case .customURL: sourceLabel = "From URL"
             case .localFile: sourceLabel = "Local File"
             }
             var rows = [valueRow("Restore Image", sourceLabel)]
@@ -86,6 +87,11 @@ final class ReviewContentViewController: NSViewController {
                 rows.append(valueRow("macOS Version", "\(entry.version) (\(entry.build))"))
                 rows.append(
                     valueRow("Download Size", DataFormatters.formatBytes(entry.sizeBytes)))
+            }
+            if creationVM.ipswSource == .customURL, let image = creationVM.pastedImage {
+                rows.append(valueRow("macOS Version", image.versionSummary))
+                rows.append(
+                    valueRow("Download Size", DataFormatters.formatBytes(image.sizeBytes)))
             }
             if creationVM.ipswSource == .localFile, let path = creationVM.ipswPath {
                 rows.append(valueRow("File", URL(fileURLWithPath: path).lastPathComponent))

--- a/Kernova/Views/Creation/WizardStyle.swift
+++ b/Kernova/Views/Creation/WizardStyle.swift
@@ -123,12 +123,17 @@ func makeWizardPathBadge(path: String, changeButton: NSButton? = nil) -> NSView 
     )
 }
 
-/// Builds a wizard badge: a symbol, one line of caption text, and an optional
-/// trailing button, in a subtle rounded container.
+/// Builds a wizard badge: a symbol, one or two lines of caption text, and an
+/// optional trailing button, in a subtle rounded container.
+///
+/// The two-line form exists so a download source states its image and its
+/// destination in one badge. As two separate badges they cost more height than
+/// the fixed-size wizard sheet has once there are four sources to list.
 @MainActor
 func makeWizardBadge(
     symbolName: String,
     text: String,
+    secondaryText: String? = nil,
     lineBreakMode: NSLineBreakMode = .byTruncatingTail,
     trailingButton: NSButton? = nil
 ) -> NSView {
@@ -143,9 +148,28 @@ func makeWizardBadge(
     label.isSelectable = false
     label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
-    let row = NSStackView(views: [icon, label] + (trailingButton.map { [$0] } ?? []))
+    let textContent: NSView
+    if let secondaryText {
+        let secondary = NSTextField(labelWithString: secondaryText)
+        secondary.font = .preferredFont(forTextStyle: .caption2)
+        secondary.textColor = .tertiaryLabelColor
+        secondary.lineBreakMode = .byTruncatingMiddle
+        secondary.maximumNumberOfLines = 1
+        secondary.isSelectable = false
+        secondary.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let column = NSStackView(views: [label, secondary])
+        column.orientation = .vertical
+        column.alignment = .leading
+        column.spacing = Spacing.hairline
+        textContent = column
+    } else {
+        textContent = label
+    }
+
+    let row = NSStackView(views: [icon, textContent] + (trailingButton.map { [$0] } ?? []))
     row.orientation = .horizontal
-    row.alignment = .firstBaseline
+    row.alignment = secondaryText == nil ? .firstBaseline : .centerY
     row.spacing = Spacing.small
 
     return makeGroupedFormBox(

--- a/Kernova/Views/Detail/InitialBootBannerView.swift
+++ b/Kernova/Views/Detail/InitialBootBannerView.swift
@@ -92,8 +92,8 @@ final class InitialBootBannerView: NSView {
                 return "An interrupted download will resume when you click Start."
             }
             return "Click Start to download the latest macOS and install."
-        case .catalogVersion:
-            let version = context.version.map { "macOS \($0)" } ?? "the chosen macOS version"
+        case .catalogVersion, .customURL:
+            let version = context.version.map { "macOS \($0)" } ?? "the chosen restore image"
             if instance.hasResumableInstallDownload {
                 return "An interrupted download of \(version) will resume when you click Start."
             }

--- a/KernovaTests/MacOSInstallContextTests.swift
+++ b/KernovaTests/MacOSInstallContextTests.swift
@@ -120,6 +120,40 @@ struct MacOSInstallContextTests {
         #expect(decoded.build == "24G90")
     }
 
+    @Test("A custom-URL context round-trips its pinned image")
+    func customURLContextRoundTrips() throws {
+        let url = try #require(URL(string: "https://mirror.example.com/R.ipsw"))
+        let original = MacOSInstallContext(
+            source: .customURL,
+            downloadDestinationPath: "/Users/me/Downloads/R.ipsw",
+            remoteURL: url,
+            version: "15.6.1",
+            build: "24G90"
+        )
+        let decoded = try JSONDecoder().decode(
+            MacOSInstallContext.self, from: try JSONEncoder().encode(original))
+
+        #expect(decoded == original)
+        #expect(decoded.source == .customURL)
+        #expect(decoded.remoteURL == url)
+    }
+
+    @Test("Only the pinned sources skip resolving the latest image")
+    func usesPinnedURLCoversPinnedSourcesOnly() {
+        #expect(MacOSInstallContext.Source.catalogVersion.usesPinnedURL)
+        #expect(MacOSInstallContext.Source.customURL.usesPinnedURL)
+        #expect(!MacOSInstallContext.Source.downloadLatest.usesPinnedURL)
+        #expect(!MacOSInstallContext.Source.localFile.usesPinnedURL)
+    }
+
+    @Test("Only the network sources own a download destination")
+    func downloadsImageCoversNetworkSourcesOnly() {
+        #expect(MacOSInstallContext.Source.downloadLatest.downloadsImage)
+        #expect(MacOSInstallContext.Source.catalogVersion.downloadsImage)
+        #expect(MacOSInstallContext.Source.customURL.downloadsImage)
+        #expect(!MacOSInstallContext.Source.localFile.downloadsImage)
+    }
+
     @Test("A context written without the pinning fields still decodes")
     func decodeWithoutPinningFields() throws {
         let json = """

--- a/KernovaTests/Mocks/MockRestoreImageProbeService.swift
+++ b/KernovaTests/Mocks/MockRestoreImageProbeService.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+@testable import Kernova
+
+/// Scripted stand-in for `RestoreImageProbing`.
+final class MockRestoreImageProbeService: RestoreImageProbing, @unchecked Sendable {
+    var probeCallCount = 0
+    var lastProbedURL: URL?
+
+    /// Thrown instead of returning, per the per-method `<method>Error` convention.
+    var probeError: (any Error)?
+    /// Returned on success; defaults to a well-formed Apple image.
+    var probeResult: ProbedRestoreImage = makeProbedImage()
+
+    func probe(_ url: URL) async throws -> ProbedRestoreImage {
+        probeCallCount += 1
+        lastProbedURL = url
+        if let error = probeError { throw error }
+        return probeResult
+    }
+}
+
+/// Builds a probed image, defaulted so a test names only what it cares about.
+func makeProbedImage(
+    urlString: String =
+        "https://updates.cdn-apple.com/x/UniversalMac_15.6.1_24G90_Restore.ipsw",
+    sizeBytes: UInt64 = 16_808_427_372,
+    version: String? = "15.6.1",
+    build: String? = "24G90"
+) -> ProbedRestoreImage {
+    ProbedRestoreImage(
+        url: URL(string: urlString) ?? URL(fileURLWithPath: "/"),
+        sizeBytes: sizeBytes,
+        version: version,
+        build: build
+    )
+}

--- a/KernovaTests/RestoreImageProbeTests.swift
+++ b/KernovaTests/RestoreImageProbeTests.swift
@@ -1,0 +1,272 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("ProbedRestoreImage Tests")
+struct ProbedRestoreImageTests {
+    private func host(_ major: Int, _ minor: Int, _ patch: Int) -> OperatingSystemVersion {
+        OperatingSystemVersion(majorVersion: major, minorVersion: minor, patchVersion: patch)
+    }
+
+    @Test("Apple's filename convention yields version and build")
+    func parsesAppleFilename() {
+        let parsed = ProbedRestoreImage.parseFilename("UniversalMac_15.6.1_24G90_Restore.ipsw")
+        #expect(parsed.version == "15.6.1")
+        #expect(parsed.build == "24G90")
+    }
+
+    @Test("A two-component version parses too")
+    func parsesTwoComponentVersion() {
+        let parsed = ProbedRestoreImage.parseFilename("UniversalMac_26.6_25G72_Restore.ipsw")
+        #expect(parsed.version == "26.6")
+        #expect(parsed.build == "25G72")
+    }
+
+    @Test("Anything off-convention yields no guess")
+    func rejectsOffConventionFilenames() {
+        for filename in [
+            "restore.ipsw",
+            "UniversalMac_15.6.1_Restore.ipsw",
+            "UniversalMac_15.6.1_24G90_Restore.zip",
+            "SomethingElse_15.6.1_24G90_Restore.ipsw",
+            "UniversalMac_Sequoia_24G90_Restore.ipsw",
+            "UniversalMac__24G90_Restore.ipsw",
+            "UniversalMac_15.6.1_24-G90_Restore.ipsw",
+        ] {
+            let parsed = ProbedRestoreImage.parseFilename(filename)
+            #expect(parsed.version == nil, "expected no version from '\(filename)'")
+            #expect(parsed.build == nil, "expected no build from '\(filename)'")
+        }
+    }
+
+    @Test("The destination is Apple's filename, and falls back when the URL has none")
+    func suggestedFilename() {
+        #expect(
+            makeProbedImage().suggestedFilename == "UniversalMac_15.6.1_24G90_Restore.ipsw")
+        #expect(
+            makeProbedImage(urlString: "https://example.com/downloads/")
+                .suggestedFilename == "RestoreImage.ipsw")
+        #expect(
+            makeProbedImage(urlString: "https://example.com/image.zip")
+                .suggestedFilename == "RestoreImage.ipsw")
+    }
+
+    @Test("Two different images never resolve to the same destination")
+    func destinationsAreDistinct() {
+        let first = makeProbedImage(
+            urlString: "https://a.example.com/UniversalMac_15.6.1_24G90_Restore.ipsw")
+        let second = makeProbedImage(
+            urlString: "https://b.example.com/UniversalMac_26.6_25G72_Restore.ipsw")
+        #expect(first.suggestedFilename != second.suggestedFilename)
+    }
+
+    @Test("Host support is unknown when the filename named no version")
+    func hostSupportUnknownWithoutVersion() {
+        let image = makeProbedImage(version: nil, build: nil)
+        #expect(image.isSupported(onHost: host(26, 0, 0)) == nil)
+    }
+
+    @Test("Host support compares numerically at the boundary")
+    func hostSupportBoundary() {
+        let image = makeProbedImage(version: "15.6.1")
+        #expect(image.isSupported(onHost: host(15, 6, 1)) == true)
+        #expect(image.isSupported(onHost: host(15, 6, 0)) == false)
+        #expect(image.isSupported(onHost: host(26, 0, 0)) == true)
+    }
+
+    @Test("The version summary degrades to what is actually known")
+    func versionSummaryDegrades() {
+        #expect(makeProbedImage().versionSummary == "macOS 15.6.1 (24G90)")
+        #expect(makeProbedImage(build: nil).versionSummary == "macOS 15.6.1")
+        #expect(makeProbedImage(version: nil).versionSummary == "Build 24G90")
+        #expect(
+            makeProbedImage(version: nil, build: nil).versionSummary == "Unrecognized version")
+    }
+}
+
+/// Stub for the probe's requests.
+///
+/// Deliberately its own class rather than `StubURLProtocol`: that one's handler
+/// is a global, and Swift Testing runs suites in parallel, so sharing it lets
+/// this suite and `IPSWServiceDownloadTests` clobber each other's handler.
+/// `.serialized` orders tests *within* a suite and does not prevent that.
+final class ProbeStubURLProtocol: URLProtocol, @unchecked Sendable {
+    struct Reply {
+        var statusCode: Int
+        var body: Data
+        var headers: [String: String]
+    }
+
+    nonisolated(unsafe) static var handler: ((URLRequest) -> Reply)?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler, let url = request.url else {
+            client?.urlProtocol(
+                self,
+                didFailWithError: NSError(
+                    domain: "ProbeStubURLProtocol", code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "No handler set"]))
+            return
+        }
+        let reply = handler(request)
+        var headers = reply.headers
+        if headers["Content-Length"] == nil { headers["Content-Length"] = "\(reply.body.count)" }
+        guard
+            let response = HTTPURLResponse(
+                url: url, statusCode: reply.statusCode, httpVersion: "HTTP/1.1",
+                headerFields: headers)
+        else {
+            preconditionFailure("ProbeStubURLProtocol: could not build a response")
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if !reply.body.isEmpty { client?.urlProtocol(self, didLoad: reply.body) }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@Suite("RestoreImageProbeService Tests", .serialized)
+struct RestoreImageProbeServiceTests {
+    private func makeService() -> RestoreImageProbeService {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses =
+            [ProbeStubURLProtocol.self] + (configuration.protocolClasses ?? [])
+        return RestoreImageProbeService(sessionConfiguration: configuration)
+    }
+
+    private var imageURL: URL {
+        URL(string: "https://updates.cdn-apple.com/x/UniversalMac_15.6.1_24G90_Restore.ipsw")
+            ?? URL(fileURLWithPath: "/")
+    }
+
+    /// Builds the tail of a zip whose central directory does or doesn't name a
+    /// `vma2` member — the only thing the probe reads.
+    ///
+    /// Laid out so the directory sits immediately before the end-of-directory
+    /// record, and the whole thing is served as one blob: the probe's tail read
+    /// covers it, and the zip64 locator is deliberately absent so the 32-bit
+    /// fields are authoritative.
+    private func makeZipTail(containsVMA2: Bool) -> Data {
+        var directory = Data()
+        directory.append(contentsOf: [0x50, 0x4B, 0x01, 0x02])  // central file header
+        let name = containsVMA2 ? "kernelcache.release.vma2" : "kernelcache.release.im4p"
+        directory.append(contentsOf: Array(name.utf8))
+
+        var blob = Data()
+        blob.append(directory)
+
+        var eocd = Data()
+        eocd.append(contentsOf: [0x50, 0x4B, 0x05, 0x06])  // EOCD signature
+        eocd.append(contentsOf: [0, 0, 0, 0])  // disk numbers
+        eocd.append(contentsOf: [1, 0, 1, 0])  // entry counts
+        withUnsafeBytes(of: UInt32(directory.count).littleEndian) { eocd.append(contentsOf: $0) }
+        withUnsafeBytes(of: UInt32(0).littleEndian) { eocd.append(contentsOf: $0) }  // offset
+        eocd.append(contentsOf: [0, 0])  // comment length
+        blob.append(eocd)
+        return blob
+    }
+
+    /// Serves `body` for every request, answering HEAD with the declared total
+    /// and range requests out of the same bytes.
+    private func serve(total: Int, body: Data, headStatus: Int = 200) {
+        ProbeStubURLProtocol.handler = { request in
+            if request.httpMethod == "HEAD" {
+                return ProbeStubURLProtocol.Reply(
+                    statusCode: headStatus, body: Data(),
+                    headers: ["Content-Length": "\(total)"])
+            }
+            guard let header = request.value(forHTTPHeaderField: "Range"),
+                let spec = header.split(separator: "=").last
+            else {
+                return ProbeStubURLProtocol.Reply(statusCode: 200, body: body, headers: [:])
+            }
+            let bounds = spec.split(separator: "-")
+            let start = Int(bounds.first ?? "0") ?? 0
+            let end = bounds.count > 1 ? (Int(bounds[1]) ?? total - 1) : total - 1
+            // The stub's body represents the file's tail, so a range that starts
+            // inside it is served from the corresponding offset.
+            let bodyStart = total - body.count
+            let lower = max(0, start - bodyStart)
+            let upper = min(body.count, end - bodyStart + 1)
+            let slice = lower < upper ? body.subdata(in: lower..<upper) : Data()
+            return ProbeStubURLProtocol.Reply(
+                statusCode: 206, body: slice,
+                headers: ["Content-Range": "bytes \(start)-\(end)/\(total)"])
+        }
+    }
+
+    @Test("An image carrying the VM hardware model is accepted")
+    func acceptsVirtualMachineImage() async throws {
+        let tail = makeZipTail(containsVMA2: true)
+        serve(total: tail.count, body: tail)
+        defer { ProbeStubURLProtocol.handler = nil }
+
+        let image = try await makeService().probe(imageURL)
+
+        #expect(image.sizeBytes == UInt64(tail.count))
+        #expect(image.version == "15.6.1")
+        #expect(image.build == "24G90")
+        #expect(image.url == imageURL)
+    }
+
+    @Test("An image with no VM hardware model is refused")
+    func refusesImageWithoutVirtualMachineModel() async {
+        let tail = makeZipTail(containsVMA2: false)
+        serve(total: tail.count, body: tail)
+        defer { ProbeStubURLProtocol.handler = nil }
+
+        await #expect(throws: RestoreImageProbeError.notAVirtualMachineImage) {
+            _ = try await makeService().probe(imageURL)
+        }
+    }
+
+    @Test("A non-HTTPS URL is refused before any request")
+    func refusesInsecureURL() async throws {
+        let http = try #require(URL(string: "http://updates.cdn-apple.com/x/R.ipsw"))
+        ProbeStubURLProtocol.handler = { _ in
+            Issue.record("The probe issued a request for a non-HTTPS URL")
+            return ProbeStubURLProtocol.Reply(statusCode: 200, body: Data(), headers: [:])
+        }
+        defer { ProbeStubURLProtocol.handler = nil }
+
+        await #expect(throws: RestoreImageProbeError.insecureURL) {
+            _ = try await makeService().probe(http)
+        }
+    }
+
+    @Test("A URL that 404s is refused with its status")
+    func refusesMissingImage() async {
+        serve(total: 0, body: Data(), headStatus: 404)
+        defer { ProbeStubURLProtocol.handler = nil }
+
+        await #expect(throws: RestoreImageProbeError.unreachable(statusCode: 404)) {
+            _ = try await makeService().probe(imageURL)
+        }
+    }
+
+    @Test("A file with no zip structure is refused as unreadable")
+    func refusesUnreadableStructure() async {
+        let junk = Data(repeating: 0x41, count: 4096)
+        serve(total: junk.count, body: junk)
+        defer { ProbeStubURLProtocol.handler = nil }
+
+        await #expect(throws: RestoreImageProbeError.unreadableStructure) {
+            _ = try await makeService().probe(imageURL)
+        }
+    }
+
+    @Test("Byte-order and search helpers behave at the edges")
+    func binaryHelpers() {
+        #expect(RestoreImageProbeService.readLE([0x01, 0x00, 0x00, 0x00], 0, UInt32.self) == 1)
+        #expect(RestoreImageProbeService.readLE([0xFF, 0xFF], 0, UInt32.self) == nil)
+        #expect(RestoreImageProbeService.readLE([0x01, 0x02], -1, UInt16.self) == nil)
+        #expect(RestoreImageProbeService.lastIndex(of: [0x02], in: [0x02, 0x01, 0x02]) == 2)
+        #expect(RestoreImageProbeService.lastIndex(of: [0x03], in: [0x02, 0x01]) == nil)
+        #expect(RestoreImageProbeService.lastIndex(of: [], in: [0x01]) == nil)
+    }
+}

--- a/KernovaTests/RestoreImageURLSheetContentViewControllerTests.swift
+++ b/KernovaTests/RestoreImageURLSheetContentViewControllerTests.swift
@@ -1,0 +1,188 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("RestoreImageURLSheetContentViewController Tests")
+@MainActor
+struct RestoreImageURLSheetContentViewControllerTests {
+    private func makeSheet(
+        probe: MockRestoreImageProbeService,
+        initialURL: String? = nil,
+        hostMajor: Int = 26
+    ) -> RestoreImageURLSheetContentViewController {
+        let vc = RestoreImageURLSheetContentViewController(
+            probeService: probe,
+            initialURL: initialURL,
+            hostVersion: OperatingSystemVersion(
+                majorVersion: hostMajor, minorVersion: 0, patchVersion: 0)
+        )
+        vc.loadViewIfNeeded()
+        return vc
+    }
+
+    /// Runs Check and awaits the production task rather than polling for it.
+    private func check(_ vc: RestoreImageURLSheetContentViewController) async {
+        findButton(titled: "Check", in: vc.view)?.performClick(nil)
+        await vc.probeTaskForTesting?.value
+    }
+
+    @Test("Use is disabled until a URL has been checked")
+    func useDisabledBeforeCheck() {
+        let vc = makeSheet(probe: MockRestoreImageProbeService())
+        #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == false)
+        #expect(vc.checkedImage == nil)
+    }
+
+    @Test("Check with an empty field does nothing")
+    func checkIgnoresEmptyField() async {
+        let probe = MockRestoreImageProbeService()
+        let vc = makeSheet(probe: probe)
+        await check(vc)
+        #expect(probe.probeCallCount == 0)
+    }
+
+    @Test("A successful check enables Use and records the image")
+    func successfulCheckEnablesUse() async {
+        let probe = MockRestoreImageProbeService()
+        let vc = makeSheet(
+            probe: probe,
+            initialURL: "https://updates.cdn-apple.com/x/UniversalMac_15.6.1_24G90_Restore.ipsw")
+
+        await check(vc)
+
+        #expect(probe.probeCallCount == 1)
+        #expect(vc.checkedImage == probe.probeResult)
+        #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == true)
+    }
+
+    @Test("A failed check leaves Use disabled and shows the reason")
+    func failedCheckKeepsUseDisabled() async {
+        let probe = MockRestoreImageProbeService()
+        probe.probeError = RestoreImageProbeError.notAVirtualMachineImage
+        let vc = makeSheet(probe: probe, initialURL: "https://example.com/R.ipsw")
+
+        await check(vc)
+
+        #expect(vc.checkedImage == nil)
+        #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == false)
+        #expect(findLabel(containing: "can't run as a virtual machine", in: vc.view) != nil)
+    }
+
+    @Test("A malformed URL is refused without reaching the probe")
+    func malformedURLNeverProbes() async {
+        let probe = MockRestoreImageProbeService()
+        let vc = makeSheet(probe: probe, initialURL: "not a url")
+
+        await check(vc)
+
+        #expect(probe.probeCallCount == 0)
+        #expect(vc.checkedImage == nil)
+        #expect(findLabel(containing: "isn't a valid URL", in: vc.view) != nil)
+    }
+
+    @Test("Choosing hands the checked image to the delegate")
+    func chooseReportsToDelegate() async {
+        let probe = MockRestoreImageProbeService()
+        let vc = makeSheet(probe: probe, initialURL: "https://example.com/R.ipsw")
+        let delegate = RecordingDelegate()
+        vc.delegate = delegate
+
+        await check(vc)
+        findButton(titled: "Use", in: vc.view)?.performClick(nil)
+
+        #expect(delegate.chosen == probe.probeResult)
+        #expect(delegate.cancelCount == 0)
+    }
+
+    @Test("Cancel reports a dismissal and no choice")
+    func cancelReportsToDelegate() {
+        let vc = makeSheet(probe: MockRestoreImageProbeService())
+        let delegate = RecordingDelegate()
+        vc.delegate = delegate
+
+        findButton(titled: "Cancel", in: vc.view)?.performClick(nil)
+
+        #expect(delegate.chosen == nil)
+        #expect(delegate.cancelCount == 1)
+    }
+
+    @Test("An image newer than the host warns without blocking Use")
+    func tooNewImageWarnsButDoesNotBlock() async {
+        let probe = MockRestoreImageProbeService()
+        probe.probeResult = makeProbedImage(version: "27.0", build: "26A100")
+        let vc = makeSheet(
+            probe: probe, initialURL: "https://example.com/R.ipsw", hostMajor: 26)
+
+        await check(vc)
+
+        // The version came from the filename, so it is a hint, not a verdict.
+        #expect(vc.checkedImage != nil)
+        #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == true)
+        #expect(findLabel(containing: "newer than this Mac", in: vc.view) != nil)
+    }
+
+    @Test("An unrecognized filename says the version is unknown")
+    func unknownVersionIsCalledOut() async {
+        let probe = MockRestoreImageProbeService()
+        probe.probeResult = makeProbedImage(
+            urlString: "https://example.com/image.ipsw", version: nil, build: nil)
+        let vc = makeSheet(probe: probe, initialURL: "https://example.com/image.ipsw")
+
+        await check(vc)
+
+        #expect(vc.checkedImage != nil)
+        #expect(findLabel(containing: "doesn't name a macOS version", in: vc.view) != nil)
+    }
+
+    @Test("Editing the URL invalidates the previous verdict")
+    func editingClearsTheVerdict() async throws {
+        let probe = MockRestoreImageProbeService()
+        let vc = makeSheet(probe: probe, initialURL: "https://example.com/R.ipsw")
+        await check(vc)
+        #expect(vc.checkedImage != nil)
+
+        let field = try #require(findTextField(in: vc.view))
+        field.stringValue = "https://example.com/other.ipsw"
+        vc.controlTextDidChange(Notification(name: NSControl.textDidChangeNotification))
+
+        #expect(vc.checkedImage == nil)
+        #expect(findButton(titled: "Use", in: vc.view)?.isEnabled == false)
+    }
+
+    // MARK: - Helpers
+
+    private final class RecordingDelegate: RestoreImageURLSheetContentViewControllerDelegate {
+        var chosen: ProbedRestoreImage?
+        var cancelCount = 0
+
+        func restoreImageURLSheet(
+            _ vc: RestoreImageURLSheetContentViewController,
+            didChoose image: ProbedRestoreImage
+        ) {
+            chosen = image
+        }
+
+        func restoreImageURLSheetDidCancel(_ vc: RestoreImageURLSheetContentViewController) {
+            cancelCount += 1
+        }
+    }
+
+    private func findLabel(containing text: String, in view: NSView) -> NSTextField? {
+        if let field = view as? NSTextField, field.stringValue.contains(text) { return field }
+        for subview in view.subviews {
+            if let found = findLabel(containing: text, in: subview) { return found }
+        }
+        return nil
+    }
+
+    /// The one editable field in the sheet.
+    private func findTextField(in view: NSView) -> NSTextField? {
+        if let field = view as? NSTextField, field.isEditable { return field }
+        for subview in view.subviews {
+            if let found = findTextField(in: subview) { return found }
+        }
+        return nil
+    }
+}

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -769,6 +769,90 @@ struct VMCreationViewModelTests {
     func downloadsImageCoversBothDownloadSources() {
         #expect(IPSWSource.downloadLatest.downloadsImage)
         #expect(IPSWSource.catalogVersion.downloadsImage)
+        #expect(IPSWSource.customURL.downloadsImage)
         #expect(!IPSWSource.localFile.downloadsImage)
+    }
+
+    // MARK: - Custom URL Source
+
+    @Test("A checked URL moves the destination to that image's filename")
+    func pastedImageUsesPerImageDestination() {
+        let vm = VMCreationViewModel()
+        let image = makeProbedImage()
+        vm.selectPastedImage(image)
+
+        #expect(vm.ipswSource == .customURL)
+        #expect(vm.pastedImage == image)
+        #expect(
+            vm.ipswDownloadPath
+                == VMCreationViewModel.downloadPath(
+                    forFilename: "UniversalMac_15.6.1_24G90_Restore.ipsw"))
+        #expect(vm.ipswDownloadPath != VMCreationViewModel.defaultIPSWDownloadPath)
+    }
+
+    @Test("An off-convention URL still lands on a real filename")
+    func pastedImageWithoutIPSWNameFallsBack() {
+        let vm = VMCreationViewModel()
+        vm.selectPastedImage(
+            makeProbedImage(urlString: "https://example.com/d/", version: nil, build: nil))
+
+        #expect(vm.ipswDownloadPath == VMCreationViewModel.defaultIPSWDownloadPath)
+    }
+
+    @Test("The URL source cannot advance until a URL is checked")
+    func customURLSourceRequiresACheckedImage() {
+        let vm = VMCreationViewModel()
+        vm.currentStep = .bootConfig
+        vm.ipswSource = .customURL
+
+        #expect(!vm.canAdvance)
+        #expect(vm.validationMessage == "Add a restore image URL to continue.")
+
+        vm.selectPastedImage(makeProbedImage())
+        #expect(vm.canAdvance)
+        #expect(vm.validationMessage == nil)
+    }
+
+    @Test("The URL source shares the overwrite warning")
+    func customURLSourceSharesDownloadWarnings() {
+        let vm = VMCreationViewModel()
+        vm.currentStep = .bootConfig
+        vm.selectPastedImage(makeProbedImage())
+        vm.ipswDownloadPath = "/usr/bin/true"  // exists on disk
+        #expect(vm.shouldShowOverwriteWarning)
+        #expect(!vm.canAdvance)
+
+        vm.confirmOverwrite()
+        #expect(!vm.shouldShowOverwriteWarning)
+        #expect(vm.canAdvance)
+    }
+
+    @Test("A URL install context pins the checked URL, version, and build")
+    func customURLInstallContextPinsTheImage() {
+        let vm = VMCreationViewModel()
+        let image = makeProbedImage()
+        vm.selectPastedImage(image)
+
+        let context = vm.buildInstallContext()
+
+        #expect(context.source == .customURL)
+        #expect(context.remoteURL == image.url)
+        #expect(context.version == "15.6.1")
+        #expect(context.build == "24G90")
+        #expect(context.downloadDestinationPath == vm.ipswDownloadPath)
+    }
+
+    @Test("Switching between pinned sources clears the other one's pick")
+    func switchingPinnedSourcesClearsTheOther() {
+        let vm = VMCreationViewModel()
+        vm.selectCatalogEntry(makeCatalogEntry())
+        vm.selectPastedImage(makeProbedImage())
+        #expect(vm.selectedCatalogEntry != nil)
+        #expect(vm.pastedImage != nil)
+
+        // Download Latest is the one source that owns neither pick.
+        vm.selectDownloadLatest()
+        #expect(vm.selectedCatalogEntry == nil)
+        #expect(vm.pastedImage == nil)
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,6 +88,12 @@ substitute mocks. Services split by concurrency: those that touch
 - `RestoreImageCatalogService` — decodes the bundled snapshot of selectable macOS restore images,
   `Kernova/Resources/RestoreImageCatalog.json`, backing the wizard's "Choose a Version…" source. It
   reaches no network; only the image the user picks is fetched, by `IPSWService`.
+- `RestoreImageProbeService` (a `final class`, for `URLSession` lifetime) — establishes that a
+  user-supplied URL serves an installable restore image, and how large it is, before any download.
+  An IPSW is a zip whose central directory names `kernelcache.release.vma2` exactly when the image
+  carries the virtual-machine hardware model, so ranged reads of the directory settle it in about
+  150 KB. `Tools/regen-restore-image-catalog.swift` applies the same check to every catalog
+  candidate, which is what puts a pasted URL on the same footing as a catalog row.
 
 `ConfigurationBuilder` translates a `VMConfiguration` into a `VZVirtualMachineConfiguration` — the
 single VZ-facing translation point, covering boot loader, CPU, memory, storage, network, display,
@@ -174,7 +180,8 @@ calls `applyLiveRemovableMediaChange(for:target:)`.
   flows such as a macOS install. It serializes lifecycle operations per VM; `stop` and `forceStop`
   deliberately bypass that serialization so a hung operation can always be cancelled.
 - `VMCreationViewModel` — a pure `@Observable` state machine for the creation wizard, with no
-  UI-framework dependency. Injects `RestoreImageCatalogProviding` for the version picker.
+  UI-framework dependency. Injects `RestoreImageCatalogProviding` for the version picker and
+  `RestoreImageProbing` for the paste-a-URL sheet.
 - `VMDirectoryWatcher` — a `DispatchSource` on the VMs directory that triggers reconciliation in
   `VMLibraryViewModel` when the library changes on disk.
 


### PR DESCRIPTION
**Stacked on #672** — base is `feat/macos-restore-image-catalog-ui`, so review that one first. #280 explicitly put custom-URL out of scope, which is why this is a separate PR rather than more commits on #672.

## Summary

Adds the fourth IPSW source: install from a restore image at a URL the user supplies. It covers what the catalog structurally cannot — seeds, and any build newer than the bundled snapshot.

## The feature is the check, not the text field

Every catalog entry was verified at generation time, so the app can trust it. A pasted URL has been verified by nobody. So the sheet points the generator's own zip-central-directory read at the URL: an IPSW is a zip whose directory names `kernelcache.release.vma2` exactly when the image carries the virtual-machine hardware model, which settles it in **about 150 KB** rather than a 16 GB download that only fails at install.

That turns an unknown string into the same facts a catalog row shows. **Use** stays disabled until it passes, so nothing unchecked reaches the install pipeline.

## Any host, because the image is signed

A restore image carries `apticket.vma2macosap.im4m`, an Apple-signed IMG4 manifest that the restore validates. An image Apple did not sign cannot install, whoever served the bytes — so a host allowlist would not be the integrity boundary, only a guess at where Apple's files live, and a wrong one the day someone has a legitimate mirror. **HTTPS is the only requirement.**

Two consequences worth stating rather than discovering:

- The signature bites at *install*, after the download. The pre-download check catches the ordinary failure (not an installable image at all) for 150 KB; a well-formed image with a bad signature still surfaces at restore.
- **This does not change the catalog's host check.** The two look alike and do opposite jobs: the catalog validates data *we* generated and shipped, where an off-Apple host means the generator misbehaved and the assertion should fire. The URL source validates a string the user typed, where an unfamiliar host means nothing.

## One fact is a guess, and is treated like one

Version and build are parsed from Apple's `UniversalMac_<version>_<build>_Restore.ipsw` convention; size and VM-capability are measured. The parse yields `nil` rather than a guess for anything off-convention, and nothing that gates the install depends on it. A filename-derived version above the host **warns without blocking** — blocking on a guess would be wrong — and an unrecognized filename says so plainly instead of showing a blank.

## The layout finding from the mock, applied

The wizard sheet is fixed at 720×540, leaving the step ~371 pt. Four options plus the two chips comes to ~390 pt. Nothing breaks — the step already lives in a scroll view with a more-below cue — but scrolling a four-item radio list to reach the last option is a regression. So the image chip and the destination chip, which are two halves of one statement, collapse into **one two-line badge for every download source**, bringing it to ~346 pt. Uniform across sources rather than special-cased.

## Changes

- **`ProbedRestoreImage`** — measured facts plus the best-effort filename parse, `suggestedFilename` (per-image destination, same reason as a catalog pick), and a tri-state `isSupported(onHost:)` whose `nil` means "unknown", not "no".
- **`RestoreImageProbing` / `RestoreImageProbeService`** — `HEAD` for size, falling back to a one-byte ranged `GET`'s `Content-Range` for servers that don't answer HEAD; then the zip64-aware directory read.
- **`IPSWSource.customURL`** and `pastedImage`; **`MacOSInstallContext.Source.customURL`** with `usesPinnedURL` / `downloadsImage` computed properties replacing the case lists that were starting to spread through the coordinator and wizard.
- **`RestoreImageURLSheetContentViewController`** — 560×320 nested sheet. Editing the URL invalidates the previous verdict so a stale Use can't commit the wrong image; the in-flight probe is cancelled on dismiss and superseded rather than raced on a second Check.
- Review gains "From URL" with version and size; the initial-boot banner names the pinned image.

## Test plan

- [x] `make test` — 1865 tests, exit 0
- [x] `make lint` — clean
- [x] Probe accepts a synthetic zip naming `vma2`, refuses one that doesn't, a 404, a non-HTTPS URL (without issuing a request), and a file with no zip structure
- [x] Filename parse yields nil for every off-convention shape tried
- [x] Per-image destinations: two different URLs never resolve to the same path
- [x] Sheet: Use gated on the check, delegate callbacks, too-new warning that doesn't block, unknown-version note, edit-invalidates-verdict
- [x] `MacOSInstallContext` round-trips the new case; `usesPinnedURL` covers exactly the two pinned sources
- [ ] **Not done:** driving the wizard on screen. Computer use has been held by another session throughout. The ~346 pt figure is computed, not observed — the four options and collapsed badge fitting without scrolling is the specific thing that wants eyes.

## Notes

`ProbeStubURLProtocol` is a second stub `URLProtocol` rather than a reuse of `StubURLProtocol`. That one's handler is a global and Swift Testing runs suites in parallel, so sharing it made this suite and `IPSWServiceDownloadTests` clobber each other — both failed, then passed on retry. `.serialized` orders tests *within* a suite and does not prevent it. Caught before pushing; the isolated stub removes the flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KeE8mfWnzrawSP8x3nV1JN