### PR TITLE
docs: Correct the wire-contract rationale in the guest Hello test

### DIFF
--- a/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
@@ -129,9 +129,9 @@ struct VsockGuestControlAgentTests {
         }
         #expect(hello.agentInfo.os == "macOS")
         #expect(hello.agentInfo.osVersion == KernovaOSVersion.current)
-        // The host renders this string as-is, so a localized `Version 26.0
-        // (Build 25A123)` — or its translation in a non-English guest — must
-        // never reach the wire.
+        // The numeric shape is the documented wire contract, so a localized
+        // `Version 26.0 (Build 25A123)` — or its translation in a non-English
+        // guest — must never reach the wire.
         #expect(hello.agentInfo.osVersion.allSatisfy { $0.isNumber || $0 == "." })
     }
 


### PR DESCRIPTION
## Summary
The surviving finding from the post-merge `/code-review medium` pass on #696: the guest Hello test's numeric-`os_version` assertion was justified with "The host renders this string as-is", a claim #696 itself made false — the host now reduces every digit-bearing report through `KernovaOSVersion.numericVersion(in:)` in `guestOSVersionDisplay`. Reasoning built on that comment (e.g. treating the wire shape as the only defense against localized strings) would start from a wrong premise. The comment now states the real rationale: the numeric shape is the documented wire contract.

## Changes
- `KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift`: one comment reworded; no code or assertion changes

## Test plan
- [x] `make lint` clean
- [x] `make test` green (all targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AdYHdbHPwmRAQrhL76tLn