### PR TITLE
fix: Classify transient install failures and explain the running-VM cap

### DIFF
--- a/Kernova/App/DetailContainerViewController.swift
+++ b/Kernova/App/DetailContainerViewController.swift
@@ -267,8 +267,8 @@ extension DetailContainerViewController: VMCreationWizardViewControllerDelegate 
 // MARK: - VMLibraryPresenting
 
 extension DetailContainerViewController: VMLibraryPresenting {
-    func presentError(_ message: String) {
-        alertsPresenter.presentError(message)
+    func presentError(_ message: String, title: String) {
+        alertsPresenter.presentError(message, title: title)
     }
 
     func presentStartFailedAttachment(_ failure: StartFailedAttachment, for instance: VMInstance) {

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -307,7 +307,8 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
         }
     }
 
-    /// Recreates the app's custom toolbar items when the customize sheet closes.
+    /// Re-applies toolbar enablement after any sheet, and recreates the app's
+    /// custom toolbar items when the closing sheet is the customize palette.
     ///
     /// RATIONALE: AppKit bakes the section-specific glass treatment into a
     /// bordered item's view at creation, and a customization drag across the
@@ -316,6 +317,10 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
     /// moved item keeps the wrong treatment. Reinserting at the same index routes
     /// through the delegate factory.
     func windowDidEndSheet(_ notification: Notification) {
+        // Every sheet, not just the palette: item enablement is applied from the
+        // observation with `autovalidates` off, so a refresh that lands while a
+        // sheet is up never heals on its own. Re-applying current state is idempotent.
+        updateToolbarItems()
         guard sheetIsCustomizationPalette, let toolbar = window?.toolbar else { return }
         sheetIsCustomizationPalette = false
 

--- a/Kernova/Services/VirtualizationService.swift
+++ b/Kernova/Services/VirtualizationService.swift
@@ -52,9 +52,7 @@ final class VirtualizationService {
                 "Failed to start VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public) [\(nsError.domain, privacy: .public) \(nsError.code, privacy: .public); underlying: \(Self.underlyingChainDescription(nsError), privacy: .public)]"
             )
             instance.tearDownSession()
-            let isTransient = Self.isTransientStartError(error)
-            instance.status = isTransient ? .stopped : .error
-            instance.errorMessage = isTransient ? nil : error.localizedDescription
+            Self.applyStartFailure(error, to: instance, transientRestingStatus: .stopped)
             throw error
         }
     }
