### PR TITLE
docs: Record VZ display dimension limits verification

### DIFF
--- a/Kernova/Services/DisplayBootSizing.swift
+++ b/Kernova/Services/DisplayBootSizing.swift
@@ -18,6 +18,10 @@ struct DisplayBootSizing: Sendable {
     static let minimumWidth = 800
     static let minimumHeight = 600
     /// Largest pixel count in either axis.
+    ///
+    /// Kernova's own cap: VZ validates both display types at 16384/axis —
+    /// measured 2026-08-01, see
+    /// `docs/research/2026-08-01-vz-display-dimension-limits.md`.
     static let maximumDimension = 8192
 
     /// Density reported for a HiDPI ("Retina") guest display.

--- a/docs/research/2026-08-01-vz-display-dimension-limits.md
+++ b/docs/research/2026-08-01-vz-display-dimension-limits.md
@@ -1,0 +1,51 @@
+# VZ display dimensions: constructors accept anything, validate() caps at 16384 per axis
+
+**Date:** 2026-08-01 · **Host:** M1 Max, 32 GB, macOS 27.0, Xcode 27.0 SDK
+
+## Summary
+
+Both VZ display types — `VZMacGraphicsDisplayConfiguration` and
+`VZVirtioGraphicsScanoutConfiguration` — enforce a **16384-pixel per-axis
+ceiling**, and enforce it only in `VZVirtualMachineConfiguration.validate()`:
+
+- The initializers never throw. Both constructed at every probed size up to
+  1,048,576 px per axis, and `pixelsPerInch` from 1 to 1,048,576. The
+  exception-at-construction failure mode hypothesized in issue #691 does not
+  exist.
+- `validate()` accepts up to exactly 16384 on each axis independently —
+  16384×16384 passes for both types, so the limit is per-axis, not area — and
+  rejects 16385 with a catchable `VZErrorDomain` error: "The display
+  dimensions are larger than the maximum supported display dimensions" (mac)
+  / "The scanout dimensions are larger than the maximum supported scanout
+  dimensions" (virtio).
+- 1×1 validates for both types; VZ imposes no floor above zero.
+- A diskless EFI VM with a 16384×16384 virtio scanout starts successfully,
+  so validate's ceiling is the real gate, not an optimistic one.
+
+Consequences for Kernova: `DisplayBootSizing.maximumDimension` (8192) sits at
+half the framework ceiling, so no UI-admitted value can be rejected; and a
+hand-edited `config.json` beyond 16384 fails at `ConfigurationBuilder`'s
+existing `try vzConfig.validate()` as an ordinary catchable error — a start
+failure, not a crash. 16384 equals the Apple-GPU maximum texture dimension,
+suggesting the ceiling is hardware-derived and could differ on other chips —
+one more reason to keep Kernova's own cap below it rather than chase it.
+
+## Method
+
+A standalone Objective-C probe (ObjC so `@try/@catch` can intercept the
+hypothesized `NSException`), compiled with `clang -fobjc-arc -framework
+Virtualization` and ad-hoc signed with `com.apple.security.virtualization`:
+
+1. **Construction:** binary search per axis over [800, 2²⁰] (and
+   `pixelsPerInch` over [1, 2²⁰]), catching `NSException`. No throw at any
+   probed value for either type.
+2. **Validation:** binary search with `validateWithError:` as the predicate
+   over full configurations — virtio scanout inside an EFI/`VZGenericPlatform`
+   config, mac display inside a `VZMacPlatformConfiguration` built from
+   `VZMacOSRestoreImage.fetchLatestSupported`'s hardware model with fresh
+   auxiliary storage and machine identifier. Both converge on 16384 per axis;
+   width and height searched independently, then the combined maximum and 1×1
+   checked directly.
+3. **Start:** the EFI config from step 2 at 16384×16384, `VZVirtualMachine`
+   on a private serial queue, `startWithCompletionHandler:` — completes
+   without error (firmware idles with no disk; stopped immediately after).


### PR DESCRIPTION
## Summary

Resolves the open question in #691 empirically: what does Virtualization.framework actually accept for display dimensions, and can a UI-admitted value crash the app?

Findings (M1 Max, macOS 27.0, Xcode 27.0 SDK; full method in the research note):

- **The initializers never throw.** `VZMacGraphicsDisplayConfiguration` and `VZVirtioGraphicsScanoutConfiguration` constructed at every probed size up to 1,048,576 px per axis (and `pixelsPerInch` 1…2^20). The construction-time NSException hypothesized in #691 does not exist.
- **The real gate is `validate()`, at 16384 px per axis for both types** — per-axis, not area (16384×16384 passes); 16385 fails with a catchable `VZErrorDomain` error. 1×1 validates, so VZ imposes no floor.
- **Start accepts what validate accepts:** a diskless EFI VM with a 16384×16384 scanout starts successfully.
- **Kernova is already safe on both fronts:** `DisplayBootSizing.maximumDimension` (8192) is half the framework ceiling, so the UI cannot admit a rejected value — and a hand-edited `config.json` beyond 16384 fails at `ConfigurationBuilder`'s existing `try vzConfig.validate()` as an ordinary catchable start error, not a crash. No behavior change needed.

16384 equals the Apple-GPU maximum texture dimension, suggesting the ceiling is hardware-derived and could differ on other chips — a reason to keep Kernova's own cap below it rather than align to it.

## Changes

- `docs/research/2026-08-01-vz-display-dimension-limits.md` — dated research note with the finding and probe method
- `DisplayBootSizing.maximumDimension` doc comment cites the measured ceiling

## Test plan

- [x] `make lint`
- [x] `make test` (full suite)

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFewKckX36GFqCRtgRPV4E