### PR TITLE
feat: Add machine-identity settings for cloning and boot blocking

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -1062,6 +1062,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         viewModel.cloneVM(instance)
     }
 
+    @objc func cloneVMAlternate(_ sender: Any?) {
+        guard let instance = activeInstance else { return }
+        viewModel.cloneVMWithOppositeMachineIdentity(instance)
+    }
+
     @objc func deleteVM(_ sender: Any?) {
         guard let instance = activeInstance else { return }
         viewModel.confirmDelete(instance)
@@ -1411,7 +1416,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             return activeInstance?.canSave ?? false
         case #selector(renameVM(_:)):
             return activeInstance?.status.canRename ?? false
-        case #selector(cloneVM(_:)):
+        case #selector(cloneVM(_:)), #selector(cloneVMAlternate(_:)):
+            if menuItem.action == #selector(cloneVMAlternate(_:)) {
+                menuItem.title =
+                    preferences.cloneGeneratesNewMachineID
+                    ? "Clone (Keep Machine ID)" : "Clone (New Machine ID)"
+            }
             guard let instance = activeInstance else { return false }
             return instance.status.canEditSettings && !viewModel.hasPreparing
         case #selector(deleteVM(_:)), #selector(deleteImmediatelyVM(_:)):
@@ -1618,6 +1628,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // Finder's single-item Rename), not a dialog.
         vmMenu.addItem(withTitle: "Rename", action: #selector(renameVM(_:)), keyEquivalent: "")
         vmMenu.addItem(withTitle: "Clone", action: #selector(cloneVM(_:)), keyEquivalent: "d")
+        // ⌥-alternate performing the opposite of the clone machine-ID setting.
+        // Title is a placeholder — `validateMenuItem(_:)` retitles per the
+        // setting on every menu open. The ⌥⌘D key equivalent is eclipsed by the
+        // system's Dock-hiding hotkey; the item still swaps in on ⌥-hold and
+        // fires from the pointer, which is its intended use.
+        let cloneAlternateItem = vmMenu.addItem(
+            withTitle: "Clone (Keep Machine ID)", action: #selector(cloneVMAlternate(_:)), keyEquivalent: "d")
+        cloneAlternateItem.keyEquivalentModifierMask = [.command, .option]
+        cloneAlternateItem.isAlternate = true
         vmMenu.addItem(withTitle: "Show in Finder", action: #selector(showVMInFinder(_:)), keyEquivalent: "")
         vmMenu.addItem(.separator())
         // "Move to Trash…" gathers input (the delete sheet lets the user pick which

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -1418,9 +1418,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             return activeInstance?.status.canRename ?? false
         case #selector(cloneVM(_:)), #selector(cloneVMAlternate(_:)):
             if menuItem.action == #selector(cloneVMAlternate(_:)) {
-                menuItem.title =
-                    preferences.cloneGeneratesNewMachineID
-                    ? "Clone (Keep Machine ID)" : "Clone (New Machine ID)"
+                menuItem.title = preferences.cloneAlternateMenuTitle
             }
             guard let instance = activeInstance else { return false }
             return instance.status.canEditSettings && !viewModel.hasPreparing
@@ -1628,15 +1626,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // Finder's single-item Rename), not a dialog.
         vmMenu.addItem(withTitle: "Rename", action: #selector(renameVM(_:)), keyEquivalent: "")
         vmMenu.addItem(withTitle: "Clone", action: #selector(cloneVM(_:)), keyEquivalent: "d")
-        // ⌥-alternate performing the opposite of the clone machine-ID setting.
-        // Title is a placeholder — `validateMenuItem(_:)` retitles per the
-        // setting on every menu open. The ⌥⌘D key equivalent is eclipsed by the
-        // system's Dock-hiding hotkey; the item still swaps in on ⌥-hold and
-        // fires from the pointer, which is its intended use.
+        // Clones with the opposite machine-identity behavior to the setting.
+        // Always visible, like Start in Recovery Mode: this menu shows advanced
+        // actions plainly, reserving ⌥-alternates for irreversible ones.
+        // `validateMenuItem(_:)` re-reads the title on every menu open, so a
+        // setting change while the menu exists is picked up. The ⌥⌘D key
+        // equivalent is eclipsed by the system's Dock-hiding hotkey; the item
+        // fires from the pointer.
         let cloneAlternateItem = vmMenu.addItem(
-            withTitle: "Clone (Keep Machine ID)", action: #selector(cloneVMAlternate(_:)), keyEquivalent: "d")
+            withTitle: preferences.cloneAlternateMenuTitle, action: #selector(cloneVMAlternate(_:)),
+            keyEquivalent: "d")
         cloneAlternateItem.keyEquivalentModifierMask = [.command, .option]
-        cloneAlternateItem.isAlternate = true
         vmMenu.addItem(withTitle: "Show in Finder", action: #selector(showVMInFinder(_:)), keyEquivalent: "")
         vmMenu.addItem(.separator())
         // "Move to Trash…" gathers input (the delete sheet lets the user pick which

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -354,7 +354,8 @@ struct VMConfiguration: Codable, Sendable, Equatable {
     ///
     /// Platform identity fields (`macAddress`, `machineIdentifierData`,
     /// `genericMachineIdentifierData`) are **not** regenerated here — the caller
-    /// must replace them with fresh VZ framework values after cloning.
+    /// always replaces `macAddress`, and replaces the machine identifiers or
+    /// keeps them per the clone machine-ID preference.
     func clonedForNewInstance(existingNames: [String]) -> VMConfiguration {
         var clone = self
         clone.id = UUID()

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -241,6 +241,27 @@ final class VMInstance {
     var hasSaveFile: Bool { bundleLayout.hasSaveFile }
     var serialLogURL: URL { bundleLayout.serialLogURL }
 
+    // MARK: - Machine Identity
+
+    /// Memoized `MachineIdentifier` file read: the outer optional separates "not
+    /// read yet" from "read, and there is no file".
+    @ObservationIgnored private var machineIdentifierFileData: Data??
+
+    /// The macOS machine identifier this VM boots with — the configuration field
+    /// when set, otherwise the bundle's identifier file.
+    ///
+    /// The fallback mirrors ``ConfigurationBuilder``, which reads the file when
+    /// the configuration carries no identifier, so a bundle holding its identity
+    /// only on disk compares equal to one holding it in the configuration. The
+    /// file is read at most once per instance.
+    var effectiveMachineIdentifierData: Data? {
+        if let fromConfiguration = configuration.machineIdentifierData { return fromConfiguration }
+        if let cached = machineIdentifierFileData { return cached }
+        let fromFile = try? Data(contentsOf: machineIdentifierURL)
+        machineIdentifierFileData = .some(fromFile)
+        return fromFile
+    }
+
     // MARK: - Runtime Removable Media
 
     /// USB mass storage devices currently attached on the XHCI controller.

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -187,7 +187,7 @@ final class VMInstance {
             return AgentStatus.synthesize(
                 upstream: vsockControlService?.agentStatus ?? .waiting,
                 lastSeenAgentVersion: configuration.lastSeenAgentVersion,
-                isInLiveSession: virtualMachine != nil,
+                isInLiveSession: hasLiveVirtualMachine,
                 agentExpectedButMissing: agentExpectedButMissing
             )
         case .linux:
@@ -270,19 +270,35 @@ final class VMInstance {
     /// running; cleared on stop/teardown.
     var liveRemovableMedia: [USBDeviceInfo] = []
 
+    #if DEBUG
+    /// Test stand-in for `virtualMachine != nil`: constructing a real
+    /// `VZVirtualMachine` requires the virtualization entitlement, which CI
+    /// test hosts lack.
+    var hasLiveVirtualMachineOverrideForTesting: Bool?
+    #endif
+
+    /// Whether a `VZVirtualMachine` for this VM is live in memory — the single
+    /// liveness read every predicate here shares.
+    var hasLiveVirtualMachine: Bool {
+        #if DEBUG
+        if let hasLiveVirtualMachineOverrideForTesting { return hasLiveVirtualMachineOverrideForTesting }
+        #endif
+        return virtualMachine != nil
+    }
+
     var canAttachUSBDevices: Bool {
-        (status == .running || status == .paused) && virtualMachine != nil
+        (status == .running || status == .paused) && hasLiveVirtualMachine
     }
 
     /// `true` when the VM is paused-to-disk but has no live `VZVirtualMachine` in memory.
     var isColdPaused: Bool {
-        status == .paused && virtualMachine == nil
+        status == .paused && !hasLiveVirtualMachine
     }
 
     /// `true` when the VM is paused with its `VZVirtualMachine` still live in
     /// memory — the resumable counterpart of ``isColdPaused``.
     var isLivePaused: Bool {
-        status == .paused && virtualMachine != nil
+        status == .paused && hasLiveVirtualMachine
     }
 
     /// `true` when this VM should keep the app alive: preparing, in an active

--- a/Kernova/Utilities/AppPreferences.swift
+++ b/Kernova/Utilities/AppPreferences.swift
@@ -30,6 +30,11 @@ struct AppPreferences {
         static let quitTerminatesApp = "quitTerminatesApp"
         static let menuBarQuitReminderDismissed = "menuBarQuitReminderDismissed"
         static let mainToolbarNewVMCollapseIndex = "KernovaMainToolbarNewVMCollapseIndex"
+        // Both stored inverted for the same reason as `quitTerminatesApp`: the
+        // unset key reads `false`, which must map to each preference's `true`
+        // default. The key names what it literally holds.
+        static let allowDuplicateMachineIDBoot = "allowDuplicateMachineIDBoot"
+        static let cloneKeepsMachineID = "cloneKeepsMachineID"
     }
 
     /// When `true`, advanced menu actions (e.g. *Start in Recovery Mode*) are
@@ -109,6 +114,25 @@ struct AppPreferences {
     var mainToolbarNewVMCollapseIndex: Int? {
         get { defaults.object(forKey: Keys.mainToolbarNewVMCollapseIndex) as? Int }
         nonmutating set { defaults.set(newValue, forKey: Keys.mainToolbarNewVMCollapseIndex) }
+    }
+
+    /// Whether starting a VM is refused while another VM with the same machine
+    /// identifier is live, defaulting to `true`.
+    ///
+    /// Two VMs sharing a machine identifier must never run at once — the
+    /// framework documents the result as undefined behavior.
+    var blockDuplicateMachineIDBoot: Bool {
+        get { !defaults.bool(forKey: Keys.allowDuplicateMachineIDBoot) }
+        nonmutating set { defaults.set(!newValue, forKey: Keys.allowDuplicateMachineIDBoot) }
+    }
+
+    /// Whether Clone gives the copy a fresh machine identifier, defaulting to `true`.
+    ///
+    /// When `false`, clones keep the source VM's identifier. The Option-held
+    /// Clone menu item performs the opposite of this setting.
+    var cloneGeneratesNewMachineID: Bool {
+        get { !defaults.bool(forKey: Keys.cloneKeepsMachineID) }
+        nonmutating set { defaults.set(!newValue, forKey: Keys.cloneKeepsMachineID) }
     }
 
     /// Re-arms every host-side reminder by clearing its dismissed flag, so each

--- a/Kernova/Utilities/AppPreferences.swift
+++ b/Kernova/Utilities/AppPreferences.swift
@@ -30,11 +30,23 @@ struct AppPreferences {
         static let quitTerminatesApp = "quitTerminatesApp"
         static let menuBarQuitReminderDismissed = "menuBarQuitReminderDismissed"
         static let mainToolbarNewVMCollapseIndex = "KernovaMainToolbarNewVMCollapseIndex"
-        // Both stored inverted for the same reason as `quitTerminatesApp`: the
-        // unset key reads `false`, which must map to each preference's `true`
-        // default. The key names what it literally holds.
+        // Also inverted — see `keepInMenuBarOnQuit`'s RATIONALE.
         static let allowDuplicateMachineIDBoot = "allowDuplicateMachineIDBoot"
         static let cloneKeepsMachineID = "cloneKeepsMachineID"
+    }
+
+    // MARK: - Inverted Storage
+
+    /// Reads the inverse of the boolean stored under the given key, so an unset
+    /// key yields a `true` default.
+    private func invertedBool(forKey key: String) -> Bool {
+        !defaults.bool(forKey: key)
+    }
+
+    /// Writes the inverse of `value` under the given key, the counterpart of
+    /// ``invertedBool(forKey:)``.
+    private func setInvertedBool(_ value: Bool, forKey key: String) {
+        defaults.set(!value, forKey: key)
     }
 
     /// When `true`, advanced menu actions (e.g. *Start in Recovery Mode*) are
@@ -88,10 +100,11 @@ struct AppPreferences {
     /// RATIONALE: the value is stored *inverted* under `quitTerminatesApp` so the
     /// file's plain `bool(forKey:)` convention — an unset key reads `false` —
     /// produces this preference's `true` default without registering defaults.
-    /// The key names what it literally holds.
+    /// The key names what it literally holds. Every `true`-defaulting preference
+    /// here works this way, through `invertedBool(forKey:)`.
     var keepInMenuBarOnQuit: Bool {
-        get { !defaults.bool(forKey: Keys.quitTerminatesApp) }
-        nonmutating set { defaults.set(!newValue, forKey: Keys.quitTerminatesApp) }
+        get { invertedBool(forKey: Keys.quitTerminatesApp) }
+        nonmutating set { setInvertedBool(newValue, forKey: Keys.quitTerminatesApp) }
     }
 
     /// Whether the user dismissed the "still running in the menu bar" reminder
@@ -122,8 +135,8 @@ struct AppPreferences {
     /// Two VMs sharing a machine identifier must never run at once — the
     /// framework documents the result as undefined behavior.
     var blockDuplicateMachineIDBoot: Bool {
-        get { !defaults.bool(forKey: Keys.allowDuplicateMachineIDBoot) }
-        nonmutating set { defaults.set(!newValue, forKey: Keys.allowDuplicateMachineIDBoot) }
+        get { invertedBool(forKey: Keys.allowDuplicateMachineIDBoot) }
+        nonmutating set { setInvertedBool(newValue, forKey: Keys.allowDuplicateMachineIDBoot) }
     }
 
     /// Whether Clone gives the copy a fresh machine identifier, defaulting to `true`.
@@ -131,8 +144,14 @@ struct AppPreferences {
     /// When `false`, clones keep the source VM's identifier. The Option-held
     /// Clone menu item performs the opposite of this setting.
     var cloneGeneratesNewMachineID: Bool {
-        get { !defaults.bool(forKey: Keys.cloneKeepsMachineID) }
-        nonmutating set { defaults.set(!newValue, forKey: Keys.cloneKeepsMachineID) }
+        get { invertedBool(forKey: Keys.cloneKeepsMachineID) }
+        nonmutating set { setInvertedBool(newValue, forKey: Keys.cloneKeepsMachineID) }
+    }
+
+    /// Title of the Option-alternate Clone menu item, which clones with the
+    /// opposite machine-identity behavior to the one this preference selects.
+    var cloneAlternateMenuTitle: String {
+        cloneGeneratesNewMachineID ? "Clone (Keep Machine ID)" : "Clone (New Machine ID)"
     }
 
     /// Re-arms every host-side reminder by clearing its dismissed flag, so each

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -315,6 +315,20 @@ final class VMLibraryViewModel {
             return
         }
 
+        if preferences.blockDuplicateMachineIDBoot,
+            let conflict = liveMachineIDConflict(for: instance)
+        {
+            Self.logger.notice(
+                "Refused to start '\(instance.name, privacy: .public)': shares a machine ID with running VM '\(conflict.name, privacy: .public)'"
+            )
+            surfaceError(
+                "“\(instance.name)” has the same machine ID as “\(conflict.name)”, which is running. "
+                    + "Two virtual machines with the same machine ID must not run at once. "
+                    + "Stop “\(conflict.name)” first, or allow this in Settings → Advanced.",
+                title: "Duplicate Machine ID")
+            return
+        }
+
         if instance.configuration.displayPreference != .inline {
             onOpenDisplayWindow?(instance)
         }
@@ -332,6 +346,31 @@ final class VMLibraryViewModel {
                 presentError(error)
             }
         }
+    }
+
+    /// The first VM with a live virtual machine sharing a machine identifier
+    /// with the given instance, if any.
+    ///
+    /// Live means any state where VZ holds the identity — including paused,
+    /// which `VMStatus.isActive` excludes.
+    private func liveMachineIDConflict(for instance: VMInstance) -> VMInstance? {
+        instances.first { other in
+            other !== instance
+                && (other.status.isActive || other.status == .paused)
+                && Self.sharesMachineIdentifier(instance.configuration, other.configuration)
+        }
+    }
+
+    private static func sharesMachineIdentifier(_ a: VMConfiguration, _ b: VMConfiguration) -> Bool {
+        if let lhs = a.machineIdentifierData, let rhs = b.machineIdentifierData, lhs == rhs {
+            return true
+        }
+        if let lhs = a.genericMachineIdentifierData, let rhs = b.genericMachineIdentifierData,
+            lhs == rhs
+        {
+            return true
+        }
+        return false
     }
 
     /// Resizes a cold-booting VM's display to the surface it is about to appear
@@ -1747,30 +1786,49 @@ final class VMLibraryViewModel {
 
     // MARK: - Clone
 
-    func cloneVM(_ instance: VMInstance) {
+    /// The Option-alternate Clone: performs the opposite of the
+    /// `cloneGeneratesNewMachineID` preference for this one clone.
+    func cloneVMWithOppositeMachineIdentity(_ instance: VMInstance) {
+        cloneVM(instance, generateNewMachineID: !preferences.cloneGeneratesNewMachineID)
+    }
+
+    /// Clones `instance`. `generateNewMachineID: nil` follows the
+    /// `cloneGeneratesNewMachineID` preference; the Option-alternate menu items
+    /// pass the opposite explicitly via `cloneVMWithOppositeMachineIdentity`.
+    func cloneVM(_ instance: VMInstance, generateNewMachineID: Bool? = nil) {
         guard instance.status.canEditSettings else {
             Self.logger.debug(
                 "Clone skipped for '\(instance.name, privacy: .public)': status '\(instance.status.displayName, privacy: .public)' does not allow editing"
             )
             return
         }
+        let generateNewID = generateNewMachineID ?? preferences.cloneGeneratesNewMachineID
         let existingNames = instances.map(\.configuration.name)
         var clonedConfig = instance.configuration.clonedForNewInstance(existingNames: existingNames)
 
         clonedConfig.macAddress = VZMACAddress.randomLocallyAdministered().string
 
-        if clonedConfig.guestOS == .macOS {
-            clonedConfig.machineIdentifierData = VZMacMachineIdentifier().dataRepresentation
-        }
-
-        if clonedConfig.bootMode == .efi || clonedConfig.bootMode == .linuxKernel {
-            clonedConfig.genericMachineIdentifierData = VZGenericMachineIdentifier().dataRepresentation
+        if generateNewID {
+            if clonedConfig.guestOS == .macOS {
+                clonedConfig.machineIdentifierData = VZMacMachineIdentifier().dataRepresentation
+            }
+            if clonedConfig.bootMode == .efi || clonedConfig.bootMode == .linuxKernel {
+                clonedConfig.genericMachineIdentifierData = VZGenericMachineIdentifier().dataRepresentation
+            }
+        } else if clonedConfig.guestOS == .macOS, clonedConfig.machineIdentifierData == nil {
+            // Older bundles carry the identifier only as a file. The bundle copy
+            // below keeps the clone bootable; lifting the data into the config
+            // additionally lets the duplicate-machine-ID boot guard see it.
+            clonedConfig.machineIdentifierData = try? Data(contentsOf: instance.machineIdentifierURL)
         }
 
         var filesToCopy = ["Disk.asif"]
         switch clonedConfig.guestOS {
         case .macOS:
             filesToCopy.append(contentsOf: ["AuxiliaryStorage", "HardwareModel"])
+            if !generateNewID {
+                filesToCopy.append("MachineIdentifier")
+            }
         case .linux:
             if clonedConfig.bootMode == .efi {
                 filesToCopy.append("EFIVariableStore")

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -315,19 +315,7 @@ final class VMLibraryViewModel {
             return
         }
 
-        if preferences.blockDuplicateMachineIDBoot,
-            let conflict = liveMachineIDConflict(for: instance)
-        {
-            Self.logger.notice(
-                "Refused to start '\(instance.name, privacy: .public)': shares a machine ID with running VM '\(conflict.name, privacy: .public)'"
-            )
-            surfaceError(
-                "“\(instance.name)” has the same machine ID as “\(conflict.name)”, which is running. "
-                    + "Two virtual machines with the same machine ID must not run at once. "
-                    + "Stop “\(conflict.name)” first, or allow this in Settings → Advanced.",
-                title: "Duplicate Machine ID")
-            return
-        }
+        if refuseIfDuplicateMachineIDConflict(instance) { return }
 
         if instance.configuration.displayPreference != .inline {
             onOpenDisplayWindow?(instance)
@@ -348,24 +336,52 @@ final class VMLibraryViewModel {
         }
     }
 
-    /// The first VM with a live virtual machine sharing a machine identifier
-    /// with the given instance, if any.
+    /// Refuses an operation that would claim a machine identity another VM
+    /// already holds, logging the refusal and surfacing the alert.
     ///
-    /// Live means any state where VZ holds the identity — including paused,
-    /// which `VMStatus.isActive` excludes.
+    /// - Returns: `true` when the caller must abort.
+    private func refuseIfDuplicateMachineIDConflict(_ instance: VMInstance) -> Bool {
+        guard preferences.blockDuplicateMachineIDBoot,
+            let conflict = liveMachineIDConflict(for: instance)
+        else { return false }
+        Self.logger.notice(
+            "Refused to run '\(instance.name, privacy: .public)': shares a machine ID with active VM '\(conflict.name, privacy: .public)'"
+        )
+        surfaceError(
+            "“\(instance.name)” has the same machine ID as “\(conflict.name)”, which is active. "
+                + "Two virtual machines with the same machine ID must not run at once. "
+                + "Stop “\(conflict.name)” first, or allow this in Settings → Advanced.",
+            title: "Duplicate Machine ID")
+        return true
+    }
+
+    /// The first VM holding a live machine identity matching the given
+    /// instance's, if any.
+    ///
+    /// Live means VZ holds the identity: any active status, or paused with the
+    /// virtual machine still in memory. A cold-paused VM has released it, and
+    /// blocking its twin on a saved state that claims nothing would be wrong.
     private func liveMachineIDConflict(for instance: VMInstance) -> VMInstance? {
         instances.first { other in
             other !== instance
-                && (other.status.isActive || other.status == .paused)
-                && Self.sharesMachineIdentifier(instance.configuration, other.configuration)
+                && (other.status.isActive || other.isLivePaused)
+                && Self.sharesMachineIdentifier(instance, other)
         }
     }
 
-    private static func sharesMachineIdentifier(_ a: VMConfiguration, _ b: VMConfiguration) -> Bool {
-        if let lhs = a.machineIdentifierData, let rhs = b.machineIdentifierData, lhs == rhs {
+    /// Whether two VMs would claim the same machine identity.
+    ///
+    /// macOS identifiers compare the *effective* value, which falls back to the
+    /// bundle's identifier file exactly as the boot path does; generic
+    /// identifiers have no such file, so they compare configuration fields.
+    private static func sharesMachineIdentifier(_ a: VMInstance, _ b: VMInstance) -> Bool {
+        if let lhs = a.effectiveMachineIdentifierData, let rhs = b.effectiveMachineIdentifierData,
+            lhs == rhs
+        {
             return true
         }
-        if let lhs = a.genericMachineIdentifierData, let rhs = b.genericMachineIdentifierData,
+        if let lhs = a.configuration.genericMachineIdentifierData,
+            let rhs = b.configuration.genericMachineIdentifierData,
             lhs == rhs
         {
             return true
@@ -595,6 +611,12 @@ final class VMLibraryViewModel {
     }
 
     func resume(_ instance: VMInstance) async {
+        // A cold resume builds a fresh VZVirtualMachine from the save file, so it
+        // claims the machine identity just as a cold boot does. A hot resume's
+        // live object already holds it, and refusing would be refusing a VM its
+        // own identity.
+        if instance.isColdPaused, refuseIfDuplicateMachineIDConflict(instance) { return }
+
         if instance.configuration.displayPreference != .inline {
             onOpenDisplayWindow?(instance)
         }
@@ -1815,11 +1837,24 @@ final class VMLibraryViewModel {
             if clonedConfig.bootMode == .efi || clonedConfig.bootMode == .linuxKernel {
                 clonedConfig.genericMachineIdentifierData = VZGenericMachineIdentifier().dataRepresentation
             }
-        } else if clonedConfig.guestOS == .macOS, clonedConfig.machineIdentifierData == nil {
-            // Older bundles carry the identifier only as a file. The bundle copy
-            // below keeps the clone bootable; lifting the data into the config
-            // additionally lets the duplicate-machine-ID boot guard see it.
-            clonedConfig.machineIdentifierData = try? Data(contentsOf: instance.machineIdentifierURL)
+        } else {
+            // Keep mode mints only what there is no identity to keep: a source
+            // whose identifier lives in the bundle file alone hands it to the
+            // clone through `filesToCopy` below, untouched here.
+            if clonedConfig.guestOS == .macOS, instance.effectiveMachineIdentifierData == nil {
+                clonedConfig.machineIdentifierData = VZMacMachineIdentifier().dataRepresentation
+                Self.logger.notice(
+                    "Clone of '\(instance.name, privacy: .public)' had no machine identifier to keep — generated a new one"
+                )
+            }
+            if clonedConfig.bootMode == .efi || clonedConfig.bootMode == .linuxKernel,
+                clonedConfig.genericMachineIdentifierData == nil
+            {
+                clonedConfig.genericMachineIdentifierData = VZGenericMachineIdentifier().dataRepresentation
+                Self.logger.notice(
+                    "Clone of '\(instance.name, privacy: .public)' had no generic machine identifier to keep — generated a new one"
+                )
+            }
         }
 
         var filesToCopy = ["Disk.asif"]

--- a/Kernova/Views/Settings/AdvancedSettingsViewController.swift
+++ b/Kernova/Views/Settings/AdvancedSettingsViewController.swift
@@ -2,15 +2,18 @@ import AppKit
 
 /// The "Advanced" pane of the Settings window.
 ///
-/// Today it hosts a single toggle — *Always show advanced options* — which
-/// controls whether advanced menu actions (e.g. *Start in Recovery Mode*) are
-/// always visible or revealed only on an Option (⌥) hold. Backed by
-/// `AppPreferences`; the menus re-read the preference each time they open, so no
-/// change notification is needed here.
+/// Hosts the *Always show advanced options* toggle — whether advanced menu
+/// actions (e.g. *Start in Recovery Mode*) are always visible or revealed only
+/// on an Option (⌥) hold — and the two machine-identity toggles: blocking
+/// duplicate machine IDs from booting, and whether Clone generates a new
+/// machine ID. All backed by `AppPreferences`; the menus re-read the
+/// preferences each time they open, so no change notification is needed here.
 @MainActor
 final class AdvancedSettingsViewController: NSViewController {
     private let preferences: AppPreferences
     private let alwaysShowSwitch = NSSwitch()
+    private let blockDuplicateIDSwitch = NSSwitch()
+    private let cloneNewIDSwitch = NSSwitch()
 
     init(preferences: AppPreferences = .shared) {
         self.preferences = preferences
@@ -28,6 +31,14 @@ final class AdvancedSettingsViewController: NSViewController {
         alwaysShowSwitch.target = self
         alwaysShowSwitch.action = #selector(alwaysShowToggled)
 
+        blockDuplicateIDSwitch.controlSize = .small
+        blockDuplicateIDSwitch.target = self
+        blockDuplicateIDSwitch.action = #selector(blockDuplicateIDToggled)
+
+        cloneNewIDSwitch.controlSize = .small
+        cloneNewIDSwitch.target = self
+        cloneNewIDSwitch.action = #selector(cloneNewIDToggled)
+
         let card = makeGroupedFormCard(rows: [
             makeGroupedFormCardRow("Always show advanced options", control: alwaysShowSwitch)
         ])
@@ -35,14 +46,40 @@ final class AdvancedSettingsViewController: NSViewController {
             "Advanced actions such as Start in Recovery Mode are normally revealed by holding the "
                 + "Option (⌥) key in menus. Turn this on to always show them.")
 
+        let blockCard = makeGroupedFormCard(rows: [
+            makeGroupedFormCardRow("Block duplicate machine IDs from booting", control: blockDuplicateIDSwitch)
+        ])
+        let blockCaption = makeGroupedFormCaption(
+            "Refuses to start a virtual machine while another VM with the same machine ID is "
+                + "running. Two VMs sharing a machine ID must never run at once — doing so is "
+                + "undefined behavior and can corrupt both.")
+
+        let cloneCard = makeGroupedFormCard(rows: [
+            makeGroupedFormCardRow("Clones get a new machine ID", control: cloneNewIDSwitch)
+        ])
+        let cloneCaption = makeGroupedFormCaption(
+            "A new machine ID gives each clone its own identity, so it can run alongside its "
+                + "source. Keeping the same ID preserves the guest's activation state — macOS 12 "
+                + "and earlier guests may not boot after their ID changes. Hold Option (⌥) on "
+                + "Clone to do the opposite of this setting for one clone.")
+
         let section = NSStackView(views: [
             makeGroupedFormSectionHeader("Advanced Options"),
             card,
             caption,
+            makeGroupedFormSectionHeader("Machine Identity"),
+            blockCard,
+            blockCaption,
+            cloneCard,
+            cloneCaption,
         ])
         section.orientation = .vertical
         section.alignment = .leading
         section.spacing = Spacing.small
+        // Keep each caption tight to its card, but separate the groups so they
+        // read as distinct settings.
+        section.setCustomSpacing(Spacing.section, after: caption)
+        section.setCustomSpacing(Spacing.section, after: blockCaption)
         section.translatesAutoresizingMaskIntoConstraints = false
 
         let root = NSView()
@@ -62,6 +99,10 @@ final class AdvancedSettingsViewController: NSViewController {
             root.widthAnchor.constraint(equalToConstant: SettingsPaneMetrics.width),
             card.widthAnchor.constraint(equalTo: section.widthAnchor),
             caption.widthAnchor.constraint(equalTo: section.widthAnchor),
+            blockCard.widthAnchor.constraint(equalTo: section.widthAnchor),
+            blockCaption.widthAnchor.constraint(equalTo: section.widthAnchor),
+            cloneCard.widthAnchor.constraint(equalTo: section.widthAnchor),
+            cloneCaption.widthAnchor.constraint(equalTo: section.widthAnchor),
         ])
         view = root
     }
@@ -74,9 +115,19 @@ final class AdvancedSettingsViewController: NSViewController {
         // section pin stretches the cards over the excess.
         preferredContentSize = view.fittingSize
         alwaysShowSwitch.state = preferences.alwaysShowAdvancedOptions ? .on : .off
+        blockDuplicateIDSwitch.state = preferences.blockDuplicateMachineIDBoot ? .on : .off
+        cloneNewIDSwitch.state = preferences.cloneGeneratesNewMachineID ? .on : .off
     }
 
     @objc private func alwaysShowToggled() {
         preferences.alwaysShowAdvancedOptions = (alwaysShowSwitch.state == .on)
+    }
+
+    @objc private func blockDuplicateIDToggled() {
+        preferences.blockDuplicateMachineIDBoot = (blockDuplicateIDSwitch.state == .on)
+    }
+
+    @objc private func cloneNewIDToggled() {
+        preferences.cloneGeneratesNewMachineID = (cloneNewIDSwitch.state == .on)
     }
 }

--- a/Kernova/Views/Settings/AdvancedSettingsViewController.swift
+++ b/Kernova/Views/Settings/AdvancedSettingsViewController.swift
@@ -51,17 +51,17 @@ final class AdvancedSettingsViewController: NSViewController {
         ])
         let blockCaption = makeGroupedFormCaption(
             "Refuses to start a virtual machine while another VM with the same machine ID is "
-                + "running. Two VMs sharing a machine ID must never run at once — doing so is "
-                + "undefined behavior and can corrupt both.")
+                + "active. Apple documents running two VMs with the same machine ID at once as "
+                + "undefined behavior.")
 
         let cloneCard = makeGroupedFormCard(rows: [
             makeGroupedFormCardRow("Clones get a new machine ID", control: cloneNewIDSwitch)
         ])
         let cloneCaption = makeGroupedFormCaption(
             "A new machine ID gives each clone its own identity, so it can run alongside its "
-                + "source. Keeping the same ID preserves the guest's activation state — macOS 12 "
-                + "and earlier guests may not boot after their ID changes. Hold Option (⌥) on "
-                + "Clone to do the opposite of this setting for one clone.")
+                + "source. macOS 12 and earlier guests may not boot after their ID changes — "
+                + "clone those keeping the ID. To do the opposite for one clone, hold Option (⌥) "
+                + "over Clone in the Virtual Machine menu or the VM's context menu.")
 
         let section = NSStackView(views: [
             makeGroupedFormSectionHeader("Advanced Options"),

--- a/Kernova/Views/Sidebar/SidebarViewController.swift
+++ b/Kernova/Views/Sidebar/SidebarViewController.swift
@@ -758,9 +758,7 @@ extension SidebarViewController {
         // machine-ID setting. Mid-menu (Rename precedes), so no anchor item is
         // needed.
         let cloneAlternate = item(
-            preferences.cloneGeneratesNewMachineID
-                ? "Clone (Keep Machine ID)" : "Clone (New Machine ID)",
-            #selector(menuCloneAlternate(_:)), instance)
+            preferences.cloneAlternateMenuTitle, #selector(menuCloneAlternate(_:)), instance)
         cloneAlternate.isEnabled = clone.isEnabled
         if !preferences.alwaysShowAdvancedOptions {
             clone.keyEquivalentModifierMask = []

--- a/Kernova/Views/Sidebar/SidebarViewController.swift
+++ b/Kernova/Views/Sidebar/SidebarViewController.swift
@@ -754,6 +754,20 @@ extension SidebarViewController {
         let clone = item("Clone", #selector(menuClone(_:)), instance)
         clone.isEnabled = status.canEditSettings && !viewModel.hasPreparing
         menu.addItem(clone)
+        // An ⌥-alternate of "Clone" performing the opposite of the clone
+        // machine-ID setting. Mid-menu (Rename precedes), so no anchor item is
+        // needed.
+        let cloneAlternate = item(
+            preferences.cloneGeneratesNewMachineID
+                ? "Clone (Keep Machine ID)" : "Clone (New Machine ID)",
+            #selector(menuCloneAlternate(_:)), instance)
+        cloneAlternate.isEnabled = clone.isEnabled
+        if !preferences.alwaysShowAdvancedOptions {
+            clone.keyEquivalentModifierMask = []
+            cloneAlternate.keyEquivalentModifierMask = [.option]
+            cloneAlternate.isAlternate = true
+        }
+        menu.addItem(cloneAlternate)
 
         menu.addItem(item("Show in Finder", #selector(menuShowInFinder(_:)), instance))
 
@@ -840,6 +854,11 @@ extension SidebarViewController {
     @objc private func menuClone(_ sender: NSMenuItem) {
         guard let instance = sender.representedObject as? VMInstance else { return }
         viewModel.cloneVM(instance)
+    }
+
+    @objc private func menuCloneAlternate(_ sender: NSMenuItem) {
+        guard let instance = sender.representedObject as? VMInstance else { return }
+        viewModel.cloneVMWithOppositeMachineIdentity(instance)
     }
 
     @objc private func menuShowInFinder(_ sender: NSMenuItem) {

--- a/KernovaTests/AppPreferencesTests.swift
+++ b/KernovaTests/AppPreferencesTests.swift
@@ -171,6 +171,16 @@ struct AppPreferencesTests {
         }
     }
 
+    @Test("cloneAlternateMenuTitle names the opposite of the clone machine-ID setting")
+    func cloneAlternateMenuTitleFollowsPreference() throws {
+        try withEphemeralPreferences { prefs, _ in
+            #expect(prefs.cloneAlternateMenuTitle == "Clone (Keep Machine ID)")
+
+            prefs.cloneGeneratesNewMachineID = false
+            #expect(prefs.cloneAlternateMenuTitle == "Clone (New Machine ID)")
+        }
+    }
+
     @Test("menuBarQuitReminderDismissed defaults to false")
     func menuBarQuitReminderDismissedDefaultsToFalse() throws {
         try withEphemeralPreferences { prefs, _ in

--- a/KernovaTests/AppPreferencesTests.swift
+++ b/KernovaTests/AppPreferencesTests.swift
@@ -125,6 +125,52 @@ struct AppPreferencesTests {
         }
     }
 
+    @Test("blockDuplicateMachineIDBoot defaults to true")
+    func blockDuplicateMachineIDBootDefaultsToTrue() throws {
+        try withEphemeralPreferences { prefs, _ in
+            #expect(prefs.blockDuplicateMachineIDBoot == true)
+        }
+    }
+
+    @Test("blockDuplicateMachineIDBoot round-trips through UserDefaults with inverted storage")
+    func blockDuplicateMachineIDBootRoundTrips() throws {
+        try withEphemeralPreferences { prefs, defaults in
+            // Stored inverted under `allowDuplicateMachineIDBoot`, so the
+            // false-default key yields the desired `true` default (see the
+            // property's doc comment).
+            prefs.blockDuplicateMachineIDBoot = false
+            #expect(prefs.blockDuplicateMachineIDBoot == false)
+            #expect(defaults.bool(forKey: "allowDuplicateMachineIDBoot") == true)
+
+            prefs.blockDuplicateMachineIDBoot = true
+            #expect(prefs.blockDuplicateMachineIDBoot == true)
+            #expect(defaults.bool(forKey: "allowDuplicateMachineIDBoot") == false)
+        }
+    }
+
+    @Test("cloneGeneratesNewMachineID defaults to true")
+    func cloneGeneratesNewMachineIDDefaultsToTrue() throws {
+        try withEphemeralPreferences { prefs, _ in
+            #expect(prefs.cloneGeneratesNewMachineID == true)
+        }
+    }
+
+    @Test("cloneGeneratesNewMachineID round-trips through UserDefaults with inverted storage")
+    func cloneGeneratesNewMachineIDRoundTrips() throws {
+        try withEphemeralPreferences { prefs, defaults in
+            // Stored inverted under `cloneKeepsMachineID`, so the false-default
+            // key yields the desired `true` default (see the property's doc
+            // comment).
+            prefs.cloneGeneratesNewMachineID = false
+            #expect(prefs.cloneGeneratesNewMachineID == false)
+            #expect(defaults.bool(forKey: "cloneKeepsMachineID") == true)
+
+            prefs.cloneGeneratesNewMachineID = true
+            #expect(prefs.cloneGeneratesNewMachineID == true)
+            #expect(defaults.bool(forKey: "cloneKeepsMachineID") == false)
+        }
+    }
+
     @Test("menuBarQuitReminderDismissed defaults to false")
     func menuBarQuitReminderDismissedDefaultsToFalse() throws {
         try withEphemeralPreferences { prefs, _ in

--- a/KernovaTests/Mocks/MockVMStorageService.swift
+++ b/KernovaTests/Mocks/MockVMStorageService.swift
@@ -37,6 +37,9 @@ final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
     var createVMBundleCallCount = 0
     var cloneVMBundleCallCount = 0
 
+    /// The `filesToCopy` argument from the most recent `cloneVMBundle` call.
+    var lastCloneFilesToCopy: [String]?
+
     // MARK: - Error Injection
 
     var createVMBundleError: (any Error)?
@@ -99,6 +102,7 @@ final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
         -> URL
     {
         cloneVMBundleCallCount += 1
+        lastCloneFilesToCopy = filesToCopy
         if let error = cloneVMBundleError { throw error }
         let url = try bundleURL(for: newConfiguration)
         // Mirrors the real service actually creating the bundle directory on disk:

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -59,34 +59,6 @@ func makeVZErrorChain(depth: Int, around error: NSError) -> NSError {
     return wrapped
 }
 
-// MARK: - Live VZVirtualMachine fixture
-
-/// A never-started `VZVirtualMachine`, for tests that need an instance to look
-/// live in memory — `isLivePaused`, `canStop`, and the duplicate-machine-ID
-/// guard all read the object's presence, not its state.
-///
-/// The smallest shape `validate()` accepts: an EFI bootloader over a scratch
-/// variable store, with nothing to boot from. The store file is removed once
-/// the machine holds it, so nothing is left in the temporary directory.
-@MainActor
-func makeIdleVirtualMachine() throws -> VZVirtualMachine {
-    let storeURL = FileManager.default.temporaryDirectory
-        .appendingPathComponent("knv-test-efi-\(UUID().uuidString)")
-    let bootLoader = VZEFIBootLoader()
-    bootLoader.variableStore = try VZEFIVariableStore(creatingVariableStoreAt: storeURL)
-
-    let configuration = VZVirtualMachineConfiguration()
-    configuration.bootLoader = bootLoader
-    configuration.platform = VZGenericPlatformConfiguration()
-    configuration.cpuCount = VZVirtualMachineConfiguration.minimumAllowedCPUCount
-    configuration.memorySize = VZVirtualMachineConfiguration.minimumAllowedMemorySize
-    try configuration.validate()
-
-    let machine = VZVirtualMachine(configuration: configuration)
-    try? FileManager.default.removeItem(at: storeURL)
-    return machine
-}
-
 // MARK: - Socket / channel factories
 
 /// Returns a connected AF_UNIX socketpair as two raw file descriptors.

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -59,6 +59,34 @@ func makeVZErrorChain(depth: Int, around error: NSError) -> NSError {
     return wrapped
 }
 
+// MARK: - Live VZVirtualMachine fixture
+
+/// A never-started `VZVirtualMachine`, for tests that need an instance to look
+/// live in memory — `isLivePaused`, `canStop`, and the duplicate-machine-ID
+/// guard all read the object's presence, not its state.
+///
+/// The smallest shape `validate()` accepts: an EFI bootloader over a scratch
+/// variable store, with nothing to boot from. The store file is removed once
+/// the machine holds it, so nothing is left in the temporary directory.
+@MainActor
+func makeIdleVirtualMachine() throws -> VZVirtualMachine {
+    let storeURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("knv-test-efi-\(UUID().uuidString)")
+    let bootLoader = VZEFIBootLoader()
+    bootLoader.variableStore = try VZEFIVariableStore(creatingVariableStoreAt: storeURL)
+
+    let configuration = VZVirtualMachineConfiguration()
+    configuration.bootLoader = bootLoader
+    configuration.platform = VZGenericPlatformConfiguration()
+    configuration.cpuCount = VZVirtualMachineConfiguration.minimumAllowedCPUCount
+    configuration.memorySize = VZVirtualMachineConfiguration.minimumAllowedMemorySize
+    try configuration.validate()
+
+    let machine = VZVirtualMachine(configuration: configuration)
+    try? FileManager.default.removeItem(at: storeURL)
+    return machine
+}
+
 // MARK: - Socket / channel factories
 
 /// Returns a connected AF_UNIX socketpair as two raw file descriptors.

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -159,6 +159,33 @@ struct VMInstanceTests {
         #expect(instance.isColdPaused == false)
     }
 
+    // MARK: - effectiveMachineIdentifierData
+
+    @Test("effectiveMachineIdentifierData prefers the configuration field")
+    func effectiveMachineIDPrefersConfiguration() {
+        let instance = makeInstance()
+        instance.configuration.machineIdentifierData = Data([1, 2, 3])
+        #expect(instance.effectiveMachineIdentifierData == Data([1, 2, 3]))
+    }
+
+    @Test("effectiveMachineIdentifierData falls back to the bundle's identifier file")
+    func effectiveMachineIDFallsBackToFile() throws {
+        let instance = makeInstance()
+        try FileManager.default.createDirectory(
+            at: instance.bundleURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: instance.bundleURL) }
+        try Data([4, 5, 6]).write(to: instance.machineIdentifierURL)
+
+        #expect(instance.configuration.machineIdentifierData == nil)
+        #expect(instance.effectiveMachineIdentifierData == Data([4, 5, 6]))
+    }
+
+    @Test("effectiveMachineIdentifierData is nil with neither a configuration field nor a file")
+    func effectiveMachineIDNilWhenAbsent() {
+        let instance = makeInstance()
+        #expect(instance.effectiveMachineIdentifierData == nil)
+    }
+
     // MARK: - isKeepingAppAlive
 
     @Test("isKeepingAppAlive is true when preparing")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -1175,7 +1175,7 @@ struct VMLibraryViewModelTests {
         let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
         let (starting, other) = appendMachineIDPair(to: viewModel)
         other.status = .paused
-        other.virtualMachine = try makeIdleVirtualMachine()
+        other.hasLiveVirtualMachineOverrideForTesting = true
 
         await viewModel.start(starting)
 
@@ -1263,7 +1263,7 @@ struct VMLibraryViewModelTests {
         let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
         let (resuming, other) = appendMachineIDPair(to: viewModel)
         resuming.status = .paused
-        resuming.virtualMachine = try makeIdleVirtualMachine()
+        resuming.hasLiveVirtualMachineOverrideForTesting = true
         other.status = .running
 
         await viewModel.resume(resuming)

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -1102,6 +1102,112 @@ struct VMLibraryViewModelTests {
         #expect(instance.status == .paused)
     }
 
+    // MARK: - Duplicate Machine ID Boot Guard
+
+    /// Two VMs carrying the given machine identifiers in whichever identity
+    /// field `guestOS` uses, both appended to `viewModel`.
+    ///
+    /// `other` is the one the tests park in a live status; `starting` is the one
+    /// they try to boot.
+    private func appendMachineIDPair(
+        to viewModel: VMLibraryViewModel,
+        guestOS: VMGuestOS = .macOS,
+        startingID: Data = Data([1, 2, 3]),
+        otherID: Data = Data([1, 2, 3])
+    ) -> (starting: VMInstance, other: VMInstance) {
+        let starting = makeInstance(name: "Starting", guestOS: guestOS)
+        let other = makeInstance(name: "Twin", guestOS: guestOS)
+        for (instance, identifier) in [(starting, startingID), (other, otherID)] {
+            if guestOS == .macOS {
+                instance.configuration.machineIdentifierData = identifier
+            } else {
+                instance.configuration.genericMachineIdentifierData = identifier
+            }
+        }
+        viewModel.instances.append(contentsOf: [starting, other])
+        return (starting, other)
+    }
+
+    @Test("start is refused while another VM with the same machine ID is running")
+    func startBlockedByRunningMachineIDTwin() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMachineIDPair(to: viewModel)
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 0)
+        #expect(presenter.errorTitle == "Duplicate Machine ID")
+        #expect(starting.status == .stopped)
+    }
+
+    @Test("start proceeds past a machine ID twin when the guard preference is off")
+    func startProceedsWhenDuplicateMachineIDGuardDisabled() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMachineIDPair(to: viewModel)
+        other.status = .running
+        preferences.blockDuplicateMachineIDBoot = false
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 1)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("start proceeds when the machine ID twin is stopped")
+    func startProceedsWhenMachineIDTwinIsStopped() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMachineIDPair(to: viewModel)
+        other.status = .stopped
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 1)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("start is refused while the machine ID twin is paused (VZ still holds the identity)")
+    func startBlockedByPausedMachineIDTwin() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMachineIDPair(to: viewModel)
+        other.status = .paused
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 0)
+        #expect(presenter.errorTitle == "Duplicate Machine ID")
+    }
+
+    @Test("start proceeds when the running VM's machine ID differs")
+    func startProceedsWhenMachineIDsDiffer() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMachineIDPair(to: viewModel, otherID: Data([4, 5, 6]))
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 1)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("start is refused while a Linux VM sharing the generic machine ID is running")
+    func startBlockedByRunningGenericMachineIDTwin() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMachineIDPair(to: viewModel, guestOS: .linux)
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 0)
+        #expect(presenter.errorTitle == "Duplicate Machine ID")
+    }
+
     // MARK: - Match-Window Boot Resolution
 
     /// Hands `start` a fixed surface, standing in for the window/screen geometry
@@ -3119,6 +3225,129 @@ struct VMLibraryViewModelTests {
             let resolved = phantom.bundleURL.appendingPathComponent(extra.path)
             #expect(fm.fileExists(atPath: resolved.path(percentEncoded: false)))
         }
+    }
+
+    // MARK: - Clone Machine Identity
+
+    /// The identifier every clone-identity source VM starts out carrying.
+    private static let sourceMachineID = Data([1, 2, 3])
+
+    /// A stopped source VM carrying `sourceMachineID` in whichever identity
+    /// field `guestOS` uses, appended to `viewModel` and registered with
+    /// `storage` so the clone's copy task can run to completion.
+    private func appendCloneSource(
+        to viewModel: VMLibraryViewModel, storage: MockVMStorageService, guestOS: VMGuestOS
+    ) -> VMInstance {
+        let instance = makeInstance(name: "Original", guestOS: guestOS)
+        instance.status = .stopped
+        if guestOS == .macOS {
+            instance.configuration.machineIdentifierData = Self.sourceMachineID
+        } else {
+            instance.configuration.genericMachineIdentifierData = Self.sourceMachineID
+        }
+        viewModel.instances.append(instance)
+        storage.bundles[instance.bundleURL] = instance.configuration
+        return instance
+    }
+
+    /// The identity field `guestOS` uses, read off the clone `viewModel`
+    /// produced from `source` once its copy task has settled.
+    private func clonedMachineID(
+        of source: VMInstance, in viewModel: VMLibraryViewModel, guestOS: VMGuestOS
+    ) async -> Data? {
+        let clone = viewModel.instances.first { $0.id != source.id }
+        await clone?.preparingState?.task.value
+        return guestOS == .macOS
+            ? clone?.configuration.machineIdentifierData
+            : clone?.configuration.genericMachineIdentifierData
+    }
+
+    @Test("cloneVM gives a macOS clone a fresh machine ID by default")
+    func cloneVMGeneratesNewMachineIDByDefault() async {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        let source = appendCloneSource(to: viewModel, storage: storage, guestOS: .macOS)
+
+        viewModel.cloneVM(source)
+        let clonedID = await clonedMachineID(of: source, in: viewModel, guestOS: .macOS)
+
+        #expect(clonedID != nil)
+        #expect(clonedID != Self.sourceMachineID)
+        #expect(storage.lastCloneFilesToCopy?.contains("MachineIdentifier") == false)
+    }
+
+    @Test("cloneVM keeps the source machine ID when the preference is off")
+    func cloneVMKeepsMachineIDWhenPreferenceOff() async {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        preferences.cloneGeneratesNewMachineID = false
+        let source = appendCloneSource(to: viewModel, storage: storage, guestOS: .macOS)
+
+        viewModel.cloneVM(source)
+        let clonedID = await clonedMachineID(of: source, in: viewModel, guestOS: .macOS)
+
+        #expect(clonedID == Self.sourceMachineID)
+        // The identifier file has to travel with the bundle, not just the config.
+        #expect(storage.lastCloneFilesToCopy?.contains("MachineIdentifier") == true)
+    }
+
+    @Test("cloneVM's explicit generateNewMachineID beats the preference")
+    func cloneVMExplicitFlagOverridesPreference() async {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        let source = appendCloneSource(to: viewModel, storage: storage, guestOS: .macOS)
+
+        // Preference left at its `true` default — the argument decides.
+        viewModel.cloneVM(source, generateNewMachineID: false)
+        let clonedID = await clonedMachineID(of: source, in: viewModel, guestOS: .macOS)
+
+        #expect(clonedID == Self.sourceMachineID)
+        #expect(storage.lastCloneFilesToCopy?.contains("MachineIdentifier") == true)
+    }
+
+    @Test("cloneVMWithOppositeMachineIdentity keeps the ID under the default preference")
+    func cloneVMWithOppositeMachineIdentityKeepsIDByDefault() async {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        let source = appendCloneSource(to: viewModel, storage: storage, guestOS: .macOS)
+
+        viewModel.cloneVMWithOppositeMachineIdentity(source)
+        let clonedID = await clonedMachineID(of: source, in: viewModel, guestOS: .macOS)
+
+        #expect(clonedID == Self.sourceMachineID)
+    }
+
+    @Test("cloneVMWithOppositeMachineIdentity generates a new ID when the preference keeps it")
+    func cloneVMWithOppositeMachineIdentityGeneratesIDWhenPreferenceOff() async {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        preferences.cloneGeneratesNewMachineID = false
+        let source = appendCloneSource(to: viewModel, storage: storage, guestOS: .macOS)
+
+        viewModel.cloneVMWithOppositeMachineIdentity(source)
+        let clonedID = await clonedMachineID(of: source, in: viewModel, guestOS: .macOS)
+
+        #expect(clonedID != nil)
+        #expect(clonedID != Self.sourceMachineID)
+    }
+
+    @Test("cloneVM regenerates an EFI clone's generic machine ID by default")
+    func cloneVMGeneratesNewGenericMachineIDByDefault() async {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        let source = appendCloneSource(to: viewModel, storage: storage, guestOS: .linux)
+
+        viewModel.cloneVM(source)
+        let clonedID = await clonedMachineID(of: source, in: viewModel, guestOS: .linux)
+
+        #expect(clonedID != nil)
+        #expect(clonedID != Self.sourceMachineID)
+    }
+
+    @Test("cloneVM keeps an EFI clone's generic machine ID when the preference is off")
+    func cloneVMKeepsGenericMachineIDWhenPreferenceOff() async {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        preferences.cloneGeneratesNewMachineID = false
+        let source = appendCloneSource(to: viewModel, storage: storage, guestOS: .linux)
+
+        viewModel.cloneVM(source)
+        let clonedID = await clonedMachineID(of: source, in: viewModel, guestOS: .linux)
+
+        #expect(clonedID == Self.sourceMachineID)
     }
 
     // MARK: - Cancel Preparing

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -1169,17 +1169,107 @@ struct VMLibraryViewModelTests {
         #expect(presenter.showError == false)
     }
 
-    @Test("start is refused while the machine ID twin is paused (VZ still holds the identity)")
-    func startBlockedByPausedMachineIDTwin() async {
+    @Test("start is refused while the machine ID twin is live-paused (VZ still holds the identity)")
+    func startBlockedByPausedMachineIDTwin() async throws {
         let virtService = MockVirtualizationService()
         let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
         let (starting, other) = appendMachineIDPair(to: viewModel)
         other.status = .paused
+        other.virtualMachine = try makeIdleVirtualMachine()
 
         await viewModel.start(starting)
 
         #expect(virtService.startCallCount == 0)
         #expect(presenter.errorTitle == "Duplicate Machine ID")
+    }
+
+    @Test("start proceeds when the machine ID twin is cold-paused (it holds no VZ identity)")
+    func startProceedsWhenMachineIDTwinIsColdPaused() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMachineIDPair(to: viewModel)
+        other.status = .paused
+        #expect(other.isColdPaused)
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 1)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("start is refused when both VMs carry their machine ID only as a bundle file")
+    func startBlockedByFileOnlyMachineIDTwin() async throws {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let starting = makeInstance(name: "Starting", guestOS: .macOS)
+        let other = makeInstance(name: "Twin", guestOS: .macOS)
+        // The identifier lives only on disk, exactly as it does in a bundle
+        // written before the configuration carried the field.
+        for instance in [starting, other] {
+            try FileManager.default.createDirectory(
+                at: instance.bundleURL, withIntermediateDirectories: true)
+            try Data([1, 2, 3]).write(to: instance.machineIdentifierURL)
+        }
+        defer {
+            for instance in [starting, other] {
+                try? FileManager.default.removeItem(at: instance.bundleURL)
+            }
+        }
+        viewModel.instances.append(contentsOf: [starting, other])
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        #expect(starting.configuration.machineIdentifierData == nil)
+        #expect(virtService.startCallCount == 0)
+        #expect(presenter.errorTitle == "Duplicate Machine ID")
+    }
+
+    @Test("a cold resume is refused while a machine ID twin is running")
+    func coldResumeBlockedByRunningMachineIDTwin() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (resuming, other) = appendMachineIDPair(to: viewModel)
+        // Cold-paused: paused with no `virtualMachine`, so the resume would build
+        // a fresh one and claim the identity.
+        resuming.status = .paused
+        other.status = .running
+
+        await viewModel.resume(resuming)
+
+        #expect(virtService.resumeCallCount == 0)
+        #expect(presenter.errorTitle == "Duplicate Machine ID")
+        #expect(resuming.status == .paused)
+    }
+
+    @Test("a cold resume proceeds past a machine ID twin when the guard preference is off")
+    func coldResumeProceedsWhenDuplicateMachineIDGuardDisabled() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (resuming, other) = appendMachineIDPair(to: viewModel)
+        resuming.status = .paused
+        other.status = .running
+        preferences.blockDuplicateMachineIDBoot = false
+
+        await viewModel.resume(resuming)
+
+        #expect(virtService.resumeCallCount == 1)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("a hot resume is never refused — the live VM already holds the identity")
+    func hotResumeIsNotBlockedByMachineIDTwin() async throws {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (resuming, other) = appendMachineIDPair(to: viewModel)
+        resuming.status = .paused
+        resuming.virtualMachine = try makeIdleVirtualMachine()
+        other.status = .running
+
+        await viewModel.resume(resuming)
+
+        #expect(virtService.resumeCallCount == 1)
+        #expect(presenter.showError == false)
     }
 
     @Test("start proceeds when the running VM's machine ID differs")
@@ -3232,18 +3322,22 @@ struct VMLibraryViewModelTests {
     /// The identifier every clone-identity source VM starts out carrying.
     private static let sourceMachineID = Data([1, 2, 3])
 
-    /// A stopped source VM carrying `sourceMachineID` in whichever identity
-    /// field `guestOS` uses, appended to `viewModel` and registered with
-    /// `storage` so the clone's copy task can run to completion.
+    /// A stopped source VM carrying `machineID` in whichever identity field
+    /// `guestOS` uses, appended to `viewModel` and registered with `storage` so
+    /// the clone's copy task can run to completion.
+    ///
+    /// Passing `nil` leaves the identity field empty, and the bundle directory is
+    /// never created, so the source has no identifier file to fall back on either.
     private func appendCloneSource(
-        to viewModel: VMLibraryViewModel, storage: MockVMStorageService, guestOS: VMGuestOS
+        to viewModel: VMLibraryViewModel, storage: MockVMStorageService, guestOS: VMGuestOS,
+        machineID: Data? = sourceMachineID
     ) -> VMInstance {
         let instance = makeInstance(name: "Original", guestOS: guestOS)
         instance.status = .stopped
         if guestOS == .macOS {
-            instance.configuration.machineIdentifierData = Self.sourceMachineID
+            instance.configuration.machineIdentifierData = machineID
         } else {
-            instance.configuration.genericMachineIdentifierData = Self.sourceMachineID
+            instance.configuration.genericMachineIdentifierData = machineID
         }
         viewModel.instances.append(instance)
         storage.bundles[instance.bundleURL] = instance.configuration
@@ -3348,6 +3442,53 @@ struct VMLibraryViewModelTests {
         let clonedID = await clonedMachineID(of: source, in: viewModel, guestOS: .linux)
 
         #expect(clonedID == Self.sourceMachineID)
+    }
+
+    @Test("a keep-mode clone of a macOS VM with no identity at all mints one")
+    func cloneVMKeepModeMintsMissingMachineID() async {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        preferences.cloneGeneratesNewMachineID = false
+        let source = appendCloneSource(
+            to: viewModel, storage: storage, guestOS: .macOS, machineID: nil)
+
+        viewModel.cloneVM(source)
+        let clonedID = await clonedMachineID(of: source, in: viewModel, guestOS: .macOS)
+
+        #expect(source.effectiveMachineIdentifierData == nil)
+        #expect(clonedID != nil)
+    }
+
+    @Test("a keep-mode clone of an EFI VM with no generic identity mints one")
+    func cloneVMKeepModeMintsMissingGenericMachineID() async {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        preferences.cloneGeneratesNewMachineID = false
+        let source = appendCloneSource(
+            to: viewModel, storage: storage, guestOS: .linux, machineID: nil)
+
+        viewModel.cloneVM(source)
+        let clonedID = await clonedMachineID(of: source, in: viewModel, guestOS: .linux)
+
+        #expect(source.configuration.genericMachineIdentifierData == nil)
+        #expect(clonedID != nil)
+    }
+
+    @Test("a keep-mode clone leaves a file-only macOS identity to the bundle copy")
+    func cloneVMKeepModeLeavesFileOnlyMachineIDToTheCopy() async throws {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        preferences.cloneGeneratesNewMachineID = false
+        let source = appendCloneSource(
+            to: viewModel, storage: storage, guestOS: .macOS, machineID: nil)
+        try FileManager.default.createDirectory(
+            at: source.bundleURL, withIntermediateDirectories: true)
+        try Self.sourceMachineID.write(to: source.machineIdentifierURL)
+        defer { try? FileManager.default.removeItem(at: source.bundleURL) }
+
+        viewModel.cloneVM(source)
+        let clonedID = await clonedMachineID(of: source, in: viewModel, guestOS: .macOS)
+
+        // Nothing minted into the configuration: the copied file is the identity.
+        #expect(clonedID == nil)
+        #expect(storage.lastCloneFilesToCopy?.contains("MachineIdentifier") == true)
     }
 
     // MARK: - Cancel Preparing


### PR DESCRIPTION
## Summary
- Two new toggles in Settings → Advanced under a "Machine Identity" section, each with an explanatory caption:
  - **Block duplicate machine IDs from booting** (default **on**) — starting or cold-resuming a VM whose machine identifier matches a VM that is live (active, or paused with its VZ object in memory) is refused with an alert naming that VM. Apple documents running two VMs with the same identifier at once as undefined behavior. Identifiers compare at their *effective* value — the config field, else the bundle's `MachineIdentifier` file, mirroring the boot path — so file-only bundles are covered. Hot resumes and the resume-to-stop path are deliberately unguarded: the VZ object already holds the identity there.
  - **Clones get a new machine ID** (default **on**, today's behavior) — when off, clones keep the source's identifier, which is what macOS 12 and earlier guests require to boot at all (see context below). Keep-mode carries a file-only identity via the bundle copy, and mints a fresh identifier only when the source has none to keep.
- A second Clone command with the opposite machine-identity behavior, titled "Clone (Keep Machine ID)" / "Clone (New Machine ID)" per the setting: an always-visible row in the Virtual Machine menu (the Start in Recovery Mode pattern — that menu shows advanced actions plainly and reserves ⌥-alternates for irreversible ones), and an Option-hold alternate of Clone in the sidebar context menu (respecting "Always show advanced options").

## Context
Testing clones of every macOS version in the library showed macOS 13+ guests tolerate a regenerated `VZMacMachineIdentifier`, but Monterey guests do not: 12.7.6 boots into an unpassable "Authentication is required to verify startup disk" gate and 12.0.1 hangs on a black display indefinitely, while their originals boot fine. Peer apps (Tart, VirtualBuddy, macosvm, UTM) all preserve the identifier on clone and regenerate only the MAC address; the concurrent-run hazard that motivated regeneration is handled here at start/cold-resume time by the guard instead.

## Changes
- `AppPreferences`: `blockDuplicateMachineIDBoot`, `cloneGeneratesNewMachineID` (both default true, stored inverted via shared helpers), `cloneAlternateMenuTitle`
- `AdvancedSettingsViewController`: Machine Identity section
- `VMInstance`: memoized `effectiveMachineIdentifierData` (config ?? one-time file read)
- `VMLibraryViewModel`: `cloneVM(_:generateNewMachineID:)`, `cloneVMWithOppositeMachineIdentity(_:)`, `refuseIfDuplicateMachineIDConflict(_:)` wired into `start(_:)` and cold `resume(_:)`; keep-mode mints only missing identifiers
- `AppDelegate` + `SidebarViewController`: the two Clone-variant menu items
- Tests: 29 new/updated — preference round-trips, clone identity modes (macOS + Linux/EFI, file-only sources, mint-when-missing), boot/cold-resume guard block/allow cases across running, live-paused, cold-paused, and file-only twins, plus a live-`VZVirtualMachine` test seam

## Notes
- The visible main-menu item's ⌥⌘D key equivalent is eclipsed by the system Dock-hiding hotkey; it fires from the pointer (commented at the construction site).

## Test plan
- [x] `make lint`
- [x] `make test` — full suite green (2056 tests)
- [x] Reviewed by `/code-review medium`, Codex review, and Codex adversarial review; all functional findings fixed (effective-ID comparison, cold-resume guard, live-paused semantics), style findings consolidated
- [ ] Manual: clone a macOS 12 VM with Keep Machine ID and verify it boots to the login screen
- [ ] Manual: start both halves of a keep-ID pair and verify the second is refused with the alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjHQdVomzmv7aNt9dxrLit