@@ -339,30 +337,44 @@ final class VirtualizationService {
     /// carrying the real code underneath, so the top level alone identifies it
     /// on the plain-start path only.
     static func isVirtualMachineLimitExceeded(_ error: Error) -> Bool {
-        var current: NSError? = error as NSError
-        var depth = 0
-        while let nsError = current, depth <= maxUnderlyingErrorDepth {
-            if nsError.domain == VZError.errorDomain,
-                VZError.Code(rawValue: nsError.code) == .virtualMachineLimitExceeded
-            {
-                return true
-            }
-            current = nsError.userInfo[NSUnderlyingErrorKey] as? NSError
-            depth += 1
+        underlyingErrorChain(error as NSError).contains {
+            $0.domain == VZError.errorDomain
+                && VZError.Code(rawValue: $0.code) == .virtualMachineLimitExceeded
         }
-        return false
     }
 
-    /// `domain code` for each error under `error`, bounded by
+    /// `domain code` for each error *under* `error`, bounded by
     /// ``maxUnderlyingErrorDepth``; `"none"` when nothing is nested.
     static func underlyingChainDescription(_ error: NSError) -> String {
-        var links: [String] = []
-        var current = error.userInfo[NSUnderlyingErrorKey] as? NSError
-        while let nsError = current, links.count < maxUnderlyingErrorDepth {
-            links.append("\(nsError.domain) \(nsError.code)")
+        let nested = underlyingErrorChain(error).dropFirst()
+        guard !nested.isEmpty else { return "none" }
+        return nested.map { "\($0.domain) \($0.code)" }.joined(separator: " → ")
+    }
+
+    /// `error` followed by up to ``maxUnderlyingErrorDepth`` of its
+    /// `NSUnderlyingErrorKey` ancestors.
+    private static func underlyingErrorChain(_ error: NSError) -> [NSError] {
+        var chain: [NSError] = []
+        var current: NSError? = error
+        while let nsError = current, chain.count <= maxUnderlyingErrorDepth {
+            chain.append(nsError)
             current = nsError.userInfo[NSUnderlyingErrorKey] as? NSError
         }
-        return links.isEmpty ? "none" : links.joined(separator: " → ")
+        return chain
+    }
+
+    /// Records a failed start or install on `instance`: a transient failure
+    /// rests at `transientRestingStatus` carrying no message, a permanent one
+    /// lands in `.error` carrying the description the banner and tooltip show.
+    ///
+    /// `transientRestingStatus` is where the VM was before the attempt —
+    /// `.stopped` for a plain start, `.initialBoot` for a pending install.
+    static func applyStartFailure(
+        _ error: Error, to instance: VMInstance, transientRestingStatus: VMStatus
+    ) {
+        let isTransient = isTransientStartError(error)
+        instance.status = isTransient ? transientRestingStatus : .error
+        instance.errorMessage = isTransient ? nil : error.localizedDescription
     }
 
     // MARK: - Private Helpers

--- a/Kernova/Services/VirtualizationService.swift
+++ b/Kernova/Services/VirtualizationService.swift
@@ -48,15 +48,13 @@ final class VirtualizationService {
             }
         } catch {
             let nsError = error as NSError
-            let underlying =
-                (nsError.userInfo[NSUnderlyingErrorKey] as? NSError)
-                .map { "\($0.domain) \($0.code)" } ?? "none"
             Self.logger.error(
-                "Failed to start VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public) [\(nsError.domain, privacy: .public) \(nsError.code, privacy: .public); underlying: \(underlying, privacy: .public)]"
+                "Failed to start VM '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public) [\(nsError.domain, privacy: .public) \(nsError.code, privacy: .public); underlying: \(Self.underlyingChainDescription(nsError), privacy: .public)]"
             )
             instance.tearDownSession()
-            instance.status = Self.isTransientStartError(error) ? .stopped : .error
-            instance.errorMessage = error.localizedDescription
+            let isTransient = Self.isTransientStartError(error)
+            instance.status = isTransient ? .stopped : .error
+            instance.errorMessage = isTransient ? nil : error.localizedDescription
             throw error
         }
     }
@@ -306,11 +304,16 @@ final class VirtualizationService {
 
     // MARK: - Error Classification
 
+    /// How far an `NSUnderlyingErrorKey` walk follows the chain — framework
+    /// `userInfo` can nest arbitrarily deep, or cyclically.
+    private static let maxUnderlyingErrorDepth = 4
+
     /// Returns `true` when the error is a transient environmental condition (e.g. too many
     /// concurrent VMs) rather than a problem with the VM itself.
     ///
-    /// Transient errors leave the VM in `.stopped` so the indicator stays grey;
-    /// permanent errors set `.error` (red).
+    /// Transient leaves a plain start in `.stopped` and an install in
+    /// `.initialBoot`, with no stored message; permanent sets `.error` (red)
+    /// and keeps the message for the banner and tooltip.
     static func isTransientStartError(_ error: Error) -> Bool {
         // Checked ahead of the builder-error rule below: contention on a disk image
         // surfaces *as* a builder error and is still transient — the lock holder is
@@ -319,15 +322,47 @@ final class VirtualizationService {
 
         if error is ConfigurationBuilderError { return false }
 
-        let nsError = error as NSError
-        guard nsError.domain == VZError.errorDomain else { return false }
+        if isVirtualMachineLimitExceeded(error) { return true }
 
-        switch VZError.Code(rawValue: nsError.code) {
-        case .virtualMachineLimitExceeded, .operationCancelled:
-            return true
-        default:
-            return false
+        // Top level only, unlike the limit code: a cancel nested under a failure
+        // describes a teardown step, not the failure that has to be classified.
+        let nsError = error as NSError
+        return nsError.domain == VZError.errorDomain
+            && VZError.Code(rawValue: nsError.code) == .operationCancelled
+    }
+
+    /// Returns `true` when `error`, or anything within
+    /// ``maxUnderlyingErrorDepth`` of its `NSUnderlyingErrorKey` chain, is
+    /// `VZError.Code.virtualMachineLimitExceeded`.
+    ///
+    /// `VZMacOSInstaller.install()` surfaces the cap as `.installationFailed`
+    /// carrying the real code underneath, so the top level alone identifies it
+    /// on the plain-start path only.
+    static func isVirtualMachineLimitExceeded(_ error: Error) -> Bool {
+        var current: NSError? = error as NSError
+        var depth = 0
+        while let nsError = current, depth <= maxUnderlyingErrorDepth {
+            if nsError.domain == VZError.errorDomain,
+                VZError.Code(rawValue: nsError.code) == .virtualMachineLimitExceeded
+            {
+                return true
+            }
+            current = nsError.userInfo[NSUnderlyingErrorKey] as? NSError
+            depth += 1
         }
+        return false
+    }
+
+    /// `domain code` for each error under `error`, bounded by
+    /// ``maxUnderlyingErrorDepth``; `"none"` when nothing is nested.
+    static func underlyingChainDescription(_ error: NSError) -> String {
+        var links: [String] = []
+        var current = error.userInfo[NSUnderlyingErrorKey] as? NSError
+        while let nsError = current, links.count < maxUnderlyingErrorDepth {
+            links.append("\(nsError.domain) \(nsError.code)")
+            current = nsError.userInfo[NSUnderlyingErrorKey] as? NSError
+        }
+        return links.isEmpty ? "none" : links.joined(separator: " → ")
     }
 
     // MARK: - Private Helpers

--- a/Kernova/Utilities/DetailAlertsPresenter.swift
+++ b/Kernova/Utilities/DetailAlertsPresenter.swift
@@ -112,8 +112,8 @@ final class DetailAlertsPresenter: NSObject {
 
     // MARK: - Imperative presentation
 
-    func presentError(_ message: String) {
-        enqueue { $0.present($0.errorConfig(message)) }
+    func presentError(_ message: String, title: String) {
+        enqueue { $0.present($0.errorConfig(message, title: title)) }
     }
 
     func presentStartFailedAttachment(_ failure: StartFailedAttachment, for instance: VMInstance) {
@@ -331,9 +331,9 @@ final class DetailAlertsPresenter: NSObject {
             ])
     }
 
-    private func errorConfig(_ message: String) -> AlertConfiguration {
+    private func errorConfig(_ message: String, title: String) -> AlertConfiguration {
         AlertConfiguration(
-            title: "Error", message: message, buttons: [AlertButton("OK", role: .cancel)])
+            title: title, message: message, buttons: [AlertButton("OK", role: .cancel)])
     }
 
     private func startFailedAttachmentConfig(

--- a/Kernova/ViewModels/VMLibraryPresenting.swift
+++ b/Kernova/ViewModels/VMLibraryPresenting.swift
@@ -36,8 +36,8 @@ struct StartFailedAttachment: Equatable, Sendable {
 /// sheets, and the creation wizard.
 @MainActor
 protocol VMLibraryPresenting: AnyObject {
-    /// Show a generic error alert with `message`.
-    func presentError(_ message: String)
+    /// Show an error alert headed `title` with `message`.
+    func presentError(_ message: String, title: String)
     /// Show the start-failed alert for an attachment that couldn't be opened,
     /// offering to remove it from the configuration and start again.
     func presentStartFailedAttachment(_ failure: StartFailedAttachment, for instance: VMInstance)

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -34,14 +34,14 @@ final class VMLibraryViewModel {
     /// in `init`) are buffered and flushed when one is set.
     @ObservationIgnored weak var presenter: (any VMLibraryPresenting)? {
         didSet {
-            guard presenter != nil, !bufferedErrorMessages.isEmpty else { return }
-            let buffered = bufferedErrorMessages
-            bufferedErrorMessages.removeAll()
-            buffered.forEach { presenter?.presentError($0) }
+            guard presenter != nil, !bufferedErrors.isEmpty else { return }
+            let buffered = bufferedErrors
+            bufferedErrors.removeAll()
+            buffered.forEach { presenter?.presentError($0.message, title: $0.title) }
         }
     }
 
-    @ObservationIgnored private var bufferedErrorMessages: [String] = []
+    @ObservationIgnored private var bufferedErrors: [(title: String, message: String)] = []
 
     /// VMs with an in-flight removable-media reconciliation Task.
     ///
@@ -239,9 +239,10 @@ final class VMLibraryViewModel {
     /// Drives the install pipeline for an `.initialBoot` (or `.error` with
     /// `installContext`) VM and, on success, chains an auto-boot.
     ///
-    /// Non-cancel errors leave the VM in `.error` so the user sees the message;
-    /// cancel returns it to `.initialBoot` for a retry that resumes the download
-    /// from the `.resumedata` sidecar if present.
+    /// A permanent failure leaves the VM in `.error` so the banner keeps the
+    /// message on screen; cancel and transient failures (the running-VM cap)
+    /// return it to `.initialBoot` for a retry that resumes the download from
+    /// the `.resumedata` sidecar if present.
     private func installAndAutoBoot(_ instance: VMInstance) {
         guard let context = instance.configuration.installContext else {
             assertionFailure("installAndAutoBoot called without installContext")
@@ -280,10 +281,9 @@ final class VMLibraryViewModel {
                     Self.logger.notice(
                         "Install cancelled for '\(instance.name, privacy: .public)' — pipeline surfaced \(error.localizedDescription, privacy: .public)"
                     )
+                } else if let explained = self.explainedFailure(for: error, on: instance) {
+                    self.surfaceError(explained.message, title: explained.title)
                 } else {
-                    Self.logger.error(
-                        "Install failed for '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)"
-                    )
                     self.presentError(error)
                 }
             }
@@ -321,6 +321,8 @@ final class VMLibraryViewModel {
                 "Failed to start '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public)")
             if let presenter, let failure = startFailedAttachment(from: error, on: instance) {
                 presenter.presentStartFailedAttachment(failure, for: instance)
+            } else if let explained = explainedFailure(for: error, on: instance) {
+                surfaceError(explained.message, title: explained.title)
             } else {
                 presentError(error)
             }
@@ -366,6 +368,29 @@ final class VMLibraryViewModel {
         default:
             return nil
         }
+    }
+
+    /// Maps a start or install failure to alert copy naming the cause and the
+    /// remedy, or `nil` when the raw error description is the right surface.
+    private func explainedFailure(
+        for error: Error, on instance: VMInstance
+    ) -> (title: String, message: String)? {
+        guard VirtualizationService.isVirtualMachineLimitExceeded(error) else { return nil }
+        let verb: String
+        switch instance.startAction {
+        case .start: verb = "Start"
+        case .install, .resumeInstall: verb = "Install"
+        }
+        let message: String
+        switch instance.configuration.guestOS {
+        case .macOS:
+            message =
+                "macOS allows at most two macOS virtual machines to run at once. Stop another macOS VM, then click \(instance.startAction.label) to try again."
+        case .linux:
+            message =
+                "The limit on running virtual machines has been reached. Stop another virtual machine, then click Start to try again."
+        }
+        return (title: "Couldn't \(verb) “\(instance.name)”", message: message)
     }
 
     /// Confirmed action of the start-failed alert: detach the failing
@@ -2121,11 +2146,11 @@ final class VMLibraryViewModel {
 
     /// Routes an error message to the presenter, buffering it if none is
     /// attached yet (e.g. during the initial `loadVMs()` in `init`).
-    private func surfaceError(_ message: String) {
+    private func surfaceError(_ message: String, title: String = "Error") {
         if let presenter {
-            presenter.presentError(message)
+            presenter.presentError(message, title: title)
         } else {
-            bufferedErrorMessages.append(message)
+            bufferedErrors.append((title: title, message: message))
         }
     }
 }

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -335,8 +335,17 @@ final class VMLifecycleCoordinator {
                 // Normalize to CancellationError for consistent caller-side handling.
                 throw CancellationError()
             } catch {
-                instance.status = .error
-                instance.errorMessage = error.localizedDescription
+                let nsError = error as NSError
+                Self.logger.error(
+                    "Install failed for '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public) [\(nsError.domain, privacy: .public) \(nsError.code, privacy: .public); underlying: \(VirtualizationService.underlyingChainDescription(nsError), privacy: .public)]"
+                )
+                if VirtualizationService.isTransientStartError(error) {
+                    instance.errorMessage = nil
+                    instance.status = .initialBoot
+                } else {
+                    instance.status = .error
+                    instance.errorMessage = error.localizedDescription
+                }
                 throw error
             }
         }

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -339,13 +339,8 @@ final class VMLifecycleCoordinator {
                 Self.logger.error(
                     "Install failed for '\(instance.name, privacy: .public)': \(error.localizedDescription, privacy: .public) [\(nsError.domain, privacy: .public) \(nsError.code, privacy: .public); underlying: \(VirtualizationService.underlyingChainDescription(nsError), privacy: .public)]"
                 )
-                if VirtualizationService.isTransientStartError(error) {
-                    instance.errorMessage = nil
-                    instance.status = .initialBoot
-                } else {
-                    instance.status = .error
-                    instance.errorMessage = error.localizedDescription
-                }
+                VirtualizationService.applyStartFailure(
+                    error, to: instance, transientRestingStatus: .initialBoot)
                 throw error
             }
         }

--- a/Kernova/Views/Detail/DetailBannerView.swift
+++ b/Kernova/Views/Detail/DetailBannerView.swift
@@ -1,33 +1,31 @@
 import AppKit
 
-/// Banner shown above the settings pane for a macOS VM that hasn't completed
-/// its initial boot yet.
+/// Tinted banner stacked above the settings form, naming the VM's state and
+/// what the user does next.
 ///
-/// Adapts its subtitle to the persisted install context so the user knows what
-/// Start will do (download + install vs. install from local IPSW vs. resume an
-/// interrupted download).
+/// `tint` colors both the icon and — at 10% alpha — the background.
 @MainActor
-final class InitialBootBannerView: NSView {
-    init(instance: VMInstance) {
+final class DetailBannerView: NSView {
+    init(tint: NSColor, symbolName: String, title: String, subtitle: String) {
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
-        build(subtitle: Self.subtitle(for: instance))
+        build(tint: tint, symbolName: symbolName, title: title, subtitle: subtitle)
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("InitialBootBannerView does not support NSCoder")
+        fatalError("DetailBannerView does not support NSCoder")
     }
 
-    private func build(subtitle subtitleText: String) {
-        // Orange tint background + bottom hairline, drawn by NSBoxes so they
-        // adapt to light/dark automatically.
+    private func build(tint: NSColor, symbolName: String, title titleText: String, subtitle subtitleText: String) {
+        // Tint background + bottom hairline, drawn by NSBoxes so they adapt to
+        // light/dark automatically.
         let background = NSBox()
         background.boxType = .custom
         background.titlePosition = .noTitle
         background.borderWidth = 0
         background.cornerRadius = 0
-        background.fillColor = .systemOrange.withAlphaComponent(0.1)
+        background.fillColor = tint.withAlphaComponent(0.1)
         addFullSizeSubview(background)
 
         let separator = NSBox()
@@ -36,12 +34,12 @@ final class InitialBootBannerView: NSView {
         separator.fillColor = .separatorColor
         separator.translatesAutoresizingMaskIntoConstraints = false
 
-        let icon = NSImageView(image: .systemSymbol("sparkles", accessibilityDescription: ""))
+        let icon = NSImageView(image: .systemSymbol(symbolName, accessibilityDescription: ""))
         icon.symbolConfiguration = NSImage.SymbolConfiguration(textStyle: .title2)
-        icon.contentTintColor = .systemOrange
+        icon.contentTintColor = tint
         icon.setContentHuggingPriority(.required, for: .horizontal)
 
-        let title = NSTextField(labelWithString: "Initial Boot")
+        let title = NSTextField(labelWithString: titleText)
         title.font = .preferredFont(forTextStyle: .headline)
         title.isSelectable = false
 
@@ -80,9 +78,32 @@ final class InitialBootBannerView: NSView {
             separator.heightAnchor.constraint(equalToConstant: 1),
         ])
     }
+}
 
-    /// Install-context-aware subtitle.
-    private static func subtitle(for instance: VMInstance) -> String {
+// MARK: - Banners
+
+extension DetailBannerView {
+    /// Banner for a macOS VM that hasn't completed its initial boot, its
+    /// subtitle naming what Start will do for the persisted install context.
+    static func initialBoot(instance: VMInstance) -> DetailBannerView {
+        DetailBannerView(
+            tint: StatusColor.warning,
+            symbolName: "sparkles",
+            title: "Initial Boot",
+            subtitle: initialBootSubtitle(for: instance))
+    }
+
+    /// Banner for a VM whose last operation failed, carrying the message
+    /// captured at the failure.
+    static func error(message: String?) -> DetailBannerView {
+        DetailBannerView(
+            tint: StatusColor.error,
+            symbolName: "exclamationmark.triangle.fill",
+            title: "Error",
+            subtitle: message ?? "The last operation failed.")
+    }
+
+    private static func initialBootSubtitle(for instance: VMInstance) -> String {
         guard let context = instance.configuration.installContext else {
             return "Click Start to install macOS."
         }

--- a/Kernova/Views/Detail/DetailRoute.swift
+++ b/Kernova/Views/Detail/DetailRoute.swift
@@ -11,6 +11,12 @@ enum DetailRoute: Equatable {
     /// VM exists but hasn't completed its initial boot; show the initial-boot
     /// banner stacked above the (editable) settings form.
     case initialBoot
+    /// The VM's last operation failed permanently; show the error banner
+    /// carrying `message` above the (editable) settings form.
+    ///
+    /// The message is part of the route so a second failure with different text
+    /// re-renders rather than comparing equal to the first.
+    case error(message: String?)
     /// A macOS install is running; show the install-progress UI.
     case install
     /// A transient status (starting, suspending, restoring, …) with no editable
@@ -26,6 +32,7 @@ enum DetailRoute: Equatable {
     static func resolve(
         preparingLabel: String?,
         status: VMStatus,
+        errorMessage: String?,
         hasInstallState: Bool,
         detailPaneMode: DetailPaneMode
     ) -> DetailRoute {
@@ -33,8 +40,10 @@ enum DetailRoute: Equatable {
             return .preparing(label: preparingLabel)
         }
         switch status {
-        case .stopped, .error:
+        case .stopped:
             return .settings(isReadOnly: false)
+        case .error:
+            return .error(message: errorMessage)
         case .initialBoot:
             return .initialBoot
         case .installing:

--- a/Kernova/Views/Detail/VMDetailRouterViewController.swift
+++ b/Kernova/Views/Detail/VMDetailRouterViewController.swift
@@ -69,6 +69,7 @@ final class VMDetailRouterViewController: NSViewController {
                 guard let self else { return }
                 _ = self.instance.preparingState
                 _ = self.instance.status
+                _ = self.instance.errorMessage
                 _ = self.instance.detailPaneMode
                 _ = self.instance.installState
             },
@@ -83,6 +84,7 @@ final class VMDetailRouterViewController: NSViewController {
         let route = DetailRoute.resolve(
             preparingLabel: instance.preparingState?.displayLabel,
             status: instance.status,
+            errorMessage: instance.errorMessage,
             hasInstallState: instance.installState != nil,
             detailPaneMode: instance.detailPaneMode)
 
@@ -103,7 +105,11 @@ final class VMDetailRouterViewController: NSViewController {
 
         case .initialBoot:
             settingsVC.reconfigure(instance: instance, viewModel: viewModel, isReadOnly: false)
-            setContent(child: settingsVC, banner: InitialBootBannerView(instance: instance))
+            setContent(child: settingsVC, banner: DetailBannerView.initialBoot(instance: instance))
+
+        case .error(let message):
+            settingsVC.reconfigure(instance: instance, viewModel: viewModel, isReadOnly: false)
+            setContent(child: settingsVC, banner: DetailBannerView.error(message: message))
 
         case .install:
             let installVC = MacOSInstallProgressViewController(instance: instance) { [weak self] in

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -29,6 +29,7 @@ extension VMInstance {
     var statusToolTip: String? {
         if let state = preparingState { return state.displayLabel }
         if status == .initialBoot { return "Click Start to install macOS" }
+        if status == .error { return errorMessage }
         guard status == .paused else { return nil }
         return isColdPaused
             ? "VM state is saved to disk"

--- a/KernovaTests/DetailRouteTests.swift
+++ b/KernovaTests/DetailRouteTests.swift
@@ -11,6 +11,7 @@ struct DetailRouteTests {
             let route = DetailRoute.resolve(
                 preparingLabel: "Cloning…",
                 status: status,
+                errorMessage: nil,
                 hasInstallState: true,
                 detailPaneMode: .display
             )
@@ -20,17 +21,30 @@ struct DetailRouteTests {
 
     // MARK: - Editable settings
 
-    @Test("Stopped and error route to editable settings")
-    func stoppedAndErrorAreEditableSettings() {
-        for status in [VMStatus.stopped, .error] {
-            let route = DetailRoute.resolve(
-                preparingLabel: nil,
-                status: status,
-                hasInstallState: false,
-                detailPaneMode: .display
-            )
-            #expect(route == .settings(isReadOnly: false))
-        }
+    @Test("Stopped routes to editable settings")
+    func stoppedIsEditableSettings() {
+        let route = DetailRoute.resolve(
+            preparingLabel: nil,
+            status: .stopped,
+            errorMessage: nil,
+            hasInstallState: false,
+            detailPaneMode: .display
+        )
+        #expect(route == .settings(isReadOnly: false))
+    }
+
+    @Test("Error routes to the error banner carrying the stored message")
+    func errorRoutesToErrorBanner() {
+        let route = DetailRoute.resolve(
+            preparingLabel: nil,
+            status: .error,
+            errorMessage: "Boot failed.",
+            hasInstallState: false,
+            detailPaneMode: .display
+        )
+        #expect(route == .error(message: "Boot failed."))
+        // A second failure with different text must not compare equal to the first.
+        #expect(route != .error(message: nil))
     }
 
     @Test("Initial boot routes to .initialBoot")
@@ -38,6 +52,7 @@ struct DetailRouteTests {
         let route = DetailRoute.resolve(
             preparingLabel: nil,
             status: .initialBoot,
+            errorMessage: nil,
             hasInstallState: false,
             detailPaneMode: .display
         )
@@ -51,6 +66,7 @@ struct DetailRouteTests {
         let route = DetailRoute.resolve(
             preparingLabel: nil,
             status: .installing,
+            errorMessage: nil,
             hasInstallState: true,
             detailPaneMode: .display
         )
@@ -62,6 +78,7 @@ struct DetailRouteTests {
         let route = DetailRoute.resolve(
             preparingLabel: nil,
             status: .installing,
+            errorMessage: nil,
             hasInstallState: false,
             detailPaneMode: .display
         )
@@ -76,6 +93,7 @@ struct DetailRouteTests {
             let display = DetailRoute.resolve(
                 preparingLabel: nil,
                 status: status,
+                errorMessage: nil,
                 hasInstallState: false,
                 detailPaneMode: .display
             )
@@ -84,6 +102,7 @@ struct DetailRouteTests {
             let settings = DetailRoute.resolve(
                 preparingLabel: nil,
                 status: status,
+                errorMessage: nil,
                 hasInstallState: false,
                 detailPaneMode: .settings
             )
@@ -99,6 +118,7 @@ struct DetailRouteTests {
             let route = DetailRoute.resolve(
                 preparingLabel: nil,
                 status: .starting,
+                errorMessage: nil,
                 hasInstallState: false,
                 detailPaneMode: paneMode
             )

--- a/KernovaTests/Mocks/MockVMLibraryPresenting.swift
+++ b/KernovaTests/Mocks/MockVMLibraryPresenting.swift
@@ -11,6 +11,8 @@ import Foundation
 @MainActor
 final class MockVMLibraryPresenting: VMLibraryPresenting {
     private(set) var errors: [String] = []
+    /// Parallel to `errors`: the alert title each message was presented under.
+    private(set) var errorTitles: [String] = []
     private(set) var startFailedAttachments: [StartFailedAttachment] = []
     private(set) var startFailedAttachmentInstances: [VMInstance] = []
     private(set) var deleteSheetInstances: [VMInstance] = []
@@ -25,7 +27,10 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
     private(set) var installerMountedPurposes: [GuestAgentInstallerPurpose] = []
     private(set) var creationWizardCount = 0
 
-    func presentError(_ message: String) { errors.append(message) }
+    func presentError(_ message: String, title: String) {
+        errors.append(message)
+        errorTitles.append(title)
+    }
     func presentStartFailedAttachment(_ failure: StartFailedAttachment, for instance: VMInstance) {
         startFailedAttachments.append(failure)
         startFailedAttachmentInstances.append(instance)
@@ -48,6 +53,7 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
 
     var showError: Bool { !errors.isEmpty }
     var errorMessage: String? { errors.last }
+    var errorTitle: String? { errorTitles.last }
     var showDeleteSheet: Bool { !deleteSheetInstances.isEmpty }
     var instanceToDelete: VMInstance? { deleteSheetInstances.last }
     /// Whether the most recent delete-sheet request asked for immediate delete.
@@ -68,6 +74,7 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
     /// Clears all recorded requests (mirrors resetting the former flags).
     func reset() {
         errors.removeAll()
+        errorTitles.removeAll()
         startFailedAttachments.removeAll()
         startFailedAttachmentInstances.removeAll()
         deleteSheetInstances.removeAll()

--- a/KernovaTests/Mocks/MockVirtualizationService.swift
+++ b/KernovaTests/Mocks/MockVirtualizationService.swift
@@ -32,11 +32,8 @@ final class MockVirtualizationService: VirtualizationProviding {
         lastStartBootIntoRecovery = bootIntoRecovery
         if let error = startError {
             instance.tearDownSession()
-            // Mirrors the real service's post-failure state, classifier included,
-            // so callers see the status and message a live failure would leave.
-            let isTransient = VirtualizationService.isTransientStartError(error)
-            instance.status = isTransient ? .stopped : .error
-            instance.errorMessage = isTransient ? nil : error.localizedDescription
+            VirtualizationService.applyStartFailure(
+                error, to: instance, transientRestingStatus: .stopped)
             throw error
         }
         instance.status = .running

--- a/KernovaTests/Mocks/MockVirtualizationService.swift
+++ b/KernovaTests/Mocks/MockVirtualizationService.swift
@@ -19,8 +19,6 @@ final class MockVirtualizationService: VirtualizationProviding {
     // MARK: - Error Injection & Recovery
 
     var startError: (any Error)?
-    /// Status to set on start failure (defaults to `.error`; set to `.stopped` to simulate transient errors).
-    var startErrorRecoveryStatus: VMStatus = .error
     var stopError: (any Error)?
     var forceStopError: (any Error)?
     var pauseError: (any Error)?
@@ -34,8 +32,11 @@ final class MockVirtualizationService: VirtualizationProviding {
         lastStartBootIntoRecovery = bootIntoRecovery
         if let error = startError {
             instance.tearDownSession()
-            instance.status = startErrorRecoveryStatus
-            instance.errorMessage = error.localizedDescription
+            // Mirrors the real service's post-failure state, classifier included,
+            // so callers see the status and message a live failure would leave.
+            let isTransient = VirtualizationService.isTransientStartError(error)
+            instance.status = isTransient ? .stopped : .error
+            instance.errorMessage = isTransient ? nil : error.localizedDescription
             throw error
         }
         instance.status = .running

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -5,6 +5,7 @@ import Observation
 import KernovaKit
 import KernovaTestSupport
 import Testing
+import Virtualization
 
 @testable import Kernova
 
@@ -27,6 +28,35 @@ import Testing
 /// inspect the raw `UserDefaults` store directly.
 func makeEphemeralPreferences(suiteName: String) -> AppPreferences {
     AppPreferences(defaults: makeEphemeralDefaults(suiteName: suiteName))
+}
+
+// MARK: - VZ error fixtures
+
+/// The plain-start shape of the running-VM cap: VZ reports the code at the top
+/// level.
+func makeVMLimitExceededError() -> NSError {
+    NSError(
+        domain: VZError.errorDomain,
+        code: VZError.Code.virtualMachineLimitExceeded.rawValue)
+}
+
+/// The install shape of the same cap: `VZMacOSInstaller.install()` reports it as
+/// `.installationFailed` with the real code underneath, so only a chain walk
+/// classifies it.
+func makeInstallVMLimitExceededError() -> NSError {
+    makeVZErrorChain(depth: 1, around: makeVMLimitExceededError())
+}
+
+/// `error` wrapped in `depth` nested `.installationFailed` errors.
+func makeVZErrorChain(depth: Int, around error: NSError) -> NSError {
+    var wrapped = error
+    for _ in 0..<depth {
+        wrapped = NSError(
+            domain: VZError.errorDomain,
+            code: VZError.Code.installationFailed.rawValue,
+            userInfo: [NSUnderlyingErrorKey: wrapped])
+    }
+    return wrapped
 }
 
 // MARK: - Socket / channel factories

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -373,6 +373,13 @@ struct VMInstanceTests {
         }
     }
 
+    @Test("statusToolTip carries the stored message in the error state")
+    func statusToolTipError() {
+        let instance = makeInstance(status: .error)
+        instance.errorMessage = "The virtual machine failed to start."
+        #expect(instance.statusToolTip == "The virtual machine failed to start.")
+    }
+
     // MARK: - Lifecycle Action Labels
 
     @Test("startAction is .start without a pending install context")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -1287,17 +1287,10 @@ struct VMLibraryViewModelTests {
 
     // MARK: - Running-VM Limit Explanation
 
-    /// The plain-start shape of the cap: VZ reports the code at the top level.
-    private func makeLimitExceededError() -> NSError {
-        NSError(
-            domain: VZError.errorDomain,
-            code: VZError.Code.virtualMachineLimitExceeded.rawValue)
-    }
-
     @Test("start explains the running-VM limit and leaves the VM stopped")
     func startExplainsRunningVMLimit() async {
         let virtService = MockVirtualizationService()
-        virtService.startError = makeLimitExceededError()
+        virtService.startError = makeVMLimitExceededError()
         let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
         let instance = makeInstance(name: "Ubuntu")
         viewModel.instances.append(instance)
@@ -1314,11 +1307,7 @@ struct VMLibraryViewModelTests {
     @Test("An install that hits the running-VM limit explains it and stays in .initialBoot")
     func installExplainsRunningVMLimit() async {
         let installService = MockMacOSInstallService()
-        // The install path's shape: the cap arrives under `.installationFailed`.
-        installService.installError = NSError(
-            domain: VZError.errorDomain,
-            code: VZError.Code.installationFailed.rawValue,
-            userInfo: [NSUnderlyingErrorKey: makeLimitExceededError()])
+        installService.installError = makeInstallVMLimitExceededError()
         let storage = MockVMStorageService()
         let viewModel = VMLibraryViewModel(
             storageService: storage,
@@ -1361,7 +1350,7 @@ struct VMLibraryViewModelTests {
         viewModel.instances.append(instance)
         virtService.startError = ConfigurationBuilderError.removableMediaAttachFailed(
             id: item.id, path: item.path, label: item.label,
-            underlying: makeLimitExceededError())
+            underlying: makeVMLimitExceededError())
 
         await viewModel.start(instance)
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -42,11 +42,11 @@ struct VMLibraryViewModelTests {
         return (vm, storageService, diskImageService, virtualizationService, usbDeviceService)
     }
 
-    private func makeInstance(name: String = "Test VM") -> VMInstance {
+    private func makeInstance(name: String = "Test VM", guestOS: VMGuestOS = .linux) -> VMInstance {
         let config = VMConfiguration(
             name: name,
-            guestOS: .linux,
-            bootMode: .efi
+            guestOS: guestOS,
+            bootMode: guestOS == .macOS ? .macOS : .efi
         )
         let bundleURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(config.id.uuidString, isDirectory: true)
@@ -1115,6 +1115,8 @@ struct VMLibraryViewModelTests {
 
         #expect(presenter.showError == true)
         #expect(presenter.errorMessage != nil)
+        // A failure with no explanation of its own keeps the generic title.
+        #expect(presenter.errorTitle == "Error")
     }
 
     @Test("start offers removal when a removable media attach fails")
@@ -1281,6 +1283,92 @@ struct VMLibraryViewModelTests {
         // An offer whose action could only no-op is worse than the plain error.
         #expect(presenter.startFailedAttachments.isEmpty)
         #expect(presenter.showError == true)
+    }
+
+    // MARK: - Running-VM Limit Explanation
+
+    /// The plain-start shape of the cap: VZ reports the code at the top level.
+    private func makeLimitExceededError() -> NSError {
+        NSError(
+            domain: VZError.errorDomain,
+            code: VZError.Code.virtualMachineLimitExceeded.rawValue)
+    }
+
+    @Test("start explains the running-VM limit and leaves the VM stopped")
+    func startExplainsRunningVMLimit() async {
+        let virtService = MockVirtualizationService()
+        virtService.startError = makeLimitExceededError()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let instance = makeInstance(name: "Ubuntu")
+        viewModel.instances.append(instance)
+
+        await viewModel.start(instance)
+
+        #expect(presenter.errorTitle == "Couldn't Start “Ubuntu”")
+        #expect(presenter.errorMessage?.contains("Stop another virtual machine") == true)
+        // Transient: nothing red, and no message left behind for the banner.
+        #expect(instance.status == .stopped)
+        #expect(instance.errorMessage == nil)
+    }
+
+    @Test("An install that hits the running-VM limit explains it and stays in .initialBoot")
+    func installExplainsRunningVMLimit() async {
+        let installService = MockMacOSInstallService()
+        // The install path's shape: the cap arrives under `.installationFailed`.
+        installService.installError = NSError(
+            domain: VZError.errorDomain,
+            code: VZError.Code.installationFailed.rawValue,
+            userInfo: [NSUnderlyingErrorKey: makeLimitExceededError()])
+        let storage = MockVMStorageService()
+        let viewModel = VMLibraryViewModel(
+            storageService: storage,
+            diskImageService: MockDiskImageService(),
+            virtualizationService: MockVirtualizationService(),
+            installService: installService,
+            ipswService: MockIPSWService(),
+            usbDeviceService: MockUSBDeviceService(),
+            fileSystem: fileSystem,
+            preferences: preferences
+        )
+        viewModel.presenter = presenter
+        let instance = makeInstance(name: "Sequoia", guestOS: .macOS)
+        instance.configuration.installContext = MacOSInstallContext(
+            source: .localFile, localIPSWPath: "/tmp/foo.ipsw")
+        instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
+        instance.status = .initialBoot
+        viewModel.instances.append(instance)
+        storage.bundles[instance.bundleURL] = instance.configuration
+
+        await viewModel.start(instance)
+        await instance.installTask?.value
+
+        #expect(presenter.errorTitle == "Couldn't Install “Sequoia”")
+        #expect(presenter.errorMessage?.contains("at most two macOS virtual machines") == true)
+        // The verb names the button actually on screen for this VM.
+        #expect(presenter.errorMessage?.contains("click Install to try again") == true)
+        #expect(instance.status == .initialBoot)
+        #expect(instance.errorMessage == nil)
+        #expect(instance.installState == nil)
+    }
+
+    @Test("An attachment failure wrapping the limit code still offers removal")
+    func attachmentFailureWinsOverLimitExplanation() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let instance = makeInstance()
+        let item = RemovableMediaItem(path: "/tmp/stale.iso", readOnly: true, label: "Stale ISO")
+        instance.configuration.removableMedia = [item]
+        viewModel.instances.append(instance)
+        virtService.startError = ConfigurationBuilderError.removableMediaAttachFailed(
+            id: item.id, path: item.path, label: item.label,
+            underlying: makeLimitExceededError())
+
+        await viewModel.start(instance)
+
+        // The removal offer is the more actionable surface, and a builder error
+        // is permanent regardless of what it wraps.
+        #expect(presenter.startFailedAttachments.count == 1)
+        #expect(presenter.errors.isEmpty)
     }
 
     @Test("forceStop presents error on service failure")

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Virtualization
 @testable import Kernova
 
 @Suite("VMLifecycleCoordinator Tests")
@@ -471,6 +472,35 @@ struct VMLifecycleCoordinatorTests {
             #expect(instance.status == .error)
             #expect(instance.errorMessage != nil)
         }
+    }
+
+    @Test("installMacOS returns the VM to .initialBoot on a transient failure")
+    func installMacOSTransientFailureReturnsToInitialBoot() async {
+        let (coordinator, _, installService, _, _) = makeCoordinator()
+        // The install path's shape for the running-VM cap: the real code arrives
+        // under `.installationFailed`, so only a chain walk classifies it.
+        installService.installError = NSError(
+            domain: VZError.errorDomain,
+            code: VZError.Code.installationFailed.rawValue,
+            userInfo: [
+                NSUnderlyingErrorKey: NSError(
+                    domain: VZError.errorDomain,
+                    code: VZError.Code.virtualMachineLimitExceeded.rawValue)
+            ])
+        let instance = makeInstance()
+        instance.errorMessage = "stale message from an earlier failure"
+        let context = MacOSInstallContext(source: .localFile, localIPSWPath: "/tmp/restore.ipsw")
+        instance.configuration.installContext = context
+        instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
+
+        await #expect(throws: (any Error).self) {
+            try await coordinator.installMacOS(on: instance, context: context)
+        }
+
+        #expect(instance.status == .initialBoot)
+        #expect(instance.errorMessage == nil)
+        // Retrying is the remedy, so the intent that drives the retry survives.
+        #expect(instance.configuration.installContext == context)
     }
 
     @Test("installMacOS clears installContext on successful completion")

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -1,6 +1,5 @@
 import Testing
 import Foundation
-import Virtualization
 @testable import Kernova
 
 @Suite("VMLifecycleCoordinator Tests")
@@ -477,16 +476,7 @@ struct VMLifecycleCoordinatorTests {
     @Test("installMacOS returns the VM to .initialBoot on a transient failure")
     func installMacOSTransientFailureReturnsToInitialBoot() async {
         let (coordinator, _, installService, _, _) = makeCoordinator()
-        // The install path's shape for the running-VM cap: the real code arrives
-        // under `.installationFailed`, so only a chain walk classifies it.
-        installService.installError = NSError(
-            domain: VZError.errorDomain,
-            code: VZError.Code.installationFailed.rawValue,
-            userInfo: [
-                NSUnderlyingErrorKey: NSError(
-                    domain: VZError.errorDomain,
-                    code: VZError.Code.virtualMachineLimitExceeded.rawValue)
-            ])
+        installService.installError = makeInstallVMLimitExceededError()
         let instance = makeInstance()
         instance.errorMessage = "stale message from an earlier failure"
         let context = MacOSInstallContext(source: .localFile, localIPSWPath: "/tmp/restore.ipsw")

--- a/KernovaTests/VMToolbarManagerTests.swift
+++ b/KernovaTests/VMToolbarManagerTests.swift
@@ -421,6 +421,20 @@ struct VMToolbarManagerTests {
         #expect(lifecycle?.subitems[2].isEnabled == true)  // stop
     }
 
+    @Test("Play enabled after a failure (error)")
+    func playEnabledWhenError() {
+        let instance = makeInstance(status: .error)
+        let manager = makeManager(instance: instance)
+        let (toolbar, _, _) = makeToolbar(manager: manager)
+
+        manager.updateToolbarItems(in: toolbar)
+
+        let lifecycle = toolbar.items.first { $0.itemIdentifier.rawValue == "testLifecycle" } as? NSToolbarItemGroup
+        #expect(lifecycle?.subitems[0].isEnabled == true)  // play (retry)
+        #expect(lifecycle?.subitems[1].isEnabled == false)  // pause
+        #expect(lifecycle?.subitems[2].isEnabled == false)  // stop
+    }
+
     @Test("All lifecycle items disabled during transitioning states")
     func lifecycleDisabledDuringTransition() {
         let instance = makeInstance(status: .starting)

--- a/KernovaTests/VirtualizationServiceTests.swift
+++ b/KernovaTests/VirtualizationServiceTests.swift
@@ -133,10 +133,96 @@ struct VirtualizationServiceTests {
 
     // MARK: - Transient Start Error Classification
 
+    private func makeLimitExceededError() -> NSError {
+        NSError(
+            domain: VZError.errorDomain,
+            code: VZError.Code.virtualMachineLimitExceeded.rawValue)
+    }
+
+    /// Mirrors the install path's shape: `VZMacOSInstaller.install()` reports the
+    /// running-VM cap as `.installationFailed` with the real code underneath.
+    private func makeInstallLimitExceededError() -> NSError {
+        makeChain(depth: 1, around: makeLimitExceededError())
+    }
+
+    /// `error` wrapped in `depth` nested `.installationFailed` errors.
+    private func makeChain(depth: Int, around error: NSError) -> NSError {
+        var wrapped = error
+        for _ in 0..<depth {
+            wrapped = NSError(
+                domain: VZError.errorDomain,
+                code: VZError.Code.installationFailed.rawValue,
+                userInfo: [NSUnderlyingErrorKey: wrapped])
+        }
+        return wrapped
+    }
+
     @Test("VM limit exceeded error is transient")
     func vmLimitExceededIsTransient() {
-        let error = NSError(domain: VZError.errorDomain, code: VZError.Code.virtualMachineLimitExceeded.rawValue)
+        let error = makeLimitExceededError()
+        #expect(VirtualizationService.isVirtualMachineLimitExceeded(error))
         #expect(VirtualizationService.isTransientStartError(error))
+    }
+
+    @Test("VM limit exceeded under an installation failure is transient")
+    func nestedVMLimitExceededIsTransient() {
+        let error = makeInstallLimitExceededError()
+        #expect(VirtualizationService.isVirtualMachineLimitExceeded(error))
+        #expect(VirtualizationService.isTransientStartError(error))
+    }
+
+    @Test("VM limit exceeded is found anywhere within the bounded chain")
+    func deeplyNestedVMLimitExceededIsFound() {
+        for depth in 2...4 {
+            let error = makeChain(depth: depth, around: makeLimitExceededError())
+            #expect(VirtualizationService.isVirtualMachineLimitExceeded(error))
+            #expect(VirtualizationService.isTransientStartError(error))
+        }
+    }
+
+    @Test("VM limit exceeded past the chain bound is not recognized")
+    func vmLimitExceededBeyondBoundIsPermanent() {
+        let error = makeChain(depth: 5, around: makeLimitExceededError())
+        #expect(!VirtualizationService.isVirtualMachineLimitExceeded(error))
+        #expect(!VirtualizationService.isTransientStartError(error))
+    }
+
+    @Test("An installation failure carrying no underlying error is permanent")
+    func installationFailedAloneIsPermanent() {
+        let error = NSError(
+            domain: VZError.errorDomain, code: VZError.Code.installationFailed.rawValue)
+        #expect(!VirtualizationService.isVirtualMachineLimitExceeded(error))
+        #expect(!VirtualizationService.isTransientStartError(error))
+    }
+
+    @Test("A builder error wrapping the VM limit stays permanent")
+    func builderErrorWrappingLimitIsPermanent() {
+        let wrapped = ConfigurationBuilderError.storageDiskAttachFailed(
+            id: UUID(), path: "/tmp/Disk.asif", label: "Main Disk",
+            underlying: makeLimitExceededError())
+        #expect(!VirtualizationService.isTransientStartError(wrapped))
+    }
+
+    @Test("A nested operation cancelled is not transient")
+    func nestedOperationCancelledIsPermanent() {
+        let error = makeChain(
+            depth: 1,
+            around: NSError(
+                domain: VZError.errorDomain, code: VZError.Code.operationCancelled.rawValue))
+        #expect(!VirtualizationService.isTransientStartError(error))
+    }
+
+    @Test("The underlying chain description names every link, bounded")
+    func underlyingChainDescriptionNamesEveryLink() {
+        #expect(
+            VirtualizationService.underlyingChainDescription(makeInstallLimitExceededError())
+                == "\(VZError.errorDomain) \(VZError.Code.virtualMachineLimitExceeded.rawValue)")
+        #expect(
+            VirtualizationService.underlyingChainDescription(makeLimitExceededError()) == "none")
+        let deep = makeChain(depth: 6, around: makeLimitExceededError())
+        #expect(
+            VirtualizationService.underlyingChainDescription(deep)
+                .components(separatedBy: " → ").count == 4)
     }
 
     @Test("operation cancelled error is transient")

--- a/KernovaTests/VirtualizationServiceTests.swift
+++ b/KernovaTests/VirtualizationServiceTests.swift
@@ -133,40 +133,16 @@ struct VirtualizationServiceTests {
 
     // MARK: - Transient Start Error Classification
 
-    private func makeLimitExceededError() -> NSError {
-        NSError(
-            domain: VZError.errorDomain,
-            code: VZError.Code.virtualMachineLimitExceeded.rawValue)
-    }
-
-    /// Mirrors the install path's shape: `VZMacOSInstaller.install()` reports the
-    /// running-VM cap as `.installationFailed` with the real code underneath.
-    private func makeInstallLimitExceededError() -> NSError {
-        makeChain(depth: 1, around: makeLimitExceededError())
-    }
-
-    /// `error` wrapped in `depth` nested `.installationFailed` errors.
-    private func makeChain(depth: Int, around error: NSError) -> NSError {
-        var wrapped = error
-        for _ in 0..<depth {
-            wrapped = NSError(
-                domain: VZError.errorDomain,
-                code: VZError.Code.installationFailed.rawValue,
-                userInfo: [NSUnderlyingErrorKey: wrapped])
-        }
-        return wrapped
-    }
-
     @Test("VM limit exceeded error is transient")
     func vmLimitExceededIsTransient() {
-        let error = makeLimitExceededError()
+        let error = makeVMLimitExceededError()
         #expect(VirtualizationService.isVirtualMachineLimitExceeded(error))
         #expect(VirtualizationService.isTransientStartError(error))
     }
 
     @Test("VM limit exceeded under an installation failure is transient")
     func nestedVMLimitExceededIsTransient() {
-        let error = makeInstallLimitExceededError()
+        let error = makeInstallVMLimitExceededError()
         #expect(VirtualizationService.isVirtualMachineLimitExceeded(error))
         #expect(VirtualizationService.isTransientStartError(error))
     }
@@ -174,7 +150,7 @@ struct VirtualizationServiceTests {
     @Test("VM limit exceeded is found anywhere within the bounded chain")
     func deeplyNestedVMLimitExceededIsFound() {
         for depth in 2...4 {
-            let error = makeChain(depth: depth, around: makeLimitExceededError())
+            let error = makeVZErrorChain(depth: depth, around: makeVMLimitExceededError())
             #expect(VirtualizationService.isVirtualMachineLimitExceeded(error))
             #expect(VirtualizationService.isTransientStartError(error))
         }
@@ -182,7 +158,7 @@ struct VirtualizationServiceTests {
 
     @Test("VM limit exceeded past the chain bound is not recognized")
     func vmLimitExceededBeyondBoundIsPermanent() {
-        let error = makeChain(depth: 5, around: makeLimitExceededError())
+        let error = makeVZErrorChain(depth: 5, around: makeVMLimitExceededError())
         #expect(!VirtualizationService.isVirtualMachineLimitExceeded(error))
         #expect(!VirtualizationService.isTransientStartError(error))
     }
@@ -199,13 +175,13 @@ struct VirtualizationServiceTests {
     func builderErrorWrappingLimitIsPermanent() {
         let wrapped = ConfigurationBuilderError.storageDiskAttachFailed(
             id: UUID(), path: "/tmp/Disk.asif", label: "Main Disk",
-            underlying: makeLimitExceededError())
+            underlying: makeVMLimitExceededError())
         #expect(!VirtualizationService.isTransientStartError(wrapped))
     }
 
     @Test("A nested operation cancelled is not transient")
     func nestedOperationCancelledIsPermanent() {
-        let error = makeChain(
+        let error = makeVZErrorChain(
             depth: 1,
             around: NSError(
                 domain: VZError.errorDomain, code: VZError.Code.operationCancelled.rawValue))
@@ -215,11 +191,11 @@ struct VirtualizationServiceTests {
     @Test("The underlying chain description names every link, bounded")
     func underlyingChainDescriptionNamesEveryLink() {
         #expect(
-            VirtualizationService.underlyingChainDescription(makeInstallLimitExceededError())
+            VirtualizationService.underlyingChainDescription(makeInstallVMLimitExceededError())
                 == "\(VZError.errorDomain) \(VZError.Code.virtualMachineLimitExceeded.rawValue)")
         #expect(
-            VirtualizationService.underlyingChainDescription(makeLimitExceededError()) == "none")
-        let deep = makeChain(depth: 6, around: makeLimitExceededError())
+            VirtualizationService.underlyingChainDescription(makeVMLimitExceededError()) == "none")
+        let deep = makeVZErrorChain(depth: 6, around: makeVMLimitExceededError())
         #expect(
             VirtualizationService.underlyingChainDescription(deep)
                 .components(separatedBy: " → ").count == 4)


### PR DESCRIPTION
## Summary
- Starting a third concurrent macOS guest previously surfaced Apple's raw text ("An error occurred during installation. The virtual machine failed to start." on the install path, the equally opaque limit text on the plain-start path) and parked the VM in the red `.error` state even though the condition is transient and retryable.
- The install path now routes through the same transient/permanent classifier the plain-start path already used. The classifier finds `.virtualMachineLimitExceeded` anywhere in the `NSUnderlyingErrorKey` chain (bounded walk), because `VZMacOSInstaller` wraps it under `.installationFailed` — verified live: `[VZErrorDomain 10007; underlying: VZErrorDomain 6]`. A transient install failure returns the VM to `.initialBoot` (orange), a transient start failure to `.stopped` (grey); red is reserved for permanent failures.
- Both paths present one consistent, actionable alert via a shared `explainedFailure` mapper: `Couldn't Install "Name"` / `Couldn't Start "Name"`, with a body naming the two-macOS-VM cap and the remedy, and the verb matching the button on screen. Unmapped failures keep the generic title, and the seam is where #573's invalid-disk-image translation can slot in later.
- Permanent failures now surface their reason: a red error banner above the settings form (the stored `errorMessage` was previously write-only) and the same text as the sidebar icon's tooltip. The initial-boot banner and the new error banner share one `DetailBannerView`.
- Toolbar enablement re-applies whenever a sheet ends, fixing the stale all-greyed toolbar after dismissing a failure alert while the context menu and double-click (which evaluate `canStart` fresh) still worked.

## Changes
- `VirtualizationService`: `isVirtualMachineLimitExceeded`, `underlyingErrorChain`, `underlyingChainDescription`, `applyStartFailure` (single outcome mapping used by the service, the coordinator, and the test mock); transient failures clear `errorMessage`
- `VMLifecycleCoordinator`: `installMacOS` catch classifies and logs the error chain
- `VMLibraryViewModel` / `VMLibraryPresenting` / `DetailAlertsPresenter` / `DetailContainerViewController`: titled `presentError` seam and the `explainedFailure` mapper on both failure paths
- `DetailRoute` / `VMDetailRouterViewController` / `DetailBannerView`: `.error(message:)` route rendering the error banner; banner layout consolidated
- `VMInstance+Display`: `errorMessage` as the `.error` tooltip
- `MainWindowController`: toolbar refresh in `windowDidEndSheet`
- Tests: classifier truth table incl. nesting bounds and the nested-cancel exclusion, transient install → `.initialBoot`, friendly copy on both paths, generic title preserved for unmapped failures, `.error` toolbar enablement, `.error` detail route, error tooltip; VZ error fixtures shared via `TestHelpers`

## Test plan
- [x] `make test` — 1955 test cases passed, 0 failed; `make lint` clean
- [x] Live: two macOS guests running, third install → friendly alert, orange icon, toolbar consistent across two consecutive failures
- [x] Live: plain start of a third macOS VM → same message shape, VM stays grey
- [x] Live: after freeing a slot the same Install click ran the real installer; cancel returned to `.initialBoot`
- [x] Live: garbage IPSW → permanent failure → red icon, error banner, tooltip
- [x] Reviews: Codex standard and adversarial both clean; `/code-review high` — zero correctness findings survived adversarial verification, three cleanup findings fixed (shared failure mapping, unified chain walk, shared test fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pg9Z7A3m97BRcYLSL7T6zw