### PR TITLE
fix: Send a numeric guest OS version from the agent

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -1012,7 +1012,7 @@
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				EXECUTABLE_NAME = KernovaMacOSAgent;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
@@ -1038,7 +1038,7 @@
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				EXECUTABLE_NAME = KernovaMacOSAgent;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
@@ -1096,7 +1096,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent.fileprovider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1127,7 +1127,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent.fileprovider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Kernova/Models/RestoreImageFilename.swift
+++ b/Kernova/Models/RestoreImageFilename.swift
@@ -94,13 +94,6 @@ struct MacOSVersion: Sendable, Equatable {
     /// Numeric components, zero-padded to three.
     let components: [Int]
 
-    /// `version` rendered the way Apple names a release: a zero patch is left
-    /// off, so `26.6.0` reads as `"26.6"` and matches the catalog's own strings.
-    static func displayString(_ version: OperatingSystemVersion) -> String {
-        let base = "\(version.majorVersion).\(version.minorVersion)"
-        return version.patchVersion == 0 ? base : "\(base).\(version.patchVersion)"
-    }
-
     /// `nil` when `version` is not a dot-separated run of numbers.
     init?(_ version: String) {
         let parsed = version.split(separator: ".").map { Int($0) }

--- a/Kernova/Services/IPSWService.swift
+++ b/Kernova/Services/IPSWService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KernovaKit
 import Virtualization
 import os
 
@@ -33,7 +34,7 @@ final class IPSWService: Sendable {
         let restoreImage = try await VZMacOSRestoreImage.latestSupported
         return LatestRestoreImage(
             url: restoreImage.url,
-            version: MacOSVersion.displayString(restoreImage.operatingSystemVersion),
+            version: KernovaOSVersion.displayString(restoreImage.operatingSystemVersion),
             build: restoreImage.buildVersion
         )
     }

--- a/Kernova/Services/LocalRestoreImageInspector.swift
+++ b/Kernova/Services/LocalRestoreImageInspector.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KernovaKit
 import Virtualization
 import os
 
@@ -27,7 +28,7 @@ struct LocalRestoreImageInspector: LocalRestoreImageInspecting {
 
         let version = image.operatingSystemVersion
         let inspected = InspectedRestoreImage(
-            version: MacOSVersion.displayString(version),
+            version: KernovaOSVersion.displayString(version),
             build: image.buildVersion,
             isSupportedOnThisHost: image.mostFeaturefulSupportedConfiguration != nil
         )

--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -217,7 +217,7 @@ final class VsockControlService {
             $0.bundledAgentVersion = bundledAgentVersion ?? ""
             $0.agentInfo = Kernova_V1_AgentInfo.with {
                 $0.os = "macOS"
-                $0.osVersion = ProcessInfo.processInfo.operatingSystemVersionString
+                $0.osVersion = KernovaOSVersion.current
                 $0.agentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "host"
             }
         }

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -29,11 +29,8 @@ extension VMInstance {
     /// The guest-reported OS version for display, or "Unknown" when no agent
     /// has vouched for one.
     ///
-    /// `Hello.agent_info.os_version` is peer-supplied: an agent sending the
-    /// documented numeric shape renders verbatim, and one sending a
-    /// human-readable string renders as the version inside it, in any locale
-    /// ("Versión 26.0 (Compilación 25A123)" → "26.0"). A value holding no digits
-    /// passes through untouched.
+    /// What an agent reports is peer-supplied, so it is read through
+    /// `KernovaOSVersion.numericVersion(in:)` rather than shown raw.
     var guestOSVersionDisplay: String {
         guard let reported = configuration.lastSeenGuestOSVersion, !reported.isEmpty else {
             return "Unknown"

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -1,4 +1,5 @@
 import AppKit
+import KernovaKit
 
 /// Display-layer properties derived from a VM's status.
 extension VMInstance {
@@ -28,15 +29,16 @@ extension VMInstance {
     /// The guest-reported OS version for display, or "Unknown" when no agent
     /// has vouched for one.
     ///
-    /// Strips the constant "Version " lead-in of the agent's
-    /// `operatingSystemVersionString` ("Version 26.0 (Build 25A123)" →
-    /// "26.0 (Build 25A123)"); any other shape passes through untouched.
+    /// `Hello.agent_info.os_version` is peer-supplied: an agent sending the
+    /// documented numeric shape renders verbatim, and one sending a
+    /// human-readable string renders as the version inside it, in any locale
+    /// ("Versión 26.0 (Compilación 25A123)" → "26.0"). A value holding no digits
+    /// passes through untouched.
     var guestOSVersionDisplay: String {
         guard let reported = configuration.lastSeenGuestOSVersion, !reported.isEmpty else {
             return "Unknown"
         }
-        let leadIn = "Version "
-        return reported.hasPrefix(leadIn) ? String(reported.dropFirst(leadIn.count)) : reported
+        return KernovaOSVersion.numericVersion(in: reported) ?? reported
     }
 
     /// Tooltip explaining the VM state variant, or `nil` for standard states.

--- a/KernovaKit/Sources/KernovaKit/KernovaOSVersion.swift
+++ b/KernovaKit/Sources/KernovaKit/KernovaOSVersion.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Numeric rendering and reading of an operating-system version, shared by the
+/// host and the guest agent so the restore-image UI and the
+/// `AgentInfo.os_version` handshake field agree on one shape.
+public enum KernovaOSVersion {
+    /// `version` rendered the way Apple names a release: a zero patch is left
+    /// off, so `26.6.0` reads as `"26.6"` and matches the catalog's own strings.
+    ///
+    /// - Parameter version: The decomposed version to render.
+    /// - Returns: A dotted-decimal string such as `"26.6"` or `"12.0.1"`.
+    public static func displayString(_ version: OperatingSystemVersion) -> String {
+        let base = "\(version.majorVersion).\(version.minorVersion)"
+        return version.patchVersion == 0 ? base : "\(base).\(version.patchVersion)"
+    }
+
+    /// The running system's version in that shape.
+    ///
+    /// Reads the decomposed `ProcessInfo.operatingSystemVersion`, since
+    /// `operatingSystemVersionString` is documented as human-readable only, not
+    /// appropriate for parsing, and is localized to the reporting machine's
+    /// locale (`ProcessInfo` reference).
+    public static var current: String {
+        displayString(ProcessInfo.processInfo.operatingSystemVersion)
+    }
+
+    /// The first dotted-decimal run in `reported`, or `nil` when it holds none.
+    ///
+    /// `AgentInfo.os_version` is peer-supplied, so a peer that sends a
+    /// human-readable string instead of the documented numeric shape still reads
+    /// as a version: `"Version 26.0 (Build 25A123)"` and its translation in any
+    /// locale both yield `"26.0"`.
+    ///
+    /// - Parameter reported: The peer-supplied version string.
+    /// - Returns: The leading dotted-decimal run, or `nil` when `reported`
+    ///   contains no digits.
+    public static func numericVersion(in reported: String) -> String? {
+        guard let match = reported.firstMatch(of: #/\d+(?:\.\d+)*/#) else { return nil }
+        return String(match.output)
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/KernovaOSVersionTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/KernovaOSVersionTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+
+@testable import KernovaKit
+
+@Suite("KernovaOSVersion")
+struct KernovaOSVersionTests {
+    // MARK: - displayString
+
+    @Test("A zero patch component is left off")
+    func zeroPatchIsLeftOff() {
+        #expect(
+            KernovaOSVersion.displayString(
+                OperatingSystemVersion(majorVersion: 26, minorVersion: 6, patchVersion: 0)) == "26.6")
+        #expect(
+            KernovaOSVersion.displayString(
+                OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0)) == "26.0")
+    }
+
+    @Test("A nonzero patch component is kept")
+    func nonzeroPatchIsKept() {
+        #expect(
+            KernovaOSVersion.displayString(
+                OperatingSystemVersion(majorVersion: 26, minorVersion: 5, patchVersion: 2)) == "26.5.2")
+        #expect(
+            KernovaOSVersion.displayString(
+                OperatingSystemVersion(majorVersion: 12, minorVersion: 0, patchVersion: 1)) == "12.0.1")
+    }
+
+    @Test("An all-zero version still renders both leading components")
+    func allZeroRendersTwoComponents() {
+        #expect(
+            KernovaOSVersion.displayString(
+                OperatingSystemVersion(majorVersion: 0, minorVersion: 0, patchVersion: 0)) == "0.0")
+    }
+
+    @Test("Multi-digit components are neither truncated nor padded")
+    func multiDigitComponentsSurvive() {
+        #expect(
+            KernovaOSVersion.displayString(
+                OperatingSystemVersion(majorVersion: 260, minorVersion: 10, patchVersion: 11))
+                == "260.10.11")
+    }
+
+    // MARK: - current
+
+    @Test("current renders the running system's decomposed version")
+    func currentMatchesProcessInfo() {
+        #expect(
+            KernovaOSVersion.current
+                == KernovaOSVersion.displayString(ProcessInfo.processInfo.operatingSystemVersion))
+    }
+
+    @Test("current carries only digits and dots, never a localized display string")
+    func currentIsNumericOnly() {
+        let reported = KernovaOSVersion.current
+        #expect(!reported.isEmpty)
+        #expect(reported.allSatisfy { $0.isNumber || $0 == "." })
+    }
+
+    // MARK: - numericVersion(in:)
+
+    @Test("An already-numeric value is returned unchanged")
+    func numericValuePassesThrough() {
+        #expect(KernovaOSVersion.numericVersion(in: "26.0") == "26.0")
+        #expect(KernovaOSVersion.numericVersion(in: "26.0.1") == "26.0.1")
+        #expect(KernovaOSVersion.numericVersion(in: "6") == "6")
+    }
+
+    @Test("The version is extracted from operatingSystemVersionString in any locale")
+    func versionExtractedFromLocalizedDisplayString() {
+        #expect(KernovaOSVersion.numericVersion(in: "Version 26.0 (Build 25A123)") == "26.0")
+        #expect(KernovaOSVersion.numericVersion(in: "Versión 26.0 (Compilación 25A123)") == "26.0")
+        #expect(KernovaOSVersion.numericVersion(in: "バージョン 26.0.1 (ビルド 25A123)") == "26.0.1")
+    }
+
+    @Test("A value holding no digits reads as nil")
+    func noDigitsReadsAsNil() {
+        #expect(KernovaOSVersion.numericVersion(in: "macOS") == nil)
+        #expect(KernovaOSVersion.numericVersion(in: "") == nil)
+    }
+
+    @Test("A trailing build suffix is dropped rather than folded into the version")
+    func trailingSuffixIsDropped() {
+        #expect(KernovaOSVersion.numericVersion(in: "6.8.0-31-generic") == "6.8.0")
+    }
+}

--- a/KernovaMacOSAgent/VsockGuestControlAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestControlAgent.swift
@@ -260,7 +260,7 @@ final class VsockGuestControlAgent: @unchecked Sendable {
             $0.capabilities = KernovaCapability.controlChannelDefaults
             $0.agentInfo = Kernova_V1_AgentInfo.with {
                 $0.os = "macOS"
-                $0.osVersion = ProcessInfo.processInfo.operatingSystemVersionString
+                $0.osVersion = KernovaOSVersion.current
                 $0.agentVersion = (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "unknown"
             }
         }

--- a/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
@@ -112,6 +112,29 @@ struct VsockGuestControlAgentTests {
         #expect(hello.capabilities.contains(KernovaCapability.clipboardStreamV1))
     }
 
+    @Test("Guest Hello reports agent_info with a numeric os_version")
+    func guestHelloReportsNumericOSVersion() async throws {
+        let (agentFd, hostFd) = try makeRawSocketPair()
+        let host = VsockChannel(fileDescriptor: hostFd)
+        host.start()
+        defer { host.close() }
+
+        let agent = makeAgent(agentFd: agentFd)
+        defer { agent.stop() }
+        agent.start()
+
+        let received = try await nextFrame(from: host)
+        guard case .hello(let hello) = received.payload else {
+            throw TestFailure("Expected Hello, got \(String(describing: received.payload))")
+        }
+        #expect(hello.agentInfo.os == "macOS")
+        #expect(hello.agentInfo.osVersion == KernovaOSVersion.current)
+        // The host renders this string as-is, so a localized `Version 26.0
+        // (Build 25A123)` — or its translation in a non-English guest — must
+        // never reach the wire.
+        #expect(hello.agentInfo.osVersion.allSatisfy { $0.isNumber || $0 == "." })
+    }
+
     // MARK: - Heartbeat
 
     @Test("Emits heartbeat frames on the configured cadence")

--- a/KernovaTests/RestoreImageProbeTests.swift
+++ b/KernovaTests/RestoreImageProbeTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KernovaKit
 import KernovaTestSupport
 import Testing
 
@@ -170,25 +171,9 @@ struct RestoreImageFilenameTests {
 
 @Suite("MacOSVersion Tests")
 struct MacOSVersionTests {
-    @Test("A version reads the way Apple names the release")
-    func displayStringDropsAZeroPatch() {
-        #expect(
-            MacOSVersion.displayString(
-                OperatingSystemVersion(majorVersion: 26, minorVersion: 5, patchVersion: 2))
-                == "26.5.2")
-        #expect(
-            MacOSVersion.displayString(
-                OperatingSystemVersion(majorVersion: 26, minorVersion: 6, patchVersion: 0))
-                == "26.6")
-        #expect(
-            MacOSVersion.displayString(
-                OperatingSystemVersion(majorVersion: 12, minorVersion: 0, patchVersion: 1))
-                == "12.0.1")
-    }
-
-    @Test("What it renders is what the catalog's own version strings parse as")
+    @Test("What KernovaOSVersion renders is what the catalog's own version strings parse as")
     func displayStringRoundTripsThroughTheParser() {
-        let rendered = MacOSVersion.displayString(
+        let rendered = KernovaOSVersion.displayString(
             OperatingSystemVersion(majorVersion: 26, minorVersion: 5, patchVersion: 2))
         #expect(MacOSVersion(rendered)?.components == [26, 5, 2])
     }

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -1089,17 +1089,34 @@ struct VMInstanceTests {
 
     // MARK: - guestOSVersionDisplay
 
-    @Test("guestOSVersionDisplay strips the operatingSystemVersionString lead-in")
-    func guestOSVersionDisplayStripsLeadIn() {
+    @Test("guestOSVersionDisplay reduces an operatingSystemVersionString report to its version")
+    func guestOSVersionDisplayReducesDisplayStringReport() {
         let instance = makeMacOSInstanceWithAgentInstalled(
             lastSeenGuestOSVersion: "Version 26.0 (Build 25A123)")
-        #expect(instance.guestOSVersionDisplay == "26.0 (Build 25A123)")
+        #expect(instance.guestOSVersionDisplay == "26.0")
     }
 
-    @Test("guestOSVersionDisplay passes other shapes through untouched")
-    func guestOSVersionDisplayPassthrough() {
-        let instance = makeMacOSInstanceWithAgentInstalled(lastSeenGuestOSVersion: "26.0")
+    @Test("guestOSVersionDisplay reduces a guest-localized report the same way")
+    func guestOSVersionDisplayReducesLocalizedReport() {
+        let instance = makeMacOSInstanceWithAgentInstalled(
+            lastSeenGuestOSVersion: "Versión 26.0 (Compilación 25A123)")
         #expect(instance.guestOSVersionDisplay == "26.0")
+    }
+
+    @Test("guestOSVersionDisplay passes the numeric shape through untouched")
+    func guestOSVersionDisplayPassthrough() {
+        #expect(
+            makeMacOSInstanceWithAgentInstalled(lastSeenGuestOSVersion: "26.0")
+                .guestOSVersionDisplay == "26.0")
+        #expect(
+            makeMacOSInstanceWithAgentInstalled(lastSeenGuestOSVersion: "26.0.1")
+                .guestOSVersionDisplay == "26.0.1")
+    }
+
+    @Test("guestOSVersionDisplay passes a report holding no digits through untouched")
+    func guestOSVersionDisplayNoDigitsPassthrough() {
+        let instance = makeMacOSInstanceWithAgentInstalled(lastSeenGuestOSVersion: "macOS")
+        #expect(instance.guestOSVersionDisplay == "macOS")
     }
 
     @Test("guestOSVersionDisplay reads Unknown for nil and empty values")

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -141,6 +141,27 @@ struct VsockControlServiceTests {
         #expect(hello.capabilities.contains(KernovaCapability.clipboardStreamV1))
     }
 
+    @Test("Host Hello reports agent_info with a numeric os_version")
+    func hostHelloReportsNumericOSVersion() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let service = makeService(channel: host)
+        service.start()
+        defer { service.stop() }
+
+        let received = try await nextFrame(from: guest)
+        guard case .hello(let hello) = received.payload else {
+            Issue.record("Expected hello payload, got \(String(describing: received.payload))")
+            return
+        }
+        #expect(hello.agentInfo.os == "macOS")
+        #expect(hello.agentInfo.osVersion == KernovaOSVersion.current)
+        #expect(hello.agentInfo.osVersion.allSatisfy { $0.isNumber || $0 == "." })
+    }
+
     @Test("Guest hello flips isConnected and populates agentVersion")
     func guestHelloPopulatesState() async throws {
         let (guest, host) = try makePair()


### PR DESCRIPTION
Closes #688

## Summary

The guest agent filled `Hello.agent_info.os_version` with `ProcessInfo.operatingSystemVersionString` — human-readable, documented by Apple as not appropriate for parsing, and localized to the guest user's Aqua-session locale. A Spanish guest therefore reported `Versión 26.0 (Compilación 25A123)`, and the host's display helper, which stripped only the English `Version ` lead-in, rendered it verbatim inside an otherwise-English Settings UI.

Both sides now report the numeric shape `AgentInfo.os_version` already documents (`26.0`, `26.0.1`), built from the decomposed `ProcessInfo.operatingSystemVersion`.

## Changes

- **`KernovaKit/KernovaOSVersion.swift`** (new) — `displayString(_:)`, `current`, and `numericVersion(in:)`.
- **`VsockGuestControlAgent.sendHello`** and **`VsockControlService.sendHello`** report `KernovaOSVersion.current`.
- **`VMInstance.guestOSVersionDisplay`** reduces a peer report through `numericVersion(in:)`.
- **`IPSWService`** / **`LocalRestoreImageInspector`** repointed off the removed `MacOSVersion.displayString`.
- Guest agent `MARKETING_VERSION` **0.51.0 → 0.52.0** (all four places — both configurations of `KernovaMacOSAgent` and `KernovaMacOSAgentFileProvider`), since a running guest needs the agent reinstalled to send the new shape.

## Deviations from the issue's suggested fix

1. **Moved the existing formatter instead of writing a new one.** The issue asked for a value built from `operatingSystemVersion` components. That exact function already existed as `MacOSVersion.displayString` in the app target, where the guest agent cannot reach it. Writing a second copy would have made a third variant of one rule, so it moved to KernovaKit as `KernovaOSVersion.displayString` and all call sites — restore-image probing included — now share it.

2. **Fixed the host's Hello too.** The issue scopes the change to the guest agent, but `VsockControlService.sendHello` had the identical expression in the identical field. The guest does not read it today, so this is wire hygiene rather than a visible bug — but fixing one side and leaving the other is a parallel logic path, and the shared helper made it a one-line change.

3. **Replaced the "Version " strip rather than keeping it verbatim.** The issue asked to keep the host-side strip as compatibility for already-installed agents. Kept as-is it would have helped only English guests — precisely *not* the population the issue is about, since an un-updated Spanish agent keeps sending the localized string until the user acts on the update affordance. `numericVersion(in:)` extracts the leading dotted-decimal run instead, which is locale-independent, so an old agent's row reads identically to an updated one in every locale. Compatibility handling stays at display time (not ingest), so values already persisted in `config.json` render correctly with no migration code. The visible cost: an old agent's row loses the `(Build 25A123)` suffix, which updated agents never send anyway.

`kernova.proto` is unchanged — its comment already documents the numeric shape by example, and the code now matches it.

## Test plan

- [x] `make format` / `make lint` clean
- [x] `make test` — full suite green (all three targets)
- [x] New `KernovaOSVersionTests`: zero/nonzero patch, all-zero and multi-digit components, `current` matching the running system and carrying only digits and dots, extraction from English/Spanish/Japanese display strings, numeric passthrough, and a digit-free report reading as `nil`
- [x] `VsockGuestControlAgentTests` and `VsockControlServiceTests` each assert a numeric `agent_info.os_version` on the wire
- [x] `VMInstanceTests` covers English, guest-localized, numeric, digit-free, and empty/`nil` reports