### PR TITLE
fix: Stop the Reminders pane from collapsing its headers and captions

### DIFF
--- a/Kernova/Views/Settings/RemindersSettingsViewController.swift
+++ b/Kernova/Views/Settings/RemindersSettingsViewController.swift
@@ -9,7 +9,7 @@ import os
 /// VM Settings pane's "Show install reminder" toggle.
 ///
 /// Three reminders are represented:
-/// - *Menu Bar Quit Reminder* and *Enable File Sharing Reminder* — app-wide,
+/// - *Menu Bar Quit Reminder* and *File Sharing Reminder* — app-wide,
 ///   backed by `AppPreferences`.
 /// - one row per VM for the *guest-agent install nudge* — per-VM, backed by each
 ///   VM's bundle configuration and written through
@@ -72,13 +72,13 @@ final class RemindersSettingsViewController: NSViewController {
         // App-wide reminders: one card, two hairline-separated rows.
         let appCard = makeGroupedFormCard(rows: [
             makeGroupedFormCardRow("Menu Bar Quit Reminder", control: menuBarQuitSwitch),
-            makeGroupedFormCardRow("Enable File Sharing Reminder", control: fileProviderSwitch),
+            makeGroupedFormCardRow("File Sharing Reminder", control: fileProviderSwitch),
         ])
         let appMenuCaption = makeGroupedFormCaption(
             "The Menu Bar Quit Reminder appears when you quit (⌘Q) and Kernova keeps running in the "
                 + "menu bar, reminding you it — and your virtual machines — are still going.")
         let appFileCaption = makeGroupedFormCaption(
-            "The Enable File Sharing Reminder appears when clipboard file sharing needs to be turned "
+            "The File Sharing Reminder appears when clipboard file sharing needs to be turned "
                 + "on for Kernova in System Settings.")
 
         // Per-VM reminders: rebuilt on every appear (VMs may be added or removed).
@@ -135,9 +135,13 @@ final class RemindersSettingsViewController: NSViewController {
         // panes for why the root must not use autoresizing-mask constraints).
         scrollView.translatesAutoresizingMaskIntoConstraints = false
 
+        // The hug must stay weaker than every subview's compression resistance:
+        // once the tab controller fixes the window height at the cap, a
+        // stronger hug squeezes the content to fit — collapsing the headers and
+        // captions — instead of letting the pane scroll.
         let hugHeight = scrollView.heightAnchor.constraint(
             equalTo: content.heightAnchor, constant: Spacing.large * 2)
-        hugHeight.priority = .defaultHigh
+        hugHeight.priority = .defaultLow
         NSLayoutConstraint.activate([
             scrollView.widthAnchor.constraint(equalToConstant: SettingsPaneMetrics.width),
             hugHeight,
@@ -155,6 +159,13 @@ final class RemindersSettingsViewController: NSViewController {
         // tab transition sizes the window: NSTabViewController reads the pane's
         // preferredContentSize when switching and does not react to a later
         // change (e.g. from viewDidLayout).
+        //
+        // Lay out at the pane's fixed width before measuring: a wrapping
+        // caption's intrinsic height stays single-line until a layout pass
+        // resolves its wrap width, so an unlaid-out fittingSize under-counts
+        // every caption and the pane comes up short.
+        view.setFrameSize(NSSize(width: SettingsPaneMetrics.width, height: Self.maxPaneHeight))
+        view.layoutSubtreeIfNeeded()
         preferredContentSize = view.fittingSize
         startVMObservation()
     }

--- a/Kernova/Views/Shared/GroupedFormStyle.swift
+++ b/Kernova/Views/Shared/GroupedFormStyle.swift
@@ -214,6 +214,10 @@ func makeGroupedFormSectionHeader(_ text: String) -> NSTextField {
     label.font = .preferredFont(forTextStyle: .subheadline)
     label.textColor = .secondaryLabelColor
     label.isSelectable = false
+    // Required so an over-constrained ancestor (e.g. a height-capped pane
+    // hugging its content) breaks its own optional constraint instead of
+    // resolving the conflict by collapsing the text to zero height.
+    label.setContentCompressionResistancePriority(.required, for: .vertical)
     return label
 }
 
@@ -224,6 +228,7 @@ func makeGroupedFormCaption(_ text: String) -> NSTextField {
     label.textColor = .secondaryLabelColor
     label.maximumNumberOfLines = 0
     label.isSelectable = false
+    label.setContentCompressionResistancePriority(.required, for: .vertical)
     return label
 }
 

--- a/KernovaTests/RemindersSettingsViewControllerTests.swift
+++ b/KernovaTests/RemindersSettingsViewControllerTests.swift
@@ -1,0 +1,111 @@
+import AppKit
+import Foundation
+import KernovaTestSupport
+import Testing
+
+@testable import Kernova
+
+/// Layout tests for the Reminders settings pane.
+///
+/// The pane hugs its content when short and scrolls past a height cap. The
+/// regression risk is the capped state: the pane's frame is fixed by the tab
+/// controller, and a hug constraint that outranks the text's compression
+/// resistance resolves the shortfall by collapsing every section header and
+/// caption to zero height instead of scrolling.
+@Suite("Reminders Settings Tests", .serialized)
+@MainActor
+struct RemindersSettingsViewControllerTests {
+    private let preferences: AppPreferences
+
+    init() {
+        self.preferences = makeEphemeralPreferences(suiteName: "test.kernova.reminders-settings")
+    }
+
+    private func makeViewModel() -> VMLibraryViewModel {
+        VMLibraryViewModel(
+            storageService: MockVMStorageService(),
+            diskImageService: MockDiskImageService(),
+            virtualizationService: MockVirtualizationService(),
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService(),
+            usbDeviceService: MockUSBDeviceService(),
+            preferences: preferences
+        )
+    }
+
+    private func makeInstance(name: String) -> VMInstance {
+        let config = VMConfiguration(name: name, guestOS: .macOS, bootMode: .efi)
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(config.id.uuidString, isDirectory: true)
+        return VMInstance(configuration: config, bundleURL: bundleURL)
+    }
+
+    /// Builds the pane with `vmCount` VMs and runs the appear-time layout the
+    /// way NSTabViewController does: it reads `preferredContentSize` at switch
+    /// time and sizes the pane's view to exactly that.
+    private func makeLaidOutController(vmCount: Int) -> RemindersSettingsViewController {
+        let viewModel = makeViewModel()
+        for index in 1...vmCount {
+            viewModel.instances.append(makeInstance(name: "VM \(index)"))
+        }
+        let controller = RemindersSettingsViewController(
+            preferences: preferences, viewModel: viewModel)
+        _ = controller.view
+        controller.viewWillAppear()
+        controller.view.setFrameSize(controller.preferredContentSize)
+        controller.view.layoutSubtreeIfNeeded()
+        return controller
+    }
+
+    private func expectHeadersAndCaptionsVisible(in root: NSView) {
+        for text in ["App Reminders", "Virtual Machine Reminders"] {
+            let header = findLabel(withText: text, in: root)
+            #expect(header != nil, "header '\(text)' missing from the view tree")
+            if let header {
+                #expect(header.frame.height > 0, "header '\(text)' collapsed: \(header.frame)")
+            }
+        }
+        for fragment in [
+            "Menu Bar Quit Reminder appears",
+            "File Sharing Reminder appears",
+            "stop its sidebar reminder",
+            "Turns every reminder above back on",
+            "managed separately",
+        ] {
+            let caption = findLabel(containing: fragment, in: root)
+            #expect(caption != nil, "caption '\(fragment)…' missing from the view tree")
+            if let caption {
+                #expect(
+                    caption.frame.height > 0, "caption '\(fragment)…' collapsed: \(caption.frame)")
+            }
+        }
+    }
+
+    @Test("A VM list past the height cap scrolls instead of collapsing the text")
+    func cappedPaneScrollsAndKeepsText() throws {
+        let controller = makeLaidOutController(vmCount: 9)
+        defer { controller.viewDidDisappear() }
+
+        expectHeadersAndCaptionsVisible(in: controller.view)
+
+        // The content must keep its natural height and overflow the capped
+        // pane — a squeezed document exactly matching the pane's height is the
+        // collapse bug, not scrolling.
+        let scrollView = try #require(controller.view as? NSScrollView)
+        let documentView = try #require(scrollView.documentView)
+        #expect(documentView.frame.height > scrollView.frame.height)
+    }
+
+    @Test("A short VM list hugs the content with the text laid out")
+    func shortPaneHugsContentAndKeepsText() throws {
+        let controller = makeLaidOutController(vmCount: 2)
+        defer { controller.viewDidDisappear() }
+
+        expectHeadersAndCaptionsVisible(in: controller.view)
+
+        // Hugged: everything fits, so nothing scrolls.
+        let scrollView = try #require(controller.view as? NSScrollView)
+        let documentView = try #require(scrollView.documentView)
+        #expect(documentView.frame.height <= scrollView.frame.height)
+    }
+}


### PR DESCRIPTION
## Summary
The Reminders settings pane has had section headers and per-group captions since it was added (#628) — but they never showed: whenever the VM list pushed the pane to its 520pt height cap, every header and caption rendered at exactly zero height, leaving bare toggle lists with no explanation of what they control.

Two stacked layout defects, reproduced by a unit test before fixing:

- **Collapse under the cap.** The pane's "hug the content" height constraint ran at priority 750. Once `NSTabViewController` fixes the window height at the cap, that equality inverts — instead of the pane hugging the content, it compresses the content by 40pt-plus, and the text fields are the weakest views, so all of them collapse to zero while the cards' switch rows survive. The scroll view never scrolls. Fixed by dropping the hug to `.defaultLow`, plus required vertical compression resistance in the shared `makeGroupedFormSectionHeader`/`makeGroupedFormCaption` factories so grouped-form text can never again resolve an over-constrained ancestor by vanishing.
- **Under-measurement on short lists.** `preferredContentSize` was read from `fittingSize` before any layout pass, when wrapping captions still measure single-line, sizing a short pane ~36pt too small (the strong hug had masked this by crushing the text to fit). The pane now lays out at its fixed width first, then measures.

Also renames the "Enable File Sharing Reminder" row to "File Sharing Reminder" so it reads as the reminder's name — parallel to "Menu Bar Quit Reminder" — rather than as a command; its caption explains when it appears.

## Changes
- `Kernova/Views/Settings/RemindersSettingsViewController.swift` — hug priority, layout-before-measure in `viewWillAppear`, row/caption/doc-comment rename
- `Kernova/Views/Shared/GroupedFormStyle.swift` — required vertical compression resistance on header and caption factories
- `KernovaTests/RemindersSettingsViewControllerTests.swift` — new: a capped 9-VM pane must scroll with every header/caption at non-zero height (fails against the old code with the exact reported signature); a short 2-VM pane must hug without scrolling

## Test plan
- [x] New Reminders pane regression tests (capped + short layouts)
- [x] Full test suite: 2123/2123 passed
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ovCoAqkx7YZs6NtZc31rB