### PR TITLE
fix: Rename the VM settings "macOS Version" row to "OS Version"

### DIFF
--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -74,7 +74,7 @@ final class VMSettingsViewController: NSViewController {
     // General
     private var nameButton = NSButton()
     private let nameField = NSTextField()
-    /// Value label of the macOS Version row; `nil` for Linux guests, which have
+    /// Value label of the OS Version row; `nil` for Linux guests, which have
     /// no agent to report one.
     private var guestOSVersionValueLabel: NSTextField?
     private var nameDisplayRow = NSView()
@@ -560,7 +560,7 @@ extension VMSettingsViewController {
         if instance.configuration.guestOS == .macOS {
             let versionLabel = makeGroupedFormValueLabel(instance.guestOSVersionDisplay)
             guestOSVersionValueLabel = versionLabel
-            rows.append(makeGroupedFormCardRow("macOS Version", control: versionLabel))
+            rows.append(makeGroupedFormCardRow("OS Version", control: versionLabel))
         } else {
             guestOSVersionValueLabel = nil
         }


### PR DESCRIPTION
## Summary
- Rename the General card's guest version row in VM settings from "macOS Version" to "OS Version"

## Changes
- `Kernova/Views/Detail/VMSettingsViewController.swift`: row title and the doc comment naming it

## Test plan
- [x] `make lint`
- [x] `make test` (full suite: 1967 XCTest + 118 Swift Testing cases, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bw7SttC9uSgpreVzWusKLr