### PR TITLE
fix: Keep the status-item menu VM rows in sync while open

### DIFF
--- a/Kernova/App/HostAgentStatusItemController.swift
+++ b/Kernova/App/HostAgentStatusItemController.swift
@@ -7,7 +7,8 @@ import os
 /// The always-visible "Kernova is running" affordance and the way to summon the
 /// GUI when the app is headless (`.accessory`, no Dock icon), so it lives for
 /// the whole life of the process. The dropdown is rebuilt from live view-model
-/// state each time it opens.
+/// state each time it opens, and its VM rows are edited in place while it is on
+/// screen so the readout tracks starts, stops, and status transitions live.
 @MainActor
 final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
     private static let logger = Logger(subsystem: "app.kernova", category: "HostAgentStatusItem")
@@ -15,6 +16,12 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
 
     private let statusItem: NSStatusItem
     private let menu = NSMenu()
+    /// The dropdown's VM rows, edited in place while the menu is on screen.
+    private lazy var vmSection = StatusMenuVMSection(
+        menu: menu, rowTarget: self, rowAction: #selector(openVMTapped(_:)))
+    /// Whether the dropdown is currently on screen, which `NSMenu` doesn't
+    /// expose; gates the live row sync.
+    private var isMenuOpen = false
 
     private let viewModel: VMLibraryViewModel
     private let preferences: AppPreferences
@@ -22,7 +29,8 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
     private let onOpen: (UUID?) -> Void
     private let onQuit: () -> Void
 
-    /// Keeps the tooltip in sync with how many VMs are running headless.
+    /// Keeps the tooltip — and, while the dropdown is open, its VM rows — in
+    /// sync with the running VMs.
     private var runningObservation: ObservationLoop?
     /// Keeps the icon/tooltip in sync with the host File Provider toggle.
     private var fileProviderObservation: ObservationLoop?
@@ -67,9 +75,16 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
         runningObservation = observeRecurring(
             track: { [weak self] in
                 guard let self else { return }
-                for instance in self.viewModel.instances { _ = instance.isKeepingAppAlive }
+                for instance in self.viewModel.instances {
+                    _ = instance.isKeepingAppAlive
+                    _ = instance.name
+                }
             },
-            apply: { [weak self] in self?.updateTooltip() }
+            apply: { [weak self] in
+                guard let self else { return }
+                self.updateTooltip()
+                self.syncMenuIfOpen()
+            }
         )
 
         fileProviderObservation = observeRecurring(
@@ -299,22 +314,7 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
             menu.addItem(.separator())
         }
 
-        let running = viewModel.instances.filter(\.isKeepingAppAlive)
-        if running.isEmpty {
-            let none = NSMenuItem(
-                title: "No virtual machines running", action: nil, keyEquivalent: "")
-            none.isEnabled = false
-            menu.addItem(none)
-        } else {
-            for instance in running {
-                let item = NSMenuItem(
-                    title: "\(instance.name) — \(instance.status.displayName)",
-                    action: #selector(openVMTapped(_:)), keyEquivalent: "")
-                item.target = self
-                item.representedObject = instance.instanceID
-                menu.addItem(item)
-            }
-        }
+        vmSection.rebuild(rows: StatusMenuVMSection.rows(for: viewModel.instances))
 
         menu.addItem(.separator())
 
@@ -324,11 +324,20 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
     }
 
     func menuWillOpen(_ menu: NSMenu) {
+        isMenuOpen = true
         pasteProgressPresenter.menuWillOpen()
     }
 
     func menuDidClose(_ menu: NSMenu) {
+        isMenuOpen = false
         pasteProgressPresenter.menuDidClose()
+    }
+
+    /// Re-syncs the dropdown's VM rows if it is on screen; a closed menu is
+    /// rebuilt by `menuNeedsUpdate` when it next opens.
+    private func syncMenuIfOpen() {
+        guard isMenuOpen else { return }
+        vmSection.sync(to: StatusMenuVMSection.rows(for: viewModel.instances))
     }
 
     private func addInfoItem(_ title: String) {

--- a/Kernova/App/HostAgentStatusItemController.swift
+++ b/Kernova/App/HostAgentStatusItemController.swift
@@ -75,10 +75,10 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
         runningObservation = observeRecurring(
             track: { [weak self] in
                 guard let self else { return }
-                for instance in self.viewModel.instances {
-                    _ = instance.isKeepingAppAlive
-                    _ = instance.name
-                }
+                // Evaluating the row model registers every property the rows
+                // (and the tooltip's running count) render, so the tracked set
+                // can't drift from the rendered set.
+                _ = StatusMenuVMSection.rows(for: self.viewModel.instances)
             },
             apply: { [weak self] in
                 guard let self else { return }
@@ -341,9 +341,7 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
     }
 
     private func addInfoItem(_ title: String) {
-        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-        item.isEnabled = false
-        menu.addItem(item)
+        menu.addItem(.statusMenuInfo(title: title))
     }
 
     // MARK: - Actions

--- a/Kernova/App/StatusMenuVMSection.swift
+++ b/Kernova/App/StatusMenuVMSection.swift
@@ -1,0 +1,121 @@
+import AppKit
+
+/// One row of the status-item dropdown's VM section.
+struct StatusMenuVMRow: Equatable {
+    let instanceID: UUID
+    let title: String
+}
+
+/// Owns the VM section of the status-item dropdown: one row per VM keeping the
+/// app alive, or a disabled placeholder when none is.
+///
+/// `menuNeedsUpdate` re-populates the section with ``rebuild(rows:)`` while the
+/// dropdown is rebuilt from scratch; state changes while it is on screen go
+/// through ``sync(to:)``, which edits the open menu in place — retitling,
+/// inserting, and removing individual items — so rows never vanish and reappear
+/// under the cursor.
+@MainActor
+final class StatusMenuVMSection {
+    private let menu: NSMenu
+    private weak var rowTarget: AnyObject?
+    private let rowAction: Selector
+
+    /// Live row items in display order; each `representedObject` is the VM's id.
+    private var rowItems: [NSMenuItem] = []
+    /// The disabled placeholder, present exactly when `rowItems` is empty.
+    private var placeholderItem: NSMenuItem?
+
+    init(menu: NSMenu, rowTarget: AnyObject, rowAction: Selector) {
+        self.menu = menu
+        self.rowTarget = rowTarget
+        self.rowAction = rowAction
+    }
+
+    /// The rows the section should show for `instances`.
+    static func rows(for instances: [VMInstance]) -> [StatusMenuVMRow] {
+        instances.filter(\.isKeepingAppAlive).map {
+            StatusMenuVMRow(
+                instanceID: $0.instanceID, title: "\($0.name) — \($0.status.displayName)")
+        }
+    }
+
+    /// Appends the section's items at the menu's current end, dropping any
+    /// previously tracked items.
+    func rebuild(rows: [StatusMenuVMRow]) {
+        placeholderItem = nil
+        rowItems = rows.map(makeRowItem)
+        if rowItems.isEmpty {
+            let placeholder = Self.makePlaceholderItem()
+            menu.addItem(placeholder)
+            placeholderItem = placeholder
+        } else {
+            for item in rowItems { menu.addItem(item) }
+        }
+    }
+
+    /// Edits the section in place to match `rows`.
+    ///
+    /// A no-op until ``rebuild(rows:)`` has put the section's items in the menu:
+    /// the section locates itself by its own items, so it has no anchor before
+    /// then (or after `removeAllItems()` clears a closed menu for rebuild).
+    func sync(to rows: [StatusMenuVMRow]) {
+        guard let start = sectionStart() else { return }
+
+        var surviving: [UUID: NSMenuItem] = [:]
+        for item in rowItems {
+            guard let id = item.representedObject as? UUID else { continue }
+            if rows.contains(where: { $0.instanceID == id }) {
+                surviving[id] = item
+            } else {
+                menu.removeItem(item)
+            }
+        }
+        if let placeholderItem, !rows.isEmpty {
+            menu.removeItem(placeholderItem)
+            self.placeholderItem = nil
+        }
+
+        rowItems = rows.enumerated().map { offset, row in
+            let target = start + offset
+            guard let existing = surviving[row.instanceID] else {
+                let item = makeRowItem(row)
+                menu.insertItem(item, at: target)
+                return item
+            }
+            if existing.title != row.title { existing.title = row.title }
+            if menu.index(of: existing) != target {
+                menu.removeItem(existing)
+                menu.insertItem(existing, at: target)
+            }
+            return existing
+        }
+
+        if rowItems.isEmpty, placeholderItem == nil {
+            let placeholder = Self.makePlaceholderItem()
+            menu.insertItem(placeholder, at: start)
+            placeholderItem = placeholder
+        }
+    }
+
+    /// The index the section's first item occupies, or `nil` when none of its
+    /// items are in the menu.
+    private func sectionStart() -> Int? {
+        guard let first = placeholderItem ?? rowItems.first else { return nil }
+        let index = menu.index(of: first)
+        return index >= 0 ? index : nil
+    }
+
+    private func makeRowItem(_ row: StatusMenuVMRow) -> NSMenuItem {
+        let item = NSMenuItem(title: row.title, action: rowAction, keyEquivalent: "")
+        item.target = rowTarget
+        item.representedObject = row.instanceID
+        return item
+    }
+
+    private static func makePlaceholderItem() -> NSMenuItem {
+        let item = NSMenuItem(
+            title: "No virtual machines running", action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        return item
+    }
+}

--- a/Kernova/App/StatusMenuVMSection.swift
+++ b/Kernova/App/StatusMenuVMSection.swift
@@ -35,7 +35,7 @@ final class StatusMenuVMSection {
     static func rows(for instances: [VMInstance]) -> [StatusMenuVMRow] {
         instances.filter(\.isKeepingAppAlive).map {
             StatusMenuVMRow(
-                instanceID: $0.instanceID, title: "\($0.name) — \($0.status.displayName)")
+                instanceID: $0.instanceID, title: "\($0.name) — \($0.statusDisplayName)")
         }
     }
 
@@ -113,8 +113,14 @@ final class StatusMenuVMSection {
     }
 
     private static func makePlaceholderItem() -> NSMenuItem {
-        let item = NSMenuItem(
-            title: "No virtual machines running", action: nil, keyEquivalent: "")
+        .statusMenuInfo(title: "No virtual machines running")
+    }
+}
+
+extension NSMenuItem {
+    /// A disabled informational row for the status-item dropdown.
+    static func statusMenuInfo(title: String) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
         item.isEnabled = false
         return item
     }

--- a/KernovaTests/StatusMenuVMSectionTests.swift
+++ b/KernovaTests/StatusMenuVMSectionTests.swift
@@ -61,6 +61,19 @@ struct StatusMenuVMSectionTests {
             ])
     }
 
+    @Test("A preparing phantom's row shows its operation, not raw status")
+    func rowModelPreparing() {
+        let phantom = makeInstance(name: "Clone", status: .stopped)
+        phantom.preparingState = VMInstance.PreparingState(operation: .cloning, task: Task {})
+
+        let rows = StatusMenuVMSection.rows(for: [phantom])
+
+        #expect(
+            rows == [
+                StatusMenuVMRow(instanceID: phantom.instanceID, title: "Clone — Cloning\u{2026}")
+            ])
+    }
+
     // MARK: - Rebuild
 
     @Test("Rebuild with no rows appends the disabled placeholder")

