### PR TITLE
fix: Add USB input fallbacks so pre-13 macOS guests get keyboard and pointer

### DIFF
--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -132,6 +132,16 @@ struct ConfigurationBuilder: Sendable {
         vzConfig.platform = platform
         vzConfig.bootLoader = VZMacOSBootLoader()
 
+        configureMacOSDevices(vzConfig, config: config)
+    }
+
+    /// Attaches the display, pointing, and keyboard devices for a macOS guest.
+    ///
+    /// Both input arrays pair the Mac device with its USB equivalent: a guest running
+    /// macOS 13.0 or later binds `VZMacTrackpadConfiguration`/`VZMacKeyboardConfiguration`
+    /// and ignores the USB devices, while an earlier guest recognizes only the USB ones
+    /// (`VZMacTrackpadConfiguration.h`, `VZMacKeyboardConfiguration.h`).
+    private func configureMacOSDevices(_ vzConfig: VZVirtualMachineConfiguration, config: VMConfiguration) {
         let graphics = VZMacGraphicsDeviceConfiguration()
         graphics.displays = [
             VZMacGraphicsDisplayConfiguration(
@@ -142,9 +152,22 @@ struct ConfigurationBuilder: Sendable {
         ]
         vzConfig.graphicsDevices = [graphics]
 
-        vzConfig.pointingDevices = [VZMacTrackpadConfiguration()]
-        vzConfig.keyboards = [VZMacKeyboardConfiguration()]
+        vzConfig.pointingDevices = [
+            VZMacTrackpadConfiguration(),
+            VZUSBScreenCoordinatePointingDeviceConfiguration(),
+        ]
+        vzConfig.keyboards = [
+            VZMacKeyboardConfiguration(),
+            VZUSBKeyboardConfiguration(),
+        ]
     }
+
+    #if DEBUG
+    /// Test-only access to `configureMacOSDevices`.
+    func configureMacOSDevicesForTesting(_ vzConfig: VZVirtualMachineConfiguration, config: VMConfiguration) {
+        configureMacOSDevices(vzConfig, config: config)
+    }
+    #endif
 
     // MARK: - EFI Boot
 

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -1049,6 +1049,59 @@ struct ConfigurationBuilderTests {
         }
     }
 
+    // MARK: - Input Devices
+
+    @Test("macOS guests get both the Mac and USB pointing/keyboard devices")
+    func macOSInputDevicesIncludeUSBFallbacks() {
+        // Called directly rather than through `assemble`: the rest of
+        // `configureMacOSBoot` needs a real `VZMacHardwareModel`, which only a
+        // restore image can mint.
+        let vz = VZVirtualMachineConfiguration()
+        let config = VMConfiguration(name: "Test macOS", guestOS: .macOS, bootMode: .macOS)
+        ConfigurationBuilder().configureMacOSDevicesForTesting(vz, config: config)
+
+        #expect(vz.pointingDevices.count == 2)
+        #expect(vz.pointingDevices.first is VZMacTrackpadConfiguration)
+        #expect(vz.pointingDevices.last is VZUSBScreenCoordinatePointingDeviceConfiguration)
+
+        #expect(vz.keyboards.count == 2)
+        #expect(vz.keyboards.first is VZMacKeyboardConfiguration)
+        #expect(vz.keyboards.last is VZUSBKeyboardConfiguration)
+    }
+
+    @Test("macOS display device carries the configured size and pixel density")
+    func macOSDisplayMatchesConfiguration() throws {
+        let vz = VZVirtualMachineConfiguration()
+        var config = VMConfiguration(name: "Test macOS", guestOS: .macOS, bootMode: .macOS)
+        config.displayWidth = 2560
+        config.displayHeight = 1600
+        config.displayPPI = 220
+        ConfigurationBuilder().configureMacOSDevicesForTesting(vz, config: config)
+
+        let graphics = try #require(vz.graphicsDevices.first as? VZMacGraphicsDeviceConfiguration)
+        let display = try #require(graphics.displays.first)
+        #expect(display.widthInPixels == 2560)
+        #expect(display.heightInPixels == 1600)
+        #expect(display.pixelsPerInch == 220)
+    }
+
+    @Test("EFI guests get only the USB pointing/keyboard devices")
+    func efiInputDevicesAreUSBOnly() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        let result = try ConfigurationBuilder().assemble(
+            from: makeLinuxConfig(), bundleURL: bundleURL, validate: false)
+        let vz = result.configuration
+
+        // The Mac devices are Mac-platform only, so a generic-platform guest
+        // must never see them.
+        #expect(vz.pointingDevices.count == 1)
+        #expect(vz.pointingDevices.first is VZUSBScreenCoordinatePointingDeviceConfiguration)
+        #expect(vz.keyboards.count == 1)
+        #expect(vz.keyboards.first is VZUSBKeyboardConfiguration)
+    }
+
     // MARK: - Path-Traversal Containment
 
     @Test("Internal storage disk path with .. escape is rejected as storageDiskNotFound")


### PR DESCRIPTION
## Summary
- `configureMacOSBoot` gave macOS guests only the Mac-specific input devices (`VZMacTrackpadConfiguration`, `VZMacKeyboardConfiguration`). Apple's SDK headers document both as recognized only by guests running macOS 13.0 and later, and the bundled catalog offers twelve macOS 12.x images — a 12.0.1 guest reproducibly boots with dead keyboard and mouse. Each input array now pairs the Mac device with its USB equivalent (`VZUSBScreenCoordinatePointingDeviceConfiguration`, `VZUSBKeyboardConfiguration`), the exact fallback shape the headers prescribe: 13+ guests bind the Mac devices and ignore the USB pair, earlier guests use the USB devices. The host does no selection, so newer guests are unaffected.
- The display/input block of `configureMacOSBoot` moves into a private `configureMacOSDevices` with a `#if DEBUG` `configureMacOSDevicesForTesting` seam (docs/TESTING.md option 2), because the rest of the macOS boot path throws without a real `VZMacHardwareModel`, which only a restore image can mint — the device arrays were otherwise untestable.
- A header sweep found these two input classes are the only Virtualization.framework devices with a guest-version binding constraint; everything else Kernova configures (virtio net/block/sound/entropy, xHCI, serial, Mac graphics, shared folders, vsock) degrades gracefully or is fully supported on macOS 12 guests, so no further old-guest accommodation is needed.

## Changes
- `Kernova/Services/ConfigurationBuilder.swift` — dual-device `pointingDevices`/`keyboards` arrays on the macOS path; extracted `configureMacOSDevices` plus DEBUG-gated test seam.
- `KernovaTests/ConfigurationBuilderTests.swift` — new coverage: both device types with Mac-first ordering on the macOS path, display size/PPI passthrough, and the EFI path staying USB-only.

## Test plan
- [x] `make test` — full suite passes
- [x] `make lint` — clean
- [x] `VZVirtualMachineConfiguration.validate()` accepts the dual arrays against real hardware models from macOS 12.0.1 (21A559) and 26.3.2 (25D2140) restore images, via a signed host-side check
- [ ] Boot the existing macOS 12.0.1 guest and confirm Setup Assistant accepts mouse and keyboard input

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfjozgrP3GfLgAj6N6NW4w