### PR TITLE
refactor: Make the wizard's install source carry its own pick

### DIFF
--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -36,6 +36,28 @@ enum IPSWSource: Sendable {
     }
 }
 
+/// The chosen source together with what that source needs to install, so a
+/// source cannot be current without its pick.
+///
+/// Set only through ``VMCreationViewModel``'s `select` methods. `Equatable` but
+/// not `Hashable` — the payloads are not — so keys go on ``IPSWSource``.
+enum IPSWSelection: Sendable, Equatable {
+    case downloadLatest
+    case catalogVersion(RestoreImageCatalogEntry)
+    case customURL(ProbedRestoreImage)
+    case localFile(path: String, bookmark: Data?)
+
+    /// Which radio this selection lights, independent of what it carries.
+    var source: IPSWSource {
+        switch self {
+        case .downloadLatest: .downloadLatest
+        case .catalogVersion: .catalogVersion
+        case .customURL: .customURL
+        case .localFile: .localFile
+        }
+    }
+}
+
 /// State machine for the VM creation wizard.
 @MainActor
 @Observable
@@ -75,14 +97,16 @@ final class VMCreationViewModel {
     // MARK: - Step 2: Boot Config
 
     var selectedBootMode: VMBootMode = .efi
-    var ipswSource: IPSWSource = .downloadLatest
-    var ipswPath: String?
-    /// The catalog image chosen for `.catalogVersion`, set through
-    /// ``selectCatalogEntry(_:)`` so the download destination moves with it.
-    private(set) var selectedCatalogEntry: RestoreImageCatalogEntry?
-    /// The checked image accepted for `.customURL`, set through
-    /// ``selectPastedImage(_:)`` on the same terms.
-    private(set) var pastedImage: ProbedRestoreImage?
+    private(set) var ipswSelection: IPSWSelection = .downloadLatest
+
+    /// Which source is current, for the radios and the source labels.
+    var ipswSource: IPSWSource { ipswSelection.source }
+
+    /// The last catalog pick, kept after the source moves off it so the version
+    /// picker re-opens on it.
+    private(set) var lastCatalogPick: RestoreImageCatalogEntry?
+    /// The last checked URL, on the same terms.
+    private(set) var lastPastedImage: ProbedRestoreImage?
     /// Always inside Downloads — there is no custom-destination picker.
     ///
     /// A pinned pick names the file through ``RestoreImageFilename``;
@@ -101,10 +125,7 @@ final class VMCreationViewModel {
     var kernelCommandLine: String?
 
     /// Security bookmarks paired with the panel-picked paths above; each is set
-    /// alongside its path at pick time. `nil` for paths adopted without a panel
-    /// (e.g. "Use Existing File", whose Downloads location the entitlement
-    /// already covers).
-    var ipswBookmark: Data?
+    /// alongside its path at pick time.
     var isoBookmark: Data?
     var kernelBookmark: Data?
     var initrdBookmark: Data?
@@ -133,18 +154,9 @@ final class VMCreationViewModel {
         case .bootConfig:
             switch selectedOS {
             case .macOS:
-                switch ipswSource {
-                case .downloadLatest:
-                    if shouldShowOverwriteWarning { return "Resolve the file conflict above to continue." }
-                case .catalogVersion:
-                    if selectedCatalogEntry == nil { return "Choose a macOS version to continue." }
-                    if shouldShowOverwriteWarning { return "Resolve the file conflict above to continue." }
-                case .customURL:
-                    if pastedImage == nil { return "Add a restore image URL to continue." }
-                    if shouldShowOverwriteWarning { return "Resolve the file conflict above to continue." }
-                case .localFile:
-                    if ipswPath == nil { return "Select a restore image file." }
-                }
+                // Reached only when `bootConfigValid` said no, and the conflict
+                // is the one thing that makes it say no for macOS.
+                return "Resolve the file conflict above to continue."
             case .linux:
                 switch selectedBootMode {
                 case .efi: return "Select an ISO image to continue."
@@ -152,7 +164,6 @@ final class VMCreationViewModel {
                 case .macOS: return "Invalid boot configuration."
                 }
             }
-            return nil
         case .resources:
             return "Enter a name for your virtual machine."
         }
@@ -185,12 +196,9 @@ final class VMCreationViewModel {
     private var bootConfigValid: Bool {
         switch selectedOS {
         case .macOS:
-            switch ipswSource {
-            case .downloadLatest: !shouldShowOverwriteWarning
-            case .catalogVersion: selectedCatalogEntry != nil && !shouldShowOverwriteWarning
-            case .customURL: pastedImage != nil && !shouldShowOverwriteWarning
-            case .localFile: ipswPath != nil
-            }
+            // A pinned pick is inseparable from its source, so the only macOS
+            // blocker left is the download-destination conflict.
+            !shouldShowOverwriteWarning
         case .linux:
             switch selectedBootMode {
             case .efi: isoPath != nil
@@ -268,26 +276,35 @@ final class VMCreationViewModel {
     /// satisfy the download step, installing something other than what the
     /// wizard shows.
     func selectCatalogEntry(_ entry: RestoreImageCatalogEntry) {
-        ipswSource = .catalogVersion
-        selectedCatalogEntry = entry
+        ipswSelection = .catalogVersion(entry)
+        lastCatalogPick = entry
         ipswDownloadPath = Self.downloadPath(forFilename: entry.suggestedFilename)
     }
 
     /// Commits a checked URL, on the same per-image destination terms as a
     /// catalog pick.
     func selectPastedImage(_ image: ProbedRestoreImage) {
-        ipswSource = .customURL
-        pastedImage = image
+        ipswSelection = .customURL(image)
+        lastPastedImage = image
         ipswDownloadPath = Self.downloadPath(forFilename: image.suggestedFilename)
     }
 
     /// Commits the "Download Latest" source, returning the destination to the
     /// fixed filename that source has always resolved to at install time.
+    ///
+    /// The one operation that drops both sheet seeds: choosing to install
+    /// whatever is newest retracts the earlier "install *this* build" answers.
     func selectDownloadLatest() {
-        ipswSource = .downloadLatest
-        selectedCatalogEntry = nil
-        pastedImage = nil
+        ipswSelection = .downloadLatest
+        lastCatalogPick = nil
+        lastPastedImage = nil
         ipswDownloadPath = Self.defaultIPSWDownloadPath
+    }
+
+    /// Commits a panel-picked file together with the grant minted for it, which
+    /// is `nil` when the bookmark could not be created.
+    func selectLocalFile(path: String, bookmark: Data?) {
+        ipswSelection = .localFile(path: path, bookmark: bookmark)
     }
 
     // MARK: - Apply Defaults
@@ -318,59 +335,44 @@ final class VMCreationViewModel {
     /// The install pipeline reads from the VM's bundle, not the wizard, on every
     /// Start until the install completes and the context is cleared.
     func buildInstallContext() -> MacOSInstallContext {
-        switch ipswSource {
+        switch ipswSelection {
         case .downloadLatest:
-            // The `!= nil` guard prevents the meaningless `nil == nil` match (no
-            // path AND no confirmation) from setting the flag.
-            return MacOSInstallContext(
+            MacOSInstallContext(
                 source: .downloadLatest,
                 downloadDestinationPath: ipswDownloadPath,
-                requestedFreshDownload: confirmedOverwritePath != nil
-                    && confirmedOverwritePath == ipswDownloadPath
+                requestedFreshDownload: requestedFreshDownload
             )
-        case .catalogVersion:
-            guard let entry = selectedCatalogEntry else {
-                Self.logger.fault("Catalog source selected with no chosen entry")
-                assertionFailure("Catalog source selected with no chosen entry")
-                return MacOSInstallContext(
-                    source: .downloadLatest,
-                    downloadDestinationPath: Self.defaultIPSWDownloadPath
-                )
-            }
-            return MacOSInstallContext(
+        case .catalogVersion(let entry):
+            MacOSInstallContext(
                 source: .catalogVersion,
                 downloadDestinationPath: ipswDownloadPath,
-                requestedFreshDownload: confirmedOverwritePath != nil
-                    && confirmedOverwritePath == ipswDownloadPath,
+                requestedFreshDownload: requestedFreshDownload,
                 remoteURL: entry.url,
                 version: entry.version,
                 build: entry.build
             )
-        case .customURL:
-            guard let image = pastedImage else {
-                Self.logger.fault("URL source selected with no checked image")
-                assertionFailure("URL source selected with no checked image")
-                return MacOSInstallContext(
-                    source: .downloadLatest,
-                    downloadDestinationPath: Self.defaultIPSWDownloadPath
-                )
-            }
-            return MacOSInstallContext(
+        case .customURL(let image):
+            MacOSInstallContext(
                 source: .customURL,
                 downloadDestinationPath: ipswDownloadPath,
-                requestedFreshDownload: confirmedOverwritePath != nil
-                    && confirmedOverwritePath == ipswDownloadPath,
+                requestedFreshDownload: requestedFreshDownload,
                 remoteURL: image.url,
                 version: image.version,
                 build: image.build
             )
-        case .localFile:
-            return MacOSInstallContext(
+        case .localFile(let path, let bookmark):
+            MacOSInstallContext(
                 source: .localFile,
-                localIPSWPath: ipswPath,
-                localIPSWBookmark: ipswBookmark
+                localIPSWPath: path,
+                localIPSWBookmark: bookmark
             )
         }
+    }
+
+    /// Whether the user confirmed overwriting the destination the wizard is
+    /// currently pointing at.
+    private var requestedFreshDownload: Bool {
+        confirmedOverwritePath == ipswDownloadPath
     }
 
     // MARK: - Resume Detection
@@ -394,21 +396,21 @@ final class VMCreationViewModel {
         confirmedOverwritePath = ipswDownloadPath
     }
 
+    /// Adopts the file already sitting at the download destination.
+    ///
+    /// No bookmark: the file was adopted without a panel, so there is no grant
+    /// to capture — and none is needed, the Downloads location being
+    /// entitlement-covered.
     func useExistingDownloadFile() {
-        ipswSource = .localFile
-        ipswPath = ipswDownloadPath
-        // Adopted without a panel: no grant to bookmark, and none needed — the
-        // Downloads location is entitlement-covered. Clearing also drops any
-        // bookmark left over from an earlier local-file pick.
-        ipswBookmark = nil
+        ipswSelection = .localFile(path: ipswDownloadPath, bookmark: nil)
     }
 
     /// The build the wizard is currently promising, or `nil` when the source
     /// names no particular image.
     var pinnedBuild: String? {
-        switch ipswSource {
-        case .catalogVersion: selectedCatalogEntry?.build
-        case .customURL: pastedImage?.build
+        switch ipswSelection {
+        case .catalogVersion(let entry): entry.build
+        case .customURL(let image): image.build
         case .downloadLatest, .localFile: nil
         }
     }

--- a/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
@@ -170,7 +170,7 @@ final class IPSWSelectionContentViewController: NSViewController {
             view.removeFromSuperview()
         }
 
-        switch creationVM.ipswSource {
+        switch creationVM.ipswSelection {
         case .downloadLatest:
             // No "Change…" affordance: the destination is always the Downloads
             // folder, the one location the sandbox's downloads entitlement covers
@@ -178,24 +178,21 @@ final class IPSWSelectionContentViewController: NSViewController {
             conditionalContainer.addArrangedSubview(
                 makeWizardPathBadge(path: creationVM.ipswDownloadPath))
             addDownloadBanners(version: nil)
-        case .catalogVersion:
-            guard let entry = creationVM.selectedCatalogEntry else { return }
+        case .catalogVersion(let entry):
             addPinnedImageBadge(
                 summary:
                     "macOS \(entry.version)  ·  Build \(entry.build)  ·  \(DataFormatters.formatBytes(entry.sizeBytes))",
                 changeAction: #selector(changeCatalogVersion)
             )
             addDownloadBanners(version: entry.version)
-        case .customURL:
-            guard let image = creationVM.pastedImage else { return }
+        case .customURL(let image):
             addPinnedImageBadge(
                 summary:
                     "\(image.versionSummary)  ·  \(DataFormatters.formatBytes(image.sizeBytes))",
                 changeAction: #selector(changePastedURL)
             )
             addDownloadBanners(version: image.version)
-        case .localFile:
-            guard let path = creationVM.ipswPath else { return }
+        case .localFile(let path, _):
             let change = makeLinkButton(
                 "Change…", target: self, action: #selector(changeLocalFile))
             conditionalContainer.addArrangedSubview(makeWizardPathBadge(path: path, changeButton: change))
@@ -371,9 +368,7 @@ final class IPSWSelectionContentViewController: NSViewController {
         panel.beginSheetModal(for: window) { [weak self] response in
             guard let self, response == .OK, let url = panel.url else { return }
             let (path, bookmark) = SecurityScopedBookmark.capture(url)
-            self.creationVM.ipswSource = .localFile
-            self.creationVM.ipswPath = path
-            self.creationVM.ipswBookmark = bookmark
+            self.creationVM.selectLocalFile(path: path, bookmark: bookmark)
             self.refresh()
         }
     }
@@ -383,7 +378,7 @@ final class IPSWSelectionContentViewController: NSViewController {
         guard let window = view.window, !catalogSheetPresenter.isShown else { return }
         let sheet = RestoreImageCatalogSheetContentViewController(
             entries: creationVM.catalogService.entries,
-            selectedBuild: creationVM.selectedCatalogEntry?.build,
+            selectedBuild: creationVM.lastCatalogPick?.build,
             generatedAt: creationVM.catalogService.generatedAt
         )
         sheet.delegate = self
@@ -395,7 +390,7 @@ final class IPSWSelectionContentViewController: NSViewController {
         guard let window = view.window, !catalogSheetPresenter.isShown else { return }
         let sheet = RestoreImageURLSheetContentViewController(
             probeService: creationVM.probeService,
-            initialURL: creationVM.pastedImage?.url.absoluteString
+            initialURL: creationVM.lastPastedImage?.url.absoluteString
         )
         sheet.delegate = self
         catalogSheetPresenter.show(content: sheet, in: window)

--- a/Kernova/Views/Creation/ReviewContentViewController.swift
+++ b/Kernova/Views/Creation/ReviewContentViewController.swift
@@ -75,25 +75,22 @@ final class ReviewContentViewController: NSViewController {
             rows: [valueRow("Networking", creationVM.networkEnabled ? "Enabled" : "Disabled")], to: form)
 
         if creationVM.selectedOS == .macOS {
-            let sourceLabel: String
-            switch creationVM.ipswSource {
-            case .downloadLatest: sourceLabel = "Download Latest"
-            case .catalogVersion: sourceLabel = "Chosen Version"
-            case .customURL: sourceLabel = "From URL"
-            case .localFile: sourceLabel = "Local File"
-            }
-            var rows = [valueRow("Restore Image", sourceLabel)]
-            if creationVM.ipswSource == .catalogVersion, let entry = creationVM.selectedCatalogEntry {
+            var rows: [NSView] = []
+            switch creationVM.ipswSelection {
+            case .downloadLatest:
+                rows.append(valueRow("Restore Image", "Download Latest"))
+            case .catalogVersion(let entry):
+                rows.append(valueRow("Restore Image", "Chosen Version"))
                 rows.append(valueRow("macOS Version", "\(entry.version) (\(entry.build))"))
                 rows.append(
                     valueRow("Download Size", DataFormatters.formatBytes(entry.sizeBytes)))
-            }
-            if creationVM.ipswSource == .customURL, let image = creationVM.pastedImage {
+            case .customURL(let image):
+                rows.append(valueRow("Restore Image", "From URL"))
                 rows.append(valueRow("macOS Version", image.versionSummary))
                 rows.append(
                     valueRow("Download Size", DataFormatters.formatBytes(image.sizeBytes)))
-            }
-            if creationVM.ipswSource == .localFile, let path = creationVM.ipswPath {
+            case .localFile(let path, _):
+                rows.append(valueRow("Restore Image", "Local File"))
                 rows.append(valueRow("File", URL(fileURLWithPath: path).lastPathComponent))
             }
             if creationVM.ipswSource.downloadsImage {

--- a/KernovaTests/IPSWSelectionContentViewControllerTests.swift
+++ b/KernovaTests/IPSWSelectionContentViewControllerTests.swift
@@ -26,7 +26,6 @@ struct IPSWSelectionContentViewControllerTests {
 
         let inspector = MockLocalRestoreImageInspector()
         let vm = VMCreationViewModel(localImageInspector: inspector)
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = path
         #expect(vm.shouldShowOverwriteWarning == true)
 
@@ -37,8 +36,7 @@ struct IPSWSelectionContentViewControllerTests {
         findButton(titled: "Use Existing File", in: vc.view)?.performClick(nil)
         await vc.adoptTaskForTesting?.value
 
-        #expect(vm.ipswSource == .localFile)
-        #expect(vm.ipswPath == path)
+        #expect(vm.ipswSelection == .localFile(path: path, bookmark: nil))
     }
 
     @Test("A file of a different build is named, and not adopted until confirmed")
@@ -50,7 +48,8 @@ struct IPSWSelectionContentViewControllerTests {
         inspector.inspectResult = InspectedRestoreImage(
             version: "14.2", build: "23C64", isSupportedOnThisHost: true)
         let vm = VMCreationViewModel(localImageInspector: inspector)
-        vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
+        let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
+        vm.selectCatalogEntry(entry)
         vm.ipswDownloadPath = path
 
         let vc = IPSWSelectionContentViewController(creationVM: vm)
@@ -58,14 +57,12 @@ struct IPSWSelectionContentViewControllerTests {
         findButton(titled: "Use Existing File", in: vc.view)?.performClick(nil)
         await vc.adoptTaskForTesting?.value
 
-        #expect(vm.ipswSource == .catalogVersion)
-        #expect(vm.ipswPath == nil)
+        #expect(vm.ipswSelection == .catalogVersion(entry))
         #expect(findLabelContaining("macOS 14.2 (23C64)", in: vc.view) != nil)
 
         // The user can still override, which is what "Use It Anyway" is for.
         findButton(titled: "Use It Anyway", in: vc.view)?.performClick(nil)
-        #expect(vm.ipswSource == .localFile)
-        #expect(vm.ipswPath == path)
+        #expect(vm.ipswSelection == .localFile(path: path, bookmark: nil))
     }
 
     @Test("An unreadable file offers only a re-download")
@@ -76,7 +73,6 @@ struct IPSWSelectionContentViewControllerTests {
         let inspector = MockLocalRestoreImageInspector()
         inspector.inspectError = LocalRestoreImageError.unreadable
         let vm = VMCreationViewModel(localImageInspector: inspector)
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = path
 
         let vc = IPSWSelectionContentViewController(creationVM: vm)
@@ -97,7 +93,6 @@ struct IPSWSelectionContentViewControllerTests {
 
         let inspector = SuspendingMockLocalRestoreImageInspector()
         let vm = VMCreationViewModel(localImageInspector: inspector)
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = path
 
         let vc = IPSWSelectionContentViewController(creationVM: vm)
@@ -112,8 +107,7 @@ struct IPSWSelectionContentViewControllerTests {
         await inFlight.value
 
         // Adopting here would leave the radios and the model disagreeing.
-        #expect(vm.ipswSource == .downloadLatest)
-        #expect(vm.ipswPath == nil)
+        #expect(vm.ipswSelection == .downloadLatest)
     }
 
     private func findLabelContaining(_ text: String, in view: NSView) -> NSTextField? {
@@ -130,7 +124,6 @@ struct IPSWSelectionContentViewControllerTests {
         defer { try? FileManager.default.removeItem(atPath: path) }
 
         let vm = VMCreationViewModel()
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = path
         #expect(vm.shouldShowOverwriteWarning == true)
 

--- a/KernovaTests/ReviewContentViewControllerTests.swift
+++ b/KernovaTests/ReviewContentViewControllerTests.swift
@@ -43,8 +43,7 @@ struct ReviewContentViewControllerTests {
     @Test("macOS + local file shows the file basename")
     func macOSLocalFileShowsFile() {
         let vm = VMCreationViewModel()
-        vm.ipswSource = .localFile
-        vm.ipswPath = "/tmp/Restore.ipsw"
+        vm.selectLocalFile(path: "/tmp/Restore.ipsw", bookmark: nil)
         let vc = ReviewContentViewController(creationVM: vm)
         vc.loadViewIfNeeded()
 

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -84,17 +84,11 @@ struct VMCreationViewModelTests {
         // macOS with downloadLatest is valid (the destination is always the
         // Downloads default; only an unresolved overwrite conflict blocks)
         vm.selectedOS = .macOS
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/nonexistent/RestoreImage.ipsw"
         #expect(vm.canAdvance == true)
 
-        // macOS with localFile but no path is invalid
-        vm.ipswSource = .localFile
-        vm.ipswPath = nil
-        #expect(vm.canAdvance == false)
-
-        // macOS with localFile and path is valid
-        vm.ipswPath = "/path/to/restore.ipsw"
+        // A local file carries its path, so it is valid the moment it is picked
+        vm.selectLocalFile(path: "/path/to/restore.ipsw", bookmark: nil)
         #expect(vm.canAdvance == true)
     }
 
@@ -109,7 +103,6 @@ struct VMCreationViewModelTests {
         let vm = VMCreationViewModel()
         vm.currentStep = .bootConfig
         vm.selectedOS = .macOS
-        vm.ipswSource = .downloadLatest
         // Use a non-existent path so the overwrite warning doesn't trigger
         vm.ipswDownloadPath = "/nonexistent/path/RestoreImage.ipsw"
         #expect(vm.canAdvance == true)
@@ -411,7 +404,7 @@ struct VMCreationViewModelTests {
     @Test("shouldShowOverwriteWarning is false when source is localFile")
     func overwriteWarningFalseForLocalFile() {
         let vm = VMCreationViewModel()
-        vm.ipswSource = .localFile
+        vm.selectLocalFile(path: "/tmp/picked.ipsw", bookmark: nil)
         vm.ipswDownloadPath = "/usr/bin/true"  // exists on disk
 
         #expect(vm.shouldShowOverwriteWarning == false)
@@ -420,7 +413,6 @@ struct VMCreationViewModelTests {
     @Test("shouldShowOverwriteWarning is false when file does not exist at path")
     func overwriteWarningFalseWhenFileDoesNotExist() {
         let vm = VMCreationViewModel()
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/nonexistent/path/RestoreImage.ipsw"
 
         #expect(vm.shouldShowOverwriteWarning == false)
@@ -429,7 +421,6 @@ struct VMCreationViewModelTests {
     @Test("shouldShowOverwriteWarning is true when download source and file exists")
     func overwriteWarningTrueWhenDownloadAndFileExists() {
         let vm = VMCreationViewModel()
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/usr/bin/true"  // exists on disk
 
         #expect(vm.shouldShowOverwriteWarning == true)
@@ -438,7 +429,6 @@ struct VMCreationViewModelTests {
     @Test("confirmOverwrite suppresses warning for current path")
     func confirmOverwriteSuppressesWarning() {
         let vm = VMCreationViewModel()
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/usr/bin/true"
         #expect(vm.shouldShowOverwriteWarning == true)
 
@@ -449,7 +439,6 @@ struct VMCreationViewModelTests {
     @Test("changing path after confirmOverwrite resets warning")
     func changingPathResetsConfirmation() {
         let vm = VMCreationViewModel()
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/usr/bin/true"
         vm.confirmOverwrite()
         #expect(vm.shouldShowOverwriteWarning == false)
@@ -462,13 +451,11 @@ struct VMCreationViewModelTests {
     @Test("useExistingDownloadFile switches source to localFile and copies path")
     func useExistingDownloadFileSwitchesSource() {
         let vm = VMCreationViewModel()
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/usr/bin/true"
 
         vm.useExistingDownloadFile()
 
-        #expect(vm.ipswSource == .localFile)
-        #expect(vm.ipswPath == "/usr/bin/true")
+        #expect(vm.ipswSelection == .localFile(path: "/usr/bin/true", bookmark: nil))
     }
 
     @Test("canAdvance is false when overwrite warning is unresolved")
@@ -476,7 +463,6 @@ struct VMCreationViewModelTests {
         let vm = VMCreationViewModel()
         vm.currentStep = .bootConfig
         vm.selectedOS = .macOS
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/usr/bin/true"  // exists on disk → triggers warning
 
         #expect(vm.shouldShowOverwriteWarning == true)
@@ -488,7 +474,6 @@ struct VMCreationViewModelTests {
         let vm = VMCreationViewModel()
         vm.currentStep = .bootConfig
         vm.selectedOS = .macOS
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/usr/bin/true"  // exists on disk → triggers warning
         #expect(vm.canAdvance == false)
 
@@ -546,23 +531,11 @@ struct VMCreationViewModelTests {
         #expect(vm.validationMessage == "Select a kernel image to continue.")
     }
 
-    @Test("validationMessage returns IPSW hint for macOS localFile with no ipswPath")
-    func validationMessageMacOSLocalFileNoIPSW() {
-        let vm = VMCreationViewModel()
-        vm.currentStep = .bootConfig
-        vm.selectedOS = .macOS
-        vm.ipswSource = .localFile
-        vm.ipswPath = nil
-
-        #expect(vm.validationMessage == "Select a restore image file.")
-    }
-
     @Test("validationMessage returns conflict hint when overwrite warning is showing")
     func validationMessageOverwriteConflict() {
         let vm = VMCreationViewModel()
         vm.currentStep = .bootConfig
         vm.selectedOS = .macOS
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/usr/bin/true"  // exists on disk → triggers warning
 
         #expect(vm.shouldShowOverwriteWarning == true)
@@ -586,7 +559,6 @@ struct VMCreationViewModelTests {
     @Test("buildInstallContext snapshots downloadLatest with chosen path")
     func buildInstallContextDownloadLatest() {
         let vm = VMCreationViewModel()
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/Users/me/Downloads/RestoreImage.ipsw"
 
         let context = vm.buildInstallContext()
@@ -599,8 +571,7 @@ struct VMCreationViewModelTests {
     @Test("buildInstallContext snapshots localFile with chosen path")
     func buildInstallContextLocalFile() {
         let vm = VMCreationViewModel()
-        vm.ipswSource = .localFile
-        vm.ipswPath = "/tmp/macOS-26.ipsw"
+        vm.selectLocalFile(path: "/tmp/macOS-26.ipsw", bookmark: nil)
 
         let context = vm.buildInstallContext()
 
@@ -610,10 +581,36 @@ struct VMCreationViewModelTests {
         #expect(!context.requestedFreshDownload)
     }
 
+    @Test("buildInstallContext carries a local pick's bookmark")
+    func buildInstallContextCarriesLocalBookmark() {
+        let vm = VMCreationViewModel()
+        let bookmark = Data([0x01, 0x02, 0x03])
+        vm.selectLocalFile(path: "/tmp/macOS-26.ipsw", bookmark: bookmark)
+
+        let context = vm.buildInstallContext()
+
+        #expect(context.localIPSWPath == "/tmp/macOS-26.ipsw")
+        #expect(context.localIPSWBookmark == bookmark)
+    }
+
+    @Test("each selection maps to its persisted install-context source")
+    func installContextSourceCoversEverySelection() {
+        let vm = VMCreationViewModel()
+        #expect(vm.buildInstallContext().source == .downloadLatest)
+
+        vm.selectCatalogEntry(makeCatalogEntry())
+        #expect(vm.buildInstallContext().source == .catalogVersion)
+
+        vm.selectPastedImage(makeProbedImage())
+        #expect(vm.buildInstallContext().source == .customURL)
+
+        vm.selectLocalFile(path: "/tmp/macOS-26.ipsw", bookmark: nil)
+        #expect(vm.buildInstallContext().source == .localFile)
+    }
+
     @Test("buildInstallContext defaults requestedFreshDownload to false")
     func buildInstallContextDefaultsFreshFalse() {
         let vm = VMCreationViewModel()
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/Users/me/Downloads/RestoreImage.ipsw"
 
         let context = vm.buildInstallContext()
@@ -624,7 +621,6 @@ struct VMCreationViewModelTests {
     @Test("buildInstallContext sets requestedFreshDownload when overwrite confirmed")
     func buildInstallContextSetsFreshOnConfirmedOverwrite() {
         let vm = VMCreationViewModel()
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/Users/me/Downloads/RestoreImage.ipsw"
         vm.confirmOverwrite()
 
@@ -639,7 +635,6 @@ struct VMCreationViewModelTests {
         // then picks a different destination, the confirmation no longer
         // applies and the wizard should treat the new path as not-yet-confirmed.
         let vm = VMCreationViewModel()
-        vm.ipswSource = .downloadLatest
         vm.ipswDownloadPath = "/Users/me/Downloads/A.ipsw"
         vm.confirmOverwrite()
         vm.ipswDownloadPath = "/Users/me/Downloads/B.ipsw"
@@ -665,8 +660,7 @@ struct VMCreationViewModelTests {
         let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
         vm.selectCatalogEntry(entry)
 
-        #expect(vm.ipswSource == .catalogVersion)
-        #expect(vm.selectedCatalogEntry == entry)
+        #expect(vm.ipswSelection == .catalogVersion(entry))
         #expect(
             vm.ipswDownloadPath
                 == VMCreationViewModel.downloadPath(
@@ -708,23 +702,8 @@ struct VMCreationViewModelTests {
         vm.selectCatalogEntry(makeCatalogEntry())
         vm.selectDownloadLatest()
 
-        #expect(vm.ipswSource == .downloadLatest)
-        #expect(vm.selectedCatalogEntry == nil)
+        #expect(vm.ipswSelection == .downloadLatest)
         #expect(vm.ipswDownloadPath == VMCreationViewModel.defaultIPSWDownloadPath)
-    }
-
-    @Test("The catalog source cannot advance until a version is chosen")
-    func catalogSourceRequiresAPick() {
-        let vm = VMCreationViewModel()
-        vm.currentStep = .bootConfig
-        vm.ipswSource = .catalogVersion
-
-        #expect(!vm.canAdvance)
-        #expect(vm.validationMessage == "Choose a macOS version to continue.")
-
-        vm.selectCatalogEntry(makeCatalogEntry())
-        #expect(vm.canAdvance)
-        #expect(vm.validationMessage == nil)
     }
 
     @Test("The overwrite warning and resume check cover the catalog source")
@@ -773,8 +752,18 @@ struct VMCreationViewModelTests {
         let destination = vm.ipswDownloadPath
         vm.useExistingDownloadFile()
 
+        #expect(vm.ipswSelection == .localFile(path: destination, bookmark: nil))
+    }
+
+    @Test("Use Existing File keeps the pick that named the file, for the sheet")
+    func useExistingKeepsTheSeed() {
+        let vm = VMCreationViewModel()
+        let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
+        vm.selectCatalogEntry(entry)
+        vm.useExistingDownloadFile()
+
         #expect(vm.ipswSource == .localFile)
-        #expect(vm.ipswPath == destination)
+        #expect(vm.lastCatalogPick == entry)
     }
 
     @Test("Only download sources own the destination")
@@ -793,8 +782,7 @@ struct VMCreationViewModelTests {
         let image = makeProbedImage()
         vm.selectPastedImage(image)
 
-        #expect(vm.ipswSource == .customURL)
-        #expect(vm.pastedImage == image)
+        #expect(vm.ipswSelection == .customURL(image))
         #expect(
             vm.ipswDownloadPath
                 == VMCreationViewModel.downloadPath(
@@ -841,20 +829,6 @@ struct VMCreationViewModelTests {
         #expect(parentPath(of: vm.ipswDownloadPath) == downloadsPath)
     }
 
-    @Test("The URL source cannot advance until a URL is checked")
-    func customURLSourceRequiresACheckedImage() {
-        let vm = VMCreationViewModel()
-        vm.currentStep = .bootConfig
-        vm.ipswSource = .customURL
-
-        #expect(!vm.canAdvance)
-        #expect(vm.validationMessage == "Add a restore image URL to continue.")
-
-        vm.selectPastedImage(makeProbedImage())
-        #expect(vm.canAdvance)
-        #expect(vm.validationMessage == nil)
-    }
-
     @Test("The URL source shares the overwrite warning")
     func customURLSourceSharesDownloadWarnings() {
         let vm = VMCreationViewModel()
@@ -898,8 +872,7 @@ struct VMCreationViewModelTests {
         let verdict = await vm.adoptExistingDownloadFile()
 
         #expect(verdict == .adopted(inspector.inspectResult))
-        #expect(vm.ipswSource == .localFile)
-        #expect(vm.ipswPath == destination)
+        #expect(vm.ipswSelection == .localFile(path: destination, bookmark: nil))
         #expect(inspector.lastInspectedURL?.path(percentEncoded: false) == destination)
     }
 
@@ -909,14 +882,14 @@ struct VMCreationViewModelTests {
         inspector.inspectResult = InspectedRestoreImage(
             version: "14.2", build: "23C64", isSupportedOnThisHost: true)
         let vm = VMCreationViewModel(localImageInspector: inspector)
-        vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
+        let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
+        vm.selectCatalogEntry(entry)
 
         let verdict = await vm.adoptExistingDownloadFile()
 
         #expect(verdict == .mismatch(expected: "24G90", found: inspector.inspectResult))
         // The wrong-image install this exists to prevent.
-        #expect(vm.ipswSource == .catalogVersion)
-        #expect(vm.ipswPath == nil)
+        #expect(vm.ipswSelection == .catalogVersion(entry))
     }
 
     @Test("An unreadable file is refused with a reason")
@@ -984,7 +957,8 @@ struct VMCreationViewModelTests {
         let inspector = SuspendingMockLocalRestoreImageInspector()
         let vm = VMCreationViewModel(localImageInspector: inspector)
         // The build matches, so only the cancellation keeps this from adopting.
-        vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
+        let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
+        vm.selectCatalogEntry(entry)
 
         let adopt = Task { await vm.adoptExistingDownloadFile() }
         try await inspector.waitUntilInspecting()
@@ -992,8 +966,7 @@ struct VMCreationViewModelTests {
         inspector.release()
 
         #expect(await adopt.value == .cancelled)
-        #expect(vm.ipswSource == .catalogVersion)
-        #expect(vm.ipswPath == nil)
+        #expect(vm.ipswSelection == .catalogVersion(entry))
     }
 
     @Test("pinnedBuild names the build each source is promising")
@@ -1016,13 +989,29 @@ struct VMCreationViewModelTests {
         let vm = VMCreationViewModel()
         vm.selectCatalogEntry(makeCatalogEntry())
         vm.selectPastedImage(makeProbedImage())
-        #expect(vm.selectedCatalogEntry != nil)
-        #expect(vm.pastedImage != nil)
+        #expect(vm.lastCatalogPick != nil)
+        #expect(vm.lastPastedImage != nil)
 
         // Download Latest is the one source that owns neither pick.
         vm.selectDownloadLatest()
-        #expect(vm.selectedCatalogEntry == nil)
-        #expect(vm.pastedImage == nil)
+        #expect(vm.lastCatalogPick == nil)
+        #expect(vm.lastPastedImage == nil)
+    }
+
+    @Test("A pinned payload leaves with its source, while the sheet seed stays")
+    func switchingSourcesDropsThePayloadButKeepsTheSeed() {
+        let vm = VMCreationViewModel()
+        let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
+        let image = makeProbedImage(build: "25G72")
+        vm.selectCatalogEntry(entry)
+        vm.selectPastedImage(image)
+
+        // Only the live source carries a payload, so no reader can reach the
+        // catalog entry while the URL source is current.
+        #expect(vm.ipswSelection == .customURL(image))
+        #expect(vm.pinnedBuild == "25G72")
+        // The seed survives so the version picker re-opens on the old pick.
+        #expect(vm.lastCatalogPick == entry)
     }
 }
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -1620,7 +1620,6 @@ struct VMLibraryViewModelTests {
         wizard.selectedOS = .macOS
         wizard.selectedBootMode = .macOS
         wizard.vmName = "Overwrite VM"
-        wizard.ipswSource = .downloadLatest
         wizard.ipswDownloadPath = destination.path(percentEncoded: false)
         wizard.confirmOverwrite()
 
@@ -1648,7 +1647,6 @@ struct VMLibraryViewModelTests {
         wizard.selectedOS = .macOS
         wizard.selectedBootMode = .macOS
         wizard.vmName = "No-overwrite VM"
-        wizard.ipswSource = .downloadLatest
         wizard.ipswDownloadPath = destination.path(percentEncoded: false)
 
         await viewModel.createVM(from: wizard)


### PR DESCRIPTION
Closes #675

The macOS creation wizard modelled its install choice as a tag enum (`ipswSource`) plus three parallel per-source optionals (`ipswPath`+`ipswBookmark`, `selectedCatalogEntry`, `pastedImage`) that no source switch cleared. Every reader had to check the tag before touching a payload, and `buildInstallContext` carried two `assertionFailure` fallbacks for states the type permitted but the design forbade. Nothing misbehaved, because every reader did check — but this shape was the direct enabler of two adopt/collision bugs fixed on #672's branch.

```swift
enum IPSWSelection: Sendable, Equatable {
    case downloadLatest
    case catalogVersion(RestoreImageCatalogEntry)
    case customURL(ProbedRestoreImage)
    case localFile(path: String, bookmark: Data?)
}
```

## Four flat cases, not the issue's `pinned` sketch

The issue sketches `pinned` carrying "the catalog entry or probed image" — but that *or* is a two-case inner enum: the same cardinality with one more nesting level at every switch. Four flat cases match what everything else already has four of: the radios, `MacOSInstallContext.Source`, and Review's labels. The property the issue asks for is unchanged — mismatched states are unrepresentable and both fallbacks are gone.

## The tag survives as a projection

`ipswSource` stays, now computed from the selection. It has two readers that genuinely want the tag without a payload: `radios: [IPSWSource: NSButton]`, which is populated before any pick exists, and `downloadsImage`. Making the payloads `Hashable` to key that dictionary on the new enum isn't just awkward, it's wrong — the key would change identity every time the payload did.

So mutation is the part that closes: `ipswSelection` is `private(set)`, and the view's three sequential writes at the file-panel callback become one `selectLocalFile(path:bookmark:)`. There is no longer an instant where the tag says `.localFile` and no path exists.

## Preselection stops being a side effect

The sheets deliberately re-open on the previous pick even when another source is active. That worked because the payloads were never cleared — preselection riding on a bug's mechanism. It's now `lastCatalogPick` / `lastPastedImage`, written by the two pinned `select` methods and cleared by `selectDownloadLatest()`, which is the one source that owns neither pick. `useExistingDownloadFile()` keeps both, as before.

## Three validation strings are deleted

With a pick inseparable from its source, `bootConfigValid`'s macOS arm reduces to the overwrite conflict, and "Choose a macOS version to continue.", "Add a restore image URL to continue." and "Select a restore image file." describe no reachable state. They were already unreachable in the shipping app — the radios commit only on an actual pick — which is why the issue notes nothing misbehaves today. Only tests reached them, by writing the impossible states directly.

## Adjacent cleanup

`buildInstallContext` repeated `confirmedOverwritePath != nil && confirmedOverwritePath == ipswDownloadPath` three times; it is now one `requestedFreshDownload` helper. The `!= nil` guard went with it: `ipswDownloadPath` is a non-optional `String`, so the `nil == nil` match its comment described could never happen.

## Test plan

- [x] `make build`
- [x] `make test` — full suite green
- [x] `make format && make lint`
- [ ] Manual wizard pass: cancel each of the three sheet-opening radios (previous radio stays lit), catalog pick → reopen picker preselected → switch to URL → reopen picker still preselected → Download Latest → both sheets re-open empty; Use Existing File on an existing download

Two impossible-state tests are deleted, path assertions strengthen to whole-selection equality, and four tests are added: the payload leaving with its source while the seed survives, Use Existing File keeping the seed, a local pick's bookmark reaching the install context (untested before), and every case mapping to its persisted `MacOSInstallContext.Source`.