### PR TITLE
feat: Retarget the guest agent to macOS 12

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -1012,7 +1012,8 @@
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
-				MARKETING_VERSION = 0.52.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 0.53.0;
 				EXECUTABLE_NAME = KernovaMacOSAgent;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
@@ -1038,7 +1039,8 @@
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
-				MARKETING_VERSION = 0.52.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 0.53.0;
 				EXECUTABLE_NAME = KernovaMacOSAgent;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
@@ -1054,6 +1056,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 0.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1069,6 +1072,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 0.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1096,7 +1100,8 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.52.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 0.53.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent.fileprovider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1127,7 +1132,8 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.52.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 0.53.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent.fileprovider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -1012,6 +1012,11 @@
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 0.53.0;
 				EXECUTABLE_NAME = KernovaMacOSAgent;
@@ -1039,6 +1044,11 @@
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 0.53.0;
 				EXECUTABLE_NAME = KernovaMacOSAgent;

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -55,7 +55,7 @@ final class VsockClipboardService: ClipboardServicing {
 
     /// Backstop for a lazy pull the peer never answers while the channel stays
     /// open.
-    private let lazyPullTimeout: Duration
+    private let lazyPullTimeout: TimeInterval
 
     /// Off-main authority for this VM's clipboard progress, aggregating every
     /// transfer of one operation into the snapshot each surface renders.
@@ -82,7 +82,7 @@ final class VsockClipboardService: ClipboardServicing {
     private let lazyCoordinator = LazyPullCoordinator()
 
     private var sender: ClipboardStreamSender?
-    private var receiver: ClipboardStreamReceiver?
+    private var receiver: (any ClipboardStreamReceiving)?
     private var consumeTask: Task<Void, Never>?
 
     /// Counter for outbound offer generations.
@@ -173,7 +173,7 @@ final class VsockClipboardService: ClipboardServicing {
     init(
         channel: VsockChannel, label: String,
         freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
-        lazyPullTimeout: Duration = ClipboardStreamTuning.lazyPullTimeout,
+        lazyPullTimeout: TimeInterval = ClipboardStreamTuning.lazyPullTimeout,
         progressRevealDelay: TimeInterval = ClipboardProgressTracker.defaultRevealDelay,
         progressIdleLinger: TimeInterval = ClipboardProgressTracker.defaultIdleLinger,
         stagingTempRoot: URL? = nil,
@@ -212,7 +212,7 @@ final class VsockClipboardService: ClipboardServicing {
         fileProvider.serviceDidStart()
 
         let sender = ClipboardStreamSender(channel: channel)
-        let receiver = ClipboardStreamReceiver(
+        let receiver = makeClipboardStreamReceiver(
             channel: channel, staging: staging,
             onTransferTimed: { [label = self.label] metrics in
                 Self.logger.notice(
@@ -389,7 +389,7 @@ final class VsockClipboardService: ClipboardServicing {
         channel: VsockChannel,
         label: String,
         sender: ClipboardStreamSender,
-        receiver: ClipboardStreamReceiver,
+        receiver: any ClipboardStreamReceiving,
         onControlFrame: @Sendable @escaping (Frame) -> Void
     ) async {
         do {
@@ -1154,7 +1154,7 @@ final class VsockClipboardService: ClipboardServicing {
                     // silence. A cancelled sleep (the pull resolved first) must
                     // NOT resume.
                     while true {
-                        do { try await Task.sleep(for: backstop) } catch { return }
+                        do { try await Task.sleep(for: .seconds(backstop)) } catch { return }
                         if pull.consumeProgress() { continue }
                         receiver.cancelAwait(transferID)
                         pull.resume(nil)
@@ -1218,10 +1218,10 @@ final class VsockClipboardService: ClipboardServicing {
         let filename: String
         let generation: UInt64
         let repIndex: Int
-        let receiver: ClipboardStreamReceiver
+        let receiver: any ClipboardStreamReceiving
         let channel: VsockChannel
         let staging: ClipboardFileStaging
-        let timeout: Duration
+        let timeout: TimeInterval
     }
 
     /// Snapshots the state for a synchronous file pull, validating that
@@ -1349,7 +1349,7 @@ final class VsockClipboardService: ClipboardServicing {
     /// pulls: runs on main (listing pull) or off-main (child pull), woken off-main
     /// either way.
     nonisolated private func awaitTreePull(
-        transferID: UInt64, receiver: ClipboardStreamReceiver,
+        transferID: UInt64, receiver: any ClipboardStreamReceiving,
         onProgress: (@Sendable (_ bytesTransferred: UInt64, _ totalBytes: UInt64) -> Void)?,
         sendRequest: @escaping () throws -> Void
     ) -> LazyPullOutcome {
@@ -1427,7 +1427,7 @@ final class VsockClipboardService: ClipboardServicing {
         generation: UInt64, repIndex: Int, childSeq: UInt32, relativePath: String,
         onProgress: @escaping @Sendable (UInt64, UInt64) -> Void
     ) -> ClipboardContent.Representation? {
-        let context: (receiver: ClipboardStreamReceiver, channel: VsockChannel)? = onMain {
+        let context: (receiver: any ClipboardStreamReceiving, channel: VsockChannel)? = onMain {
             guard let promise = self.inboundPromise, promise.generation == generation,
                 promise.reps.indices.contains(repIndex), let receiver = self.receiver
             else { return nil }

--- a/KernovaKit/Package.swift
+++ b/KernovaKit/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "KernovaKit",
     platforms: [
-        .macOS(.v15)
+        .macOS(.v12)
     ],
     products: [
         .library(name: "KernovaKit", targets: ["KernovaKit"]),
@@ -25,6 +25,7 @@ let package = Package(
         ),
         .target(
             name: "KernovaTestSupport",
+            dependencies: ["KernovaKit"],
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]

--- a/KernovaKit/Sources/KernovaKit/ClipboardFileProviderReminder.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileProviderReminder.swift
@@ -90,12 +90,17 @@ public enum ClipboardFileProviderReminder {
         "Text and images paste normally. File sharing from your Mac is unavailable — reinstall the Kernova guest agent to restore it."
     }
 
-    /// Actionable command opening System Settings to enable the extension —
+    /// Actionable command opening the settings app to enable the extension —
     /// identical wording on both sides.
     ///
-    /// Ellipsis: it navigates to System Settings to gather the user's action.
+    /// Ellipsis: it navigates to the settings app to gather the user's action.
+    /// Named for the app the running OS actually has: System Settings on 13+,
+    /// System Preferences before.
     public static func enableCommandTitle() -> String {
-        "Enable in System Settings…"
+        if #available(macOS 13.0, *) {
+            return "Enable in System Settings…"
+        }
+        return "Enable in System Preferences…"
     }
 
     /// Command silencing the proactive status-item badge — identical wording

--- a/KernovaKit/Sources/KernovaKit/ClipboardFileProviderSettings.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileProviderSettings.swift
@@ -11,11 +11,19 @@ public enum ClipboardFileProviderSettings {
     ///
     /// These deep links are private and unguaranteed across macOS releases, so a
     /// caller tries them in order and opens the first that works; the exact
-    /// anchor is not load-bearing.
-    public static let enablementDeepLinks: [String] = [
-        "x-apple.systempreferences:com.apple.ExtensionsPreferences?extensionPointIdentifier=com.apple.fileprovider-nonui",
-        "x-apple.systempreferences:com.apple.LoginItems-Settings.extension?ExtensionItems",
-    ]
+    /// anchor is not load-bearing. Below 13 the pane identifiers are System
+    /// Preferences', whose Extensions pane hosts the File Provider toggles.
+    public static var enablementDeepLinks: [String] {
+        if #available(macOS 13.0, *) {
+            return [
+                "x-apple.systempreferences:com.apple.ExtensionsPreferences?extensionPointIdentifier=com.apple.fileprovider-nonui",
+                "x-apple.systempreferences:com.apple.LoginItems-Settings.extension?ExtensionItems",
+            ]
+        }
+        return [
+            "x-apple.systempreferences:com.apple.preferences.extensions"
+        ]
+    }
 
     /// Opens System Settings to the File-Providers enablement pane, trying
     /// `enablementDeepLinks` in order and stopping at the first that opens.

--- a/KernovaKit/Sources/KernovaKit/ClipboardFileProviderSettings.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileProviderSettings.swift
@@ -1,31 +1,45 @@
 import AppKit
 
-/// System Settings deep links for enabling a clipboard File Provider extension.
+/// Settings-app deep links for enabling a clipboard File Provider extension.
 ///
-/// macOS gates third-party File Provider extensions behind a per-extension toggle
-/// in System Settings → General → Login Items & Extensions → File Providers, off
-/// by default.
+/// macOS gates third-party File Provider extensions behind a per-extension
+/// toggle, off by default: System Settings → General → Login Items &
+/// Extensions → File Providers on 13+, System Preferences → Extensions → Added
+/// Extensions below.
 public enum ClipboardFileProviderSettings {
-    /// `x-apple.systempreferences:` URLs that open the File-Providers enablement
-    /// UI, most specific first.
-    ///
-    /// These deep links are private and unguaranteed across macOS releases, so a
-    /// caller tries them in order and opens the first that works; the exact
-    /// anchor is not load-bearing. Below 13 the pane identifiers are System
-    /// Preferences', whose Extensions pane hosts the File Provider toggles.
+    /// URLs that open the File-Providers enablement UI on the running OS, most
+    /// specific first.
     public static var enablementDeepLinks: [String] {
-        if #available(macOS 13.0, *) {
+        if #available(macOS 13.0, *) { return enablementDeepLinks(systemSettings: true) }
+        return enablementDeepLinks(systemSettings: false)
+    }
+
+    /// The candidate list for an OS that has System Settings (macOS 13+) or one
+    /// that still has System Preferences — taken as a parameter so both lists
+    /// are reachable from either OS.
+    ///
+    /// A caller tries them in order and opens the first that works; the exact
+    /// anchor is not load-bearing. Below 13 the leading entry is the Extensions
+    /// pane bundle's own file URL rather than an `x-apple.systempreferences:`
+    /// one, because System Preferences does not route the
+    /// `com.apple.preferences.extensions` pane id — it opens at the main grid,
+    /// with or without a trailing anchor, while `NSWorkspace` still reports
+    /// success (`docs/research/2026-08-03-macos12-extensions-pane-deep-link.md`).
+    /// Opening the bundle lands on Extensions with the agent's checkbox in view.
+    public static func enablementDeepLinks(systemSettings: Bool) -> [String] {
+        guard systemSettings else {
             return [
-                "x-apple.systempreferences:com.apple.ExtensionsPreferences?extensionPointIdentifier=com.apple.fileprovider-nonui",
-                "x-apple.systempreferences:com.apple.LoginItems-Settings.extension?ExtensionItems",
+                "file:///System/Library/PreferencePanes/Extensions.prefPane",
+                "x-apple.systempreferences:com.apple.preferences.extensions",
             ]
         }
         return [
-            "x-apple.systempreferences:com.apple.preferences.extensions"
+            "x-apple.systempreferences:com.apple.ExtensionsPreferences?extensionPointIdentifier=com.apple.fileprovider-nonui",
+            "x-apple.systempreferences:com.apple.LoginItems-Settings.extension?ExtensionItems",
         ]
     }
 
-    /// Opens System Settings to the File-Providers enablement pane, trying
+    /// Opens the settings app to the File-Providers enablement pane, trying
     /// `enablementDeepLinks` in order and stopping at the first that opens.
     ///
     /// - Returns: `true` if a URL was opened, `false` if every candidate failed.

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
@@ -22,20 +22,20 @@ import Foundation
 /// transfer's state is partitioned between its two lanes (see
 /// `InboundTransfer`), and the terminal transition is claimed once under the
 /// transfer's own lock.
-public final class ClipboardStreamReceiver: @unchecked Sendable {
-    /// Opens the append-only staging sink for one disk-streamed transfer.
-    public typealias SinkFactory =
-        @Sendable (_ generation: UInt64, _ filename: String) throws ->
-        StagingSink
+public final class ClipboardStreamReceiver<Clock: EngineClock>: ClipboardStreamReceiving,
+    @unchecked Sendable
+{
+    private typealias Transfer = InboundTransfer<Clock.Instant>
 
+    private let clock: Clock
     private let channel: VsockChannel
     private let staging: ClipboardFileStaging
 
-    private let makeSink: SinkFactory
+    private let makeSink: ClipboardSinkFactory
     private let windowBytes: Int
     private let ackQuantum: Int
-    private let ackLatencyBound: Duration
-    private let stallTimeout: Duration
+    private let ackLatencyBound: TimeInterval
+    private let stallTimeout: TimeInterval
 
     /// Inline payloads at/below this size reassemble in RAM; larger ones spill to
     /// the staging file and are mmapped back (so there is no inline size cap).
@@ -49,7 +49,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     private let onTransferTimed: (@Sendable (ClipboardTransferMetrics) -> Void)?
 
     private let lock = NSLock()
-    private var transfers: [UInt64: InboundTransfer] = [:]
+    private var transfers: [UInt64: Transfer] = [:]
 
     /// Off-actor delivery handlers registered per `transfer_id` by a lazy pull
     /// coordinator.
@@ -65,17 +65,19 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// `onComplete`, `onAbort`, and `onTransferTimed` are called off the owning
     /// actor, on whichever lane finished the transfer.
     public init(
+        clock: Clock,
         channel: VsockChannel,
         staging: ClipboardFileStaging,
         windowBytes: Int = ClipboardStreamTuning.defaultWindowBytes,
-        ackLatencyBound: Duration = ClipboardStreamTuning.ackLatencyBound,
-        stallTimeout: Duration = ClipboardStreamTuning.inboundStallTimeout,
+        ackLatencyBound: TimeInterval = ClipboardStreamTuning.ackLatencyBound,
+        stallTimeout: TimeInterval = ClipboardStreamTuning.inboundStallTimeout,
         maxResidentInlineBytes: Int = ClipboardStreamTuning.maxResidentInlineBytes,
-        sinkFactory: SinkFactory? = nil,
+        sinkFactory: ClipboardSinkFactory? = nil,
         onTransferTimed: (@Sendable (ClipboardTransferMetrics) -> Void)? = nil,
         onComplete: @escaping @Sendable (UInt64, ClipboardContent.Representation) -> Void,
         onAbort: @escaping @Sendable (ClipboardStreamAbortInfo) -> Void
     ) {
+        self.clock = clock
         self.channel = channel
         self.staging = staging
         self.makeSink =
@@ -96,14 +98,15 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// Begins an inbound transfer: free-space check, sink open, and the initial
     /// ack that tells the sender to go.
     public func handleBegin(_ begin: Kernova_V1_ClipboardStreamBegin) {
-        let transfer = InboundTransfer(
+        let transfer = Transfer(
             transferID: begin.transferID,
             generation: begin.generation,
             uti: begin.uti,
             filename: begin.filename,
             isInline: begin.isInline,
             totalBytes: Int(clamping: begin.totalBytes),
-            maxResidentInlineBytes: maxResidentInlineBytes
+            maxResidentInlineBytes: maxResidentInlineBytes,
+            now: self.clock.now
         )
         // Ignore a duplicate transfer_id rather than overwrite an in-flight
         // transfer (which would orphan its open sink + partial temp file). [L4]
@@ -195,7 +198,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
                 return
             }
 
-            let now = ContinuousClock.now
+            let now = self.clock.now
             if transfer.firstChunkAt == nil { transfer.firstChunkAt = now }
 
             let writeQueue = transfer.writeQueue
@@ -268,7 +271,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     }
 
     /// Completes a RAM-resident inline transfer, on the receive lane.
-    private func finishResident(_ transfer: InboundTransfer) {
+    private func finishResident(_ transfer: Transfer) {
         // Final ack: close the sender's cumulative credit ledger, since a tail
         // below one ack quantum was never acked mid-stream.
         if transfer.receivedBytes > transfer.ackedBytes {
@@ -286,7 +289,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
 
     /// Commits a disk-streamed transfer's staging file and completes it, on the
     /// write lane behind the transfer's whole write backlog.
-    private func finishStaged(_ transfer: InboundTransfer, byteCount: Int, digest: Data) {
+    private func finishStaged(_ transfer: Transfer, byteCount: Int, digest: Data) {
         // Final ack: every byte is durably written now, so this closes the
         // sender's cumulative credit ledger even if the tail sat below one
         // quantum.
@@ -360,22 +363,22 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// Called from whichever lane finished the transfer, always off the owning
     /// actor — the contract the delivery closures are written against.
     private func deliver(
-        _ transfer: InboundTransfer, _ representation: ClipboardContent.Representation,
+        _ transfer: Transfer, _ representation: ClipboardContent.Representation,
         byteCount: Int
     ) {
         guard transfer.finishOnce() else { return }
         remove(transfer.transferID)
         if let onTransferTimed {
-            let completedAt = ContinuousClock.now
+            let completedAt = clock.now
             onTransferTimed(
                 ClipboardTransferMetrics(
                     transferID: transfer.transferID,
                     uti: transfer.uti,
                     byteCount: byteCount,
                     streamedToDisk: transfer.streamsToDisk,
-                    duration: transfer.beganAt.duration(to: completedAt),
+                    duration: clock.seconds(from: transfer.beganAt, to: completedAt),
                     streamingDuration: transfer.firstChunkAt.map {
-                        $0.duration(to: completedAt)
+                        clock.seconds(from: $0, to: completedAt)
                     }))
         }
         deliverComplete(transfer.transferID, representation)
@@ -466,7 +469,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
 
     // MARK: - Private
 
-    private func transfer(_ id: UInt64) -> InboundTransfer? {
+    private func transfer(_ id: UInt64) -> Transfer? {
         lock.withLock { transfers[id] }
     }
 
@@ -528,7 +531,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
         ClipboardTransferID.generation(of: id)
     }
 
-    private func teardown(_ transfer: InboundTransfer) {
+    private func teardown(_ transfer: Transfer) {
         transfer.queue.async { [weak self] in
             guard let self, transfer.finishOnce() else { return }
             transfer.stallTimer?.cancel()
@@ -551,11 +554,11 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// The timer fires on the transfer's receive lane and compares against
     /// `lastChunkAt`, which each arriving chunk refreshes with a plain store; a
     /// tick that loses the race to completion is a no-op. [H2]
-    private func startStallTimer(_ transfer: InboundTransfer) {
+    private func startStallTimer(_ transfer: Transfer) {
         let timer = DispatchSource.makeTimerSource(queue: transfer.queue)
         timer.setEventHandler { [weak self, weak transfer] in
             guard let self, let transfer, !transfer.isFinished else { return }
-            guard transfer.lastChunkAt.duration(to: .now) >= self.stallTimeout else { return }
+            guard self.clock.seconds(since: transfer.lastChunkAt) >= self.stallTimeout else { return }
             self.fail(transfer, code: "stall.timeout", message: "Sender stopped sending")
         }
         // The timeout is a dead-sender backstop, not a precise deadline:
@@ -563,7 +566,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
         // a stall within ~1–2.5× it (still well under the 120 s lazy-pull
         // backstop) and lets the OS coalesce the per-transfer wakeup for the
         // whole life of a long healthy transfer.
-        let interval = stallTimeout.timeInterval
+        let interval = stallTimeout
         timer.schedule(
             deadline: .now() + interval, repeating: interval,
             leeway: .milliseconds(Int(interval * 500)))
@@ -577,7 +580,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// Runs strictly in stream order behind every earlier chunk of the same
     /// transfer, so `writtenBytes` is always a true durable *prefix* of the
     /// payload — which is what lets its ack carry credit.
-    private func performWrite(_ transfer: InboundTransfer, _ data: Data) {
+    private func performWrite(_ transfer: Transfer, _ data: Data) {
         guard !transfer.isFinished else { return }
         guard let sink = transfer.sink else {
             // Fail loudly rather than drop the bytes: the receive lane has
@@ -609,7 +612,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
                 return
             }
         }
-        ackIfDue(transfer, upTo: transfer.writtenBytes, now: .now)
+        ackIfDue(transfer, upTo: transfer.writtenBytes, now: clock.now)
     }
 
     /// Sends a coalesced cumulative ack once a quantum of durably-written bytes
@@ -620,11 +623,11 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// sender's fixed no-ack deadline when durable writes run slow. The tail
     /// below one quantum is acked at End.
     private func ackIfDue(
-        _ transfer: InboundTransfer, upTo count: Int, now: ContinuousClock.Instant
+        _ transfer: Transfer, upTo count: Int, now: Clock.Instant
     ) {
         guard
             count - transfer.ackedBytes >= ackQuantum
-                || transfer.lastAckAt.duration(to: now) >= ackLatencyBound
+                || clock.seconds(from: transfer.lastAckAt, to: now) >= ackLatencyBound
         else { return }
         sendAck(transfer, upTo: count)
     }
@@ -635,7 +638,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// On the disk path the ack is emitted from the write lane, ordered behind
     /// any pending appends, so it reports the same durably-written prefix every
     /// other ack does.
-    private func reAck(_ transfer: InboundTransfer) {
+    private func reAck(_ transfer: Transfer) {
         guard let writeQueue = transfer.writeQueue else {
             sendAck(transfer, upTo: transfer.receivedBytes)
             return
@@ -646,9 +649,9 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
         }
     }
 
-    private func sendAck(_ transfer: InboundTransfer, upTo count: Int) {
+    private func sendAck(_ transfer: Transfer, upTo count: Int) {
         transfer.ackedBytes = count
-        transfer.lastAckAt = .now
+        transfer.lastAckAt = clock.now
         send(
             .with {
                 $0.protocolVersion = 1
@@ -660,7 +663,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             })
     }
 
-    private func failDiskFull(_ transfer: InboundTransfer) {
+    private func failDiskFull(_ transfer: Transfer) {
         let available = staging.availableCapacity().map { Int(clamping: $0) }
         sendAbortFrame(transfer.transferID, code: "disk.full", message: "Not enough disk space")
         finishFailed(
@@ -673,7 +676,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
 
     /// Fails a transfer from **either** lane: sends the abort frame and tears
     /// down whatever local state exists.
-    private func fail(_ transfer: InboundTransfer, code: String, message: String) {
+    private func fail(_ transfer: Transfer, code: String, message: String) {
         sendAbortFrame(transfer.transferID, code: code, message: message)
         finishFailed(
             transfer,
@@ -682,7 +685,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
                 neededBytes: nil, availableBytes: nil))
     }
 
-    private func finishFailed(_ transfer: InboundTransfer, info: ClipboardStreamAbortInfo) {
+    private func finishFailed(_ transfer: Transfer, info: ClipboardStreamAbortInfo) {
         guard transfer.finishOnce() else { return }
         // Callable from either lane: each hop below lands on the lane that owns
         // the state it touches, and the abort is delivered without waiting on
@@ -701,7 +704,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// once the write lane drains, so a caller that needs the file gone must
     /// wait for that, not for the abort. A RAM-resident inline transfer has no
     /// sink and nothing to clean up.
-    private func abortSink(_ transfer: InboundTransfer) {
+    private func abortSink(_ transfer: Transfer) {
         guard let writeQueue = transfer.writeQueue else { return }
         writeQueue.async { transfer.sink?.abort() }
     }
@@ -729,7 +732,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     ///
     /// Read on the transfer's receive lane, the anchor's isolation domain, so an
     /// assertion never races the repeating watchdog timer.
-    func lastChunkAtForTesting(_ transferID: UInt64) -> ContinuousClock.Instant? {
+    func lastChunkAtForTesting(_ transferID: UInt64) -> Clock.Instant? {
         guard let transfer = transfer(transferID) else { return nil }
         return transfer.queue.sync { transfer.lastChunkAt }
     }
@@ -751,21 +754,21 @@ public struct ClipboardTransferMetrics: Sendable, Equatable {
     public let byteCount: Int
     /// Whether the payload streamed to a staging file (vs. reassembling in RAM).
     public let streamedToDisk: Bool
-    /// Begin processed → digest verified and committed.
-    public let duration: Duration
-    /// First chunk arrival → digest verified and committed, excluding the
-    /// go-signal round-trip and the sender's source-open ramp. `nil` for a
-    /// zero-byte transfer, which never carries a chunk.
-    public let streamingDuration: Duration?
+    /// Begin processed → digest verified and committed, in seconds.
+    public let duration: TimeInterval
+    /// First chunk arrival → digest verified and committed, in seconds,
+    /// excluding the go-signal round-trip and the sender's source-open ramp.
+    /// `nil` for a zero-byte transfer, which never carries a chunk.
+    public let streamingDuration: TimeInterval?
 
     /// One-line human-readable rendering for the throughput log line, e.g.
     /// `"10485760 bytes (public.data) in 0.052 s — 192.3 MiB/s (disk, streamed 0.049 s)"`.
     public var logSummary: String {
-        let seconds = duration.timeInterval
+        let seconds = duration
         let rate = seconds > 0 ? Double(byteCount) / 1_048_576 / seconds : 0
         var detail = streamedToDisk ? "disk" : "memory"
         if let streamingDuration {
-            detail += String(format: ", streamed %.3f s", streamingDuration.timeInterval)
+            detail += String(format: ", streamed %.3f s", streamingDuration)
         }
         return String(
             format: "%ld bytes (%@) in %.3f s — %.1f MiB/s (%@)",
@@ -819,7 +822,7 @@ private struct Awaiter {
 /// so in their own docs and rely on the hand-off being ordered by the `async`
 /// that moves the work across. The one contended decision — which path reaches
 /// the terminal state first — goes through `finishOnce()`.
-private final class InboundTransfer: @unchecked Sendable {
+private final class InboundTransfer<Instant: Comparable & Sendable>: @unchecked Sendable {
     let transferID: UInt64
     let generation: UInt64
     let uti: String
@@ -839,12 +842,12 @@ private final class InboundTransfer: @unchecked Sendable {
     var streamsToDisk: Bool { writeQueue != nil }
 
     /// When `handleBegin` created this transfer.
-    let beganAt = ContinuousClock.now
+    let beganAt: Instant
     /// When the first chunk arrived.
     ///
     /// Written on `queue`; frozen once End is accepted, so the write lane's
     /// completion barrier — ordered after that — reads the final value.
-    var firstChunkAt: ContinuousClock.Instant?
+    var firstChunkAt: Instant?
 
     /// Receive lane: bytes accepted off the wire — validated, hashed, and
     /// either buffered or handed to the write lane.
@@ -866,7 +869,7 @@ private final class InboundTransfer: @unchecked Sendable {
     /// against `ackLatencyBound` on each durably-written chunk.
     ///
     /// Same lane ownership as `ackedBytes`.
-    var lastAckAt = ContinuousClock.now
+    var lastAckAt: Instant
     /// Write lane: bytes written since the last free-space re-check.
     var bytesSinceCheck = 0
     /// Receive lane: running SHA-256 over the accepted bytes.
@@ -883,7 +886,7 @@ private final class InboundTransfer: @unchecked Sendable {
     var endReceived = false
     /// Receive lane: when the last chunk *arrived* (seeded at acceptance) — the
     /// stall watchdog's activity anchor, which backstops a dead sender.
-    var lastChunkAt = ContinuousClock.now
+    var lastChunkAt: Instant
     /// Receive lane: the per-transfer stall watchdog, a repeating timer on
     /// `queue` that checks `lastChunkAt` — started once per transfer, cancelled
     /// on finish, never re-armed per chunk.
@@ -913,7 +916,7 @@ private final class InboundTransfer: @unchecked Sendable {
 
     init(
         transferID: UInt64, generation: UInt64, uti: String, filename: String, isInline: Bool,
-        totalBytes: Int, maxResidentInlineBytes: Int
+        totalBytes: Int, maxResidentInlineBytes: Int, now: Instant
     ) {
         self.transferID = transferID
         self.generation = generation
@@ -921,6 +924,9 @@ private final class InboundTransfer: @unchecked Sendable {
         self.filename = filename
         self.isInline = isInline
         self.totalBytes = totalBytes
+        self.beganAt = now
+        self.lastAckAt = now
+        self.lastChunkAt = now
         self.queue = DispatchQueue(
             label: "app.kernova.clipboard.stream-recv.\(transferID)", qos: .userInitiated)
         self.writeQueue =

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiving.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiving.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Opens the append-only staging sink for one disk-streamed transfer.
+public typealias ClipboardSinkFactory =
+    @Sendable (_ generation: UInt64, _ filename: String) throws ->
+    StagingSink
+
+/// The clock-independent surface of `ClipboardStreamReceiver`, for holders that
+/// must run below macOS 13 and so cannot store a concrete clock instantiation.
+public protocol ClipboardStreamReceiving: AnyObject, Sendable {
+    /// Begins an inbound transfer: free-space check, sink open, and the initial
+    /// ack that tells the sender to go.
+    func handleBegin(_ begin: Kernova_V1_ClipboardStreamBegin)
+
+    /// Accepts one chunk of an in-flight transfer.
+    func handleChunk(_ chunk: Kernova_V1_ClipboardChunk)
+
+    /// Verifies and commits a completed transfer.
+    func handleEnd(_ end: Kernova_V1_ClipboardStreamEnd)
+
+    /// Tears down an inbound transfer on a peer `ClipboardStreamAbort`.
+    func handleAbort(_ abort: Kernova_V1_ClipboardStreamAbort)
+
+    /// Aborts every in-flight transfer for a superseded generation.
+    func cancel(generation: UInt64)
+
+    /// Aborts every in-flight transfer (channel teardown / capability disable).
+    func cancelAll()
+
+    /// Consumer-requested cancel of one lazy pull.
+    func cancel(transferID: UInt64)
+
+    /// Registers an off-actor delivery handler for a single transfer.
+    func awaitTransfer(
+        _ transferID: UInt64,
+        onComplete: @escaping @Sendable (ClipboardContent.Representation) -> Void,
+        onAbort: @escaping @Sendable (ClipboardStreamAbortInfo) -> Void,
+        onProgress: (@Sendable (_ bytesReceived: Int, _ totalBytes: Int) -> Void)?
+    )
+
+    /// Deregisters a per-transfer delivery handler without firing it.
+    func cancelAwait(_ transferID: UInt64)
+}
+
+extension ClipboardStreamReceiving {
+    /// `awaitTransfer` without a progress handler.
+    public func awaitTransfer(
+        _ transferID: UInt64,
+        onComplete: @escaping @Sendable (ClipboardContent.Representation) -> Void,
+        onAbort: @escaping @Sendable (ClipboardStreamAbortInfo) -> Void
+    ) {
+        awaitTransfer(transferID, onComplete: onComplete, onAbort: onAbort, onProgress: nil)
+    }
+}
+
+/// Builds a receiver on the platform-default clock — `ContinuousClock` on
+/// macOS 13+, `CLOCK_MONOTONIC` below — erased for holders that run on 12.
+public func makeClipboardStreamReceiver(
+    channel: VsockChannel,
+    staging: ClipboardFileStaging,
+    windowBytes: Int = ClipboardStreamTuning.defaultWindowBytes,
+    ackLatencyBound: TimeInterval = ClipboardStreamTuning.ackLatencyBound,
+    stallTimeout: TimeInterval = ClipboardStreamTuning.inboundStallTimeout,
+    maxResidentInlineBytes: Int = ClipboardStreamTuning.maxResidentInlineBytes,
+    sinkFactory: ClipboardSinkFactory? = nil,
+    onTransferTimed: (@Sendable (ClipboardTransferMetrics) -> Void)? = nil,
+    onComplete: @escaping @Sendable (UInt64, ClipboardContent.Representation) -> Void,
+    onAbort: @escaping @Sendable (ClipboardStreamAbortInfo) -> Void
+) -> any ClipboardStreamReceiving {
+    if #available(macOS 13.0, *) {
+        return ClipboardStreamReceiver(
+            clock: ContinuousEngineClock(),
+            channel: channel,
+            staging: staging,
+            windowBytes: windowBytes,
+            ackLatencyBound: ackLatencyBound,
+            stallTimeout: stallTimeout,
+            maxResidentInlineBytes: maxResidentInlineBytes,
+            sinkFactory: sinkFactory,
+            onTransferTimed: onTransferTimed,
+            onComplete: onComplete,
+            onAbort: onAbort
+        )
+    }
+    return ClipboardStreamReceiver(
+        clock: MonotonicEngineClock(),
+        channel: channel,
+        staging: staging,
+        windowBytes: windowBytes,
+        ackLatencyBound: ackLatencyBound,
+        stallTimeout: stallTimeout,
+        maxResidentInlineBytes: maxResidentInlineBytes,
+        sinkFactory: sinkFactory,
+        onTransferTimed: onTransferTimed,
+        onComplete: onComplete,
+        onAbort: onAbort
+    )
+}

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
@@ -18,7 +18,7 @@ public final class ClipboardStreamSender: @unchecked Sendable {
     private let channel: VsockChannel
     private let chunkSize: Int
     private let windowBytes: Int
-    private let noAckTimeout: Duration
+    private let noAckTimeout: TimeInterval
 
     private let lock = NSLock()
     private var transfers: [UInt64: OutboundTransfer] = [:]
@@ -34,7 +34,7 @@ public final class ClipboardStreamSender: @unchecked Sendable {
         channel: VsockChannel,
         chunkSize: Int = ClipboardStreamTuning.defaultChunkPayloadSize,
         windowBytes: Int = ClipboardStreamTuning.defaultWindowBytes,
-        noAckTimeout: Duration = .seconds(10)
+        noAckTimeout: TimeInterval = 10
     ) {
         self.channel = channel
         self.chunkSize = max(1, chunkSize)
@@ -367,10 +367,10 @@ private final class OutboundTransfer: @unchecked Sendable {
 
     /// Blocks until there is credit for a `chunkSize` chunk at `offset`, the
     /// transfer is aborted, or the no-ack deadline elapses without progress.
-    func awaitCredit(offset: Int, chunkSize: Int, timeout: Duration) -> CreditOutcome {
+    func awaitCredit(offset: Int, chunkSize: Int, timeout: TimeInterval) -> CreditOutcome {
         condition.lock()
         defer { condition.unlock() }
-        let deadline = Date(timeIntervalSinceNow: timeout.timeInterval)
+        let deadline = Date(timeIntervalSinceNow: timeout)
         while true {
             if aborted { return .aborted(abortReason) }
             // Honor the receiver-advertised window (updated by acks under this

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamTuning.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamTuning.swift
@@ -37,7 +37,7 @@ public enum ClipboardStreamTuning {
     /// four chunk-write times, so under degraded I/O sustained per-chunk writes
     /// in the 2.5–10 s range trip the sender's 10 s no-ack deadline and abort a
     /// live transfer.
-    public static let ackLatencyBound: Duration = .seconds(1)
+    public static let ackLatencyBound: TimeInterval = 1
 
     /// Upper bound on how much an inline reassembly buffer pre-reserves: 64 MiB.
     ///
@@ -71,7 +71,7 @@ public enum ClipboardStreamTuning {
     /// an open file descriptor and a partial temp file until channel teardown.
     /// Larger than the sender's 10 s no-ack timeout so a slow-but-live transfer
     /// is never killed.
-    public static let inboundStallTimeout: Duration = .seconds(30)
+    public static let inboundStallTimeout: TimeInterval = 30
 
     /// Backstop on how long a lazy pull blocks the consuming thread *without
     /// progress* before giving up: 120 s of **inactivity**.
@@ -80,7 +80,7 @@ public enum ClipboardStreamTuning {
     /// re-arms it (`LazyPullCoordinator.heartbeat`), so a healthy transfer of any
     /// size never trips it. Made absolute, it silently kills large,
     /// still-progressing transfers that need more than one window to stream.
-    public static let lazyPullTimeout: Duration = .seconds(120)
+    public static let lazyPullTimeout: TimeInterval = 120
 
     /// Sentinel `maxAcceptByteCount` meaning "no explicit ceiling" — the
     /// requester could not measure its free space.
@@ -99,12 +99,4 @@ public enum ClipboardStreamTuning {
     /// fallback — with the File Provider on there is no size limit
     /// (CLIPBOARD.md §1).
     public static let maxDeadlineSafeFileBytes = 256 * 1024 * 1024
-}
-
-extension Duration {
-    /// This duration as fractional seconds, for `DispatchTime`/`Date` math.
-    var timeInterval: TimeInterval {
-        let (s, attos) = components
-        return Double(s) + Double(attos) / 1_000_000_000_000_000_000
-    }
 }

--- a/KernovaKit/Sources/KernovaKit/EngineClock.swift
+++ b/KernovaKit/Sources/KernovaKit/EngineClock.swift
@@ -1,0 +1,94 @@
+import Darwin
+import Foundation
+
+/// Monotonic time source for the stream engine and the guest agent's liveness
+/// watchdogs — `Swift.Clock`, one floor lower, so code that must run on
+/// macOS 12 guests can still store real `ContinuousClock.Instant`s on 13+.
+///
+/// Conformances MUST count time the system spends asleep: the liveness
+/// watchdogs measure elapsed time across VM save/restore, and an uptime clock
+/// (`DispatchTime`/`mach_absolute_time`) freezes there and never fires them.
+public protocol EngineClock: Sendable {
+    /// A point in this clock's timeline.
+    associatedtype Instant: Comparable, Sendable
+
+    /// The current instant.
+    var now: Instant { get }
+
+    /// Seconds from `start` to `end`; negative when `end` precedes `start`.
+    func seconds(from start: Instant, to end: Instant) -> TimeInterval
+
+    /// Suspends the current task for at least `interval` seconds, throwing
+    /// `CancellationError` when the task is cancelled.
+    func sleep(for interval: TimeInterval) async throws
+}
+
+extension EngineClock {
+    /// Seconds elapsed from `start` to `now`.
+    public func seconds(since start: Instant) -> TimeInterval {
+        seconds(from: start, to: now)
+    }
+}
+
+/// `ContinuousClock` as an `EngineClock` — the conformance every macOS 13+
+/// system runs, storing genuine `ContinuousClock.Instant`s.
+@available(macOS 13.0, *)
+public struct ContinuousEngineClock: EngineClock {
+    private let clock = ContinuousClock()
+
+    /// Creates a continuous-clock instance.
+    public init() {}
+
+    /// The current `ContinuousClock` instant.
+    public var now: ContinuousClock.Instant { clock.now }
+
+    /// Seconds from `start` to `end`; negative when `end` precedes `start`.
+    public func seconds(
+        from start: ContinuousClock.Instant, to end: ContinuousClock.Instant
+    ) -> TimeInterval {
+        start.duration(to: end) / .seconds(1)
+    }
+
+    /// Suspends via `ContinuousClock.sleep(until:)`.
+    public func sleep(for interval: TimeInterval) async throws {
+        try await clock.sleep(until: clock.now + .seconds(interval))
+    }
+}
+
+/// `CLOCK_MONOTONIC` as an `EngineClock` — the macOS 12 fallback.
+///
+/// Darwin's `CLOCK_MONOTONIC` advances across system sleep (unlike Linux's),
+/// matching `ContinuousClock`; `CLOCK_UPTIME_RAW`/`mach_absolute_time` do not.
+public struct MonotonicEngineClock: EngineClock {
+    /// A `CLOCK_MONOTONIC` reading in nanoseconds.
+    public struct Instant: Comparable, Sendable {
+        let nanoseconds: UInt64
+
+        /// Orders instants by their nanosecond reading.
+        public static func < (lhs: Instant, rhs: Instant) -> Bool {
+            lhs.nanoseconds < rhs.nanoseconds
+        }
+    }
+
+    /// Creates a monotonic-clock instance.
+    public init() {}
+
+    /// The current `CLOCK_MONOTONIC` reading.
+    public var now: Instant {
+        Instant(nanoseconds: clock_gettime_nsec_np(CLOCK_MONOTONIC))
+    }
+
+    /// Seconds from `start` to `end`; negative when `end` precedes `start`.
+    public func seconds(from start: Instant, to end: Instant) -> TimeInterval {
+        if end.nanoseconds >= start.nanoseconds {
+            return TimeInterval(end.nanoseconds - start.nanoseconds) / 1_000_000_000
+        }
+        return -TimeInterval(start.nanoseconds - end.nanoseconds) / 1_000_000_000
+    }
+
+    /// Suspends via `Task.sleep(nanoseconds:)`.
+    public func sleep(for interval: TimeInterval) async throws {
+        let clamped = min(max(interval, 0), 1_000_000_000)
+        try await Task.sleep(nanoseconds: UInt64(clamped * 1_000_000_000))
+    }
+}

--- a/KernovaKit/Sources/KernovaKit/FileProviderRelayTransport.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderRelayTransport.swift
@@ -31,11 +31,14 @@ public protocol FileProviderRelayTransport: AnyObject, Sendable {
 /// and keeps the control connection warm — reconnecting on the Darwin doorbell or
 /// an XPC invalidation.
 ///
-/// The service is addressed by ITEM IDENTIFIER — on the guest side too, which shares
-/// this connector. The path-based `FileManager.getFileProviderServicesForItem(at:)`
-/// needs `~/Library/CloudStorage` access the sandboxed host app lacks (Cocoa 257),
-/// and reaching through our own dataless root risks reentrant materialization. Only
-/// the second constraint binds the unsandboxed guest agent.
+/// On macOS 13+ the service is addressed by ITEM IDENTIFIER — on the guest side
+/// too, which shares this connector. The path-based
+/// `FileManager.getFileProviderServicesForItem(at:)` needs `~/Library/CloudStorage`
+/// access the sandboxed host app lacks (Cocoa 257), and reaching through our own
+/// dataless root risks reentrant materialization. Below 13 — only the unsandboxed
+/// guest agent, which neither constraint binds when the lookup stops at the root —
+/// the identifier-addressed selector does not exist, so the connector resolves the
+/// root's user-visible URL and addresses that one dirent, never a descendant.
 ///
 /// `@unchecked Sendable`: all mutable state is guarded by `lock`; the immutable
 /// addressing/logging values are set once in `init`.
@@ -113,14 +116,7 @@ public final class FileProviderServicingConnector: NSObject,
                 completion(nil)
                 return
             }
-            manager.getService(named: serviceName, for: .rootContainer) { service, error in
-                guard let service else {
-                    logger.error(
-                        "getService(named: \(serviceName.rawValue, privacy: .public)) failed: \(error?.localizedDescription ?? "no service offered", privacy: .public)"
-                    )
-                    completion(nil)
-                    return
-                }
+            let openConnection: @Sendable (NSFileProviderService) -> Void = { service in
                 service.getFileProviderConnection { connection, error in
                     guard let connection else {
                         logger.error(
@@ -130,6 +126,43 @@ public final class FileProviderServicingConnector: NSObject,
                         return
                     }
                     completion(connection)
+                }
+            }
+            if #available(macOS 13.0, *) {
+                manager.getService(named: serviceName, for: .rootContainer) { service, error in
+                    guard let service else {
+                        logger.error(
+                            "getService(named: \(serviceName.rawValue, privacy: .public)) failed: \(error?.localizedDescription ?? "no service offered", privacy: .public)"
+                        )
+                        completion(nil)
+                        return
+                    }
+                    openConnection(service)
+                }
+            } else {
+                // The 13+ branch above compiles ungated at the 12 floor, but its
+                // selector ships in macOS 13 and Monterey aborts on it
+                // (docs/research/2026-08-02-macos12-fileprovider-getservice.md), so
+                // Monterey takes the URL-addressed lookup against the root dirent.
+                manager.getUserVisibleURL(for: .rootContainer) { url, error in
+                    guard let url else {
+                        logger.error(
+                            "getUserVisibleURL(for: .rootContainer) failed: \(error?.localizedDescription ?? "nil URL", privacy: .public)"
+                        )
+                        completion(nil)
+                        return
+                    }
+                    FileManager.default.getFileProviderServicesForItem(at: url) {
+                        services, error in
+                        guard let service = services?[serviceName] else {
+                            logger.error(
+                                "getFileProviderServicesForItem(at:) offered no '\(serviceName.rawValue, privacy: .public)': \(error?.localizedDescription ?? "no error", privacy: .public)"
+                            )
+                            completion(nil)
+                            return
+                        }
+                        openConnection(service)
+                    }
                 }
             }
         }

--- a/KernovaKit/Sources/KernovaKit/FileProviderRelayTransport.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderRelayTransport.swift
@@ -262,7 +262,14 @@ public final class FileProviderServicingConnector: NSObject,
         connection.exportedInterface = NSXPCInterface(with: FileProviderRelay.self)
         connection.remoteObjectInterface = NSXPCInterface(with: FileProviderControl.self)
         if let extensionRequirement {
-            connection.setCodeSigningRequirement(extensionRequirement)
+            if #available(macOS 13.0, *) {
+                connection.setCodeSigningRequirement(extensionRequirement)
+            } else {
+                // Unreachable in practice: the only pre-13 process is the guest
+                // agent, and `FileProviderConfig.guest()` supplies no requirement.
+                logger.fault("Code-signing requirement configured but unenforceable below macOS 13")
+                assertionFailure("Code-signing requirement configured but unenforceable below macOS 13")
+            }
         }
         connection.invalidationHandler = { [weak self] in self?.handleConnectionDropped(connection) }
         connection.interruptionHandler = { [weak self] in self?.handleConnectionDropped(connection) }

--- a/KernovaKit/Sources/KernovaKit/FileProviderServiceSource.swift
+++ b/KernovaKit/Sources/KernovaKit/FileProviderServiceSource.swift
@@ -122,7 +122,14 @@ final class FileProviderServiceSource: NSObject, NSFileProviderServiceSource,
         // Non-throwing: arms a framework-enforced check, so an impostor owner's
         // calls invalidate rather than failing here.
         if let requirement = config.ownerCodeSigningRequirement {
-            newConnection.setCodeSigningRequirement(requirement)
+            if #available(macOS 13.0, *) {
+                newConnection.setCodeSigningRequirement(requirement)
+            } else {
+                // Unreachable in practice: the only pre-13 process is the guest
+                // agent, and `FileProviderConfig.guest()` supplies no requirement.
+                logger.fault("Code-signing requirement configured but unenforceable below macOS 13")
+                assertionFailure("Code-signing requirement configured but unenforceable below macOS 13")
+            }
         }
         newConnection.invalidationHandler = { [weak self] in self?.clearConnection(newConnection) }
         newConnection.interruptionHandler = { [weak self] in self?.clearConnection(newConnection) }

--- a/KernovaKit/Sources/KernovaKit/KernovaOSVersion.swift
+++ b/KernovaKit/Sources/KernovaKit/KernovaOSVersion.swift
@@ -1,9 +1,11 @@
 import Foundation
+import os
 
 /// Numeric rendering and reading of an operating-system version, shared by the
 /// host and the guest agent so the restore-image UI and the
 /// `AgentInfo.os_version` handshake field agree on one shape.
 public enum KernovaOSVersion {
+    private static let logger = Logger(subsystem: "app.kernova", category: "KernovaOSVersion")
     /// `version` rendered the way Apple names a release: a zero patch is left
     /// off, so `26.6.0` reads as `"26.6"` and matches the catalog's own strings.
     ///
@@ -35,7 +37,16 @@ public enum KernovaOSVersion {
     /// - Returns: The leading dotted-decimal run, or `nil` when `reported`
     ///   contains no digits.
     public static func numericVersion(in reported: String) -> String? {
-        guard let match = reported.firstMatch(of: #/\d+(?:\.\d+)*/#) else { return nil }
-        return String(match.output)
+        guard let regex = try? NSRegularExpression(pattern: #"\d+(?:\.\d+)*"#) else {
+            logger.fault("Dotted-decimal version pattern failed to compile")
+            assertionFailure("Dotted-decimal version pattern failed to compile")
+            return nil
+        }
+        let fullRange = NSRange(reported.startIndex..., in: reported)
+        guard
+            let match = regex.firstMatch(in: reported, range: fullRange),
+            let matchRange = Range(match.range, in: reported)
+        else { return nil }
+        return String(reported[matchRange])
     }
 }

--- a/KernovaKit/Sources/KernovaKit/LazyPullCoordinator.swift
+++ b/KernovaKit/Sources/KernovaKit/LazyPullCoordinator.swift
@@ -44,8 +44,8 @@ public final class LazyPullCoordinator: @unchecked Sendable {
     /// Test-only; defaults to a wait identical to the Release path below. Lets a
     /// test control when a window "elapses" instead of racing wall-clock
     /// scheduling.
-    var windowWaitForTesting: (@Sendable (DispatchSemaphore, Duration) -> Void) = { semaphore, timeout in
-        _ = semaphore.wait(timeout: .now() + timeout.timeInterval)
+    var windowWaitForTesting: (@Sendable (DispatchSemaphore, TimeInterval) -> Void) = { semaphore, timeout in
+        _ = semaphore.wait(timeout: .now() + timeout)
     }
     #endif
 
@@ -79,7 +79,7 @@ public final class LazyPullCoordinator: @unchecked Sendable {
     /// - Returns: the outcome the matching transfer resolved with.
     public func pull(
         transferID: UInt64,
-        timeout: Duration = ClipboardStreamTuning.lazyPullTimeout,
+        timeout: TimeInterval = ClipboardStreamTuning.lazyPullTimeout,
         send: () -> Void
     ) -> LazyPullOutcome {
         let slot = Slot()
@@ -109,7 +109,7 @@ public final class LazyPullCoordinator: @unchecked Sendable {
             #if DEBUG
             windowWaitForTesting(slot.semaphore, timeout)
             #else
-            _ = slot.semaphore.wait(timeout: .now() + timeout.timeInterval)
+            _ = slot.semaphore.wait(timeout: .now() + timeout)
             #endif
             let outcome: LazyPullOutcome? = lock.withLock {
                 if slot.resolved {

--- a/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
@@ -1,14 +1,15 @@
 import Foundation
+import KernovaKit
 
 // MARK: - testWaitBackstop
 
-/// Default stuck-condition backstop for every test wait helper.
+/// Default stuck-condition backstop for every test wait helper, in seconds.
 ///
 /// Sized past any plausible CI scheduler stall — starved macos-26 runners have
 /// defeated 5 s and 10 s backstops. Success-path waits must not pass a smaller
 /// explicit timeout; explicit values are for behavior-under-test deadlines only
 /// (docs/TESTING.md, "Async waits in tests").
-public let testWaitBackstop: Duration = .seconds(60)
+public let testWaitBackstop: TimeInterval = 60
 
 // MARK: - TestFailure
 
@@ -72,29 +73,34 @@ public final class AsyncGate: @unchecked Sendable {
     }
 
     /// Suspend until `predicate()` holds (re-checked on each `notify()`), or
-    /// throw `TestFailure` after `timeout`.
+    /// throw `TestFailure` after `timeout` seconds.
     public func wait(
-        timeout: Duration = testWaitBackstop,
+        timeout: TimeInterval = testWaitBackstop,
         isolation: isolated (any Actor)? = #isolation,
         until predicate: () -> Bool
     ) async throws {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
+        let clock = MonotonicEngineClock()
+        let start = clock.now
         while !predicate() {
-            if ContinuousClock.now >= deadline {
-                throw TestFailure("Condition not met within \(timeout)")
+            if clock.seconds(since: start) >= timeout {
+                throw TestFailure("Condition not met within \(timeout) s")
             }
-            await armOnce(deadline: deadline, isolation: isolation, predicate: predicate)
+            await armOnce(
+                clock: clock, start: start, timeout: timeout,
+                isolation: isolation, predicate: predicate)
         }
     }
 
     /// Suspends until the next `notify()`, an immediate hit (the predicate
     /// already holds at arm time, closing the arm-vs-notify race), or the
-    /// `deadline` backstop — whichever comes first.
+    /// deadline backstop (`start` + `timeout`) — whichever comes first.
     // `isolation` uses the Swift `isolated` keyword to pin this helper to the
     // caller's actor, so it is intentionally never referenced by name.
     // periphery:ignore:parameters isolation
     private func armOnce(
-        deadline: ContinuousClock.Instant,
+        clock: MonotonicEngineClock,
+        start: MonotonicEngineClock.Instant,
+        timeout: TimeInterval,
         isolation: isolated (any Actor)?,
         predicate: () -> Bool
     ) async {
@@ -119,7 +125,7 @@ public final class AsyncGate: @unchecked Sendable {
             // Resume at the deadline even if no notify arrives, so a stuck
             // condition fails the wait instead of hanging.
             backstop = Task {
-                try? await Task.sleep(until: deadline, clock: ContinuousClock())
+                try? await clock.sleep(for: max(0, timeout - clock.seconds(since: start)))
                 self.lock.withLock { self.waiters[id] = nil }
                 once.fire { cont.resume() }
             }
@@ -133,21 +139,23 @@ public final class AsyncGate: @unchecked Sendable {
 // `isolation` uses the Swift `isolated` keyword to inherit the caller's actor
 // isolation, so it is intentionally never referenced by name.
 // periphery:ignore:parameters isolation
-/// Polls `predicate` every 50 ms until it returns `true` or `timeout` elapses.
+/// Polls `predicate` every 50 ms until it returns `true` or `timeout` seconds
+/// elapse.
 ///
 /// The deadline here *is* the pass/fail criterion — prefer `AsyncGate` for a new
 /// timing-sensitive wait; polling is for predicates with no signal to await.
 public func waitUntil(
-    timeout: Duration = testWaitBackstop,
+    timeout: TimeInterval = testWaitBackstop,
     isolation: isolated (any Actor)? = #isolation,
     _ predicate: () -> Bool
 ) async throws {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while !predicate() && ContinuousClock.now < deadline {
-        try await Task.sleep(for: .milliseconds(50))
+    let clock = MonotonicEngineClock()
+    let start = clock.now
+    while !predicate() && clock.seconds(since: start) < timeout {
+        try await Task.sleep(nanoseconds: 50_000_000)
     }
     guard predicate() else {
-        throw TestFailure("Predicate did not become true within \(timeout)")
+        throw TestFailure("Predicate did not become true within \(timeout) s")
     }
 }
 

--- a/KernovaKit/Sources/KernovaTestSupport/EngineClockKind.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/EngineClockKind.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// The two production `EngineClock` conformances, as a parameterization axis
+/// for suites that must exercise both on every CI run.
+///
+/// `.continuous` names `ContinuousEngineClock` (macOS 13+); on a pre-13 runner
+/// — where that clock cannot exist — helpers substitute the monotonic clock.
+public enum EngineClockKind: String, CaseIterable, Sendable {
+    case continuous
+    case monotonic
+}

--- a/KernovaKit/Sources/KernovaTestSupport/EphemeralDefaults.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/EphemeralDefaults.swift
@@ -17,7 +17,7 @@ public func makeEphemeralDefaults(suiteName: String) -> UserDefaults {
     }
     defaults.removePersistentDomain(forName: suiteName)
     if let plistURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
-        .first?.appending(path: "Preferences/\(suiteName).plist")
+        .first?.appendingPathComponent("Preferences/\(suiteName).plist")
     {
         try? FileManager.default.removeItem(at: plistURL)
     }
@@ -39,7 +39,7 @@ public func withEphemeralDefaults<T>(
     defer {
         defaults.removePersistentDomain(forName: suiteName)
         if let plistURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
-            .first?.appending(path: "Preferences/\(suiteName).plist")
+            .first?.appendingPathComponent("Preferences/\(suiteName).plist")
         {
             try? FileManager.default.removeItem(at: plistURL)
         }

--- a/KernovaKit/Sources/KernovaTestSupport/TestEngineClock.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/TestEngineClock.swift
@@ -1,0 +1,109 @@
+import Foundation
+import KernovaKit
+
+/// Manually advanced `EngineClock` for deterministic timing tests: time moves
+/// only through `advance(by:)`, which resumes every parked sleeper whose
+/// deadline it reaches, in deadline order.
+///
+/// Await `onSleep` (or check `sleeperCount`) to know a sleeper has parked
+/// before advancing — advancing first would miss it.
+public final class TestEngineClock: EngineClock, @unchecked Sendable {
+    /// A point on the test timeline: seconds since the clock's zero.
+    public struct Instant: Comparable, Sendable {
+        let offset: TimeInterval
+
+        /// Orders instants by their offset on the test timeline.
+        public static func < (lhs: Instant, rhs: Instant) -> Bool {
+            lhs.offset < rhs.offset
+        }
+    }
+
+    private struct Sleeper {
+        let id: UInt64
+        let deadline: TimeInterval
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private let lock = NSLock()
+    private var current: TimeInterval = 0
+    private var sleepers: [Sleeper] = []
+    private var nextID: UInt64 = 1
+    /// Sleep ids cancelled before their continuation parked.
+    private var preCancelled: Set<UInt64> = []
+    private var onSleepStorage: (@Sendable (TimeInterval) -> Void)?
+
+    /// Creates a clock at time zero with no sleepers.
+    public init() {}
+
+    /// Fired (on the sleeping task's thread) each time a sleeper parks, with
+    /// its interval — the event a test awaits before advancing the clock.
+    public var onSleep: (@Sendable (TimeInterval) -> Void)? {
+        get { lock.withLock { onSleepStorage } }
+        set { lock.withLock { onSleepStorage = newValue } }
+    }
+
+    /// Number of currently parked sleepers.
+    public var sleeperCount: Int { lock.withLock { sleepers.count } }
+
+    /// The current manual time.
+    public var now: Instant { lock.withLock { Instant(offset: current) } }
+
+    /// Seconds from `start` to `end`; negative when `end` precedes `start`.
+    public func seconds(from start: Instant, to end: Instant) -> TimeInterval {
+        end.offset - start.offset
+    }
+
+    /// Parks until `advance(by:)` reaches the deadline, throwing
+    /// `CancellationError` on task cancellation.
+    public func sleep(for interval: TimeInterval) async throws {
+        let id: UInt64 = lock.withLock {
+            defer { nextID += 1 }
+            return nextID
+        }
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                enum Disposition { case parked, elapsed, cancelled }
+                let disposition: Disposition = lock.withLock {
+                    if preCancelled.remove(id) != nil { return .cancelled }
+                    guard interval > 0 else { return .elapsed }
+                    sleepers.append(
+                        Sleeper(id: id, deadline: current + interval, continuation: continuation))
+                    return .parked
+                }
+                switch disposition {
+                case .parked: onSleep?(interval)
+                case .elapsed: continuation.resume()
+                case .cancelled: continuation.resume(throwing: CancellationError())
+                }
+            }
+        } onCancel: {
+            self.cancelSleeper(id)
+        }
+    }
+
+    /// Advances the test timeline, resuming every sleeper whose deadline is
+    /// reached, in `(deadline, park order)` order.
+    public func advance(by interval: TimeInterval) {
+        let due: [Sleeper] = lock.withLock {
+            current += interval
+            let reached = current
+            let ready = sleepers.filter { $0.deadline <= reached }
+                .sorted { ($0.deadline, $0.id) < ($1.deadline, $1.id) }
+            sleepers.removeAll { $0.deadline <= reached }
+            return ready
+        }
+        for sleeper in due { sleeper.continuation.resume() }
+    }
+
+    private func cancelSleeper(_ id: UInt64) {
+        let continuation: CheckedContinuation<Void, any Error>? = lock.withLock {
+            if let index = sleepers.firstIndex(where: { $0.id == id }) {
+                return sleepers.remove(at: index).continuation
+            }
+            preCancelled.insert(id)
+            return nil
+        }
+        continuation?.resume(throwing: CancellationError())
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardFileProviderSettingsTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardFileProviderSettingsTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import KernovaKit
+
+@Suite("ClipboardFileProviderSettings")
+struct ClipboardFileProviderSettingsTests {
+    @Test("every candidate on both OS eras parses as a URL", arguments: [true, false])
+    func everyCandidateParses(systemSettings: Bool) {
+        let candidates = ClipboardFileProviderSettings.enablementDeepLinks(
+            systemSettings: systemSettings)
+        #expect(!candidates.isEmpty)
+        for string in candidates {
+            #expect(URL(string: string) != nil, "unparseable candidate: \(string)")
+        }
+    }
+
+    /// The file URL has to lead: it is the only candidate that fails honestly.
+    ///
+    /// `NSWorkspace.open` reports success for an `x-apple.systempreferences:`
+    /// URL whose pane id does not resolve, so an entry placed after one can
+    /// never run — and on 12 the file URL is also the only one that arrives.
+    @Test("the System Preferences list leads with the pane bundle's file URL")
+    func preSystemSettingsListLeadsWithFileURL() throws {
+        let candidates = ClipboardFileProviderSettings.enablementDeepLinks(systemSettings: false)
+        let leading = try #require(candidates.first.flatMap { URL(string: $0) })
+        #expect(leading.isFileURL)
+        #expect(leading.pathExtension == "prefPane")
+    }
+
+    @Test("the System Settings list addresses the File Provider extension point")
+    func systemSettingsListNamesTheExtensionPoint() {
+        let candidates = ClipboardFileProviderSettings.enablementDeepLinks(systemSettings: true)
+        #expect(candidates.first?.contains("com.apple.fileprovider-nonui") == true)
+    }
+
+    @Test("the running OS picks the era-appropriate list")
+    func runningOSPicksItsOwnList() {
+        let expected: [String]
+        if #available(macOS 13.0, *) {
+            expected = ClipboardFileProviderSettings.enablementDeepLinks(systemSettings: true)
+        } else {
+            expected = ClipboardFileProviderSettings.enablementDeepLinks(systemSettings: false)
+        }
+        #expect(ClipboardFileProviderSettings.enablementDeepLinks == expected)
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
@@ -12,7 +12,7 @@ struct ClipboardStreamTests {
     private static let chunk = 4096
     private static let window = 16384  // 4 chunks
 
-    private func roomyHarness(noAckTimeout: Duration = .seconds(10)) throws -> StreamHarness {
+    private func roomyHarness(noAckTimeout: TimeInterval = 10) throws -> StreamHarness<MonotonicEngineClock> {
         try StreamHarness(
             chunkSize: Self.chunk, windowBytes: Self.window, noAckTimeout: noAckTimeout,
             freeSpaceProvider: { _ in 100 * 1024 * 1024 * 1024 })  // 100 GiB
@@ -24,9 +24,9 @@ struct ClipboardStreamTests {
     /// a few KiB exercises several quantum boundaries. The ack latency bound is
     /// pushed out of reach so the expected ack schedules stay pure byte-quantum
     /// functions — deterministic even on a stalled CI scheduler.
-    private func quantumHarness() throws -> StreamHarness {
+    private func quantumHarness() throws -> StreamHarness<MonotonicEngineClock> {
         try StreamHarness(
-            chunkSize: 1024, windowBytes: 16384, ackLatencyBound: .seconds(600),
+            chunkSize: 1024, windowBytes: 16384, ackLatencyBound: 600,
             freeSpaceProvider: { _ in 100 * 1024 * 1024 * 1024 })
     }
 
@@ -38,6 +38,30 @@ struct ClipboardStreamTests {
     }
 
     // MARK: - Round trips
+
+    @Test("an inline multi-chunk payload round-trips on the modern clock conformance")
+    func inlineRoundTripOnContinuousClock() async throws {
+        // The default harness runs every suite on `MonotonicEngineClock` (the
+        // macOS 12 fallback); this is the package-level pass over the other
+        // production conformance, so both real clocks stream on every CI run.
+        guard #available(macOS 13.0, *) else { return }
+        let harness = try StreamHarness(
+            clock: ContinuousEngineClock(), chunkSize: Self.chunk, windowBytes: Self.window)
+        defer { harness.tearDown() }
+
+        var bytes = Data()
+        for i in 0..<(Self.chunk * 4 + 57) { bytes.append(UInt8((i * 17 + 3) & 0xFF)) }
+        let rep = ClipboardContent.Representation(uti: "public.utf8-plain-text", data: bytes)
+
+        harness.sender.startTransfer(
+            transferID: 1, generation: 1, representation: rep, maxAcceptByteCount: .max,
+            isInline: true, isCurrent: { _ in true })
+
+        try await harness.collector.gate.wait { harness.collector.representation(1) != nil }
+        let received = try #require(harness.collector.representation(1))
+        #expect(received.inMemoryData == bytes)
+        #expect(harness.collector.abortCount == 0)
+    }
 
     @Test("an inline multi-chunk payload round-trips with identical bytes and digest")
     func inlineRoundTrip() async throws {
@@ -202,7 +226,7 @@ struct ClipboardStreamTests {
             transferID: 3, generation: 1, representation: rep, maxAcceptByteCount: .max,
             isInline: false, isCurrent: { _ in true })
 
-        try await harness.collector.gate.wait(timeout: .seconds(60)) {
+        try await harness.collector.gate.wait(timeout: 60) {
             harness.collector.representation(3) != nil || harness.collector.abortCount > 0
         }
         let received = try #require(harness.collector.representation(3))
@@ -314,14 +338,14 @@ struct ClipboardStreamTests {
 
     @Test("a stale last-ack forces an ack on the next chunk even below the byte quantum")
     func staleLastAckForcesAckBelowQuantum() async throws {
-        // ackLatencyBound: .zero makes every landing chunk see a stale last-ack
+        // ackLatencyBound: 0 makes every landing chunk see a stale last-ack
         // (elapsed ≥ 0 always holds), deterministically forcing the
         // latency-bound path that the production 1 s value only takes under
         // degraded I/O — the guard that slow durable writes cannot stretch the
         // gap between credit-opening acks past the sender's fixed no-ack
         // deadline (#377).
         let harness = try StreamHarness(
-            chunkSize: 1024, windowBytes: 16384, ackLatencyBound: .zero,
+            chunkSize: 1024, windowBytes: 16384, ackLatencyBound: 0,
             freeSpaceProvider: { _ in 100 * 1024 * 1024 * 1024 })
         defer { harness.tearDown() }
 
@@ -392,13 +416,13 @@ struct ClipboardStreamTests {
     /// is a pure function of which writes the test released — never of how long
     /// a loaded CI runner took to run them.
     private func gatedHarness(freeSpace: @escaping @Sendable () -> Int64 = { 100 << 30 }) throws
-        -> (harness: StreamHarness, sink: Box<GatedSink?>)
+        -> (harness: StreamHarness<MonotonicEngineClock>, sink: Box<GatedSink?>)
     {
         let stagingBox = Box<ClipboardFileStaging?>(nil)
         let sinkBox = Box<GatedSink?>(nil)
         let harness = try StreamHarness(
             chunkSize: Self.chunk, windowBytes: Self.window,
-            ackLatencyBound: .seconds(600),
+            ackLatencyBound: 600,
             freeSpaceProvider: { _ in freeSpace() },
             sinkFactory: { generation, filename in
                 guard let staging = stagingBox.value else {
@@ -417,7 +441,7 @@ struct ClipboardStreamTests {
     /// Opens an inbound file transfer of `totalBytes` and waits for its
     /// go-signal ack, so the staging sink is open before the test drives chunks.
     private func beginFileTransfer(
-        _ harness: StreamHarness, id: UInt64, totalBytes: Int, filename: String
+        _ harness: StreamHarness<MonotonicEngineClock>, id: UInt64, totalBytes: Int, filename: String
     ) async throws {
         harness.receiver.handleBegin(
             .with {
@@ -433,7 +457,7 @@ struct ClipboardStreamTests {
     /// Progress is the receive lane's own signal — it fires per *accepted*
     /// chunk, before those bytes reach the sink — which is what makes the write
     /// lane's independence observable.
-    private func trackProgress(_ harness: StreamHarness, _ id: UInt64) -> (
+    private func trackProgress(_ harness: StreamHarness<MonotonicEngineClock>, _ id: UInt64) -> (
         received: Box<Int>, gate: AsyncGate
     ) {
         let received = Box<Int>(0)
@@ -1080,7 +1104,7 @@ struct ClipboardStreamTests {
         // and the no-ack deadline must fire.
         let harness = try StreamHarness(
             chunkSize: Self.chunk, windowBytes: Self.window,
-            noAckTimeout: .milliseconds(200), suppressAcks: true,
+            noAckTimeout: 0.2, suppressAcks: true,
             freeSpaceProvider: { _ in 100 * 1024 * 1024 * 1024 })
         defer { harness.tearDown() }
 
@@ -1099,7 +1123,7 @@ struct ClipboardStreamTests {
     func inboundStallTimesOut() async throws {
         let harness = try StreamHarness(
             chunkSize: Self.chunk, windowBytes: Self.window,
-            stallTimeout: .milliseconds(150),
+            stallTimeout: 0.15,
             freeSpaceProvider: { _ in 100 * 1024 * 1024 * 1024 })
         defer { harness.tearDown() }
 
@@ -1131,7 +1155,7 @@ struct ClipboardStreamTests {
         // watching *after* activity, not just after Begin.
         let harness = try StreamHarness(
             chunkSize: Self.chunk, windowBytes: Self.window,
-            stallTimeout: .milliseconds(150),
+            stallTimeout: 0.15,
             freeSpaceProvider: { _ in 100 * 1024 * 1024 * 1024 })
         defer { harness.tearDown() }
 

--- a/KernovaKit/Tests/KernovaKitTests/FileProviderDomainHostTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/FileProviderDomainHostTests.swift
@@ -526,7 +526,7 @@ struct FileProviderDomainHostEnablementTests {
 
         host.setEnabled(true)
 
-        try await collector.gate.wait(timeout: .seconds(20)) { collector.values.contains(.unavailable) }
+        try await collector.gate.wait(timeout: 20) { collector.values.contains(.unavailable) }
         #expect(
             addDomain.callCount == 0,
             "a failed registry read means the state is unknown — it must not blindly add")
@@ -550,7 +550,7 @@ struct FileProviderDomainHostEnablementTests {
         host.setEnabled(true)
 
         // add success → domainRegistered = true → confirm read throws → .unavailable.
-        try await collector.gate.wait(timeout: .seconds(20)) { collector.values.contains(.unavailable) }
+        try await collector.gate.wait(timeout: 20) { collector.values.contains(.unavailable) }
         #expect(
             host.domainRegisteredForTesting,
             "a throwing confirm read must not clear domainRegistered (would wedge publish)")
@@ -559,7 +559,7 @@ struct FileProviderDomainHostEnablementTests {
         // re-probes and reports the true state.
         domainSource.setResult(.success([matchingDomain(identifierString)]))
         center.post(name: .fileProviderDomainDidChange, object: nil)
-        try await collector.gate.wait(timeout: .seconds(20)) { collector.values.contains(.needsEnabling) }
+        try await collector.gate.wait(timeout: 20) { collector.values.contains(.needsEnabling) }
     }
 
     // MARK: - Servicing warm-up + failure handling
@@ -597,7 +597,7 @@ struct FileProviderDomainHostEnablementTests {
 
         host.setEnabled(true)
 
-        try await collector.gate.wait(timeout: .seconds(20)) {
+        try await collector.gate.wait(timeout: 20) {
             collector.values.contains(.unavailable)
         }
         #expect(
@@ -636,7 +636,7 @@ struct FileProviderDomainHostEnablementTests {
 
         host.setEnabled(true)
 
-        try await domainSource.gate.wait(timeout: .seconds(20)) { domainSource.callCount >= 1 }
+        try await domainSource.gate.wait(timeout: 20) { domainSource.callCount >= 1 }
     }
 
     @Test("posting the domain-change notification while enabled re-probes via fetchDomains and applies the result")
@@ -706,7 +706,7 @@ struct FileProviderDomainHostEnablementTests {
 
         host.setEnabled(true)
         // Wait until the add is in flight (held) — we're mid-registration.
-        try await addDomain.addCalledGate.wait(timeout: .seconds(20)) { addDomain.callCount >= 1 }
+        try await addDomain.addCalledGate.wait(timeout: 20) { addDomain.callCount >= 1 }
 
         // Disable while the add is still outstanding.
         host.setEnabled(false)
@@ -743,7 +743,7 @@ struct FileProviderDomainHostEnablementTests {
         await awaitMainQueueTurn()
 
         // Let the (failing) registration land before disabling.
-        try await collector.gate.wait(timeout: .seconds(20)) {
+        try await collector.gate.wait(timeout: 20) {
             collector.values.contains(.unavailable)
         }
 

--- a/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
@@ -58,7 +58,7 @@ struct LazyPullCoordinatorTests {
     private func runPull(
         _ coordinator: LazyPullCoordinator,
         transferID: UInt64,
-        timeout: Duration,
+        timeout: TimeInterval,
         send: @escaping @Sendable () -> Void = {}
     ) async -> LazyPullOutcome {
         await withCheckedContinuation { (cont: CheckedContinuation<LazyPullOutcome, Never>) in
@@ -85,7 +85,7 @@ struct LazyPullCoordinatorTests {
     @Test("pull blocks until deliver wakes it with the representation")
     func deliverWakesPull() async throws {
         let coordinator = LazyPullCoordinator()
-        async let outcome = runPull(coordinator, transferID: 7, timeout: .seconds(5))
+        async let outcome = runPull(coordinator, transferID: 7, timeout: 5)
         try await pollUntil { coordinator.pendingSlotCountForTesting == 1 }
         coordinator.deliver(7, inlineRep("hello"))
 
@@ -100,7 +100,7 @@ struct LazyPullCoordinatorTests {
     @Test("pull surfaces an abort delivered while it waits")
     func abortWakesPull() async throws {
         let coordinator = LazyPullCoordinator()
-        async let outcome = runPull(coordinator, transferID: 3, timeout: .seconds(5))
+        async let outcome = runPull(coordinator, transferID: 3, timeout: 5)
         try await pollUntil { coordinator.pendingSlotCountForTesting == 1 }
         coordinator.abort(
             3,
@@ -119,7 +119,7 @@ struct LazyPullCoordinatorTests {
     @Test("pull times out when no outcome is delivered")
     func pullTimesOut() async throws {
         let coordinator = LazyPullCoordinator()
-        let outcome = await runPull(coordinator, transferID: 5, timeout: .milliseconds(120))
+        let outcome = await runPull(coordinator, transferID: 5, timeout: 0.12)
         guard case .timedOut = outcome else {
             Issue.record("Expected .timedOut, got \(outcome)")
             return
@@ -164,7 +164,7 @@ struct LazyPullCoordinatorTests {
         // The window value itself is moot here — `windowWaitForTesting`
         // controls boundary timing directly — but 300 ms documents the real
         // production window this test stands in for.
-        async let outcome = runPull(coordinator, transferID: 11, timeout: .milliseconds(300))
+        async let outcome = runPull(coordinator, transferID: 11, timeout: 0.3)
         try await window1Entered.wait { sawFirstWindow.value }
         coordinator.heartbeat(11)
         releaseWindow1.signal()
@@ -187,7 +187,7 @@ struct LazyPullCoordinatorTests {
     func heartbeatNoOpWhenAbsent() async throws {
         let coordinator = LazyPullCoordinator()
         coordinator.heartbeat(404)  // nobody waiting
-        async let outcome = runPull(coordinator, transferID: 12, timeout: .seconds(5))
+        async let outcome = runPull(coordinator, transferID: 12, timeout: 5)
         try await pollUntil { coordinator.pendingSlotCountForTesting == 1 }
         coordinator.deliver(12, inlineRep("done"))
         // A late heartbeat after the slot resolves must not crash or hang.
@@ -201,8 +201,8 @@ struct LazyPullCoordinatorTests {
     @Test("failAll unblocks every waiting pull with .cancelled")
     func failAllCancels() async throws {
         let coordinator = LazyPullCoordinator()
-        async let a = runPull(coordinator, transferID: 1, timeout: .seconds(5))
-        async let b = runPull(coordinator, transferID: 2, timeout: .seconds(5))
+        async let a = runPull(coordinator, transferID: 1, timeout: 5)
+        async let b = runPull(coordinator, transferID: 2, timeout: 5)
         try await pollUntil { coordinator.pendingSlotCountForTesting == 2 }
         coordinator.failAll()
 
@@ -219,8 +219,8 @@ struct LazyPullCoordinatorTests {
     @Test("interleaved transfers resolve to their own outcomes")
     func interleavedDemux() async throws {
         let coordinator = LazyPullCoordinator()
-        async let first = runPull(coordinator, transferID: 100, timeout: .seconds(5))
-        async let second = runPull(coordinator, transferID: 200, timeout: .seconds(5))
+        async let first = runPull(coordinator, transferID: 100, timeout: 5)
+        async let second = runPull(coordinator, transferID: 200, timeout: 5)
         try await pollUntil { coordinator.pendingSlotCountForTesting == 2 }
 
         coordinator.deliver(100, inlineRep("first"))
@@ -245,7 +245,7 @@ struct LazyPullCoordinatorTests {
     @Test("a duplicate delivery after the slot resolves is a no-op")
     func idempotentDelivery() async throws {
         let coordinator = LazyPullCoordinator()
-        async let outcome = runPull(coordinator, transferID: 9, timeout: .seconds(5))
+        async let outcome = runPull(coordinator, transferID: 9, timeout: 5)
         try await pollUntil { coordinator.pendingSlotCountForTesting == 1 }
         coordinator.deliver(9, inlineRep("once"))
         // Second delivery and a late abort must not crash or change the result.
@@ -276,10 +276,10 @@ struct LazyPullCoordinatorTests {
     )
     func pullSupersedesInFlightPullForSameID() async throws {
         let coordinator = LazyPullCoordinator()
-        async let first = runPull(coordinator, transferID: 7, timeout: .seconds(5))
+        async let first = runPull(coordinator, transferID: 7, timeout: 5)
         try await pollUntil { coordinator.pendingSlotCountForTesting == 1 }
 
-        async let second = runPull(coordinator, transferID: 7, timeout: .seconds(5))
+        async let second = runPull(coordinator, transferID: 7, timeout: 5)
         // The registration itself resolves the displaced pull — no need to
         // wait for a timeout window (CLIPBOARD.md §9: wake immediately).
         guard case .superseded = await first else {
@@ -307,16 +307,16 @@ struct LazyPullCoordinatorTests {
         // key — including a later successor's — leaving `deliver` unable to
         // reach anyone.
         let coordinator = LazyPullCoordinator()
-        async let first = runPull(coordinator, transferID: 7, timeout: .seconds(5))
+        async let first = runPull(coordinator, transferID: 7, timeout: 5)
         try await pollUntil { coordinator.pendingSlotCountForTesting == 1 }
 
-        async let second = runPull(coordinator, transferID: 7, timeout: .seconds(5))
+        async let second = runPull(coordinator, transferID: 7, timeout: 5)
         guard case .superseded = await first else {
             Issue.record("Expected .superseded for the first pull")
             return
         }
 
-        async let third = runPull(coordinator, transferID: 7, timeout: .seconds(5))
+        async let third = runPull(coordinator, transferID: 7, timeout: 5)
         guard case .superseded = await second else {
             Issue.record("Expected .superseded for the second pull")
             return
@@ -397,11 +397,11 @@ struct LazyPullCoordinatorTests {
             onComplete: { rep in coordinator.deliver(transferID, rep) },
             onAbort: { info in coordinator.abort(transferID, info) })
 
-        async let firstAttempt = runPull(coordinator, transferID: transferID, timeout: .seconds(5))
+        async let firstAttempt = runPull(coordinator, transferID: transferID, timeout: 5)
         try await pollUntil { coordinator.pendingSlotCountForTesting == 1 }
 
         // The retry: a second concurrent pull for the identical id.
-        async let secondAttempt = runPull(coordinator, transferID: transferID, timeout: .seconds(5))
+        async let secondAttempt = runPull(coordinator, transferID: transferID, timeout: 5)
         guard case .superseded = await firstAttempt else {
             Issue.record("Expected .superseded for the displaced first attempt")
             return
@@ -718,7 +718,7 @@ struct LazyPullCoordinatorTests {
         coordinator.cancelBeforeStart(42)
         #expect(coordinator.preCancelledCountForTesting == 1)
 
-        let outcome = await runPull(coordinator, transferID: 42, timeout: .seconds(5)) {
+        let outcome = await runPull(coordinator, transferID: 42, timeout: 5) {
             sendCalled.value = true
         }
 
@@ -740,7 +740,7 @@ struct LazyPullCoordinatorTests {
         let gate = AsyncGate()
 
         let pullTask = Task {
-            await runPull(coordinator, transferID: 7, timeout: .seconds(5)) {
+            await runPull(coordinator, transferID: 7, timeout: 5) {
                 sendRan.value = true
                 gate.notify()
             }
@@ -768,7 +768,7 @@ struct LazyPullCoordinatorTests {
 
         coordinator.cancelBeforeStart(999)
 
-        let outcome = await runPull(coordinator, transferID: 1, timeout: .seconds(5)) {
+        let outcome = await runPull(coordinator, transferID: 1, timeout: 5) {
             coordinator.deliver(1, ClipboardContent.Representation(uti: "public.data", data: Data()))
         }
 

--- a/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
+++ b/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
@@ -79,16 +79,17 @@ func materializedFiles(under directory: URL) -> [URL] {
     }
 }
 
-/// Polls `predicate` until it holds or `timeout` elapses.
+/// Polls `predicate` until it holds or `timeout` seconds elapse.
 func pollUntil(
-    timeout: Duration = testWaitBackstop, _ predicate: @Sendable () -> Bool
+    timeout: TimeInterval = testWaitBackstop, _ predicate: @Sendable () -> Bool
 ) async throws {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
+    let clock = MonotonicEngineClock()
+    let start = clock.now
     while !predicate() {
-        if ContinuousClock.now >= deadline {
-            throw StreamTestFailure("Condition not met within \(timeout)")
+        if clock.seconds(since: start) >= timeout {
+            throw StreamTestFailure("Condition not met within \(timeout) s")
         }
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(nanoseconds: 10_000_000)
     }
 }
 
@@ -279,9 +280,9 @@ final class StreamCollector: @unchecked Sendable {
 /// (channel B) over a socketpair, with two routing tasks standing in for the
 /// owning services: A's inbound acks/aborts feed the sender; B's inbound
 /// begin/chunk/end/abort feed the receiver.
-final class StreamHarness: @unchecked Sendable {
+final class StreamHarness<Clock: EngineClock>: @unchecked Sendable {
     let sender: ClipboardStreamSender
-    let receiver: ClipboardStreamReceiver
+    let receiver: ClipboardStreamReceiver<Clock>
     let staging: ClipboardFileStaging
     /// Parent of the staging root; tests scan it for materialized temp files.
     let stagingTempRoot: URL
@@ -292,15 +293,16 @@ final class StreamHarness: @unchecked Sendable {
     private var routeTasks: [Task<Void, Never>] = []
 
     init(
+        clock: Clock,
         chunkSize: Int,
         windowBytes: Int,
-        noAckTimeout: Duration = .seconds(10),
-        ackLatencyBound: Duration = ClipboardStreamTuning.ackLatencyBound,
-        stallTimeout: Duration = ClipboardStreamTuning.inboundStallTimeout,
+        noAckTimeout: TimeInterval = 10,
+        ackLatencyBound: TimeInterval = ClipboardStreamTuning.ackLatencyBound,
+        stallTimeout: TimeInterval = ClipboardStreamTuning.inboundStallTimeout,
         maxResidentInlineBytes: Int = ClipboardStreamTuning.maxResidentInlineBytes,
         suppressAcks: Bool = false,
         freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
-        sinkFactory: ClipboardStreamReceiver.SinkFactory? = nil
+        sinkFactory: ClipboardSinkFactory? = nil
     ) throws {
         (a, b) = try makeStartedChannelPair()
         stagingTempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
@@ -313,6 +315,7 @@ final class StreamHarness: @unchecked Sendable {
             channel: a, chunkSize: chunkSize, windowBytes: windowBytes, noAckTimeout: noAckTimeout)
         let collector = self.collector
         receiver = ClipboardStreamReceiver(
+            clock: clock,
             channel: b, staging: staging, windowBytes: windowBytes,
             ackLatencyBound: ackLatencyBound, stallTimeout: stallTimeout,
             maxResidentInlineBytes: maxResidentInlineBytes,
@@ -364,5 +367,34 @@ final class StreamHarness: @unchecked Sendable {
         a.close()
         b.close()
         staging.sweep()
+    }
+}
+
+extension StreamHarness where Clock == MonotonicEngineClock {
+    /// Harness on the macOS 12 fallback clock — the default for tests that
+    /// don't parameterize over clocks.
+    convenience init(
+        chunkSize: Int,
+        windowBytes: Int,
+        noAckTimeout: TimeInterval = 10,
+        ackLatencyBound: TimeInterval = ClipboardStreamTuning.ackLatencyBound,
+        stallTimeout: TimeInterval = ClipboardStreamTuning.inboundStallTimeout,
+        maxResidentInlineBytes: Int = ClipboardStreamTuning.maxResidentInlineBytes,
+        suppressAcks: Bool = false,
+        freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
+        sinkFactory: ClipboardSinkFactory? = nil
+    ) throws {
+        try self.init(
+            clock: MonotonicEngineClock(),
+            chunkSize: chunkSize,
+            windowBytes: windowBytes,
+            noAckTimeout: noAckTimeout,
+            ackLatencyBound: ackLatencyBound,
+            stallTimeout: stallTimeout,
+            maxResidentInlineBytes: maxResidentInlineBytes,
+            suppressAcks: suppressAcks,
+            freeSpaceProvider: freeSpaceProvider,
+            sinkFactory: sinkFactory
+        )
     }
 }

--- a/KernovaMacOSAgent/AgentAppDelegate.swift
+++ b/KernovaMacOSAgent/AgentAppDelegate.swift
@@ -43,7 +43,7 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
 
     private var vsockConnection: VsockHostConnection?
     private var clipboardAgent: VsockGuestClipboardAgent?
-    private var controlAgent: VsockGuestControlAgent?
+    private var controlAgent: (any VsockGuestControlling)?
     private var statusItemController: AgentStatusItemController?
 
     /// Hosts the File Provider XPC relay and clipboard domain, gated on host
@@ -122,7 +122,7 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
 
         // `onPolicy` gates the log + clipboard + File Provider capabilities;
         // `onStateChange` drives the status-item icon.
-        let controlAgent = VsockGuestControlAgent(
+        let controlAgent = makeVsockGuestControlAgent(
             onPolicy: { [weak self] policy in
                 vsockConnection.setEnabled(policy.logForwardingEnabled)
                 clipboardAgent.setEnabled(policy.clipboardSharingEnabled)
@@ -210,7 +210,7 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
     private func installSignalHandlers(
         vsockConnection: VsockHostConnection,
         clipboardAgent: VsockGuestClipboardAgent,
-        controlAgent: VsockGuestControlAgent
+        controlAgent: any VsockGuestControlling
     ) {
         signal(SIGINT, SIG_IGN)
         signal(SIGTERM, SIG_IGN)

--- a/KernovaMacOSAgent/AgentStatusItemController.swift
+++ b/KernovaMacOSAgent/AgentStatusItemController.swift
@@ -224,7 +224,11 @@ final class AgentStatusItemController: NSObject, NSMenuDelegate {
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
         options[.version] = buildNumber.isEmpty ? "Debug" : "\(buildNumber) | Debug"
         #endif
-        NSApp.activate()
+        if #available(macOS 14.0, *) {
+            NSApp.activate()
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+        }
         NSApp.orderFrontStandardAboutPanel(options: options)
     }
 

--- a/KernovaMacOSAgent/VsockGuestClient.swift
+++ b/KernovaMacOSAgent/VsockGuestClient.swift
@@ -69,6 +69,74 @@ private let socketTimeoutSeconds: Int = 30
 // stays under the 5 s retryInterval.
 private let connectTimeoutSeconds: Int = 3
 
+/// Carries the result of a blocking `connect(2)` back to a waiter that may have
+/// already given up, and settles which side owns the socket when the deadline and
+/// the syscall land together.
+///
+/// Exactly one of `finish` and `abandon` sees the other as unfinished, so the fd
+/// has exactly one owner and is never closed while the call is still in flight.
+final class BlockingConnectHandoff: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: Int32?
+    private var abandoned = false
+
+    /// Records the syscall's `errno` (`0` on success).
+    ///
+    /// - Returns: `true` while the waiter is still there — it takes the socket;
+    ///   `false` once the waiter has abandoned the attempt, leaving the caller
+    ///   holding the socket.
+    func finish(errno: Int32) -> Bool {
+        lock.withLock {
+            recorded = errno
+            return !abandoned
+        }
+    }
+
+    /// Gives up on a syscall that has outrun its deadline.
+    ///
+    /// - Returns: `true` when it had not finished — the worker now owns the
+    ///   socket; `false` when it beat the deadline, leaving `outcome` readable.
+    func abandon() -> Bool {
+        lock.withLock {
+            guard recorded == nil else { return false }
+            abandoned = true
+            return true
+        }
+    }
+
+    /// The recorded `errno`, or `nil` while the syscall is still in flight.
+    var outcome: Int32? { lock.withLock { recorded } }
+}
+
+/// Admits one in-flight blocking `connect(2)` per client label.
+///
+/// An abandoned connect stays parked in the kernel while the reconnect loop keeps
+/// retrying on its own schedule; without this gate a host that never accepts
+/// would strand one thread per retry for the life of the process. A label's slot
+/// frees the moment its syscall returns, so recovery needs no separate sweep.
+final class BlockingConnectGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var inFlight: Set<String> = []
+
+    /// Claims the slot for `label`, refusing it while an earlier connect is parked.
+    ///
+    /// - Returns: `true` when the slot was free and is now held.
+    func claim(_ label: String) -> Bool {
+        lock.withLock { inFlight.insert(label).inserted }
+    }
+
+    func release(_ label: String) {
+        lock.withLock { _ = inFlight.remove(label) }
+    }
+
+    /// Whether `label` currently holds the slot — for tests.
+    func isClaimed(_ label: String) -> Bool {
+        lock.withLock { inFlight.contains(label) }
+    }
+}
+
+private let blockingConnectGate = BlockingConnectGate()
+
 /// Maintains a long-lived `socket(AF_VSOCK, SOCK_STREAM)` connection to the host
 /// on one vsock port, reconnecting on disconnect or connect failure.
 ///
@@ -250,12 +318,11 @@ final class VsockGuestClient<Clock: EngineClock>: VsockReconnecting, @unchecked 
 
     /// Opens a raw `AF_VSOCK / SOCK_STREAM` socket and connects it to the host.
     ///
-    /// macOS 13+ connects non-blocking-plus-poll, so `connect(2)` cannot block
-    /// the reconnect loop past `connectTimeoutSeconds`. Monterey connects
-    /// blocking: its virtio-vsock driver never completes a non-blocking connect
-    /// (docs/research/2026-08-02-macos12-vsock-nonblocking-connect.md), and
-    /// blocking is safe there because vsock is local-only — the hypervisor
-    /// answers accept or refusal promptly, with no remote peer to wait out.
+    /// Both paths bound the connect at `connectTimeoutSeconds`, by different
+    /// means: macOS 13+ uses the non-blocking-plus-poll idiom, while Monterey —
+    /// whose virtio-vsock driver never completes a non-blocking connect
+    /// (docs/research/2026-08-02-macos12-vsock-nonblocking-connect.md) — runs a
+    /// blocking `connect(2)` on a throwaway thread it can walk away from.
     private static func openVsockToHost(
         port: UInt32, label: String, clock: Clock
     ) -> Result<Int32, VsockProviderError> {
@@ -280,23 +347,93 @@ final class VsockGuestClient<Clock: EngineClock>: VsockReconnecting, @unchecked 
                 return .failure(.transient("connect() to '\(label)' port \(port) did not complete"))
             }
         } else {
-            let rc = withUnsafePointer(to: &addr) { ptr -> Int32 in
-                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
-                    connect(fd, sa, socklen_t(MemoryLayout<sockaddr_vm>.size))
-                }
-            }
-            guard rc == 0 else {
-                let err = errno
+            switch connectBlocking(fd: fd, addr: addr, label: label, port: port) {
+            case .connected:
+                break
+            case .failed(let err):
                 close(fd)
                 logger.warning(
                     "connect() to '\(label, privacy: .public)' port \(port, privacy: .public) failed: errno=\(err, privacy: .public)"
                 )
                 return .failure(.transient("connect() to '\(label)' port \(port) failed: errno=\(err)"))
+            case .abandoned:
+                // The worker owns `fd` and closes it when the kernel returns.
+                return .failure(
+                    .transient("connect() to '\(label)' port \(port) outran \(connectTimeoutSeconds)s"))
+            case .busy:
+                close(fd)
+                return .failure(
+                    .transient("connect() to '\(label)' port \(port) is still parked from an earlier attempt"))
             }
         }
 
         applySocketTimeouts(fd: fd, label: label)
         return .success(fd)
+    }
+
+    /// What a bounded blocking `connect(2)` did.
+    private enum BlockingConnectOutcome {
+        case connected
+        case failed(errno: Int32)
+        /// The deadline passed with the syscall still in the kernel. The worker
+        /// thread owns `fd` and closes it when the call returns — the caller
+        /// must not.
+        case abandoned
+        /// An earlier attempt on this label is still parked; no socket was used.
+        case busy
+    }
+
+    /// Connects `fd` with a blocking `connect(2)`, bounded at
+    /// `connectTimeoutSeconds` by running the call on a thread the caller can
+    /// walk away from.
+    ///
+    /// Darwin bounds `connect(2)` with no socket option — `SO_SNDTIMEO` covers
+    /// only `send` — and a vsock connect does park indefinitely when the host
+    /// stops accepting
+    /// (docs/research/2026-08-02-macos12-vsock-blocking-connect-parks.md), which
+    /// on the loop's own thread strands the client for the life of the process.
+    /// Abandoning a thread rather than closing its socket keeps fd ownership
+    /// unambiguous: nothing is closed while a syscall still holds it.
+    private static func connectBlocking(
+        fd: Int32, addr: sockaddr_vm, label: String, port: UInt32
+    ) -> BlockingConnectOutcome {
+        guard blockingConnectGate.claim(label) else { return .busy }
+
+        let handoff = BlockingConnectHandoff()
+        let ready = DispatchSemaphore(value: 0)
+        let worker = Thread {
+            var addrCopy = addr
+            let rc = withUnsafePointer(to: &addrCopy) { ptr -> Int32 in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                    connect(fd, sa, socklen_t(MemoryLayout<sockaddr_vm>.size))
+                }
+            }
+            let recorded = rc == 0 ? 0 : errno
+            let waiterPresent = handoff.finish(errno: recorded)
+            blockingConnectGate.release(label)
+            if waiterPresent {
+                ready.signal()
+            } else {
+                close(fd)
+            }
+        }
+        worker.name = "app.kernova.macosagent.vsock-connect"
+        worker.start()
+
+        if ready.wait(timeout: .now() + .seconds(connectTimeoutSeconds)) == .success,
+            let err = handoff.outcome
+        {
+            return err == 0 ? .connected : .failed(errno: err)
+        }
+        if handoff.abandon() {
+            logger.warning(
+                "connect() to '\(label, privacy: .public)' port \(port, privacy: .public) still blocked after \(connectTimeoutSeconds, privacy: .public)s — abandoning it"
+            )
+            return .abandoned
+        }
+        // The syscall landed between the deadline expiring and the abandon.
+        guard let err = handoff.outcome else { return .abandoned }
+        return err == 0 ? .connected : .failed(errno: err)
     }
 
     /// Connects `fd` in non-blocking mode with the connect-plus-poll idiom.

--- a/KernovaMacOSAgent/VsockGuestClient.swift
+++ b/KernovaMacOSAgent/VsockGuestClient.swift
@@ -248,13 +248,14 @@ final class VsockGuestClient<Clock: EngineClock>: VsockReconnecting, @unchecked 
 
     // MARK: - Socket helpers (static — no instance state read)
 
-    /// Opens a raw `AF_VSOCK / SOCK_STREAM` socket and connects to the host with
-    /// the non-blocking-connect-plus-poll idiom, so `connect(2)` cannot block the
-    /// reconnect loop past `connectTimeoutSeconds`.
+    /// Opens a raw `AF_VSOCK / SOCK_STREAM` socket and connects it to the host.
     ///
-    /// Darwin's `SO_RCVTIMEO`/`SO_SNDTIMEO` bound only `recv`/`send`, never
-    /// `connect(2)`. Non-blocking mode covers the connect phase only; blocking
-    /// mode is restored afterwards so those socket-level timeouts still apply.
+    /// macOS 13+ connects non-blocking-plus-poll, so `connect(2)` cannot block
+    /// the reconnect loop past `connectTimeoutSeconds`. Monterey connects
+    /// blocking: its virtio-vsock driver never completes a non-blocking connect
+    /// (docs/research/2026-08-02-macos12-vsock-nonblocking-connect.md), and
+    /// blocking is safe there because vsock is local-only — the hypervisor
+    /// answers accept or refusal promptly, with no remote peer to wait out.
     private static func openVsockToHost(
         port: UInt32, label: String, clock: Clock
     ) -> Result<Int32, VsockProviderError> {
@@ -262,21 +263,6 @@ final class VsockGuestClient<Clock: EngineClock>: VsockReconnecting, @unchecked 
         guard fd >= 0 else {
             let err = errno
             return .failure(classifySocketErrno(err, label: label))
-        }
-
-        let originalFlags = fcntl(fd, F_GETFL, 0)
-        guard originalFlags >= 0 else {
-            let err = errno
-            close(fd)
-            logger.error("fcntl(F_GETFL) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
-            return .failure(.transient("fcntl(F_GETFL) failed for '\(label)': errno=\(err)"))
-        }
-        guard fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK) >= 0 else {
-            let err = errno
-            close(fd)
-            logger.error(
-                "fcntl(F_SETFL, O_NONBLOCK) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
-            return .failure(.transient("fcntl(F_SETFL, O_NONBLOCK) failed for '\(label)': errno=\(err)"))
         }
 
         var addr = sockaddr_vm()
@@ -287,7 +273,58 @@ final class VsockGuestClient<Clock: EngineClock>: VsockReconnecting, @unchecked 
         addr.svm_port = port
         addr.svm_cid = UInt32(VMADDR_CID_HOST)
 
-        let rc = withUnsafePointer(to: &addr) { ptr -> Int32 in
+        if #available(macOS 13.0, *) {
+            guard connectNonBlocking(fd: fd, addr: addr, label: label, port: port, clock: clock)
+            else {
+                close(fd)
+                return .failure(.transient("connect() to '\(label)' port \(port) did not complete"))
+            }
+        } else {
+            let rc = withUnsafePointer(to: &addr) { ptr -> Int32 in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                    connect(fd, sa, socklen_t(MemoryLayout<sockaddr_vm>.size))
+                }
+            }
+            guard rc == 0 else {
+                let err = errno
+                close(fd)
+                logger.warning(
+                    "connect() to '\(label, privacy: .public)' port \(port, privacy: .public) failed: errno=\(err, privacy: .public)"
+                )
+                return .failure(.transient("connect() to '\(label)' port \(port) failed: errno=\(err)"))
+            }
+        }
+
+        applySocketTimeouts(fd: fd, label: label)
+        return .success(fd)
+    }
+
+    /// Connects `fd` in non-blocking mode with the connect-plus-poll idiom.
+    ///
+    /// Darwin's `SO_RCVTIMEO`/`SO_SNDTIMEO` bound only `recv`/`send`, never
+    /// `connect(2)`. Non-blocking mode covers the connect phase only; blocking
+    /// mode is restored afterwards so those socket-level timeouts still apply.
+    /// The caller owns `fd` on both paths and must `close()` it on a `false`
+    /// return.
+    @available(macOS 13.0, *)
+    private static func connectNonBlocking(
+        fd: Int32, addr: sockaddr_vm, label: String, port: UInt32, clock: Clock
+    ) -> Bool {
+        let originalFlags = fcntl(fd, F_GETFL, 0)
+        guard originalFlags >= 0 else {
+            let err = errno
+            logger.error("fcntl(F_GETFL) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+            return false
+        }
+        guard fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK) >= 0 else {
+            let err = errno
+            logger.error(
+                "fcntl(F_SETFL, O_NONBLOCK) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+            return false
+        }
+
+        var addrCopy = addr
+        let rc = withUnsafePointer(to: &addrCopy) { ptr -> Int32 in
             ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
                 connect(fd, sa, socklen_t(MemoryLayout<sockaddr_vm>.size))
             }
@@ -296,28 +333,23 @@ final class VsockGuestClient<Clock: EngineClock>: VsockReconnecting, @unchecked 
         if rc != 0 {
             let connectErr = errno
             guard connectErr == EINPROGRESS else {
-                close(fd)
                 logger.warning(
                     "connect() to '\(label, privacy: .public)' port \(port, privacy: .public) failed: errno=\(connectErr, privacy: .public)"
                 )
-                return .failure(.transient("connect() to '\(label)' port \(port) failed: errno=\(connectErr)"))
+                return false
             }
             guard awaitConnectCompletion(fd: fd, label: label, port: port, clock: clock) else {
-                close(fd)
-                return .failure(.transient("connect() to '\(label)' port \(port) did not complete"))
+                return false
             }
         }
 
         guard fcntl(fd, F_SETFL, originalFlags) >= 0 else {
             let err = errno
-            close(fd)
             logger.error(
                 "fcntl(F_SETFL) restore failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
-            return .failure(.transient("fcntl(F_SETFL) restore failed for '\(label)': errno=\(err)"))
+            return false
         }
-
-        applySocketTimeouts(fd: fd, label: label)
-        return .success(fd)
+        return true
     }
 
     /// Waits up to `connectTimeoutSeconds` for an in-flight non-blocking connect
@@ -325,6 +357,7 @@ final class VsockGuestClient<Clock: EngineClock>: VsockReconnecting, @unchecked 
     ///
     /// The caller owns `fd` on both paths and must `close()` it on a `false`
     /// return — this helper never takes ownership.
+    @available(macOS 13.0, *)
     private static func awaitConnectCompletion(
         fd: Int32, label: String, port: UInt32, clock: Clock
     ) -> Bool {

--- a/KernovaMacOSAgent/VsockGuestClient.swift
+++ b/KernovaMacOSAgent/VsockGuestClient.swift
@@ -3,6 +3,72 @@ import KernovaKit
 import Darwin
 import os
 
+/// The clock-independent surface of `VsockGuestClient`, for holders that must
+/// run below macOS 13 and so cannot store a concrete clock instantiation.
+protocol VsockReconnecting: AnyObject, Sendable {
+    /// Begins the connect/serve/reconnect loop (idempotent).
+    func start(serve: @escaping @Sendable (VsockChannel) async -> Void)
+    /// Pauses the reconnect loop and tears down any active channel.
+    func pause()
+    /// Resumes the reconnect loop after `pause()`.
+    func resume()
+    /// Stops the loop for good and tears down any active channel.
+    func stop()
+    /// Currently-attached channel, for synchronous best-effort sends.
+    var liveChannel: VsockChannel? { get }
+}
+
+/// Builds a client on the platform-default clock — `ContinuousClock` on
+/// macOS 13+, `CLOCK_MONOTONIC` below — erased for holders that run on 12.
+func makeVsockGuestClient(
+    port: UInt32, label: String, retryInterval: TimeInterval = 5
+) -> any VsockReconnecting {
+    if #available(macOS 13.0, *) {
+        return VsockGuestClient(
+            port: port, label: label, clock: ContinuousEngineClock(), retryInterval: retryInterval)
+    }
+    return VsockGuestClient(
+        port: port, label: label, clock: MonotonicEngineClock(), retryInterval: retryInterval)
+}
+
+/// Outcome of a `VsockSocketProvider` failure: `.transient` retries the
+/// connect loop, `.permanent` halts it for good.
+enum VsockProviderError: Error, Sendable, Equatable {
+    /// Retry-able — peer not ready, transient kernel resource pressure.
+    case transient(String)
+    /// Not retry-able — the kernel has no `AF_VSOCK` support.
+    case permanent(String)
+}
+
+/// Opens a SOCK_STREAM fd for the given port and label.
+typealias VsockSocketProvider =
+    @Sendable (_ port: UInt32, _ label: String) -> Result<Int32, VsockProviderError>
+
+/// Classifies a `socket(AF_VSOCK)` errno as permanent or transient.
+///
+/// `EAFNOSUPPORT` and `EPROTONOSUPPORT` mean the kernel has no `AF_VSOCK`
+/// support and will never succeed; everything else may clear up.
+func classifySocketErrno(_ err: Int32, label: String) -> VsockProviderError {
+    switch err {
+    case EAFNOSUPPORT, EPROTONOSUPPORT:
+        clientLogger.error(
+            "socket(AF_VSOCK) unsupported for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+        return .permanent("socket(AF_VSOCK) unsupported for '\(label)': errno=\(err)")
+    default:
+        clientLogger.warning(
+            "socket(AF_VSOCK) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
+        return .transient("socket(AF_VSOCK) failed for '\(label)': errno=\(err)")
+    }
+}
+
+// File-scope stand-ins for `static let`s, which a generic type cannot hold.
+private let clientLogger = Logger(subsystem: "app.kernova.macosagent", category: "VsockGuestClient")
+private let socketTimeoutSeconds: Int = 30
+// vsock is local-only with no SYN dance: connect is normally immediate
+// success or immediate ECONNREFUSED, so 3 s is a generous ceiling that still
+// stays under the 5 s retryInterval.
+private let connectTimeoutSeconds: Int = 3
+
 /// Maintains a long-lived `socket(AF_VSOCK, SOCK_STREAM)` connection to the host
 /// on one vsock port, reconnecting on disconnect or connect failure.
 ///
@@ -11,37 +77,20 @@ import os
 /// Lifecycle logging uses raw `os.Logger`, never `KernovaLogger` — the agent
 /// wires that sink through this very transport, so a write failure would
 /// schedule another send through the broken channel.
-final class VsockGuestClient: @unchecked Sendable {
-    /// Outcome of a `VsockSocketProvider` failure: `.transient` retries the
-    /// connect loop, `.permanent` halts it for good.
-    enum VsockProviderError: Error, Sendable, Equatable {
-        /// Retry-able — peer not ready, transient kernel resource pressure.
-        case transient(String)
-        /// Not retry-able — the kernel has no `AF_VSOCK` support.
-        case permanent(String)
-    }
-
-    /// Opens a SOCK_STREAM fd for the given port and label.
-    typealias VsockSocketProvider =
-        @Sendable (_ port: UInt32, _ label: String) -> Result<Int32, VsockProviderError>
-
+final class VsockGuestClient<Clock: EngineClock>: VsockReconnecting, @unchecked Sendable {
     private enum LoopOutcome: Equatable {
         case retry
         /// Exit the loop; client is now permanently inert.
         case terminate
     }
 
-    private static let logger = Logger(subsystem: "app.kernova.macosagent", category: "VsockGuestClient")
-    private static let socketTimeoutSeconds: Int = 30
-    // vsock is local-only with no SYN dance: connect is normally immediate
-    // success or immediate ECONNREFUSED, so 3 s is a generous ceiling that still
-    // stays under the 5 s retryInterval.
-    private static let connectTimeoutSeconds: Int = 3
+    private static var logger: Logger { clientLogger }
 
     let port: UInt32
     let label: String
 
-    private let retryInterval: Duration
+    private let clock: Clock
+    private let retryInterval: TimeInterval
     private let socketProvider: VsockSocketProvider
 
     private let lock = NSLock()
@@ -58,15 +107,17 @@ final class VsockGuestClient: @unchecked Sendable {
     init(
         port: UInt32,
         label: String,
-        retryInterval: Duration = .seconds(5),
+        clock: Clock,
+        retryInterval: TimeInterval = 5,
         socketProvider: VsockSocketProvider? = nil
     ) {
         self.port = port
         self.label = label
+        self.clock = clock
         self.retryInterval = retryInterval
         self.socketProvider =
             socketProvider ?? { port, label in
-                VsockGuestClient.openVsockToHost(port: port, label: label)
+                VsockGuestClient.openVsockToHost(port: port, label: label, clock: clock)
             }
     }
 
@@ -141,7 +192,7 @@ final class VsockGuestClient: @unchecked Sendable {
                 }
             }
             guard !Task.isCancelled else { break }
-            try? await Task.sleep(for: retryInterval)
+            try? await clock.sleep(for: retryInterval)
         }
     }
 
@@ -205,7 +256,7 @@ final class VsockGuestClient: @unchecked Sendable {
     /// `connect(2)`. Non-blocking mode covers the connect phase only; blocking
     /// mode is restored afterwards so those socket-level timeouts still apply.
     private static func openVsockToHost(
-        port: UInt32, label: String
+        port: UInt32, label: String, clock: Clock
     ) -> Result<Int32, VsockProviderError> {
         let fd = socket(AF_VSOCK, SOCK_STREAM, 0)
         guard fd >= 0 else {
@@ -251,7 +302,7 @@ final class VsockGuestClient: @unchecked Sendable {
                 )
                 return .failure(.transient("connect() to '\(label)' port \(port) failed: errno=\(connectErr)"))
             }
-            guard awaitConnectCompletion(fd: fd, label: label, port: port) else {
+            guard awaitConnectCompletion(fd: fd, label: label, port: port, clock: clock) else {
                 close(fd)
                 return .failure(.transient("connect() to '\(label)' port \(port) did not complete"))
             }
@@ -269,39 +320,21 @@ final class VsockGuestClient: @unchecked Sendable {
         return .success(fd)
     }
 
-    /// Classifies a `socket(AF_VSOCK)` errno as permanent or transient.
-    ///
-    /// `EAFNOSUPPORT` and `EPROTONOSUPPORT` mean the kernel has no `AF_VSOCK`
-    /// support and will never succeed; everything else may clear up.
-    static func classifySocketErrno(_ err: Int32, label: String) -> VsockProviderError {
-        switch err {
-        case EAFNOSUPPORT, EPROTONOSUPPORT:
-            logger.error(
-                "socket(AF_VSOCK) unsupported for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
-            return .permanent("socket(AF_VSOCK) unsupported for '\(label)': errno=\(err)")
-        default:
-            logger.warning("socket(AF_VSOCK) failed for '\(label, privacy: .public)': errno=\(err, privacy: .public)")
-            return .transient("socket(AF_VSOCK) failed for '\(label)': errno=\(err)")
-        }
-    }
-
     /// Waits up to `connectTimeoutSeconds` for an in-flight non-blocking connect
     /// to complete on `fd`.
     ///
     /// The caller owns `fd` on both paths and must `close()` it on a `false`
     /// return — this helper never takes ownership.
-    private static func awaitConnectCompletion(fd: Int32, label: String, port: UInt32) -> Bool {
+    private static func awaitConnectCompletion(
+        fd: Int32, label: String, port: UInt32, clock: Clock
+    ) -> Bool {
         var pfd = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
-        let deadline = ContinuousClock.now + .seconds(connectTimeoutSeconds)
+        let start = clock.now
 
         var pollRc: Int32
         repeat {
-            let remaining = deadline - ContinuousClock.now
-            let remainingMs = Int32(
-                max(
-                    0,
-                    Double(remaining.components.seconds) * 1000
-                        + Double(remaining.components.attoseconds) / 1e15))
+            let remaining = Double(connectTimeoutSeconds) - clock.seconds(since: start)
+            let remainingMs = Int32(max(0, remaining * 1000))
             pollRc = withUnsafeMutablePointer(to: &pfd) { poll($0, 1, remainingMs) }
             let err = errno
             if pollRc < 0 && err != EINTR {

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -77,7 +77,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// handshake.
     private static let pasteSourceName = "Mac"
 
-    private let client: VsockGuestClient
+    private let client: any VsockReconnecting
     private let pasteboard: Pasteboard
 
     /// The File Provider host, when one is wired (production only).
@@ -111,7 +111,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
 
     /// Streaming engine for the current connection.
     private var sender: ClipboardStreamSender?
-    private var receiver: ClipboardStreamReceiver?
+    private var receiver: (any ClipboardStreamReceiving)?
 
     #if DEBUG
     /// Test seam.
@@ -233,7 +233,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     convenience init() {
         self.init(
             pasteboard: NSPasteboard.general,
-            client: VsockGuestClient(port: KernovaVsockPort.clipboard, label: "clipboard"),
+            client: makeVsockGuestClient(port: KernovaVsockPort.clipboard, label: "clipboard"),
             stagingTempRoot: FileProviderContainer(config: .guest()).stagingRootURL()
                 ?? FileManager.default.temporaryDirectory
         )
@@ -243,7 +243,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// client, and optionally a `freeSpaceProvider` to simulate a full disk and a
     /// `stagingTempRoot` to isolate the staging directory between parallel tests.
     init(
-        pasteboard: Pasteboard, client: VsockGuestClient,
+        pasteboard: Pasteboard, client: any VsockReconnecting,
         freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
         stagingTempRoot: URL = FileManager.default.temporaryDirectory
     ) {
@@ -374,7 +374,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         // The engine is created off-main (its callbacks hop to main themselves);
         // only the published references are assigned on the main queue.
         let sender = ClipboardStreamSender(channel: channel)
-        let receiver = ClipboardStreamReceiver(
+        let receiver = makeClipboardStreamReceiver(
             channel: channel, staging: self.staging,
             // The only measured throughput number for the real vsock link, so it
             // logs at `.notice` (persisted) rather than `.debug`.
@@ -1096,7 +1096,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// (woken off-main), like every paste-time pull.
     private func buildPublishFolder(
         repIndex: Int, info: Kernova_V1_ClipboardRepresentationInfo, promise: InboundPromise,
-        channel: VsockChannel, receiver: ClipboardStreamReceiver
+        channel: VsockChannel, receiver: any ClipboardStreamReceiving
     ) -> FileProviderPublishFolder? {
         guard
             let listing = pullTreeListing(
@@ -1180,7 +1180,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// off-main into the coordinator, never hopping to the thread this call
     /// holds.
     private func awaitPull(
-        transferID: UInt64, receiver: ClipboardStreamReceiver,
+        transferID: UInt64, receiver: any ClipboardStreamReceiving,
         onProgress: (@Sendable (_ bytesTransferred: UInt64, _ totalBytes: UInt64) -> Void)?,
         sendRequest: @escaping () throws -> Void
     ) -> LazyPullOutcome {
@@ -1225,7 +1225,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// (docs/CLIPBOARD.md §2).
     private func pullRepresentation(
         _ repIndex: Int, promise: InboundPromise, channel: VsockChannel,
-        receiver: ClipboardStreamReceiver, deadlineBound: Bool,
+        receiver: any ClipboardStreamReceiving, deadlineBound: Bool,
         onProgress: (@Sendable (_ bytesTransferred: UInt64, _ totalBytes: UInt64) -> Void)? = nil
     ) -> ClipboardContent.Representation? {
         let info = promise.reps[repIndex]
@@ -1351,7 +1351,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// failure so the caller falls back to the archive path.
     private func pullTreeListing(
         repIndex: Int, promise: InboundPromise, channel: VsockChannel,
-        receiver: ClipboardStreamReceiver
+        receiver: any ClipboardStreamReceiving
     ) -> Kernova_V1_ClipboardTreeListing? {
         let transferID = ClipboardTransferID.makeChild(
             generation: promise.generation, repIndex: repIndex, childSeq: 0, hostMinted: false)
@@ -1397,7 +1397,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// Returns the staged `.file` rep, or `nil` on failure.
     private func pullChild(
         generation: UInt64, repIndex: Int, childSeq: UInt32, relativePath: String,
-        channel: VsockChannel, receiver: ClipboardStreamReceiver,
+        channel: VsockChannel, receiver: any ClipboardStreamReceiving,
         onProgress: @escaping @Sendable (UInt64, UInt64) -> Void
     ) -> ClipboardContent.Representation? {
         let transferID = ClipboardTransferID.makeChild(
@@ -1634,7 +1634,7 @@ extension VsockGuestClipboardAgent: FileProviderPullProvider {
         struct PullContext {
             let promise: InboundPromise
             let channel: VsockChannel
-            let receiver: ClipboardStreamReceiver
+            let receiver: any ClipboardStreamReceiving
         }
         // Snapshot on main: the request must address the *current* offer and a
         // live connection.
@@ -1669,7 +1669,7 @@ extension VsockGuestClipboardAgent: FileProviderPullProvider {
         dispatchPrecondition(condition: .notOnQueue(.main))
         let transferID = ClipboardTransferID.make(
             generation: generation, repIndex: repIndex, hostMinted: false)
-        let receiver: ClipboardStreamReceiver? = DispatchQueue.main.sync { self.receiver }
+        let receiver: (any ClipboardStreamReceiving)? = DispatchQueue.main.sync { self.receiver }
         Self.logger.notice(
             "Cancelling file clipboard pull \(transferID, privacy: .public) on consumer request")
         receiver?.cancel(transferID: transferID)
@@ -1687,7 +1687,7 @@ extension VsockGuestClipboardAgent: FileProviderPullProvider {
         onProgress: @escaping @Sendable (UInt64, UInt64) -> Void = { _, _ in }
     ) -> Result<String, FileProviderPullError> {
         dispatchPrecondition(condition: .notOnQueue(.main))
-        let context: (channel: VsockChannel, receiver: ClipboardStreamReceiver)? =
+        let context: (channel: VsockChannel, receiver: any ClipboardStreamReceiving)? =
             DispatchQueue.main.sync {
                 guard let promise = inboundPromise, promise.generation == generation,
                     promise.reps.indices.contains(repIndex),
@@ -1715,7 +1715,7 @@ extension VsockGuestClipboardAgent: FileProviderPullProvider {
         dispatchPrecondition(condition: .notOnQueue(.main))
         let transferID = ClipboardTransferID.makeChild(
             generation: generation, repIndex: repIndex, childSeq: childSeq, hostMinted: false)
-        let receiver: ClipboardStreamReceiver? = DispatchQueue.main.sync { self.receiver }
+        let receiver: (any ClipboardStreamReceiving)? = DispatchQueue.main.sync { self.receiver }
         Self.logger.notice(
             "Cancelling child clipboard pull \(transferID, privacy: .public) on consumer request")
         receiver?.cancel(transferID: transferID)

--- a/KernovaMacOSAgent/VsockGuestControlAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestControlAgent.swift
@@ -2,6 +2,49 @@ import Foundation
 import KernovaKit
 import os
 
+/// The clock-independent surface of `VsockGuestControlAgent`, for holders that
+/// must run below macOS 13 and so cannot store a concrete clock instantiation.
+protocol VsockGuestControlling: AnyObject, Sendable {
+    /// Begins the connect/serve/reconnect loop (idempotent).
+    func start()
+    /// Stops the loop and tears down any active channel.
+    func stop()
+    /// Thread-safe host-connection state for the menu-bar UI to pull on open.
+    var connectionState: HostConnectionState { get }
+    /// Thread-safe read of the host's bundled agent version; empty when unknown.
+    var hostBundledAgentVersion: String { get }
+    /// Thread-safe read of the negotiated gate for folder placeholder trees.
+    var hostSupportsClipboardDirTree: Bool { get }
+}
+
+/// Builds a control agent on the platform-default clock — `ContinuousClock` on
+/// macOS 13+, `CLOCK_MONOTONIC` below — erased for holders that run on 12.
+func makeVsockGuestControlAgent(
+    onPolicy: (@Sendable (Kernova_V1_PolicyUpdate) -> Void)? = nil,
+    onStateChange: (@Sendable (HostConnectionState) -> Void)? = nil
+) -> any VsockGuestControlling {
+    if #available(macOS 13.0, *) {
+        let clock = ContinuousEngineClock()
+        return VsockGuestControlAgent(
+            clock: clock,
+            client: VsockGuestClient(port: KernovaVsockPort.control, label: "control", clock: clock),
+            onPolicy: onPolicy,
+            onStateChange: onStateChange
+        )
+    }
+    let clock = MonotonicEngineClock()
+    return VsockGuestControlAgent(
+        clock: clock,
+        client: VsockGuestClient(port: KernovaVsockPort.control, label: "control", clock: clock),
+        onPolicy: onPolicy,
+        onStateChange: onStateChange
+    )
+}
+
+// File-scope stand-in for a `static let`, which a generic type cannot hold.
+private let controlAgentLogger = Logger(
+    subsystem: "app.kernova.macosagent", category: "VsockGuestControlAgent")
+
 /// Guest-side control-channel agent that talks to the host's
 /// `VsockControlService` on `KernovaVsockPort.control`.
 ///
@@ -10,14 +53,15 @@ import os
 /// carries the version handshake, a recurring heartbeat, and a watchdog that
 /// closes the channel once inbound traffic stops for `terminateAfter`, leaving
 /// `VsockGuestClient` to rebuild it.
-final class VsockGuestControlAgent: @unchecked Sendable {
-    private static let logger = Logger(subsystem: "app.kernova.macosagent", category: "VsockGuestControlAgent")
+final class VsockGuestControlAgent<Clock: EngineClock>: VsockGuestControlling, @unchecked Sendable {
+    private static var logger: Logger { controlAgentLogger }
 
-    private let client: VsockGuestClient
-    private let heartbeatInterval: Duration
-    private let unresponsiveAfter: Duration
-    private let terminateAfter: Duration
-    private let livenessTickInterval: Duration
+    private let clock: Clock
+    private let client: any VsockReconnecting
+    private let heartbeatInterval: TimeInterval
+    private let unresponsiveAfter: TimeInterval
+    private let terminateAfter: TimeInterval
+    private let livenessTickInterval: TimeInterval
 
     /// Invoked on every inbound `PolicyUpdate`, with the raw protobuf snapshot.
     private let onPolicy: (@Sendable (Kernova_V1_PolicyUpdate) -> Void)?
@@ -28,7 +72,7 @@ final class VsockGuestControlAgent: @unchecked Sendable {
     private let onStateChange: (@Sendable (HostConnectionState) -> Void)?
 
     private let lock = NSLock()
-    private var lastInboundFrame: ContinuousClock.Instant?
+    private var lastInboundFrame: Clock.Instant?
     private var unresponsiveLogged: Bool = false
     private var nextHeartbeatNonce: UInt64 = 1
 
@@ -57,24 +101,14 @@ final class VsockGuestControlAgent: @unchecked Sendable {
     /// Thread-safe read of the negotiated gate for folder placeholder trees.
     var hostSupportsClipboardDirTree: Bool { lock.withLock { hostSupportsClipboardDirTreeStorage } }
 
-    /// Production init — connects to the control port with default cadences.
-    convenience init(
-        onPolicy: (@Sendable (Kernova_V1_PolicyUpdate) -> Void)? = nil,
-        onStateChange: (@Sendable (HostConnectionState) -> Void)? = nil
-    ) {
-        self.init(
-            client: VsockGuestClient(port: KernovaVsockPort.control, label: "control"),
-            onPolicy: onPolicy,
-            onStateChange: onStateChange
-        )
-    }
-
-    /// Designated init; tests inject a socketpair-backed client and small cadences.
+    /// Designated init; production goes through `makeVsockGuestControlAgent`,
+    /// tests inject a socketpair-backed client and small cadences.
     init(
-        client: VsockGuestClient,
-        heartbeatInterval: Duration = .seconds(5),
-        unresponsiveAfter: Duration = .seconds(15),
-        terminateAfter: Duration = .seconds(30),
+        clock: Clock,
+        client: any VsockReconnecting,
+        heartbeatInterval: TimeInterval = 5,
+        unresponsiveAfter: TimeInterval = 15,
+        terminateAfter: TimeInterval = 30,
         onPolicy: (@Sendable (Kernova_V1_PolicyUpdate) -> Void)? = nil,
         onStateChange: (@Sendable (HostConnectionState) -> Void)? = nil
     ) {
@@ -82,6 +116,7 @@ final class VsockGuestControlAgent: @unchecked Sendable {
             unresponsiveAfter < terminateAfter,
             "VsockGuestControlAgent: unresponsiveAfter (\(unresponsiveAfter)) must be < terminateAfter (\(terminateAfter))"
         )
+        self.clock = clock
         self.client = client
         self.heartbeatInterval = heartbeatInterval
         self.unresponsiveAfter = unresponsiveAfter
@@ -150,10 +185,11 @@ final class VsockGuestControlAgent: @unchecked Sendable {
 
         let heartbeatInterval = self.heartbeatInterval
         let livenessTickInterval = self.livenessTickInterval
+        let clock = self.clock
         let heartbeatTask = Task { [weak self] in
             while !Task.isCancelled {
                 do {
-                    try await Task.sleep(for: heartbeatInterval)
+                    try await clock.sleep(for: heartbeatInterval)
                 } catch {
                     return
                 }
@@ -164,7 +200,7 @@ final class VsockGuestControlAgent: @unchecked Sendable {
         let livenessTask = Task { [weak self] in
             while !Task.isCancelled {
                 do {
-                    try await Task.sleep(for: livenessTickInterval)
+                    try await clock.sleep(for: livenessTickInterval)
                 } catch {
                     return
                 }
@@ -202,7 +238,7 @@ final class VsockGuestControlAgent: @unchecked Sendable {
 
         // Any inbound traffic counts as liveness.
         lock.withLock {
-            lastInboundFrame = ContinuousClock.now
+            lastInboundFrame = clock.now
             unresponsiveLogged = false
         }
         updateConnectionState(.connected)
@@ -297,23 +333,23 @@ final class VsockGuestControlAgent: @unchecked Sendable {
     // MARK: - Liveness
 
     private func checkLiveness(channel: VsockChannel) {
-        let snapshot: (last: ContinuousClock.Instant?, alreadyLogged: Bool) = lock.withLock {
+        let snapshot: (last: Clock.Instant?, alreadyLogged: Bool) = lock.withLock {
             (lastInboundFrame, unresponsiveLogged)
         }
         guard let last = snapshot.last else {
             // Host hasn't sent anything yet — keep waiting.
             return
         }
-        let elapsed = ContinuousClock.now - last
+        let elapsed = clock.seconds(since: last)
         if elapsed > terminateAfter {
             Self.logger.warning(
-                "Host control channel silent for \(elapsed.formatted(.units(allowed: [.seconds])), privacy: .public) — closing"
+                "Host control channel silent for \(Int(elapsed.rounded()), privacy: .public) s — closing"
             )
             channel.close()
         } else if elapsed > unresponsiveAfter {
             if !snapshot.alreadyLogged {
                 Self.logger.warning(
-                    "Host control channel silent for \(elapsed.formatted(.units(allowed: [.seconds])), privacy: .public) — host appears unresponsive"
+                    "Host control channel silent for \(Int(elapsed.rounded()), privacy: .public) s — host appears unresponsive"
                 )
                 lock.withLock { unresponsiveLogged = true }
             }

--- a/KernovaMacOSAgent/VsockHostConnection.swift
+++ b/KernovaMacOSAgent/VsockHostConnection.swift
@@ -16,7 +16,7 @@ final class VsockHostConnection: @unchecked Sendable {
     /// VM start to the first vsock connect on macOS.
     static let logBufferLimit = 256
 
-    private let client: VsockGuestClient
+    private let client: any VsockReconnecting
 
     let lock = NSLock()
     var pendingLogs: [Frame] = []
@@ -40,7 +40,7 @@ final class VsockHostConnection: @unchecked Sendable {
     }
 
     init() {
-        self.client = VsockGuestClient(port: KernovaVsockPort.log, label: "log")
+        self.client = makeVsockGuestClient(port: KernovaVsockPort.log, label: "log")
         // Default-disabled: no connect attempts until the host's first
         // `PolicyUpdate(logForwardingEnabled: true)`.
         self.client.pause()

--- a/KernovaMacOSAgentTests/TestHelpers.swift
+++ b/KernovaMacOSAgentTests/TestHelpers.swift
@@ -49,7 +49,7 @@ func nextFrame(from channel: VsockChannel) async throws -> Frame {
         return try await iterator.next()
     }
     let timeoutTask = Task<Void, Never> {
-        try? await Task.sleep(for: timeout)
+        try? await MonotonicEngineClock().sleep(for: timeout)
         receiver.cancel()
     }
     defer { timeoutTask.cancel() }
@@ -60,7 +60,7 @@ func nextFrame(from channel: VsockChannel) async throws -> Frame {
         }
         return frame
     } catch is CancellationError {
-        throw TestFailure("Timed out waiting for a frame after \(timeout)")
+        throw TestFailure("Timed out waiting for a frame after \(timeout) s")
     }
 }
 
@@ -77,14 +77,35 @@ func awaitFirst<T: Sendable>(_ stream: AsyncStream<T>) async throws -> T {
         return await iterator.next()
     }
     let timeoutTask = Task<Void, Never> {
-        try? await Task.sleep(for: timeout)
+        try? await MonotonicEngineClock().sleep(for: timeout)
         task.cancel()
     }
     defer { timeoutTask.cancel() }
     guard let value = await task.value else {
-        throw TestFailure("Timed out waiting for stream value after \(timeout)")
+        throw TestFailure("Timed out waiting for stream value after \(timeout) s")
     }
     return value
+}
+
+// MARK: - Clock-parameterized client factory
+
+/// Builds a `VsockGuestClient` on the clock `kind` names, erased for tests
+/// parameterized over both production clocks (`EngineClockKind.allCases`).
+func makeTestClient(
+    kind: EngineClockKind,
+    port: UInt32,
+    label: String,
+    retryInterval: TimeInterval,
+    socketProvider: VsockSocketProvider? = nil
+) -> any VsockReconnecting {
+    if kind == .continuous, #available(macOS 13.0, *) {
+        return VsockGuestClient(
+            port: port, label: label, clock: ContinuousEngineClock(),
+            retryInterval: retryInterval, socketProvider: socketProvider)
+    }
+    return VsockGuestClient(
+        port: port, label: label, clock: MonotonicEngineClock(),
+        retryInterval: retryInterval, socketProvider: socketProvider)
 }
 
 // MARK: - AtomicInt

--- a/KernovaMacOSAgentTests/VsockGuestClientTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClientTests.swift
@@ -10,7 +10,7 @@ struct VsockGuestClientTests {
 
     @Test("start invokes serve closure with a connected channel")
     func startInvokesServeClosure() async throws {
-        let fastRetry: Duration = .milliseconds(50)
+        let fastRetry: TimeInterval = 0.05
         let (localFd, remoteFd) = try makeRawSocketPair()
         let remote = VsockChannel(fileDescriptor: remoteFd)
         remote.start()
@@ -18,7 +18,8 @@ struct VsockGuestClientTests {
 
         let (servedStream, continuation) = AsyncStream<Void>.makeStream()
 
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: .monotonic,
             port: 12345,
             label: "test",
             retryInterval: fastRetry
@@ -35,7 +36,7 @@ struct VsockGuestClientTests {
 
     @Test("liveChannel is non-nil while serve is running and nil after serve returns")
     func liveChannelLifecycle() async throws {
-        let fastRetry: Duration = .milliseconds(50)
+        let fastRetry: TimeInterval = 0.05
         let (localFd, remoteFd) = try makeRawSocketPair()
         let remote = VsockChannel(fileDescriptor: remoteFd)
         remote.start()
@@ -43,7 +44,8 @@ struct VsockGuestClientTests {
         // Return localFd on first call, transient failure thereafter — prevents
         // reuse of a closed fd if the client retries after the remote closes.
         let callCount = AtomicInt()
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: .monotonic,
             port: 12345,
             label: "test",
             retryInterval: fastRetry
@@ -76,7 +78,7 @@ struct VsockGuestClientTests {
     /// guard fires and `serve` is never called.
     @Test("stop while reconnecting aborts loop without calling serve")
     func stopMidConnectAbortBeforeServe() async throws {
-        let fastRetry: Duration = .milliseconds(50)
+        let fastRetry: TimeInterval = 0.05
         let serveCallCount = AtomicInt()
         let providerEnteredGate = DispatchSemaphore(value: 0)
         let providerReleaseGate = DispatchSemaphore(value: 0)
@@ -86,7 +88,8 @@ struct VsockGuestClientTests {
         remote.start()
         defer { remote.close() }
 
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: .monotonic,
             port: 12345,
             label: "test",
             retryInterval: fastRetry
@@ -115,7 +118,7 @@ struct VsockGuestClientTests {
 
         // Await the background work by sleeping; the provider returns .success(localFd)
         // but aborted==true so serve is not invoked.
-        try await Task.sleep(for: .milliseconds(300))
+        try await Task.sleep(nanoseconds: 300_000_000)
 
         #expect(serveCallCount.value == 0)
         #expect(client.liveChannel == nil)
@@ -123,13 +126,14 @@ struct VsockGuestClientTests {
 
     @Test("stop mid-serve tears down the channel and does not re-invoke serve")
     func stopMidServe() async throws {
-        let fastRetry: Duration = .milliseconds(50)
+        let fastRetry: TimeInterval = 0.05
         let (localFd, remoteFd) = try makeRawSocketPair()
         _ = remoteFd  // keep alive; remote end closed when test exits
 
         let callCounter = CallCounter()
 
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: .monotonic,
             port: 12345,
             label: "test",
             retryInterval: fastRetry
@@ -148,17 +152,18 @@ struct VsockGuestClientTests {
         // Stop while serve is in flight
         client.stop()
 
-        try await Task.sleep(for: .milliseconds(150))
+        try await Task.sleep(nanoseconds: 150_000_000)
         #expect(await callCounter.value == 1)
         #expect(client.liveChannel == nil)
     }
 
     @Test("stop before start is a no-op; subsequent start is also a no-op")
     func stopBeforeStartIsNoOp() async throws {
-        let fastRetry: Duration = .milliseconds(50)
+        let fastRetry: TimeInterval = 0.05
         let provideCounter = AtomicInt()
 
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: .monotonic,
             port: 12345,
             label: "test",
             retryInterval: fastRetry
@@ -170,14 +175,14 @@ struct VsockGuestClientTests {
         client.stop()
         client.start { _ in }
 
-        try await Task.sleep(for: .milliseconds(100))
+        try await Task.sleep(nanoseconds: 100_000_000)
         #expect(provideCounter.value == 0)
         #expect(client.liveChannel == nil)
     }
 
     @Test("start is idempotent — second call before stop is a no-op")
     func startIsIdempotent() async throws {
-        let fastRetry: Duration = .milliseconds(50)
+        let fastRetry: TimeInterval = 0.05
         let (localFd, remoteFd) = try makeRawSocketPair()
         let remote = VsockChannel(fileDescriptor: remoteFd)
         remote.start()
@@ -185,7 +190,8 @@ struct VsockGuestClientTests {
 
         let provideCounter = AtomicInt()
 
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: .monotonic,
             port: 12345,
             label: "test",
             retryInterval: fastRetry
@@ -206,13 +212,15 @@ struct VsockGuestClientTests {
         // Second start — no-op
         client.start { _ in }
 
-        try await Task.sleep(for: .milliseconds(100))
+        try await Task.sleep(nanoseconds: 100_000_000)
         #expect(provideCounter.value == 1)
     }
 
-    @Test("socketProvider returning transient failure triggers retry until a real fd arrives")
-    func providerTransientFailureTriggersRetry() async throws {
-        let fastRetry: Duration = .milliseconds(50)
+    @Test(
+        "socketProvider returning transient failure triggers retry until a real fd arrives",
+        arguments: EngineClockKind.allCases)
+    func providerTransientFailureTriggersRetry(kind: EngineClockKind) async throws {
+        let fastRetry: TimeInterval = 0.05
         let targetAttempt = 3
 
         let (localFd, remoteFd) = try makeRawSocketPair()
@@ -223,7 +231,8 @@ struct VsockGuestClientTests {
         let attemptCounter = AtomicInt()
         let (servedStream, continuation) = AsyncStream<Void>.makeStream()
 
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: kind,
             port: 12345,
             label: "test",
             retryInterval: fastRetry
@@ -246,10 +255,11 @@ struct VsockGuestClientTests {
 
     @Test("permanent socket-provider failure halts the reconnect loop")
     func permanentFailureHaltsLoop() async throws {
-        let fastRetry: Duration = .milliseconds(50)
+        let fastRetry: TimeInterval = 0.05
         let provideCounter = AtomicInt()
 
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: .monotonic,
             port: 12345,
             label: "test",
             retryInterval: fastRetry
@@ -262,7 +272,7 @@ struct VsockGuestClientTests {
         client.start { _ in }
 
         // Wait several retry intervals — if the loop kept retrying we'd see >1 calls.
-        try await Task.sleep(for: .milliseconds(300))
+        try await Task.sleep(nanoseconds: 300_000_000)
 
         #expect(provideCounter.value == 1)
         #expect(client.liveChannel == nil)
@@ -272,10 +282,11 @@ struct VsockGuestClientTests {
     /// `start` calls are no-ops — the client cannot be restarted.
     @Test("start after permanent termination is a no-op — provider is never called again")
     func startAfterPermanentTerminationIsNoOp() async throws {
-        let fastRetry: Duration = .milliseconds(50)
+        let fastRetry: TimeInterval = 0.05
         let provideCounter = AtomicInt()
 
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: .monotonic,
             port: 12345,
             label: "test",
             retryInterval: fastRetry
@@ -296,7 +307,7 @@ struct VsockGuestClientTests {
         client.start { _ in }
 
         // Wait another retry window; provider count must remain 1.
-        try await Task.sleep(for: .milliseconds(300))
+        try await Task.sleep(nanoseconds: 300_000_000)
         #expect(provideCounter.value == 1)
         #expect(client.liveChannel == nil)
     }
@@ -308,7 +319,7 @@ struct VsockGuestClientTests {
 struct ClassifySocketErrnoTests {
     @Test("EAFNOSUPPORT classifies as permanent")
     func eafnosupportIsPermanent() {
-        let result = VsockGuestClient.classifySocketErrno(EAFNOSUPPORT, label: "test")
+        let result = classifySocketErrno(EAFNOSUPPORT, label: "test")
         if case .permanent = result {
         } else {
             Issue.record("Expected .permanent for EAFNOSUPPORT, got \(result)")
@@ -317,7 +328,7 @@ struct ClassifySocketErrnoTests {
 
     @Test("EPROTONOSUPPORT classifies as permanent")
     func eprotonosupportIsPermanent() {
-        let result = VsockGuestClient.classifySocketErrno(EPROTONOSUPPORT, label: "test")
+        let result = classifySocketErrno(EPROTONOSUPPORT, label: "test")
         if case .permanent = result {
         } else {
             Issue.record("Expected .permanent for EPROTONOSUPPORT, got \(result)")
@@ -326,7 +337,7 @@ struct ClassifySocketErrnoTests {
 
     @Test("EMFILE (resource exhaustion) classifies as transient")
     func emfileIsTransient() {
-        let result = VsockGuestClient.classifySocketErrno(EMFILE, label: "test")
+        let result = classifySocketErrno(EMFILE, label: "test")
         if case .transient = result {
         } else {
             Issue.record("Expected .transient for EMFILE, got \(result)")
@@ -335,7 +346,7 @@ struct ClassifySocketErrnoTests {
 
     @Test("EACCES (access control) classifies as transient — sandbox may clear")
     func eaccesIsTransient() {
-        let result = VsockGuestClient.classifySocketErrno(EACCES, label: "test")
+        let result = classifySocketErrno(EACCES, label: "test")
         if case .transient = result {
         } else {
             Issue.record("Expected .transient for EACCES, got \(result)")
@@ -344,7 +355,7 @@ struct ClassifySocketErrnoTests {
 
     @Test("errno 0 (unknown/default) classifies as transient")
     func zeroErrnoIsTransient() {
-        let result = VsockGuestClient.classifySocketErrno(0, label: "test")
+        let result = classifySocketErrno(0, label: "test")
         if case .transient = result {
         } else {
             Issue.record("Expected .transient for errno=0, got \(result)")
@@ -353,16 +364,19 @@ struct ClassifySocketErrnoTests {
 
     // MARK: - pause / resume
 
-    @Test("pause() before connect prevents the loop from invoking serve")
-    func pauseBeforeStartSuppressesConnect() async throws {
-        let fastRetry: Duration = .milliseconds(20)
+    @Test(
+        "pause() before connect prevents the loop from invoking serve",
+        arguments: EngineClockKind.allCases)
+    func pauseBeforeStartSuppressesConnect(kind: EngineClockKind) async throws {
+        let fastRetry: TimeInterval = 0.02
         let (localFd, remoteFd) = try makeRawSocketPair()
         let remote = VsockChannel(fileDescriptor: remoteFd)
         remote.start()
         defer { remote.close() }
 
         let calls = AtomicInt()
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: kind,
             port: 12345,
             label: "test",
             retryInterval: fastRetry
@@ -376,7 +390,7 @@ struct ClassifySocketErrnoTests {
         client.start { _ in }
 
         // Give the loop several retry intervals to attempt a connect.
-        try await Task.sleep(for: .milliseconds(150))
+        try await Task.sleep(nanoseconds: 150_000_000)
         #expect(calls.value == 0, "Paused client should not invoke socketProvider")
     }
 
@@ -395,10 +409,11 @@ struct ClassifySocketErrnoTests {
         let providerSleepMs = 100
         let providerEntered = AtomicInt()
 
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: .monotonic,
             port: 12345,
             label: "test",
-            retryInterval: .milliseconds(20)
+            retryInterval: 0.02
         ) { _, _ in
             _ = providerEntered.increment()
             // Block the synchronous provider long enough for the test to
@@ -414,7 +429,7 @@ struct ClassifySocketErrnoTests {
         client.start { _ in
             _ = serveCalled.increment()
             // Hold so the test sees the increment if the bug regresses.
-            try? await Task.sleep(for: .seconds(1))
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
         }
 
         // Wait for the provider to be entered, then pause while it's mid-sleep.
@@ -424,22 +439,25 @@ struct ClassifySocketErrnoTests {
         client.pause()
 
         // Wait past the provider's sleep so connectAndServe has returned.
-        try await Task.sleep(for: .milliseconds(providerSleepMs + 100))
+        try await Task.sleep(nanoseconds: UInt64(providerSleepMs + 100) * 1_000_000)
         #expect(
             serveCalled.value == 0,
             "serve() must not run when pause() landed during connectAndServe")
     }
 
-    @Test("resume() lets the loop connect after a pre-start pause")
-    func resumeAllowsConnectAfterPause() async throws {
-        let fastRetry: Duration = .milliseconds(20)
+    @Test(
+        "resume() lets the loop connect after a pre-start pause",
+        arguments: EngineClockKind.allCases)
+    func resumeAllowsConnectAfterPause(kind: EngineClockKind) async throws {
+        let fastRetry: TimeInterval = 0.02
         let (localFd, remoteFd) = try makeRawSocketPair()
         let remote = VsockChannel(fileDescriptor: remoteFd)
         remote.start()
         defer { remote.close() }
 
         let calls = AtomicInt()
-        let client = VsockGuestClient(
+        let client = makeTestClient(
+            kind: kind,
             port: 12345,
             label: "test",
             retryInterval: fastRetry
@@ -457,7 +475,7 @@ struct ClassifySocketErrnoTests {
         }
 
         // Sanity: paused, no connect.
-        try await Task.sleep(for: .milliseconds(100))
+        try await Task.sleep(nanoseconds: 100_000_000)
         #expect(calls.value == 0)
 
         // Resume: loop wakes within retryInterval and connects.

--- a/KernovaMacOSAgentTests/VsockGuestClientTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClientTests.swift
@@ -485,6 +485,89 @@ struct ClassifySocketErrnoTests {
     }
 }
 
+@Suite("Bounded blocking connect: socket ownership and the one-per-label gate")
+struct BlockingConnectTests {
+    @Test("A syscall that beats the deadline hands the socket to the waiter")
+    func syscallBeatsDeadline() {
+        let handoff = BlockingConnectHandoff()
+
+        #expect(handoff.finish(errno: 0))
+        #expect(handoff.abandon() == false)
+        #expect(handoff.outcome == 0)
+    }
+
+    @Test("A syscall that outruns the deadline keeps the socket")
+    func syscallOutrunsDeadline() {
+        let handoff = BlockingConnectHandoff()
+
+        #expect(handoff.abandon())
+        #expect(handoff.outcome == nil)
+        #expect(handoff.finish(errno: ECONNREFUSED) == false)
+        #expect(handoff.outcome == ECONNREFUSED)
+    }
+
+    @Test("A failing syscall reports its errno to a waiter still present")
+    func failingSyscallReportsErrno() {
+        let handoff = BlockingConnectHandoff()
+
+        #expect(handoff.finish(errno: ECONNREFUSED))
+        #expect(handoff.outcome == ECONNREFUSED)
+    }
+
+    @Test("Only one connect per label is admitted until its slot is released")
+    func gateAdmitsOnePerLabel() {
+        let gate = BlockingConnectGate()
+
+        #expect(gate.claim("control"))
+        #expect(gate.isClaimed("control"))
+        #expect(gate.claim("control") == false)
+
+        gate.release("control")
+        #expect(gate.isClaimed("control") == false)
+        #expect(gate.claim("control"))
+    }
+
+    @Test("Labels hold their slots independently")
+    func gateSeparatesLabels() {
+        let gate = BlockingConnectGate()
+
+        #expect(gate.claim("control"))
+        #expect(gate.claim("clipboard"))
+        #expect(gate.claim("control") == false)
+
+        gate.release("control")
+        #expect(gate.claim("clipboard") == false)
+        #expect(gate.isClaimed("clipboard"))
+    }
+
+    @Test("Releasing a label that never claimed one is inert")
+    func gateReleaseIsIdempotent() {
+        let gate = BlockingConnectGate()
+
+        gate.release("control")
+        #expect(gate.claim("control"))
+        gate.release("control")
+        gate.release("control")
+        #expect(gate.claim("control"))
+    }
+
+    @Test("Concurrent claims on one label admit exactly one winner")
+    func gateAdmitsExactlyOneUnderContention() async {
+        let gate = BlockingConnectGate()
+        let winners = CallCounter()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<32 {
+                group.addTask {
+                    if gate.claim("control") { await winners.increment() }
+                }
+            }
+        }
+
+        #expect(await winners.value == 1)
+    }
+}
+
 // MARK: - Concurrency helpers
 
 /// Actor-isolated counter for tracking cross-task call counts.

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -350,7 +350,8 @@ struct VsockGuestClipboardAgentTests {
         let client = VsockGuestClient(
             port: 49152,
             label: "clipboard-test",
-            retryInterval: .milliseconds(50)
+            clock: MonotonicEngineClock(),
+            retryInterval: 0.05
         ) { _, _ in
             provided.increment() == 1 ? .success(agentFd) : .failure(.transient("test: no fd"))
         }
@@ -1272,10 +1273,11 @@ struct VsockGuestClipboardAgentTests {
         // promptly — well under the lazy-pull backstop — rather than hanging.
         let pull = Task { await offCooperativePool { agent.fetchStagedFile(generation: 11, repIndex: 0) } }
         _ = try await awaitRequest(on: hostChannel)
-        let start = ContinuousClock.now
+        let wallClock = MonotonicEngineClock()
+        let start = wallClock.now
         hostChannel.close()
         let outcome = await pull.value
-        #expect(ContinuousClock.now - start < .seconds(5))
+        #expect(wallClock.seconds(since: start) < 5)
         guard case .failure(.pullFailed) = outcome else {
             Issue.record("expected .pullFailed after teardown, got \(outcome)")
             return
@@ -2524,23 +2526,24 @@ struct VsockGuestClipboardAgentTests {
         // and the send-failure handler resolves the pull synchronously via
         // `cancelAwait` + `coordinator.abort`, so `invokeProvider` returns nil on
         // the same thread without ever blocking toward the 120 s backstop.
-        let start = ContinuousClock.now
+        let wallClock = MonotonicEngineClock()
+        let start = wallClock.now
         let provided: Data? = await offCooperativePool {
             DispatchQueue.main.sync {
                 agent.liveChannelForTesting?.close()
                 return pasteboard.invokeProvider(forType: .string)
             }
         }
-        let elapsed = ContinuousClock.now - start
+        let elapsed = wallClock.seconds(since: start)
 
         #expect(provided == nil)
         // Promptly: well under the lazy-pull backstop. A regression that didn't
         // resolve the pull on send failure would block the full timeout.
         #expect(
-            elapsed < .seconds(5),
+            elapsed < 5,
             """
             Send failure must resolve the pull promptly, not block toward the \
-            \(ClipboardStreamTuning.lazyPullTimeout) backstop (took \(elapsed))
+            \(ClipboardStreamTuning.lazyPullTimeout) s backstop (took \(elapsed) s)
             """)
     }
 
@@ -2565,7 +2568,8 @@ struct VsockGuestClipboardAgentTests {
         let client = VsockGuestClient(
             port: 49152,
             label: "clipboard-reconnect-test",
-            retryInterval: .milliseconds(50)
+            clock: MonotonicEngineClock(),
+            retryInterval: 0.05
         ) { _, _ in
             let n = provideCount.increment()
             guard let fd = fdBox.fd(at: n - 1) else {
@@ -2699,7 +2703,8 @@ struct VsockGuestClipboardAgentTests {
         let client = VsockGuestClient(
             port: 49152,
             label: "clipboard-sync-publish-test",
-            retryInterval: .milliseconds(50)
+            clock: MonotonicEngineClock(),
+            retryInterval: 0.05
         ) { _, _ in
             provideCount.increment() == 1 ? .success(agentFd) : .failure(.transient("test: no more fds"))
         }
@@ -2833,7 +2838,7 @@ struct VsockGuestClipboardAgentTests {
         agent.start()
 
         // Without setEnabled(true), no connection should come up.
-        try await Task.sleep(for: .milliseconds(150))
+        try await Task.sleep(nanoseconds: 150_000_000)
         let stillNil = DispatchQueue.main.sync { agent.liveChannelForTesting }
         #expect(stillNil == nil)
 
@@ -3139,7 +3144,7 @@ struct VsockGuestClipboardAgentTests {
     /// agent's reaction (if any) runs on the main queue and would have been
     /// dispatched before this window elapses.
     private func maybeNextFrame(
-        from channel: VsockChannel, window: Duration = .milliseconds(200),
+        from channel: VsockChannel, window: TimeInterval = 0.2,
         skippingAcks: Bool = false
     ) async throws -> Frame? {
         let receiver = Task<Frame?, Never> {
@@ -3150,7 +3155,7 @@ struct VsockGuestClipboardAgentTests {
             }
             return nil
         }
-        try await Task.sleep(for: window)
+        try await MonotonicEngineClock().sleep(for: window)
         receiver.cancel()
         return await receiver.value
     }

--- a/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
@@ -40,21 +40,21 @@ struct VsockGuestControlAgentTests {
     /// Default outbound-heartbeat cadence: small so `heartbeatOutboundCadence`
     /// doesn't drag, and harmless to every other test (extra heartbeats only
     /// keep the connection alive).
-    private static let testHeartbeat: Duration = .milliseconds(40)
+    private static let testHeartbeat: TimeInterval = 0.04
 
     /// Default liveness windows, set far beyond any test's wall-clock budget.
     ///
     /// The watchdog can't tear the channel down mid-test at these values. Tests
     /// that *exercise* the watchdog pass explicit short windows to opt back in.
     ///
-    /// The watchdog measures `ContinuousClock.now - lastInboundFrame`, which
+    /// The watchdog measures elapsed time since `lastInboundFrame`, which
     /// keeps advancing while a contended CI MainActor stalls the test. With a
     /// short default, any non-watchdog test that paused past the window saw the
     /// channel closed out from under it — surfacing as an EOF / `.closed` flake.
     /// Making the watchdog an explicit opt-in removes that coupling. Mirrors
     /// `VsockControlServiceTests` / `makeService`. See docs/TESTING.md "Async waits in tests".
-    private static let watchdogDisabledUnresponsive: Duration = .seconds(3_600)
-    private static let watchdogDisabledTerminate: Duration = .seconds(7_200)
+    private static let watchdogDisabledUnresponsive: TimeInterval = 3_600
+    private static let watchdogDisabledTerminate: TimeInterval = 7_200
 
     /// Builds a single-fd-shot agent with the liveness watchdog disabled by
     /// default.
@@ -63,29 +63,38 @@ struct VsockGuestControlAgentTests {
     /// `client` provider hands `agentFd` on the first call, transient failure
     /// after — so reconnect tests must use a multi-fd provider explicitly.
     private func makeAgent(
+        kind: EngineClockKind = .monotonic,
         agentFd: Int32,
-        heartbeatInterval: Duration? = nil,
-        unresponsiveAfter: Duration? = nil,
-        terminateAfter: Duration? = nil,
+        heartbeatInterval: TimeInterval? = nil,
+        unresponsiveAfter: TimeInterval? = nil,
+        terminateAfter: TimeInterval? = nil,
         onPolicy: (@Sendable (Kernova_V1_PolicyUpdate) -> Void)? = nil,
         onStateChange: (@Sendable (HostConnectionState) -> Void)? = nil
-    ) -> VsockGuestControlAgent {
+    ) -> any VsockGuestControlling {
         let provided = AtomicInt()
-        let client = VsockGuestClient(
-            port: KernovaVsockPort.control,
-            label: "control-test",
-            retryInterval: .seconds(60)
-        ) { _, _ in
+        let provider: VsockSocketProvider = { _, _ in
             provided.increment() == 1 ? .success(agentFd) : .failure(.transient("test: no fd"))
         }
-        return VsockGuestControlAgent(
-            client: client,
-            heartbeatInterval: heartbeatInterval ?? Self.testHeartbeat,
-            unresponsiveAfter: unresponsiveAfter ?? Self.watchdogDisabledUnresponsive,
-            terminateAfter: terminateAfter ?? Self.watchdogDisabledTerminate,
-            onPolicy: onPolicy,
-            onStateChange: onStateChange
-        )
+        func build<C: EngineClock>(_ clock: C) -> any VsockGuestControlling {
+            VsockGuestControlAgent(
+                clock: clock,
+                client: VsockGuestClient(
+                    port: KernovaVsockPort.control,
+                    label: "control-test",
+                    clock: clock,
+                    retryInterval: 60,
+                    socketProvider: provider),
+                heartbeatInterval: heartbeatInterval ?? Self.testHeartbeat,
+                unresponsiveAfter: unresponsiveAfter ?? Self.watchdogDisabledUnresponsive,
+                terminateAfter: terminateAfter ?? Self.watchdogDisabledTerminate,
+                onPolicy: onPolicy,
+                onStateChange: onStateChange
+            )
+        }
+        if kind == .continuous, #available(macOS 13.0, *) {
+            return build(ContinuousEngineClock())
+        }
+        return build(MonotonicEngineClock())
     }
 
     // MARK: - Hello
@@ -137,8 +146,8 @@ struct VsockGuestControlAgentTests {
 
     // MARK: - Heartbeat
 
-    @Test("Emits heartbeat frames on the configured cadence")
-    func heartbeatOutboundCadence() async throws {
+    @Test("Emits heartbeat frames on the configured cadence", arguments: EngineClockKind.allCases)
+    func heartbeatOutboundCadence(kind: EngineClockKind) async throws {
         let (agentFd, hostFd) = try makeRawSocketPair()
         let host = VsockChannel(fileDescriptor: hostFd)
         host.start()
@@ -160,15 +169,16 @@ struct VsockGuestControlAgentTests {
         // the stall, the test reads them back-to-back with near-zero gaps and
         // passes — which is correct for "is the timer running" but does NOT
         // catch "MainActor → late delivery".
-        let cadence: Duration = .milliseconds(100)
-        let agent = makeAgent(agentFd: agentFd, heartbeatInterval: cadence)
+        let cadence: TimeInterval = 0.1
+        let agent = makeAgent(kind: kind, agentFd: agentFd, heartbeatInterval: cadence)
         defer { agent.stop() }
         agent.start()
 
         // First frame is the agent Hello — discard.
         _ = try await nextFrame(from: host)
 
-        var stamps: [ContinuousClock.Instant] = []
+        let wallClock = MonotonicEngineClock()
+        var stamps: [MonotonicEngineClock.Instant] = []
         while stamps.count < 3 {
             // Use the shared 5 s default. If the timer is genuinely broken
             // we'll still fail in bounded time (≤15 s); if it's just slow,
@@ -176,14 +186,14 @@ struct VsockGuestControlAgentTests {
             // sharper "cadence drift" error than a generic timeout.
             let frame = try await nextFrame(from: host)
             if case .heartbeat = frame.payload {
-                stamps.append(.now)
+                stamps.append(wallClock.now)
             }
         }
 
         // Loop above guarantees stamps.count == 3, so gaps has exactly 2
-        // elements and reduce(.zero, max) is the natural non-optional form.
-        let gaps = zip(stamps.dropFirst(), stamps).map { $0 - $1 }
-        let maxGap = gaps.reduce(.zero, max)
+        // elements and reduce(0, max) is the natural non-optional form.
+        let gaps = zip(stamps.dropFirst(), stamps).map { wallClock.seconds(from: $1, to: $0) }
+        let maxGap = gaps.reduce(0, max)
         // 10× cadence tolerance: catches "timer not running" / "cadence
         // misconfigured" without flagging single-tick scheduling jitter.
         let tolerance = cadence * 10
@@ -204,7 +214,7 @@ struct VsockGuestControlAgentTests {
 
         // Wider heartbeat cadence (100 ms) + final-read timeout (800 ms) for
         // the same CI-jitter reason as `heartbeatOutboundCadence`.
-        let agent = makeAgent(agentFd: agentFd, heartbeatInterval: .milliseconds(100))
+        let agent = makeAgent(agentFd: agentFd, heartbeatInterval: 0.1)
         defer { agent.stop() }
         agent.start()
 
@@ -216,7 +226,7 @@ struct VsockGuestControlAgentTests {
         try host.send(makeHostHelloFrame())
         for n in 1...3 {
             try host.send(makeHeartbeatFrame(nonce: UInt64(n)))
-            try await Task.sleep(for: .milliseconds(50))
+            try await Task.sleep(nanoseconds: 50_000_000)
         }
 
         // The agent should still be sending heartbeats: read the next frame
@@ -241,7 +251,7 @@ struct VsockGuestControlAgentTests {
         host.start()
         defer { host.close() }
 
-        let agent = makeAgent(agentFd: agentFd, heartbeatInterval: .milliseconds(100))
+        let agent = makeAgent(agentFd: agentFd, heartbeatInterval: 0.1)
         defer { agent.stop() }
         agent.start()
 
@@ -257,8 +267,10 @@ struct VsockGuestControlAgentTests {
         #expect(agent.connectionState == .connected)
     }
 
-    @Test("connectionState reports .unresponsive after the host goes silent")
-    func connectionStateUnresponsive() async throws {
+    @Test(
+        "connectionState reports .unresponsive after the host goes silent",
+        arguments: EngineClockKind.allCases)
+    func connectionStateUnresponsive(kind: EngineClockKind) async throws {
         let (agentFd, hostFd) = try makeRawSocketPair()
         let host = VsockChannel(fileDescriptor: hostFd)
         host.start()
@@ -269,9 +281,10 @@ struct VsockGuestControlAgentTests {
         // channel down during the test.
         let states = StateBox()
         let agent = makeAgent(
+            kind: kind,
             agentFd: agentFd,
-            heartbeatInterval: .milliseconds(50),
-            unresponsiveAfter: .milliseconds(150),
+            heartbeatInterval: 0.05,
+            unresponsiveAfter: 0.15,
             onStateChange: { states.record($0) })
         defer { agent.stop() }
         agent.start()
@@ -285,8 +298,10 @@ struct VsockGuestControlAgentTests {
 
     // MARK: - Liveness teardown + reconnect
 
-    @Test("Silent host past terminateAfter closes the channel; client reconnects with a fresh Hello")
-    func unresponsiveHostTriggersReconnect() async throws {
+    @Test(
+        "Silent host past terminateAfter closes the channel; client reconnects with a fresh Hello",
+        arguments: EngineClockKind.allCases)
+    func unresponsiveHostTriggersReconnect(kind: EngineClockKind) async throws {
         let (agentFd0, hostFd0) = try makeRawSocketPair()
         let (agentFd1, hostFd1) = try makeRawSocketPair()
 
@@ -303,11 +318,7 @@ struct VsockGuestControlAgentTests {
         let fdBox = FdBox(fds: [agentFd0, agentFd1])
         let provideCount = AtomicInt()
 
-        let client = VsockGuestClient(
-            port: KernovaVsockPort.control,
-            label: "control-reconnect-test",
-            retryInterval: .milliseconds(50)
-        ) { _, _ in
+        let provider: VsockSocketProvider = { _, _ in
             let n = provideCount.increment()
             guard let fd = fdBox.fd(at: n - 1) else {
                 return .failure(.transient("test: no fd at index \(n - 1)"))
@@ -315,12 +326,26 @@ struct VsockGuestControlAgentTests {
             return .success(fd)
         }
 
-        let agent = VsockGuestControlAgent(
-            client: client,
-            heartbeatInterval: .milliseconds(100),
-            unresponsiveAfter: .milliseconds(200),
-            terminateAfter: .milliseconds(500)
-        )
+        func build<C: EngineClock>(_ clock: C) -> any VsockGuestControlling {
+            VsockGuestControlAgent(
+                clock: clock,
+                client: VsockGuestClient(
+                    port: KernovaVsockPort.control,
+                    label: "control-reconnect-test",
+                    clock: clock,
+                    retryInterval: 0.05,
+                    socketProvider: provider),
+                heartbeatInterval: 0.1,
+                unresponsiveAfter: 0.2,
+                terminateAfter: 0.5
+            )
+        }
+        let agent: any VsockGuestControlling
+        if kind == .continuous, #available(macOS 13.0, *) {
+            agent = build(ContinuousEngineClock())
+        } else {
+            agent = build(MonotonicEngineClock())
+        }
         defer { agent.stop() }
         agent.start()
 

--- a/KernovaTests/RestoreImageProbeTests.swift
+++ b/KernovaTests/RestoreImageProbeTests.swift
@@ -265,7 +265,7 @@ final class ProbeStubURLProtocol: URLProtocol, @unchecked Sendable {
         DispatchQueue.global().async { [self] in
             deliver(reply.body.prefix(Self.bodyPrimerBytes), finishing: false)
             let backstop =
-                DispatchTime.now() + .seconds(Int(testWaitBackstop.components.seconds))
+                DispatchTime.now() + .seconds(Int(testWaitBackstop))
             guard cancelled.wait(timeout: backstop) == .timedOut else { return }
             deliver(reply.body.dropFirst(Self.bodyPrimerBytes))
         }

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -85,7 +85,7 @@ func makeRawSocketPair() throws -> (Int32, Int32) {
 ///   peer-disconnect bug.
 @MainActor
 func nextFrame(from channel: VsockChannel) async throws -> Frame {
-    let timeout = testWaitBackstop
+    let timeout: Duration = .seconds(testWaitBackstop)
     let receiver = Task<Frame?, Error> {
         var iterator = channel.incoming.makeAsyncIterator()
         return try await iterator.next()
@@ -158,7 +158,7 @@ func expectEOF(on channel: VsockChannel) async {
 /// keep `waitUntil`.
 @MainActor
 func waitForChange(
-    timeout: Duration = testWaitBackstop,
+    timeout: Duration = .seconds(testWaitBackstop),
     until predicate: @escaping @MainActor () -> Bool
 ) async throws {
     let deadline = ContinuousClock.now.advanced(by: timeout)

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -1925,7 +1925,7 @@ struct VsockClipboardServiceTests {
         // regression the pull resolves `.pullFailed` when this fires, so the
         // test fails either way and the value's size never masks it.
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", lazyPullTimeout: .seconds(5))
+            channel: host, label: "test-\(UUID().uuidString)", lazyPullTimeout: 5)
         service.start()
         defer { service.stop() }
 
@@ -2423,7 +2423,7 @@ struct VsockClipboardServiceTests {
         // the production 120 s.
         let service = VsockClipboardService(
             channel: host, label: "test-\(UUID().uuidString)",
-            lazyPullTimeout: .milliseconds(200))
+            lazyPullTimeout: 0.2)
         service.start()
         defer { service.stop() }
 
@@ -2502,7 +2502,7 @@ struct VsockClipboardServiceTests {
         // failure-kind-agnostic — materializeForPreview skips the generation
         // latch on any nil pull result, timeout and abort alike.
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", lazyPullTimeout: .seconds(60))
+            channel: host, label: "test-\(UUID().uuidString)", lazyPullTimeout: 60)
         service.start()
         defer { service.stop() }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Kernova is a pure-AppKit Mac app for creating and running virtual machines directly on Apple Silicon — no third-party hypervisor, no kernel extensions, no licensing. It's for developers, QA engineers, and power users who want fast, disposable macOS and Linux VMs that feel like part of the Mac: a real source list of machines, one-click lifecycle, and deep host integration — shared clipboard, files, audio, and an in-guest agent — all inside the App Sandbox.
 
-Requires macOS 26 (Tahoe) or later on Apple Silicon.
+Requires macOS 26 (Tahoe) or later on Apple Silicon to run the app. macOS guests are supported back to 12.0.1 (Monterey), including the in-guest agent.
 
 <p align="center">
   <picture>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,8 +7,10 @@ actor isolation. It records what exists and how the pieces connect; what a compo
 owned by its own doc comment.
 
 Kernova manages virtual machines through Apple's Virtualization.framework, with macOS and Linux
-guests. Pure AppKit (no `import SwiftUI` in the app target), macOS 26, Swift 6 strict concurrency,
-no non-Apple dependencies.
+guests. Pure AppKit (no `import SwiftUI` in the app target), Swift 6 strict concurrency,
+no non-Apple dependencies. The app targets macOS 26; the guest agent, its File Provider
+extension, and `KernovaKit` deploy back to macOS 12 so the agent runs in every macOS guest the
+catalog can install.
 
 Clipboard rules are in [CLIPBOARD.md](CLIPBOARD.md), sandbox/signing/launch model in
 [SANDBOX.md](SANDBOX.md), toolbar construction in [TOOLBAR.md](TOOLBAR.md).
@@ -143,7 +145,10 @@ Clipboard (principles and trade-off rules: [CLIPBOARD.md](CLIPBOARD.md)):
   `NSPasteboard`.
 - `VsockClipboardService` — the macOS transport, over `VsockChannel`, driving `KernovaKit`'s
   `ClipboardStreamSender`/`ClipboardStreamReceiver`. Offers are metadata-only; bytes stream on
-  request.
+  request. The receiver and the agent's watchdog types are generic over `EngineClock`
+  (`ContinuousClock` on macOS 13+, `CLOCK_MONOTONIC` on 12), chosen once at construction behind
+  `#available` and held through clock-free facade protocols (`ClipboardStreamReceiving`,
+  `VsockReconnecting`, `VsockGuestControlling`) by owners that must run on 12.
 - `HostClipboardPublisher`, `ClipboardPassthroughCoordinator` — host-side publication of inbound
   guest content, and the auto-publish path.
 - `HostClipboardFileProvider` — app-level singleton, not per VM: the Mac has one pasteboard and one

--- a/docs/research/2026-08-02-macos12-fileprovider-getservice.md
+++ b/docs/research/2026-08-02-macos12-fileprovider-getservice.md
@@ -1,0 +1,48 @@
+# macOS 12 lacks the getService selector, and Swift compiles the call ungated
+
+**Date:** 2026-08-02 · **Host:** M1 Max, 32 GB, macOS 27.0, MacOSX27.0 SDK · **Guest:** macOS 12.7.6, Kernova library VM
+
+## Summary
+
+`-[NSFileProviderManager getServiceWithName:itemIdentifier:completionHandler:]`
+(Swift: `getService(named:for:completionHandler:)`) is declared
+`FILEPROVIDER_API_AVAILABILITY_V2_V5` = `API_AVAILABLE(macos(13.0), ios(16.0))`
+on its category, and Monterey's FileProvider framework really does not
+implement the selector: calling it on a 12.7.6 guest raises an unrecognized
+selector through `___forwarding___` and aborts the process. The Swift
+importer, however, does not surface the category-level availability —
+`swiftc -typecheck -target arm64-apple-macos12.0` accepts the ungated call
+with zero diagnostics — so a "compiles clean at the 12 floor" gate cannot
+catch this class of break. FileProvider APIs on the 12-floor targets need
+their availability read off the ObjC macros in `NSFileProviderDefines.h`,
+not inferred from the compiler.
+
+The pre-13 client route is `FileManager.getFileProviderServicesForItem(at:)`
+(`API_AVAILABLE(macos(10.13))`) against the domain root's user-visible URL
+(`getUserVisibleURL(for:)`, macos(11.0)); the extension-side
+`NSFileProviderServicing` protocol is `FILEPROVIDER_API_AVAILABILITY_V3_IOS`
+= macos(11.0), so the servicing endpoint itself exists on 12.
+
+## Method
+
+1. Guest agent 0.53.0 (81) on the 12.7.6 guest crash-looped on launchd's
+   10 s `ThrottleInterval` from the first host policy carrying
+   `clipboard=true` (stable for 25 min before it under `clipboard=false`).
+   Crash report: `EXC_CRASH (SIGABRT)`, `abort()` after
+   `objc_exception_throw` / `___forwarding___`, on dispatch queue
+   `app.kernova.fileprovider.connector`; app-specific backtrace frames 5–7
+   demangle to `FileProviderServicingConnector.init(config:)`'s connect
+   closure ← `connect` ← `connectIfNeeded`.
+2. MacOSX27.0 SDK: `NSFileProviderService.h` puts the manager category under
+   `FILEPROVIDER_API_AVAILABILITY_V2_V5`; `NSFileProviderDefines.h` expands
+   that to `API_AVAILABLE(macos(13.0), ios(16.0))`.
+3. Importer probe: a five-line file calling
+   `manager.getService(named:for:completionHandler:)` with no `#available`
+   guard typechecks clean at `-target arm64-apple-macos12.0`.
+4. Same-header audit of every other FileProvider symbol the agent-side code
+   calls — `signalEnumerator(for:)`, `domains`, `add`, `removeAllDomains`,
+   `waitForStabilization`, `getIdentifierForUserVisibleFile(at:)`,
+   `getUserVisibleURL(for:)`, `temporaryDirectoryURL`,
+   `NSFileProviderDomain(identifier:displayName:)`, `userEnabled` — lands on
+   macos(11.0) via `V2_V3`/`V3_IOS` or the class-level macro; the getService
+   category is the only 13.0 declaration reachable from the guest agent.

--- a/docs/research/2026-08-02-macos12-vsock-blocking-connect-parks.md
+++ b/docs/research/2026-08-02-macos12-vsock-blocking-connect-parks.md
@@ -1,0 +1,45 @@
+# A macOS 12 vsock connect parks indefinitely when the host stops accepting
+
+**Date:** 2026-08-02 · **Host:** M1 Max, 32 GB, macOS 27.0 · **Guest:** macOS 12.7.6, Kernova library VM, 4 vCPU / 8 GB
+
+Supersedes the closing claim of
+`2026-08-02-macos12-vsock-nonblocking-connect.md`, which held that a blocking
+connect is safe on this transport because the hypervisor answers promptly.
+
+## Summary
+
+A blocking `connect(2)` on an `AF_VSOCK` socket stays in the kernel
+indefinitely — observed parked for over 12 minutes — whenever the host side
+holds a listener that never accepts. Darwin bounds `connect(2)` with no socket
+option (`SO_SNDTIMEO` and `SO_RCVTIMEO` cover only `send`/`recv`), so a blocking
+connect issued on the reconnect loop's own thread strands that loop for the life
+of the process: the guest agent stays alive, logs nothing further, and never
+reconnects, while its status reads disconnected. The host meanwhile sees
+nothing at all — consistent with the queued request surfacing at the listener
+only when the guest closes the fd, so a guest that never closes never appears.
+
+Bounding it therefore takes a thread the caller can abandon, not a timeout
+value. Abandoning the thread rather than closing its socket keeps descriptor
+ownership unambiguous — closing an fd out from under an in-flight syscall is
+undefined, and the fd number can be reused the moment `close` returns.
+
+## Method
+
+The guest agent's control, log, and clipboard clients against Kernova's
+listeners, with the agent built from this branch's macOS 12 floor:
+
+1. A mid-session clipboard-sharing enable (host policy `clipboard=false` →
+   `true` on a running VM) resumes two paused reconnect loops at once. The
+   control channel closed within ~5 s of that policy frame, at the same instant
+   the guest's File Provider servicing connection came up.
+2. `sample <agent pid> 2` then showed all 1491 samples of the reconnect thread
+   in `__connect` (in `libsystem_kernel.dylib`), below
+   `VsockGuestClient.openVsockToHost(port:label:clock:)` — parked, not spinning.
+3. The park outlasted every recovery the guest offers: it held across ~12
+   minutes, and `SIGKILL` on the agent was needed to clear it.
+4. The host logged no `Accepted vsock connection` for the whole window while its
+   own liveness timer kept ticking every 5 s, so the host was idle and willing —
+   the connect never reached it.
+5. After a guest restart the same build connected immediately and held 29
+   consecutive 5 s heartbeats with the identical `clipboard=true` policy, which
+   places the trigger in the mid-session enable rather than the policy value.

--- a/docs/research/2026-08-02-macos12-vsock-nonblocking-connect.md
+++ b/docs/research/2026-08-02-macos12-vsock-nonblocking-connect.md
@@ -1,0 +1,41 @@
+# macOS 12 vsock never completes a non-blocking connect
+
+**Date:** 2026-08-02 · **Host:** M1 Max, 32 GB, macOS 27.0 · **Guest:** macOS 12.7.6, Kernova library VM, 4 vCPU / 8 GB
+
+## Summary
+
+On a Monterey guest, `connect(2)` on an `O_NONBLOCK` `AF_VSOCK` socket
+returns `EINPROGRESS` and then never completes: `poll(POLLOUT)` returns
+immediately with `revents = POLLHUP` (0x10) and `SO_ERROR == 0`,
+`getpeername(2)` keeps reporting `ENOTCONN` through an entire 3 s deadline, a
+probing re-`connect(2)` is rejected with `EINVAL` (not the classic BSD
+`EALREADY`/`EISCONN`), and the host's `VZVirtioSocketListener` sees the
+connection arrive only at the moment the guest closes the fd — the queued
+request surfaces during socket teardown, so a host-side accept is evidence of
+the guest *giving up*, not of establishment. The same `connect(2)` issued on
+a blocking socket completes immediately (the 2026-07-31 note's end-to-end
+probe). macOS 13+ guests complete the identical non-blocking sequence with a
+normal `POLLOUT`. Non-blocking connect is therefore unusable on Monterey
+vsock; a blocking connect is safe there because the transport is local-only —
+the hypervisor answers accept or refusal promptly, with no remote peer to
+wait out.
+
+## Method
+
+The guest agent's own connect path (`VsockGuestClient.openVsockToHost`)
+against Kernova's always-installed control listener on port 49154, observed
+from both ends of the same instants across three agent builds:
+
+1. Poll-verdict build (`revents` treated as failure): guest logs `connect()
+   to 'control' port 49154 failed: revents=16` within ~10 ms of the attempt,
+   every 5 s retry; that log line renders the `revents` fallback only when
+   `getsockopt(SO_ERROR)` returned 0. Host log shows an `Accepted vsock
+   connection` / channel-EOF pair ms apart at the same cadence.
+2. `connect(2)`-probe build: `failed: errno=22` (EINVAL) on the same instant
+   cadence.
+3. `getpeername(2)`-probe build: the retry cadence stretches from ~5 s to
+   ~8 s — the 5 s retry sleep plus the full 3 s deadline spent in
+   `ENOTCONN` — and the host's accept timestamp still lands ms before the
+   guest's close, pinning the accept to teardown rather than establishment.
+4. The 2026-07-31 note's Ruby probe (blocking `Socket#connect`) completes on
+   the same guest, isolating the failure to the non-blocking path.

--- a/docs/research/2026-08-03-macos12-extensions-pane-deep-link.md
+++ b/docs/research/2026-08-03-macos12-extensions-pane-deep-link.md
@@ -1,0 +1,43 @@
+# macOS 12 routes to the Extensions pane by bundle path, not by pane id
+
+**Date:** 2026-08-03 · **Host:** M1 Max, 32 GB, macOS 27.0 · **Guest:** macOS 12.7.6, Kernova library VM, 4 vCPU / 8 GB
+
+## Summary
+
+On macOS 12, `NSWorkspace.open` of a
+`x-apple.systempreferences:com.apple.preferences.extensions` URL launches
+System Preferences at the main grid and returns `true`. The pane id is correct —
+it is the `CFBundleIdentifier` of `/System/Library/PreferencePanes/Extensions.prefPane` —
+and it still does not route, with or without a query anchor. Because the scheme
+is claimed by System Preferences, the `true` return says only that the app
+opened, so an ordered candidate list can never fall through past one of these
+URLs.
+
+Opening the pane bundle itself — `NSWorkspace.open` of
+`file:///System/Library/PreferencePanes/Extensions.prefPane` — does route,
+whether System Preferences is closed or already showing another pane. It lands
+on Extensions with the **Added Extensions** category selected, which is where a
+File Provider extension's enablement checkbox appears (Monterey's Extensions
+sidebar has no File Providers category). The selection is not sticky: it lands
+on Added Extensions even when the previous visit left another category chosen.
+
+## Method
+
+Guest agent 0.53.0 installed on the guest, its File Provider domain registered
+and awaiting the user toggle. Each candidate was opened from the guest's
+Terminal after `killall "System Preferences"`, and the resulting window read off
+the VM display:
+
+1. `x-apple.systempreferences:com.apple.preferences.extensions` → main grid.
+2. `x-apple.systempreferences:com.apple.preferences.extensions?extensionPointIdentifier=com.apple.fileprovider-nonui`
+   (the anchor form that works on 13+) → main grid.
+3. `file:///System/Library/PreferencePanes/Extensions.prefPane` → Extensions,
+   Added Extensions selected, listing the agent's extension with its checkbox
+   unchecked.
+4. Candidate 3 repeated after clicking the Share Menu category → Added
+   Extensions again; and repeated without the `killall`, from a window showing
+   Sound → Extensions again.
+
+`defaults read /System/Library/PreferencePanes/Extensions.prefPane/Contents/Info CFBundleIdentifier`
+returned `com.apple.preferences.extensions`, confirming candidate 1 named the
+pane correctly.


### PR DESCRIPTION
Implements the retarget in #686 (left open: its real-guest validation checklist is still outstanding — see Test plan).

## Summary

Lowers the deployment floor of the guest agent, its File Provider extension, KernovaKit, and KernovaMacOSAgentTests from macOS 26 to 12.0, so every macOS guest the catalog can install (back to 12.0.1) can run the agent.

Two separable bodies of work: a **clock seam** that lets the shared engine compile at the lower floor, and a set of **runtime compatibility fixes** that only a real Monterey guest surfaced.

### The clock seam

The core design is a generic clock abstraction rather than the originally-agreed single substituted path (rationale recorded in the issue's amended "Agreed approach"): the stream engine and the agent's watchdog/reconnect types are generic over a new `EngineClock` protocol with an associated `Instant` — `Swift.Clock`, one floor lower. `@available` cannot gate stored properties (a field is layout, not code), but a stored property of an associated type is legal at the 12 floor because layout resolves per instantiation. So:

- **macOS 13+ (host and modern guests)** run `ContinuousEngineClock`, storing genuine `ContinuousClock.Instant`s end-to-end — zero behavior change and no adapter code on the modern path.
- **macOS 12 guests** run `MonotonicEngineClock` on `clock_gettime_nsec_np(CLOCK_MONOTONIC)`, which counts time asleep on Darwin — matching `ContinuousClock` semantics across VM save/restore, where an uptime clock (`DispatchTime`/`mach_absolute_time`) would silently freeze the liveness watchdogs. The clockid choice lives in exactly one line.
- **Tests** get a manually advanced `TestEngineClock`, and the timing-relevant suites run parameterized over both real conformances, so the code path a 12 guest executes is exercised on every CI run.

`#available` appears only at construction sites (holders that must run on 12 store clock-free facades: `ClipboardStreamReceiving`, `VsockReconnecting`, `VsockGuestControlling`) and at genuine capability gaps: `setCodeSigningRequirement` (13+, unreachable on guests and fault-logged if ever hit), `NSApplication.activate()` vs `activate(ignoringOtherApps:)` (14), and the settings-app deep links plus "Enable in System Preferences…" copy below 13.

Rejected alternatives: call-site `#available` branching (impossible — the stored-property availability ban); a scalar type-erased seam (modern path would run epoch-conversion adapter code instead of native instants); forking the engine into parallel `@available` types (duplicates ~800 lines of the subtlest concurrency code). When the 12 floor is eventually dropped, `EngineClock` collapses onto `Swift.Clock` by deleting the legacy conformance and the construction branches.

`ClipboardStreamSender` and `LazyPullCoordinator` turned out to need no clock at all — their `Duration`s were semaphore/condition deadlines, now `TimeInterval` (identical wait mechanics). Boundary currency (tuning constants, transfer metrics, facade surfaces) is `TimeInterval` throughout.

### Runtime compatibility

Lowering the deployment target surfaces none of what follows: it was all found by running the agent on a 12.7.6 guest, and each finding carries a dated research note with its method. The `getService` case is the sharp one — its availability is declared on the Objective-C *category*, which the Swift importer does not surface, so `swiftc -typecheck -target arm64-apple-macos12.0` accepts the call with zero diagnostics and Monterey aborts on the selector at runtime. Every other guest-reachable FileProvider symbol was audited against the same header.

The `getService` abort presented as the agent's status icon disappearing: a crash loop on launchd's 10-second throttle, starting the instant clipboard sharing was enabled, because that policy is what arms the servicing connector. Fixing it exposed the parked connect underneath. Through both, the host's liveness watchdog logged the channel silent every 5 seconds without ever tearing it down or clearing `isConnected` — pre-existing on `main`, so filed as #703 rather than widened into this PR.

## Changes

**Floor and the clock seam**

- New: `EngineClock.swift`, `ClipboardStreamReceiving.swift` (KernovaKit); `TestEngineClock.swift`, `EngineClockKind.swift` (KernovaTestSupport)
- `ClipboardStreamReceiver` generic over the clock (all four stored timestamps are `Clock.Instant`); sender/coordinator/tuning move to `TimeInterval`
- `VsockGuestClient` and `VsockGuestControlAgent` generic over the clock; `AgentAppDelegate`, `VsockHostConnection`, `VsockGuestClipboardAgent` hold facades; `classifySocketErrno` hoisted to file scope (a generic type can't hold static stored properties)
- The reported OS version parses without Swift Regex (13+)

**macOS 12 runtime compatibility**

- `openVsockToHost` connects blocking below macOS 13: Monterey's virtio-vsock driver never completes a non-blocking `connect(2)` (`docs/research/2026-08-02-macos12-vsock-nonblocking-connect.md`). The macOS 13+ path keeps the non-blocking-plus-poll idiom unchanged
- That blocking connect is bounded at the same `connectTimeoutSeconds` ceiling by running it on a throwaway thread the loop abandons: Darwin bounds `connect(2)` with no socket option, and a vsock connect does park indefinitely when the host holds a listener that never accepts (`docs/research/2026-08-02-macos12-vsock-blocking-connect-parks.md`). The abandoned worker keeps its socket and closes it when the kernel returns, so nothing is closed under an in-flight syscall, and `BlockingConnectGate` admits one connect per label so a stalled host cannot accumulate a thread per retry
- The File Provider servicing connector addresses its service by the domain root's user-visible URL below macOS 13: `getService(named:for:)` is a macOS 13 selector that Swift compiles ungated at the 12 floor, so a Monterey guest aborted on it the moment clipboard sharing was enabled (`docs/research/2026-08-02-macos12-fileprovider-getservice.md`)
- The "Enable in System Preferences…" command reaches the Extensions pane by opening the pane bundle's own file URL below 13: `com.apple.preferences.extensions` is the pane's real bundle identifier and System Preferences still does not route it, so the command used to leave the user at the main grid (`docs/research/2026-08-03-macos12-extensions-pane-deep-link.md`). The OS-era split moved into `enablementDeepLinks(systemSettings:)` so both candidate lists are testable from either OS

**Build**

- Per-target `MACOSX_DEPLOYMENT_TARGET = 12.0` (agent, agent FP extension, agent tests — project level stays 26); KernovaKit `platforms: .macOS(.v12)`; agent `MARKETING_VERSION` 0.52.0 → 0.53.0 in all four places (rebased over #696's own 0.52.0 bump) (forces guest reinstall per BUILD.md)
- `LD_RUNPATH_SEARCH_PATHS` on the agent app target, which had none and so inherited a list without `@executable_path/../Frameworks` — when Xcode links the packages dynamically the agent embeds frameworks it cannot resolve, and `install.command` aborts at its `--version` probe. The agent's own File Provider extension already declared both paths

**Tests and docs**

- Clock parameterization via `EngineClockKind`; `KernovaMacOSAgentTests` verified free of any macOS 13+ API; `AsyncWaits`/`EphemeralDefaults` made 12-safe
- `ClipboardFileProviderSettingsTests` pins that the deep-link candidate able to fail honestly stays ahead of the `x-apple.systempreferences:` one that reports success regardless
- README and ARCHITECTURE state host-vs-guest floors separately; ARCHITECTURE notes the clock seam and facades

## Test plan

- [x] `make test` green: host, agent, and package targets (2076 cases; the package built at the 12.0 floor)
- [x] KernovaKit + KernovaTestSupport compile at an `arm64-apple-macos27.0` target under `-warnings-as-errors` with zero diagnostics — the modern-end cleanliness gate from the issue
- [x] `make lint` green
- [x] 12.7.6 real guest: `install.command` succeeds and the control handshake completes and holds — host logs `Guest agent connected (service=1, agent=0.53.0, caps=control.v1,control.heartbeat.v1,clipboard.stream.v1,clipboard.dirtree.v1)` with no reconnect churn after
- [x] 12.7.6 real guest, clipboard sharing enabled: agent survives (no crash reports, PID stable), guest and host File Provider servicing connections both establish, host→guest passthrough verified end to end — a marker string put on the host pasteboard came back from `pbpaste` in the guest — and the control channel held 26 consecutive heartbeats across a mid-session clipboard off→on toggle, the sequence that first exposed all of this
- [x] 12.7.6 real guest, File Provider enablement: the status-item "Enable in System Preferences…" command lands on Extensions → Added Extensions with the agent's checkbox in view, and checking it there moves the guest's availability from `needsEnabling` to `ready`
- [ ] Remaining real-guest validation (issue #686, requirements 3–4): 12.0.1 and a modern guest, guest→host clipboard direction, File Provider file transfer end to end on 12 (app-group container sharing verified by data flow, stabilization behavior), and the save/restore watchdog pass — the only step that executes `MonotonicEngineClock` under the time-asleep condition the clockid choice exists for
- [ ] SANDBOX.md criterion-C qualification per what that testing shows (issue #686, requirement 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QADQnA4BCWirzxtTWNdBTw
