### PR TITLE
fix: Clear the existing-file banner when the install source changes

### DIFF
--- a/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
@@ -137,16 +137,16 @@ final class IPSWSelectionContentViewController: NSViewController {
             refresh()
         case .catalogVersion:
             // Same deferred-commit rule as Choose Local File below.
-            updateRadioSelection()
+            refresh()
             selectCatalogVersion()
         case .customURL:
-            updateRadioSelection()
+            refresh()
             selectPastedURL()
         case .localFile:
-            // Selection only commits when the user actually picks a file. Re-sync
-            // the radios to the (still-current) model so the just-clicked radio
-            // doesn't stay selected if the picker is cancelled, then open it.
-            updateRadioSelection()
+            // Selection only commits when the user actually picks a file. Re-render
+            // from the (still-current) model so the just-clicked radio doesn't stay
+            // selected if the picker is cancelled, then open it.
+            refresh()
             selectIPSWFile()
         }
     }

--- a/KernovaTests/IPSWSelectionContentViewControllerTests.swift
+++ b/KernovaTests/IPSWSelectionContentViewControllerTests.swift
@@ -136,6 +136,65 @@ struct IPSWSelectionContentViewControllerTests {
         #expect(findButton(titled: "Download & Replace", in: vc.view) == nil)
     }
 
+    @Test("Switching install source clears a stale mismatch banner")
+    func sourceSwitchClearsMismatchBanner() async {
+        let path = makeTempIPSW()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let inspector = MockLocalRestoreImageInspector()
+        inspector.inspectResult = InspectedRestoreImage(
+            version: "14.2", build: "23C64", isSupportedOnThisHost: true)
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
+        vm.selectCatalogEntry(entry)
+        vm.ipswDownloadPath = path
+
+        let vc = IPSWSelectionContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+        findButton(titled: "Use Existing File", in: vc.view)?.performClick(nil)
+        await vc.adoptTaskForTesting?.value
+        #expect(findButton(titled: "Use It Anyway", in: vc.view) != nil)
+
+        // Clicking another source drops the verdict, so the button that would
+        // adopt the file that verdict described has to go with it.
+        radio(titled: "Choose Local File…", in: vc.view)?.performClick(nil)
+
+        #expect(findButton(titled: "Use It Anyway", in: vc.view) == nil)
+        #expect(vm.ipswSelection == .catalogVersion(entry))
+        #expect(radio(titled: "Choose a Version…", in: vc.view)?.state == .on)
+        #expect(radio(titled: "Choose Local File…", in: vc.view)?.state == .off)
+    }
+
+    @Test("Switching install source clears a stale checking banner")
+    func sourceSwitchClearsCheckingBanner() async throws {
+        let path = makeTempIPSW()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let inspector = SuspendingMockLocalRestoreImageInspector()
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        vm.ipswDownloadPath = path
+
+        let vc = IPSWSelectionContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+        findButton(titled: "Use Existing File", in: vc.view)?.performClick(nil)
+        let inFlight = try #require(vc.adoptTaskForTesting)
+        try await inspector.waitUntilInspecting()
+        #expect(findLabelContaining("Checking the file already", in: vc.view) != nil)
+
+        // The switch cancels the check, so its banner would never resolve on its
+        // own — and while it shows it hides the only controls that clear the
+        // overwrite warning blocking Next.
+        radio(titled: "Choose a Version…", in: vc.view)?.performClick(nil)
+
+        #expect(findLabelContaining("Checking the file already", in: vc.view) == nil)
+        #expect(findButton(titled: "Use Existing File", in: vc.view) != nil)
+        #expect(findButton(titled: "Download & Replace", in: vc.view) != nil)
+
+        inspector.release()
+        await inFlight.value
+        #expect(vm.ipswSelection == .downloadLatest)
+    }
+
     // MARK: - Helpers
 
     @MainActor


### PR DESCRIPTION
Closes #677

## Summary

`sourceRadioClicked(_:)` clears `existingFileNotice` for every source, but only the `.downloadLatest` branch rebuilt the view. The other three called `updateRadioSelection()`, which restyles the radios and never touches `conditionalContainer` — so the banner rendered from the now-cleared notice stayed on screen.

Two ways that bites:

- A stranded **"Checking the file already at this location…"** banner has no buttons, and `clearExistingFileNotice()` already cancelled the inspection that would have replaced it, so it never resolves. Because a verdict banner supersedes the plain overwrite banner, it hides **Use Existing File** and **Download & Replace** — the only controls that clear `shouldShowOverwriteWarning`. Next stays disabled saying "Resolve the file conflict above to continue.", pointing at a banner that no longer offers a way to resolve it, and the "Checking…" wording makes it read as a hang. Recovery needs a Back/forward remount.
- A stranded `.mismatch` banner keeps a live **Use It Anyway** button that still adopts the image at the old destination, after the user has moved on to a different source.

## Changes

- `Kernova/Views/Creation/IPSWSelectionContentViewController.swift` — the `.catalogVersion`, `.customURL` and `.localFile` branches call `refresh()` instead of `updateRadioSelection()`, matching `.downloadLatest`.

  `refresh()` is `updateRadioSelection()` + `rebuildConditional()`, and the model is unchanged on these paths, so the deferred-commit rule is untouched: the rebuild re-renders the *same* selection, just without the cleared notice, and the radios still only commit on an actual pick. `rebuildConditional()` reads view-model state and rebuilds views only — no downloads, no sheet presentation, no `adoptTask`/presenter mutation — and it runs before the picker is presented, so it cannot race the pick. The sheet and panel completion handlers already call `clearExistingFileNotice()` + `refresh()` themselves on commit.

- `KernovaTests/IPSWSelectionContentViewControllerTests.swift` — two regression tests.

## Test plan

- [x] `make test` — full suite green (2003 tests, 0 failures)
- [x] `make lint` — clean
- [x] Negative control: reverting only the controller change fails exactly the two new tests and no others

## Notes

No `RATIONALE:` comments added. No architecture, docs or AGENTS.md impact — no component boundary, public type, or actor isolation changed.