### PR TITLE
fix: Buffer the detail banner above the settings form

### DIFF
--- a/Kernova/Views/Detail/VMDetailRouterViewController.swift
+++ b/Kernova/Views/Detail/VMDetailRouterViewController.swift
@@ -147,6 +147,8 @@ final class VMDetailRouterViewController: NSViewController {
             banner.translatesAutoresizingMaskIntoConstraints = false
             contentStack.addArrangedSubview(banner)
             banner.widthAnchor.constraint(equalTo: contentStack.widthAnchor).isActive = true
+            // Buffer below the banner so it doesn't crowd the first section title.
+            contentStack.setCustomSpacing(Spacing.section, after: banner)
             currentBanner = banner
         }
 


### PR DESCRIPTION
## Summary
- The error and initial-boot banners in the VM detail pane stacked flush against the settings form, so the banner's bottom hairline crowded the "General" section title (screenshot-reported).
- `VMDetailRouterViewController.setContent` now opens a `Spacing.section` (18 pt) gap below the banner via `setCustomSpacing`, matching the buffer the in-form read-only lock banner already reserves "so it doesn't crowd the first section title".
- The no-banner layout (form flush under the toolbar, deliberate per the in-code comment) is untouched.

## Changes
- `Kernova/Views/Detail/VMDetailRouterViewController.swift`: custom stack spacing after the banner in `setContent`.

## Test plan
- [x] `make lint` clean
- [x] Full test suite passes (2121 passed, 0 failed)
- [ ] Visual: select a VM in the error state; the "General" header sits clear of the banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK7n7duZFJdKcTTXuwdVJ1