### PR TITLE
feat: Name the image "Download Latest" will install

### DIFF
--- a/Kernova/Models/LatestRestoreImage.swift
+++ b/Kernova/Models/LatestRestoreImage.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// The newest restore image Apple offers that this host can install, as
+/// Virtualization reports it.
+///
+/// The install re-resolves the latest image when it starts, so what a wizard
+/// step shows from this is a preview of that answer, not a pin on it.
+struct LatestRestoreImage: Sendable, Equatable {
+    var url: URL
+    /// Marketing version, e.g. `"26.5.2"`.
+    var version: String
+    /// Apple build identifier, e.g. `"25F84"`.
+    var build: String
+}

--- a/Kernova/Models/RestoreImageFilename.swift
+++ b/Kernova/Models/RestoreImageFilename.swift
@@ -94,6 +94,13 @@ struct MacOSVersion: Sendable, Equatable {
     /// Numeric components, zero-padded to three.
     let components: [Int]
 
+    /// `version` rendered the way Apple names a release: a zero patch is left
+    /// off, so `26.6.0` reads as `"26.6"` and matches the catalog's own strings.
+    static func displayString(_ version: OperatingSystemVersion) -> String {
+        let base = "\(version.majorVersion).\(version.minorVersion)"
+        return version.patchVersion == 0 ? base : "\(base).\(version.patchVersion)"
+    }
+
     /// `nil` when `version` is not a dot-separated run of numbers.
     init?(_ version: String) {
         let parsed = version.split(separator: ".").map { Int($0) }

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -28,10 +28,14 @@ final class IPSWService: Sendable {
 
     // MARK: - Protocol Methods
 
-    func fetchLatestRestoreImageURL() async throws -> URL {
+    func fetchLatestRestoreImage() async throws -> LatestRestoreImage {
         Self.logger.info("Fetching latest supported macOS restore image...")
         let restoreImage = try await VZMacOSRestoreImage.latestSupported
-        return restoreImage.url
+        return LatestRestoreImage(
+            url: restoreImage.url,
+            version: MacOSVersion.displayString(restoreImage.operatingSystemVersion),
+            build: restoreImage.buildVersion
+        )
     }
 
     /// Downloads a macOS restore image from a remote URL to the specified destination.

--- a/Kernova/Services/LocalRestoreImageInspector.swift
+++ b/Kernova/Services/LocalRestoreImageInspector.swift
@@ -27,7 +27,7 @@ struct LocalRestoreImageInspector: LocalRestoreImageInspecting {
 
         let version = image.operatingSystemVersion
         let inspected = InspectedRestoreImage(
-            version: Self.versionString(version),
+            version: MacOSVersion.displayString(version),
             build: image.buildVersion,
             isSupportedOnThisHost: image.mostFeaturefulSupportedConfiguration != nil
         )
@@ -35,12 +35,5 @@ struct LocalRestoreImageInspector: LocalRestoreImageInspecting {
             "Inspected local restore image: \(inspected.summary, privacy: .public), supported=\(inspected.isSupportedOnThisHost, privacy: .public)"
         )
         return inspected
-    }
-
-    /// Renders a version, dropping a zero patch the way Apple writes it.
-    static func versionString(_ version: OperatingSystemVersion) -> String {
-        version.patchVersion == 0
-            ? "\(version.majorVersion).\(version.minorVersion)"
-            : "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
     }
 }

--- a/Kernova/Services/Protocols/IPSWProviding.swift
+++ b/Kernova/Services/Protocols/IPSWProviding.swift
@@ -2,7 +2,8 @@ import Foundation
 
 /// Abstraction for IPSW (macOS restore image) fetching and downloading.
 protocol IPSWProviding: Sendable {
-    func fetchLatestRestoreImageURL() async throws -> URL
+    /// The newest restore image Apple offers that this host can install.
+    func fetchLatestRestoreImage() async throws -> LatestRestoreImage
 
     /// Downloads the image at `remoteURL` to `destinationURL`, resuming a
     /// partial download already beside it.

--- a/Kernova/Services/Protocols/RestoreImageProbing.swift
+++ b/Kernova/Services/Protocols/RestoreImageProbing.swift
@@ -42,7 +42,11 @@ protocol RestoreImageProbing: Sendable {
     /// How large the file at `url` is, without downloading it or reading its
     /// structure.
     ///
-    /// The size half of ``probe(_:)``, on its own, for a URL whose contents are
-    /// already trusted — an image Virtualization itself named.
+    /// Holds the URL guarantees ``probe(_:)`` rests on, so both entry points
+    /// enforce them. A scheme other than `https` is refused with
+    /// ``RestoreImageProbeError/insecureURL`` before any request is issued, and a
+    /// server stating a length of zero with
+    /// ``RestoreImageProbeError/unknownSize`` — a returned size is always
+    /// greater than zero.
     func size(of url: URL) async throws -> UInt64
 }

--- a/Kernova/Services/Protocols/RestoreImageProbing.swift
+++ b/Kernova/Services/Protocols/RestoreImageProbing.swift
@@ -38,4 +38,11 @@ protocol RestoreImageProbing: Sendable {
     /// Establishes that `url` serves an image that can install into a VM, and
     /// how large it is, without downloading it.
     func probe(_ url: URL) async throws -> ProbedRestoreImage
+
+    /// How large the file at `url` is, without downloading it or reading its
+    /// structure.
+    ///
+    /// The size half of ``probe(_:)``, on its own, for a URL whose contents are
+    /// already trusted — an image Virtualization itself named.
+    func size(of url: URL) async throws -> UInt64
 }

--- a/Kernova/Services/RestoreImageProbeService.swift
+++ b/Kernova/Services/RestoreImageProbeService.swift
@@ -45,7 +45,7 @@ final class RestoreImageProbeService: RestoreImageProbing {
             throw RestoreImageProbeError.insecureURL
         }
 
-        let sizeBytes = try await totalSize(of: url)
+        let sizeBytes = try await size(of: url)
         guard sizeBytes > 0, let totalBytes = Int64(exactly: sizeBytes) else {
             throw RestoreImageProbeError.unknownSize
         }
@@ -76,7 +76,7 @@ final class RestoreImageProbeService: RestoreImageProbing {
     /// serves the ranged `GET`s the rest of the probe is built from, so a
     /// non-2xx `HEAD` is not fatal: the one-byte ranged `GET`'s `Content-Range`
     /// settles the size, and its status settles whether the URL is live at all.
-    private func totalSize(of url: URL) async throws -> UInt64 {
+    func size(of url: URL) async throws -> UInt64 {
         var head = URLRequest(url: url)
         head.httpMethod = "HEAD"
         if let response = try await responseWithoutBody(for: head),

--- a/Kernova/Services/RestoreImageProbeService.swift
+++ b/Kernova/Services/RestoreImageProbeService.swift
@@ -41,12 +41,9 @@ final class RestoreImageProbeService: RestoreImageProbing {
     }
 
     func probe(_ url: URL) async throws -> ProbedRestoreImage {
-        guard url.scheme?.lowercased() == "https" else {
-            throw RestoreImageProbeError.insecureURL
-        }
-
+        // `size(of:)` owns the HTTPS-only refusal and the non-zero floor.
         let sizeBytes = try await size(of: url)
-        guard sizeBytes > 0, let totalBytes = Int64(exactly: sizeBytes) else {
+        guard let totalBytes = Int64(exactly: sizeBytes) else {
             throw RestoreImageProbeError.unknownSize
         }
 
@@ -77,6 +74,10 @@ final class RestoreImageProbeService: RestoreImageProbing {
     /// non-2xx `HEAD` is not fatal: the one-byte ranged `GET`'s `Content-Range`
     /// settles the size, and its status settles whether the URL is live at all.
     func size(of url: URL) async throws -> UInt64 {
+        guard url.scheme?.lowercased() == "https" else {
+            throw RestoreImageProbeError.insecureURL
+        }
+
         var head = URLRequest(url: url)
         head.httpMethod = "HEAD"
         if let response = try await responseWithoutBody(for: head),
@@ -100,9 +101,13 @@ final class RestoreImageProbeService: RestoreImageProbing {
             throw RestoreImageProbeError.rangeRequestsUnsupported
         }
         // `Content-Range: bytes 0-0/19772077142` — the total is after the slash.
+        // A stated zero is refused here rather than returned: callers format the
+        // result as a download size, and `bytes 0-0/0` is a server that does not
+        // know the length, not a file with no bytes.
         guard let range = response.value(forHTTPHeaderField: "Content-Range"),
             let total = range.split(separator: "/").last,
-            let bytes = UInt64(total.trimmingCharacters(in: .whitespaces))
+            let bytes = UInt64(total.trimmingCharacters(in: .whitespaces)),
+            bytes > 0
         else {
             throw RestoreImageProbeError.unknownSize
         }

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -70,20 +70,26 @@ final class VMCreationViewModel {
     /// touch it.
     let catalogService: any RestoreImageCatalogProviding
 
-    /// Backs the "Paste an IPSW URL…" sheet's pre-download check.
+    /// Backs the "Paste an IPSW URL…" sheet's pre-download check; its size read
+    /// alone also sizes the image "Download Latest" would fetch.
     let probeService: any RestoreImageProbing
 
     /// Reads an IPSW already on disk before the wizard adopts it.
     let localImageInspector: any LocalRestoreImageInspecting
 
+    /// Names what "Download Latest" will fetch, for the wizard to show.
+    let ipswService: any IPSWProviding
+
     init(
         catalogService: any RestoreImageCatalogProviding = RestoreImageCatalogService(),
         probeService: any RestoreImageProbing = RestoreImageProbeService(),
-        localImageInspector: any LocalRestoreImageInspecting = LocalRestoreImageInspector()
+        localImageInspector: any LocalRestoreImageInspecting = LocalRestoreImageInspector(),
+        ipswService: any IPSWProviding = IPSWService()
     ) {
         self.catalogService = catalogService
         self.probeService = probeService
         self.localImageInspector = localImageInspector
+        self.ipswService = ipswService
     }
 
     // MARK: - Wizard State
@@ -101,6 +107,24 @@ final class VMCreationViewModel {
 
     /// Which source is current, for the radios and the source labels.
     var ipswSource: IPSWSource { ipswSelection.source }
+
+    /// What "Download Latest" will fetch, once ``loadLatestImageDetails()`` has
+    /// answered; `nil` until then, and after a lookup that failed.
+    ///
+    /// Display only. The install resolves the latest image itself when it
+    /// starts, so this pins nothing — which is why the source still promises no
+    /// particular build (see ``pinnedBuild``).
+    private(set) var latestImage: LatestRestoreImage?
+
+    /// How large ``latestImage`` is, when the server reported a size.
+    ///
+    /// A second read, so it can be absent while the version and build are
+    /// known; the wizard then names those alone.
+    private(set) var latestImageSizeBytes: UInt64?
+
+    /// The lookup in flight, so a second trigger joins it instead of starting
+    /// another.
+    private var latestImageTask: Task<Void, Never>?
 
     /// The last catalog pick, kept after the source moves off it so the version
     /// picker re-opens on it.
@@ -305,6 +329,47 @@ final class VMCreationViewModel {
     /// is `nil` when the bookmark could not be created.
     func selectLocalFile(path: String, bookmark: Data?) {
         ipswSelection = .localFile(path: path, bookmark: bookmark)
+    }
+
+    // MARK: - Latest Image Lookup
+
+    /// Looks up what "Download Latest" would fetch, so the wizard can name the
+    /// version, build and size that source otherwise leaves unsaid.
+    ///
+    /// Idempotent: calls while a lookup runs join it, calls after one succeeded
+    /// do nothing, and one that failed retries on the next call — a wizard the
+    /// user is walking through triggers this more than once. A failure is not
+    /// surfaced: the wizard names the download destination alone, which is what
+    /// it showed before the lookup existed.
+    ///
+    /// - Returns: the lookup to await for its result, or `nil` when the details
+    ///   are already known and nothing had to run.
+    @discardableResult
+    func loadLatestImageDetails() -> Task<Void, Never>? {
+        if let latestImageTask { return latestImageTask }
+        guard latestImage == nil else { return nil }
+        let ipswService = self.ipswService
+        let probeService = self.probeService
+        let task = Task { [weak self] in
+            defer { self?.latestImageTask = nil }
+            let image: LatestRestoreImage
+            do {
+                image = try await ipswService.fetchLatestRestoreImage()
+            } catch {
+                Self.logger.warning(
+                    "Could not look up the latest restore image: \(error.localizedDescription, privacy: .public)"
+                )
+                return
+            }
+            // The size is a separate request, and the version and build are
+            // worth showing without it.
+            let sizeBytes = try? await probeService.size(of: image.url)
+            guard let self else { return }
+            self.latestImage = image
+            self.latestImageSizeBytes = sizeBytes
+        }
+        latestImageTask = task
+        return task
     }
 
     // MARK: - Apply Defaults

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -111,9 +111,7 @@ final class VMCreationViewModel {
     /// What "Download Latest" will fetch, once ``loadLatestImageDetails()`` has
     /// answered; `nil` until then, and after a lookup that failed.
     ///
-    /// Display only. The install resolves the latest image itself when it
-    /// starts, so this pins nothing — which is why the source still promises no
-    /// particular build (see ``pinnedBuild``).
+    /// Display only, on the terms ``LatestRestoreImage`` states.
     private(set) var latestImage: LatestRestoreImage?
 
     /// How large ``latestImage`` is, when the server reported a size.

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -271,7 +271,7 @@ final class VMLifecycleCoordinator {
                         }
                         remoteURL = pinnedURL
                     } else {
-                        remoteURL = try await ipswService.fetchLatestRestoreImageURL()
+                        remoteURL = try await ipswService.fetchLatestRestoreImage().url
                     }
 
                     try await ipswService.downloadRestoreImage(

--- a/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
@@ -1,12 +1,12 @@
 import AppKit
 import UniformTypeIdentifiers
 
-/// Step 2 of the creation wizard for macOS guests: choose the IPSW restore image
-/// source (download latest vs. local file), show the chosen path, and surface
+/// Step 2 of the creation wizard for macOS guests: choose where the IPSW restore
+/// image comes from, show which image that is and where it lands, and surface
 /// overwrite/resume warnings.
 ///
 /// All controls mutate the shared ``VMCreationViewModel`` and then call
-/// ``refresh()`` to reconcile the radios, path badge, and banners in place. The
+/// ``refresh()`` to reconcile the radios, badge, and banners in place. The
 /// shell observes the model separately to keep its Next button in sync.
 @MainActor
 final class IPSWSelectionContentViewController: NSViewController {
@@ -29,10 +29,15 @@ final class IPSWSelectionContentViewController: NSViewController {
     private var existingFileNotice: ExistingFileNotice?
     /// In-flight inspection, so a second click can't race the first.
     private var adoptTask: Task<Void, Never>?
+    /// Redraws the badge once the model's latest-image lookup lands.
+    private var latestImageTask: Task<Void, Never>?
 
     #if DEBUG
     /// Awaited by tests instead of polling for the verdict to land.
     var adoptTaskForTesting: Task<Void, Never>? { adoptTask }
+
+    /// Awaited by tests instead of polling for the badge to be redrawn.
+    var latestImageTaskForTesting: Task<Void, Never>? { latestImageTask }
     #endif
     /// Shows the "more content below" cue while this step's content overflows the
     /// sheet; a hint only.
@@ -107,6 +112,11 @@ final class IPSWSelectionContentViewController: NSViewController {
         refresh()
     }
 
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        startLatestImageLookup()
+    }
+
     override func viewWillDisappear() {
         super.viewWillDisappear()
         // The step is swapped out on navigation; a picker left attached to a
@@ -114,6 +124,27 @@ final class IPSWSelectionContentViewController: NSViewController {
         catalogSheetPresenter.reset()
         adoptTask?.cancel()
         adoptTask = nil
+        // Only this VC's redraw is dropped: the lookup itself belongs to the
+        // model, so it still lands for the Review step.
+        latestImageTask?.cancel()
+        latestImageTask = nil
+    }
+
+    /// Asks the model what "Download Latest" will fetch, and shows it when the
+    /// answer lands.
+    ///
+    /// The model's lookup is idempotent, so re-entering the step joins one
+    /// already running rather than starting a second.
+    private func startLatestImageLookup() {
+        guard latestImageTask == nil, let lookup = creationVM.loadLatestImageDetails() else {
+            return
+        }
+        latestImageTask = Task { [weak self] in
+            await lookup.value
+            guard let self, !Task.isCancelled else { return }
+            self.latestImageTask = nil
+            self.rebuildConditional()
+        }
     }
 
     // MARK: - Source radios
@@ -135,6 +166,8 @@ final class IPSWSelectionContentViewController: NSViewController {
         case .downloadLatest:
             creationVM.selectDownloadLatest()
             refresh()
+            // Retries a lookup that failed while another source was selected.
+            startLatestImageLookup()
         case .catalogVersion:
             // Same deferred-commit rule as Choose Local File below.
             refresh()
@@ -172,23 +205,39 @@ final class IPSWSelectionContentViewController: NSViewController {
 
         switch creationVM.ipswSelection {
         case .downloadLatest:
-            // No "Change…" affordance: the destination is always the Downloads
-            // folder, the one location the sandbox's downloads entitlement covers
-            // without per-pick grants.
-            conditionalContainer.addArrangedSubview(
-                makeWizardPathBadge(path: creationVM.ipswDownloadPath))
+            if let latest = creationVM.latestImage {
+                // Nothing here is the user's to change: installing a particular
+                // build is what the other sources are for, and the destination
+                // is always Downloads, the one location the sandbox's downloads
+                // entitlement covers without per-pick grants.
+                addPinnedImageBadge(
+                    parts: [
+                        "macOS \(latest.version)", "Build \(latest.build)",
+                        creationVM.latestImageSizeBytes.map(DataFormatters.formatBytes),
+                    ],
+                    changeAction: nil
+                )
+            } else {
+                conditionalContainer.addArrangedSubview(
+                    makeWizardPathBadge(path: creationVM.ipswDownloadPath))
+            }
+            // `version: nil` even once the lookup lands: this source pins no
+            // build and shares one destination filename, so the file already
+            // sitting there may be any image, and naming the version the badge
+            // shows would describe that file wrongly.
             addDownloadBanners(version: nil)
         case .catalogVersion(let entry):
             addPinnedImageBadge(
-                summary:
-                    "macOS \(entry.version)  ·  Build \(entry.build)  ·  \(DataFormatters.formatBytes(entry.sizeBytes))",
+                parts: [
+                    "macOS \(entry.version)", "Build \(entry.build)",
+                    DataFormatters.formatBytes(entry.sizeBytes),
+                ],
                 changeAction: #selector(changeCatalogVersion)
             )
             addDownloadBanners(version: entry.version)
         case .customURL(let image):
             addPinnedImageBadge(
-                summary:
-                    "\(image.versionSummary)  ·  \(DataFormatters.formatBytes(image.sizeBytes))",
+                parts: [image.versionSummary, DataFormatters.formatBytes(image.sizeBytes)],
                 changeAction: #selector(changePastedURL)
             )
             addDownloadBanners(version: image.version)
@@ -199,17 +248,21 @@ final class IPSWSelectionContentViewController: NSViewController {
         }
     }
 
-    /// Adds the one badge a pinned-image source shows: what was chosen, and
-    /// where it will land.
+    /// Adds the one badge a download source shows: which image it will fetch,
+    /// and where that image will land.
     ///
     /// One two-line badge rather than two badges — with four sources listed,
-    /// two badges no longer fit the fixed-size sheet without scrolling.
-    private func addPinnedImageBadge(summary: String, changeAction: Selector) {
-        let change = makeLinkButton("Change…", target: self, action: changeAction)
+    /// two badges no longer fit the fixed-size sheet without scrolling. Every
+    /// source composes its title line from `parts` here, so they read alike;
+    /// a part the source doesn't know drops out.
+    private func addPinnedImageBadge(parts: [String?], changeAction: Selector?) {
+        let change = changeAction.map {
+            makeLinkButton("Change…", target: self, action: $0)
+        }
         conditionalContainer.addArrangedSubview(
             makeWizardBadge(
                 symbolName: "shippingbox.fill",
-                text: summary,
+                text: parts.compactMap { $0 }.joined(separator: "  ·  "),
                 secondaryText: wizardAbbreviateWithTilde(creationVM.ipswDownloadPath),
                 trailingButton: change
             ))

--- a/Kernova/Views/Creation/ReviewContentViewController.swift
+++ b/Kernova/Views/Creation/ReviewContentViewController.swift
@@ -79,6 +79,16 @@ final class ReviewContentViewController: NSViewController {
             switch creationVM.ipswSelection {
             case .downloadLatest:
                 rows.append(valueRow("Restore Image", "Download Latest"))
+                // Only once the lookup has answered — this source names no
+                // particular image on its own.
+                if let latest = creationVM.latestImage {
+                    rows.append(
+                        valueRow("macOS Version", "\(latest.version) (\(latest.build))"))
+                    if let sizeBytes = creationVM.latestImageSizeBytes {
+                        rows.append(
+                            valueRow("Download Size", DataFormatters.formatBytes(sizeBytes)))
+                    }
+                }
             case .catalogVersion(let entry):
                 rows.append(valueRow("Restore Image", "Chosen Version"))
                 rows.append(valueRow("macOS Version", "\(entry.version) (\(entry.build))"))

--- a/Kernova/Views/Creation/ReviewContentViewController.swift
+++ b/Kernova/Views/Creation/ReviewContentViewController.swift
@@ -4,12 +4,21 @@ import AppKit
 ///
 /// Read-only rows plus a "start after create" switch, built from a snapshot of
 /// the shared ``VMCreationViewModel``. The shell rebuilds this VC each time the
-/// review step is entered, so it always reflects current values; no intra-step
-/// observation is needed.
+/// review step is entered, so it always reflects current values; the only
+/// intra-step change is the latest-image lookup landing.
 @MainActor
 final class ReviewContentViewController: NSViewController {
     private let creationVM: VMCreationViewModel
     private let startSwitch = NSSwitch()
+    /// Rebuilt by ``rebuildSummary()`` when the latest-image lookup lands.
+    private let summary = NSStackView()
+    /// Redraws the rows once the model's latest-image lookup lands.
+    private var latestImageTask: Task<Void, Never>?
+
+    #if DEBUG
+    /// Awaited by tests instead of polling for the rows to be redrawn.
+    var latestImageTaskForTesting: Task<Void, Never>? { latestImageTask }
+    #endif
     /// Shows the "more content below" cue while this summary doesn't fit the
     /// sheet; a hint only.
     private var scrollMoreIndicator: ScrollMoreIndicator?
@@ -29,7 +38,12 @@ final class ReviewContentViewController: NSViewController {
         let subtitle = makeWizardSubtitle(
             "Review your virtual machine settings before creating it.")
 
-        let summary = makeSummary()
+        summary.orientation = .vertical
+        summary.alignment = .leading
+        summary.spacing = Spacing.standard
+        summary.translatesAutoresizingMaskIntoConstraints = false
+        rebuildSummary()
+
         let stack = NSStackView(views: [title, subtitle, summary])
         stack.orientation = .vertical
         stack.alignment = .leading
@@ -47,12 +61,49 @@ final class ReviewContentViewController: NSViewController {
         scrollMoreIndicator = ScrollMoreIndicator(scrollView: scrollView)
     }
 
-    private func makeSummary() -> NSView {
-        let form = NSStackView()
-        form.orientation = .vertical
-        form.alignment = .leading
-        form.spacing = Spacing.standard
-        form.translatesAutoresizingMaskIntoConstraints = false
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        startLatestImageLookup()
+    }
+
+    override func viewWillDisappear() {
+        super.viewWillDisappear()
+        // Only this VC's redraw is dropped: the lookup itself belongs to the
+        // model, so it still lands for the step shown next.
+        latestImageTask?.cancel()
+        latestImageTask = nil
+    }
+
+    /// Asks the model what "Download Latest" will fetch, and names it in the rows
+    /// when the answer lands.
+    ///
+    /// A user who reached this step before a slow lookup answered would otherwise
+    /// never see those rows. The model's lookup is idempotent, so this joins one
+    /// already running rather than starting a second, and retries one that failed
+    /// on an earlier step.
+    private func startLatestImageLookup() {
+        // The rows it fills in belong to this one source; every other source
+        // already names its image, and a Linux guest has none.
+        guard creationVM.selectedOS == .macOS, creationVM.ipswSource == .downloadLatest else {
+            return
+        }
+        guard latestImageTask == nil, let lookup = creationVM.loadLatestImageDetails() else {
+            return
+        }
+        latestImageTask = Task { [weak self] in
+            await lookup.value
+            guard let self, !Task.isCancelled else { return }
+            self.latestImageTask = nil
+            self.rebuildSummary()
+        }
+    }
+
+    /// Fills the summary in from the model, replacing whatever it already held.
+    private func rebuildSummary() {
+        for view in summary.arrangedSubviews {
+            summary.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
 
         addSection(
             "General",
@@ -60,7 +111,7 @@ final class ReviewContentViewController: NSViewController {
                 valueRow("Name", creationVM.vmName),
                 valueRow("Operating System", creationVM.selectedOS.displayName),
                 valueRow("Boot Mode", creationVM.effectiveBootMode.displayName),
-            ], to: form)
+            ], to: summary)
 
         addSection(
             "Resources",
@@ -68,11 +119,11 @@ final class ReviewContentViewController: NSViewController {
                 valueRow("CPU Cores", "\(creationVM.cpuCount)"),
                 valueRow("Memory", "\(creationVM.memoryInGB) GB"),
                 valueRow("Disk Size", DataFormatters.formatDiskSize(creationVM.diskSizeInGB)),
-            ], to: form)
+            ], to: summary)
 
         addSection(
             "Network",
-            rows: [valueRow("Networking", creationVM.networkEnabled ? "Enabled" : "Disabled")], to: form)
+            rows: [valueRow("Networking", creationVM.networkEnabled ? "Enabled" : "Disabled")], to: summary)
 
         if creationVM.selectedOS == .macOS {
             var rows: [NSView] = []
@@ -107,7 +158,7 @@ final class ReviewContentViewController: NSViewController {
                 rows.append(
                     valueRow("Save to", wizardAbbreviateWithTilde(creationVM.ipswDownloadPath)))
             }
-            addSection("Installation", rows: rows, to: form)
+            addSection("Installation", rows: rows, to: summary)
         }
 
         if creationVM.selectedOS == .linux {
@@ -118,20 +169,18 @@ final class ReviewContentViewController: NSViewController {
             if let path = creationVM.kernelPath {
                 rows.append(valueRow("Kernel", URL(fileURLWithPath: path).lastPathComponent))
             }
-            if !rows.isEmpty { addSection("Boot", rows: rows, to: form) }
+            if !rows.isEmpty { addSection("Boot", rows: rows, to: summary) }
         }
 
         startSwitch.controlSize = .small
         startSwitch.state = creationVM.startAfterCreate ? .on : .off
         startSwitch.target = self
         startSwitch.action = #selector(startToggled)
-        if let last = form.arrangedSubviews.last {
-            form.setCustomSpacing(18, after: last)
+        if let last = summary.arrangedSubviews.last {
+            summary.setCustomSpacing(18, after: last)
         }
         addCard(
-            [makeGroupedFormCardRow("Start this VM after creation", control: startSwitch)], to: form)
-
-        return form
+            [makeGroupedFormCardRow("Start this VM after creation", control: startSwitch)], to: summary)
     }
 
     /// Adds a section: a header followed by a grouped card of its rows.

--- a/KernovaTests/IPSWSelectionContentViewControllerTests.swift
+++ b/KernovaTests/IPSWSelectionContentViewControllerTests.swift
@@ -19,6 +19,60 @@ struct IPSWSelectionContentViewControllerTests {
             findLabel(withText: wizardAbbreviateWithTilde(vm.ipswDownloadPath), in: vc.view) != nil)
     }
 
+    @Test("Download Latest names the image it will fetch, the way a pinned pick does")
+    func downloadLatestShowsLookedUpImage() async {
+        let probeService = MockRestoreImageProbeService()
+        probeService.sizeResult = 19_772_077_142
+        let vm = VMCreationViewModel(probeService: probeService, ipswService: MockIPSWService())
+
+        let vc = IPSWSelectionContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+        // Mounting the step is what asks; the badge upgrades when it answers.
+        vc.viewDidAppear()
+        await vc.latestImageTaskForTesting?.value
+
+        #expect(
+            findLabelContaining(
+                "macOS 26.5.2  ·  Build 25F84  ·  \(DataFormatters.formatBytes(19_772_077_142))",
+                in: vc.view) != nil)
+        // The destination stays on the badge's second line.
+        #expect(
+            findLabel(withText: wizardAbbreviateWithTilde(vm.ipswDownloadPath), in: vc.view) != nil)
+        // Nothing about "latest" is the user's to change.
+        #expect(findButton(titled: "Change…", in: vc.view) == nil)
+    }
+
+    @Test("A size the server won't report leaves the version and build on the badge")
+    func downloadLatestShowsImageWithoutItsSize() async {
+        let probeService = MockRestoreImageProbeService()
+        probeService.sizeError = RestoreImageProbeError.unknownSize
+        let vm = VMCreationViewModel(probeService: probeService, ipswService: MockIPSWService())
+
+        let vc = IPSWSelectionContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+        vc.viewDidAppear()
+        await vc.latestImageTaskForTesting?.value
+
+        #expect(findLabelContaining("macOS 26.5.2  ·  Build 25F84", in: vc.view) != nil)
+    }
+
+    @Test("A failed lookup leaves the destination-only badge the step always had")
+    func downloadLatestFallsBackToThePathBadge() async {
+        let ipswService = MockIPSWService()
+        ipswService.fetchError = URLError(.notConnectedToInternet)
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(), ipswService: ipswService)
+
+        let vc = IPSWSelectionContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+        vc.viewDidAppear()
+        await vc.latestImageTaskForTesting?.value
+
+        #expect(
+            findLabel(withText: wizardAbbreviateWithTilde(vm.ipswDownloadPath), in: vc.view) != nil)
+        #expect(findLabelContaining("Build", in: vc.view) == nil)
+    }
+
     @Test("Overwrite warning shows when a file exists; Use Existing switches to local file")
     func overwriteUseExisting() async {
         let path = makeTempIPSW()

--- a/KernovaTests/Mocks/MockIPSWService.swift
+++ b/KernovaTests/Mocks/MockIPSWService.swift
@@ -23,10 +23,14 @@ final class MockIPSWService: IPSWProviding, @unchecked Sendable {
     var fetchError: (any Error)?
     var downloadError: (any Error)?
 
-    func fetchLatestRestoreImageURL() async throws -> URL {
+    /// Returned on success; defaults to a plausible newest release.
+    var fetchResult = LatestRestoreImage(
+        url: MockIPSWService.mockRestoreImageURL, version: "26.5.2", build: "25F84")
+
+    func fetchLatestRestoreImage() async throws -> LatestRestoreImage {
         fetchCallCount += 1
         if let error = fetchError { throw error }
-        return Self.mockRestoreImageURL
+        return fetchResult
     }
 
     func downloadRestoreImage(

--- a/KernovaTests/Mocks/MockRestoreImageProbeService.swift
+++ b/KernovaTests/Mocks/MockRestoreImageProbeService.swift
@@ -6,17 +6,28 @@ import Foundation
 final class MockRestoreImageProbeService: RestoreImageProbing, @unchecked Sendable {
     var probeCallCount = 0
     var lastProbedURL: URL?
+    var sizeCallCount = 0
+    var lastSizedURL: URL?
 
     /// Thrown instead of returning, per the per-method `<method>Error` convention.
     var probeError: (any Error)?
+    var sizeError: (any Error)?
     /// Returned on success; defaults to a well-formed Apple image.
     var probeResult: ProbedRestoreImage = makeProbedImage()
+    var sizeResult: UInt64 = 19_772_077_142
 
     func probe(_ url: URL) async throws -> ProbedRestoreImage {
         probeCallCount += 1
         lastProbedURL = url
         if let error = probeError { throw error }
         return probeResult
+    }
+
+    func size(of url: URL) async throws -> UInt64 {
+        sizeCallCount += 1
+        lastSizedURL = url
+        if let error = sizeError { throw error }
+        return sizeResult
     }
 }
 

--- a/KernovaTests/RestoreImageProbeTests.swift
+++ b/KernovaTests/RestoreImageProbeTests.swift
@@ -168,6 +168,32 @@ struct RestoreImageFilenameTests {
     }
 }
 
+@Suite("MacOSVersion Tests")
+struct MacOSVersionTests {
+    @Test("A version reads the way Apple names the release")
+    func displayStringDropsAZeroPatch() {
+        #expect(
+            MacOSVersion.displayString(
+                OperatingSystemVersion(majorVersion: 26, minorVersion: 5, patchVersion: 2))
+                == "26.5.2")
+        #expect(
+            MacOSVersion.displayString(
+                OperatingSystemVersion(majorVersion: 26, minorVersion: 6, patchVersion: 0))
+                == "26.6")
+        #expect(
+            MacOSVersion.displayString(
+                OperatingSystemVersion(majorVersion: 12, minorVersion: 0, patchVersion: 1))
+                == "12.0.1")
+    }
+
+    @Test("What it renders is what the catalog's own version strings parse as")
+    func displayStringRoundTripsThroughTheParser() {
+        let rendered = MacOSVersion.displayString(
+            OperatingSystemVersion(majorVersion: 26, minorVersion: 5, patchVersion: 2))
+        #expect(MacOSVersion(rendered)?.components == [26, 5, 2])
+    }
+}
+
 /// Stub for the probe's requests.
 ///
 /// Deliberately its own class rather than `StubURLProtocol`: that one's handler
@@ -434,6 +460,16 @@ struct RestoreImageProbeServiceTests {
         #expect(image.version == "15.6.1")
         #expect(image.build == "24G90")
         #expect(image.url == imageURL)
+    }
+
+    @Test("The size alone is read without touching the image's structure")
+    func sizeReadsOnlyTheLength() async throws {
+        // No zip structure at all: a size read must not depend on one, which is
+        // what lets it serve an image Virtualization already vouched for.
+        serve(total: 19_772_077_142, body: Data())
+        defer { ProbeStubURLProtocol.reset() }
+
+        #expect(try await makeService().size(of: imageURL) == 19_772_077_142)
     }
 
     @Test("An image with no VM hardware model is refused")

--- a/KernovaTests/RestoreImageProbeTests.swift
+++ b/KernovaTests/RestoreImageProbeTests.swift
@@ -497,6 +497,45 @@ struct RestoreImageProbeServiceTests {
         }
     }
 
+    @Test("The size read refuses a non-HTTPS URL before any request too")
+    func sizeRefusesInsecureURL() async throws {
+        let http = try #require(URL(string: "http://updates.cdn-apple.com/x/R.ipsw"))
+        ProbeStubURLProtocol.reset()
+        ProbeStubURLProtocol.handler = { _ in
+            Issue.record("The size read issued a request for a non-HTTPS URL")
+            return ProbeStubURLProtocol.Reply(statusCode: 200, body: Data(), headers: [:])
+        }
+        defer { ProbeStubURLProtocol.reset() }
+
+        await #expect(throws: RestoreImageProbeError.insecureURL) {
+            _ = try await makeService().size(of: http)
+        }
+    }
+
+    @Test("A server stating a length of zero is refused, not reported as a size")
+    func refusesZeroLength() async {
+        ProbeStubURLProtocol.reset()
+        ProbeStubURLProtocol.handler = { request in
+            if request.httpMethod == "HEAD" {
+                return ProbeStubURLProtocol.Reply(
+                    statusCode: 200, body: Data(), headers: ["Content-Length": "0"])
+            }
+            return ProbeStubURLProtocol.Reply(
+                statusCode: 206, body: Data([0x00]),
+                headers: ["Content-Range": "bytes 0-0/0"])
+        }
+        defer { ProbeStubURLProtocol.reset() }
+
+        // Both entry points, since a zero reaching either one would be formatted
+        // as a download size.
+        await #expect(throws: RestoreImageProbeError.unknownSize) {
+            _ = try await makeService().size(of: imageURL)
+        }
+        await #expect(throws: RestoreImageProbeError.unknownSize) {
+            _ = try await makeService().probe(imageURL)
+        }
+    }
+
     @Test("A URL that answers nothing but 404 is refused with its status")
     func refusesMissingImage() async {
         ProbeStubURLProtocol.reset()

--- a/KernovaTests/RestoreImageURLSheetContentViewControllerTests.swift
+++ b/KernovaTests/RestoreImageURLSheetContentViewControllerTests.swift
@@ -228,6 +228,11 @@ private final class SuspendingProbeService: RestoreImageProbing, @unchecked Send
         return probeResult
     }
 
+    /// Not exercised here: the sheet checks a URL, it never asks for a size alone.
+    func size(of url: URL) async throws -> UInt64 {
+        probeResult.sizeBytes
+    }
+
     /// Suspends until `probe` is in flight.
     func waitUntilProbing() async throws {
         try await gate.wait(until: { self.lock.withLock { self.isProbing } })

--- a/KernovaTests/ReviewContentViewControllerTests.swift
+++ b/KernovaTests/ReviewContentViewControllerTests.swift
@@ -40,6 +40,23 @@ struct ReviewContentViewControllerTests {
             findLabel(withText: wizardAbbreviateWithTilde(vm.ipswDownloadPath), in: vc.view) != nil)
     }
 
+    @Test("macOS + download names the looked-up version, build and size")
+    func macOSDownloadShowsLookedUpImage() async {
+        let probeService = MockRestoreImageProbeService()
+        probeService.sizeResult = 19_772_077_142
+        let vm = VMCreationViewModel(probeService: probeService, ipswService: MockIPSWService())
+        await vm.loadLatestImageDetails()?.value
+
+        let vc = ReviewContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+
+        #expect(findLabel(withText: "Download Latest", in: vc.view) != nil)
+        #expect(findLabel(withText: "26.5.2 (25F84)", in: vc.view) != nil)
+        #expect(
+            findLabel(
+                withText: DataFormatters.formatBytes(19_772_077_142), in: vc.view) != nil)
+    }
+
     @Test("macOS + local file shows the file basename")
     func macOSLocalFileShowsFile() {
         let vm = VMCreationViewModel()

--- a/KernovaTests/ReviewContentViewControllerTests.swift
+++ b/KernovaTests/ReviewContentViewControllerTests.swift
@@ -57,6 +57,61 @@ struct ReviewContentViewControllerTests {
                 withText: DataFormatters.formatBytes(19_772_077_142), in: vc.view) != nil)
     }
 
+    @Test("A lookup landing after this step appears fills the version and size in")
+    func macOSDownloadFillsInLateLookup() async {
+        let probeService = MockRestoreImageProbeService()
+        probeService.sizeResult = 19_772_077_142
+        let vm = VMCreationViewModel(probeService: probeService, ipswService: MockIPSWService())
+
+        let vc = ReviewContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+        // Reaching the step ahead of the answer, as a slow or offline lookup does.
+        #expect(findLabel(withText: "26.5.2 (25F84)", in: vc.view) == nil)
+
+        vc.viewDidAppear()
+        await vc.latestImageTaskForTesting?.value
+
+        #expect(findLabel(withText: "26.5.2 (25F84)", in: vc.view) != nil)
+        #expect(
+            findLabel(
+                withText: DataFormatters.formatBytes(19_772_077_142), in: vc.view) != nil)
+        // The rows that were already there survive the redraw.
+        #expect(findLabel(withText: "Download Latest", in: vc.view) != nil)
+    }
+
+    @Test("A lookup that fails leaves the step showing the destination alone")
+    func macOSDownloadSurvivesFailedLookup() async {
+        let ipswService = MockIPSWService()
+        ipswService.fetchError = URLError(.notConnectedToInternet)
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(), ipswService: ipswService)
+
+        let vc = ReviewContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+        vc.viewDidAppear()
+        await vc.latestImageTaskForTesting?.value
+
+        #expect(findLabel(withText: "Download Latest", in: vc.view) != nil)
+        #expect(findLabel(withText: "macOS Version", in: vc.view) == nil)
+        #expect(
+            findLabel(withText: wizardAbbreviateWithTilde(vm.ipswDownloadPath), in: vc.view) != nil)
+    }
+
+    @Test("A Linux review never reaches for a restore image")
+    func linuxSkipsLatestImageLookup() {
+        let ipswService = MockIPSWService()
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(), ipswService: ipswService)
+        vm.selectedOS = .linux
+
+        let vc = ReviewContentViewController(creationVM: vm)
+        vc.loadViewIfNeeded()
+        vc.viewDidAppear()
+
+        #expect(vc.latestImageTaskForTesting == nil)
+        #expect(ipswService.fetchCallCount == 0)
+    }
+
     @Test("macOS + local file shows the file basename")
     func macOSLocalFileShowsFile() {
         let vm = VMCreationViewModel()

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -1013,6 +1013,84 @@ struct VMCreationViewModelTests {
         // The seed survives so the version picker re-opens on the old pick.
         #expect(vm.lastCatalogPick == entry)
     }
+
+    // MARK: - Latest Image Lookup
+
+    @Test("The lookup names the version, build and size Download Latest will fetch")
+    func latestImageLookupPopulatesDetails() async {
+        let ipswService = MockIPSWService()
+        let probeService = MockRestoreImageProbeService()
+        probeService.sizeResult = 19_772_077_142
+        let vm = VMCreationViewModel(probeService: probeService, ipswService: ipswService)
+
+        await vm.loadLatestImageDetails()?.value
+
+        #expect(vm.latestImage?.version == "26.5.2")
+        #expect(vm.latestImage?.build == "25F84")
+        #expect(vm.latestImageSizeBytes == 19_772_077_142)
+        // The size is read for the image the lookup named, not for the wizard's
+        // own destination.
+        #expect(probeService.lastSizedURL == ipswService.fetchResult.url)
+    }
+
+    @Test("A second lookup joins the first instead of re-fetching")
+    func latestImageLookupRunsOnce() async {
+        let ipswService = MockIPSWService()
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(), ipswService: ipswService)
+
+        let first = vm.loadLatestImageDetails()
+        #expect(vm.loadLatestImageDetails() == first)
+        await first?.value
+
+        // Nothing left to look up, so a later call starts nothing at all.
+        #expect(vm.loadLatestImageDetails() == nil)
+        #expect(ipswService.fetchCallCount == 1)
+    }
+
+    @Test("A failed lookup leaves the details unset, and the next call retries")
+    func latestImageLookupFailureRetries() async {
+        let ipswService = MockIPSWService()
+        ipswService.fetchError = URLError(.notConnectedToInternet)
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(), ipswService: ipswService)
+
+        await vm.loadLatestImageDetails()?.value
+        #expect(vm.latestImage == nil)
+        #expect(vm.latestImageSizeBytes == nil)
+
+        // Back online, the wizard asks again — a failure must not latch.
+        ipswService.fetchError = nil
+        await vm.loadLatestImageDetails()?.value
+        #expect(vm.latestImage?.build == "25F84")
+        #expect(ipswService.fetchCallCount == 2)
+    }
+
+    @Test("A size that can't be read still leaves the version and build to show")
+    func latestImageLookupSurvivesAnUnknownSize() async {
+        let probeService = MockRestoreImageProbeService()
+        probeService.sizeError = RestoreImageProbeError.unknownSize
+        let vm = VMCreationViewModel(probeService: probeService, ipswService: MockIPSWService())
+
+        await vm.loadLatestImageDetails()?.value
+
+        #expect(vm.latestImage?.version == "26.5.2")
+        #expect(vm.latestImageSizeBytes == nil)
+    }
+
+    @Test("The looked-up image pins nothing: any usable file at the destination is adopted")
+    func latestImageLookupPinsNoBuild() async {
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(), ipswService: MockIPSWService())
+
+        await vm.loadLatestImageDetails()?.value
+
+        // Naming a build here would make a file of a different build a
+        // mismatch, at a destination this source shares with every other
+        // Download Latest.
+        #expect(vm.latestImage != nil)
+        #expect(vm.pinnedBuild == nil)
+    }
 }
 
 /// Inspector stand-in that stays inside `inspect` until the test releases it,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,8 +181,10 @@ calls `applyLiveRemovableMediaChange(for:target:)`.
   It serializes lifecycle operations per VM; `stop` and `forceStop` deliberately bypass that
   serialization so a hung operation can always be cancelled.
 - `VMCreationViewModel` — a pure `@Observable` state machine for the creation wizard, with no
-  UI-framework dependency. Injects `RestoreImageCatalogProviding` for the version picker and
-  `RestoreImageProbing` for the paste-a-URL sheet.
+  UI-framework dependency. Each macOS restore-image source is backed by an injected service
+  protocol, so the wizard can name the version, build and size the source will install before
+  anything is downloaded — including "Download Latest", which reaches `IPSWProviding` for what VZ
+  would resolve. The install re-resolves that image itself, so nothing shown here pins it.
 - `VMDirectoryWatcher` — a `DispatchSource` on the VMs directory that triggers reconciliation in
   `VMLibraryViewModel` when the library changes on disk.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -184,7 +184,7 @@ calls `applyLiveRemovableMediaChange(for:target:)`.
   UI-framework dependency. Each macOS restore-image source is backed by an injected service
   protocol, so the wizard can name the version, build and size the source will install before
   anything is downloaded — including "Download Latest", which reaches `IPSWProviding` for what VZ
-  would resolve. The install re-resolves that image itself, so nothing shown here pins it.
+  would resolve.
 - `VMDirectoryWatcher` — a `DispatchSource` on the VMs directory that triggers reconciliation in
   `VMLibraryViewModel` when the library changes on disk.
 


### PR DESCRIPTION
## Summary

Step 2 of the macOS wizard treated its four sources unevenly: a catalog pick or a pasted URL rendered a two-line card naming the image (`macOS 26.5.2 · Build 25F84 · 19.77 GB`) over its destination, while **Download Latest** showed a bare `doc.fill` capsule with only `~/Downloads/RestoreImage.ipsw`. Nothing in the wizard knew what "latest" resolved to — `VZMacOSRestoreImage.latestSupported` was consulted only at install time, and `IPSWService` discarded everything but the URL.

Download Latest now shows the same badge, and the Review step gains the matching **macOS Version** / **Download Size** rows.

Verified against Apple live: the badge reads `macOS 26.6 · Build 25G72 · 19.77 GB` over `~/Downloads/RestoreImage.ipsw`, and Review reads `26.6 (25G72)` / `19.77 GB`.

## The argument

**The lookup is display-only, and that boundary is load-bearing.** The install still resolves the latest image when it starts, so `pinnedBuild` stays `nil` for this source — which is exactly what lets `adoptExistingDownloadFile()` accept any usable image at the shared `RestoreImage.ipsw` destination. For the same reason the overwrite banner keeps `version: nil` even once the lookup lands: the file already sitting at that shared path may be any build, so naming the version the badge shows would describe *that file* wrongly. Both facts are commented at their call sites, since the "obvious" follow-up edit is to thread the version through.

**Degradation is a first-class path, not an error state.** The version/build lookup and the size read are separate requests, so three outcomes render: full card; version and build without a size; and — when `latestSupported` itself fails — today's destination-only capsule, unchanged. No error banner, no spinner: the wizard stays usable offline, and a later re-entry into the step retries. That also keeps the capsule doubling as the pre-answer state, so there is no layout jump beyond the badge growing its second line.

**One composer for every source's title line.** The catalog and pasted-URL branches each formatted their own `·`-joined string; a third copy would have been the point where they drift. `addPinnedImageBadge(parts:changeAction:)` now takes optional parts and joins them, so Download Latest matches the catalog card *by construction* rather than by a matching format string. `changeAction` became optional in the same move — there is no "Change…" on this source, since picking a particular build is what the other three sources are for.

## Route and rejected alternatives

- **Where the size comes from.** `IPSWService` doing its own HEAD would have duplicated `RestoreImageProbeService`'s hardened HEAD-then-ranged-GET size read; extracting that into a shared helper would also have put an extra round trip on the *install* path, where only `.url` is wanted and a stalled HEAD would delay a multi-GB download. Instead `RestoreImageProbing` exposes the existing size read as `size(of:)` (the private `totalSize` promoted, zero new logic), and the view model composes the two calls. The full `probe()` is wrong here regardless — it reads ~150 KB of zip central directory to prove VM-capability, which is redundant for a URL Virtualization itself named.
- **Where the state lives.** In the view model, not the step's view controller: the Review step is a second reader, and a lookup that survives leaving step 2 is what lets Review show the answer. The model owns the task and dedupes it; the step's VC owns only a redraw that awaits it.
- **How the view learns.** An `ObservationLoop` on the new properties worked, but left the view update reachable in tests only through yields. Awaiting the production task instead — the seam `docs/TESTING.md` prescribes — makes every view assertion deterministic.
- **Fetch trigger on `viewDidAppear`, not `init`.** ~120 call sites construct `VMCreationViewModel()`; triggering in `init` (or in `selectDownloadLatest()`) would have put a live network fetch into every one of them. Nothing fetches until the step is actually shown.

## Test plan

- [x] `make test` — full suite green
- [x] `make lint` — clean
- [x] Live: badge upgrades in place on step 2; Review rows present; overwrite banner stays version-less
- [x] New coverage — model: populate, join-in-flight, retry-after-failure, size-failure degradation, `pinnedBuild` still `nil`; views: rich badge with no `Change…`, badge without a size, capsule fallback, Review rows; service: `size(of:)` against a body with no zip structure; `MacOSVersion.displayString` incl. the zero-patch case

## Notes

- No `RATIONALE:` comments added.
- `docs/ARCHITECTURE.md`: the `VMCreationViewModel` entry listed two of its injected protocols and already omitted a third. Replaced the list (derivable from the initializer) with the invariant the new dependency edge adds — each source is backed by a service protocol able to name its image before anything downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc7usmCKut3vJdEFZH4riR