--- a/KernovaTests/StatusMenuVMSectionTests.swift
+++ b/KernovaTests/StatusMenuVMSectionTests.swift
@@ -1,0 +1,231 @@
+import AppKit
+import Testing
+
+@testable import Kernova
+
+/// Unit tests for `StatusMenuVMSection` — the status-item dropdown's VM rows.
+///
+/// `rebuild(rows:)` covers the from-scratch path `menuNeedsUpdate` runs on each
+/// open; `sync(to:)` covers the in-place edits applied while the menu is on
+/// screen, where item identity matters: a surviving row must be retitled, never
+/// replaced, so the menu doesn't collapse under the cursor.
+@Suite("StatusMenuVMSection")
+@MainActor
+struct StatusMenuVMSectionTests {
+    private final class RowTarget: NSObject {
+        @objc func rowTapped(_ sender: NSMenuItem) {}
+    }
+
+    private func makeInstance(name: String = "Test VM", status: VMStatus = .running) -> VMInstance {
+        let config = VMConfiguration(name: name, guestOS: .linux, bootMode: .efi)
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(config.id.uuidString, isDirectory: true)
+        return VMInstance(configuration: config, bundleURL: bundleURL, status: status)
+    }
+
+    private func row(_ id: UUID, _ title: String) -> StatusMenuVMRow {
+        StatusMenuVMRow(instanceID: id, title: title)
+    }
+
+    /// Builds a menu shaped like the real dropdown — items above and below the
+    /// section — with the section rebuilt from `rows`.
+    private func makeSection(
+        rows: [StatusMenuVMRow]
+    ) -> (menu: NSMenu, section: StatusMenuVMSection, target: RowTarget) {
+        let menu = NSMenu()
+        let target = RowTarget()
+        let section = StatusMenuVMSection(
+            menu: menu, rowTarget: target, rowAction: #selector(RowTarget.rowTapped(_:)))
+        menu.addItem(NSMenuItem(title: "Open Kernova", action: nil, keyEquivalent: ""))
+        menu.addItem(.separator())
+        section.rebuild(rows: rows)
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Quit Kernova", action: nil, keyEquivalent: ""))
+        return (menu, section, target)
+    }
+
+    // MARK: - Row model
+
+    @Test("rows(for:) includes only VMs keeping the app alive, titled name — status")
+    func rowModel() {
+        let running = makeInstance(name: "Build VM", status: .running)
+        let starting = makeInstance(name: "CI VM", status: .starting)
+        let stopped = makeInstance(name: "Idle VM", status: .stopped)
+
+        let rows = StatusMenuVMSection.rows(for: [running, starting, stopped])
+
+        #expect(
+            rows == [
+                StatusMenuVMRow(instanceID: running.instanceID, title: "Build VM — Running"),
+                StatusMenuVMRow(instanceID: starting.instanceID, title: "CI VM — Starting"),
+            ])
+    }
+
+    // MARK: - Rebuild
+
+    @Test("Rebuild with no rows appends the disabled placeholder")
+    func rebuildEmpty() {
+        let (menu, _, _) = makeSection(rows: [])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Open Kernova", "", "No virtual machines running", "", "Quit Kernova",
+            ])
+        #expect(menu.items[2].isEnabled == false)
+        #expect(menu.items[2].action == nil)
+    }
+
+    @Test("Rebuild appends one wired row per VM")
+    func rebuildRows() {
+        let first = UUID()
+        let second = UUID()
+        let (menu, _, target) = makeSection(
+            rows: [row(first, "One — Running"), row(second, "Two — Starting")])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Open Kernova", "", "One — Running", "Two — Starting", "", "Quit Kernova",
+            ])
+        #expect(menu.items[2].representedObject as? UUID == first)
+        #expect(menu.items[3].representedObject as? UUID == second)
+        #expect(menu.items[2].target === target)
+        #expect(menu.items[2].action == #selector(RowTarget.rowTapped(_:)))
+    }
+
+    // MARK: - Sync
+
+    @Test("A status change retitles the existing item in place")
+    func titleUpdatePreservesIdentity() {
+        let id = UUID()
+        let (menu, section, _) = makeSection(rows: [row(id, "VM — Running")])
+        let item = menu.items[2]
+
+        section.sync(to: [row(id, "VM — Suspending")])
+
+        #expect(menu.items[2] === item)
+        #expect(item.title == "VM — Suspending")
+        #expect(menu.items.count == 5)
+    }
+
+    @Test("A VM stopping loses its row while other rows stay in place")
+    func removalLeavesSurvivors() {
+        let stopping = UUID()
+        let surviving = UUID()
+        let (menu, section, _) = makeSection(
+            rows: [row(stopping, "One — Running"), row(surviving, "Two — Running")])
+        let survivor = menu.items[3]
+
+        section.sync(to: [row(surviving, "Two — Running")])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Open Kernova", "", "Two — Running", "", "Quit Kernova",
+            ])
+        #expect(menu.items[2] === survivor)
+    }
+
+    @Test("The last VM stopping swaps its row for the placeholder")
+    func lastRemovalInsertsPlaceholder() {
+        let id = UUID()
+        let (menu, section, _) = makeSection(rows: [row(id, "VM — Stopping")])
+
+        section.sync(to: [])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Open Kernova", "", "No virtual machines running", "", "Quit Kernova",
+            ])
+        #expect(menu.items[2].isEnabled == false)
+    }
+
+    @Test("A VM starting replaces the placeholder with its row")
+    func firstRowRemovesPlaceholder() {
+        let id = UUID()
+        let (menu, section, target) = makeSection(rows: [])
+
+        section.sync(to: [row(id, "VM — Starting")])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Open Kernova", "", "VM — Starting", "", "Quit Kernova",
+            ])
+        #expect(menu.items[2].representedObject as? UUID == id)
+        #expect(menu.items[2].target === target)
+    }
+
+    @Test("A newly started VM inserts at its position among existing rows")
+    func insertionAmongExistingRows() {
+        let first = UUID()
+        let third = UUID()
+        let (menu, section, _) = makeSection(
+            rows: [row(first, "One — Running"), row(third, "Three — Running")])
+        let second = UUID()
+
+        section.sync(to: [
+            row(first, "One — Running"),
+            row(second, "Two — Starting"),
+            row(third, "Three — Running"),
+        ])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Open Kernova", "", "One — Running", "Two — Starting", "Three — Running",
+                "", "Quit Kernova",
+            ])
+    }
+
+    @Test("Sync reorders surviving rows to match the model")
+    func reorder() {
+        let first = UUID()
+        let second = UUID()
+        let (menu, section, _) = makeSection(
+            rows: [row(first, "One — Running"), row(second, "Two — Running")])
+        let firstItem = menu.items[2]
+        let secondItem = menu.items[3]
+
+        section.sync(to: [row(second, "Two — Running"), row(first, "One — Running")])
+
+        #expect(menu.items[2] === secondItem)
+        #expect(menu.items[3] === firstItem)
+    }
+
+    @Test("Rows stay anchored when items are inserted above the section")
+    func prefixInsertionKeepsAnchor() {
+        let id = UUID()
+        let (menu, section, _) = makeSection(rows: [row(id, "VM — Running")])
+        menu.insertItem(NSMenuItem(title: "Paste readout", action: nil, keyEquivalent: ""), at: 0)
+        menu.insertItem(.separator(), at: 1)
+        let started = UUID()
+
+        section.sync(to: [row(id, "VM — Running"), row(started, "New — Starting")])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Paste readout", "", "Open Kernova", "", "VM — Running", "New — Starting",
+                "", "Quit Kernova",
+            ])
+    }
+
+    @Test("Sync before the section is in the menu is a no-op")
+    func syncBeforeRebuild() {
+        let menu = NSMenu()
+        let target = RowTarget()
+        let section = StatusMenuVMSection(
+            menu: menu, rowTarget: target, rowAction: #selector(RowTarget.rowTapped(_:)))
+
+        section.sync(to: [row(UUID(), "VM — Running")])
+
+        #expect(menu.items.isEmpty)
+    }
+
+    @Test("Sync after the menu was cleared for rebuild is a no-op")
+    func syncAfterRemoveAllItems() {
+        let id = UUID()
+        let (menu, section, _) = makeSection(rows: [row(id, "VM — Running")])
+        menu.removeAllItems()
+
+        section.sync(to: [row(id, "VM — Stopping")])
+
+        #expect(menu.items.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- The status-item dropdown was a snapshot built in `menuNeedsUpdate`, so an open menu never reflected VM state changes — a VM shutting down kept showing Running until the menu was reopened.
- New `StatusMenuVMSection` owns the VM section: `rebuild(rows:)` serves the existing on-open rebuild, and `sync(to:)` edits the open menu in place — retitling surviving rows with item identity preserved (nothing collapses under the cursor), inserting and removing individual rows, and swapping the "No virtual machines running" placeholder in and out. It anchors by its own item references, so it composes with the paste-progress rows inserted above it and no-ops when its items aren't in the menu.
- The controller's existing running-VMs observation — which already fires on every status transition, since `isKeepingAppAlive` reads `status` — now also syncs the open menu, gated by an `isMenuOpen` flag set from `menuWillOpen`/`menuDidClose`. Tracked reads gain `instance.name` so a rename while running updates too. No new observation or scheduling machinery: the main-actor hop is delivered during menu tracking, as the live clipboard paste readout already demonstrates.

## Changes
- `Kernova/App/StatusMenuVMSection.swift` (new)
- `Kernova/App/HostAgentStatusItemController.swift`
- `KernovaTests/StatusMenuVMSectionTests.swift` (new)

## Test plan
- [x] `make test` — full suite green, including the 12 new `StatusMenuVMSectionTests` (row model, in-place retitle identity, individual insert/remove, placeholder swaps, reorder, prefix-insertion anchoring, no-anchor no-ops)
- [x] `make lint`
- [ ] Live check: with the menu open, stop a running guest and watch its row retitle and drop off mid-track

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmA36oPRimwviSYoRZTfPK