### PR TITLE
test: Clear the dead-code scan findings

### DIFF
--- a/KernovaTests/IPSWServiceDownloadTests.swift
+++ b/KernovaTests/IPSWServiceDownloadTests.swift
@@ -959,10 +959,10 @@ struct IPSWServiceDownloadTests {
         }
         defer { StubURLProtocol.handler = nil }
 
-        // `fileExistsResult` defaults to true, so the discard sees an image at
-        // the destination; the recording mock leaves the real path absent, so
-        // the skip-existing fast path (a real-FileManager check) stays out of
-        // the way and the GET below is the replacement download.
+        // `MockFileSystem.fileExists` always reports true, so the discard sees
+        // an image at the destination; the recording mock leaves the real path
+        // absent, so the skip-existing fast path (a real-FileManager check)
+        // stays out of the way and the GET below is the replacement download.
         let fileSystem = MockFileSystem()
         let service = Self.makeServiceWithStub(fileSystem: fileSystem)
         try await service.downloadRestoreImage(

--- a/KernovaTests/Mocks/MockFileSystem.swift
+++ b/KernovaTests/Mocks/MockFileSystem.swift
@@ -8,8 +8,8 @@ import Foundation
 /// exercising delete flows never deposit fixture files in the user's real
 /// Trash (and don't need to create fixture files at all — assertions read
 /// the recorded URLs). Errors are injectable per operation to drive the
-/// missing-file-swallow and failure-alert paths; `fileExistsResult` serves
-/// existence-gated branches like the coordinator's fresh-download cleanup.
+/// missing-file-swallow and failure-alert paths. `fileExists` always reports
+/// true, so existence-gated branches take their present-file path.
 ///
 /// Lock-based because production trashes from `Task.detached`, so calls
 /// arrive off the test's isolation.
@@ -19,7 +19,6 @@ final class MockFileSystem: FileSystemOperating, @unchecked Sendable {
         var removedURLs: [URL] = []
         var trashError: (any Error)?
         var removeError: (any Error)?
-        var fileExistsResult = true
     }
 
     private let lock = NSLock()
@@ -47,15 +46,10 @@ final class MockFileSystem: FileSystemOperating, @unchecked Sendable {
         set { lock.withLock { state.removeError = newValue } }
     }
 
-    var fileExistsResult: Bool {
-        get { lock.withLock { state.fileExistsResult } }
-        set { lock.withLock { state.fileExistsResult = newValue } }
-    }
-
     // MARK: - FileSystemOperating
 
-    func fileExists(atPath path: String) -> Bool {
-        lock.withLock { state.fileExistsResult }
+    func fileExists(atPath _: String) -> Bool {
+        true
     }
 
     func trashItem(at url: URL) throws {

--- a/KernovaTests/Mocks/RestoreImageCatalogFixtures.swift
+++ b/KernovaTests/Mocks/RestoreImageCatalogFixtures.swift
@@ -2,17 +2,6 @@ import Foundation
 
 @testable import Kernova
 
-/// In-memory stand-in for `RestoreImageCatalogProviding`.
-struct MockRestoreImageCatalogService: RestoreImageCatalogProviding {
-    var entries: [RestoreImageCatalogEntry]
-    var generatedAt: String?
-
-    init(entries: [RestoreImageCatalogEntry] = [], generatedAt: String? = "2026-07-28") {
-        self.entries = entries
-        self.generatedAt = generatedAt
-    }
-}
-
 /// Builds a catalog entry, defaulted so a test only names what it cares about.
 func makeCatalogEntry(
     version: String = "15.6.1",

--- a/KernovaTests/RemindersSettingsViewControllerTests.swift
+++ b/KernovaTests/RemindersSettingsViewControllerTests.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Foundation
-import KernovaTestSupport
 import Testing
 
 @testable import Kernova

--- a/KernovaTests/StatusMenuVMSectionTests.swift
+++ b/KernovaTests/StatusMenuVMSectionTests.swift
@@ -13,7 +13,7 @@ import Testing
 @MainActor
 struct StatusMenuVMSectionTests {
     private final class RowTarget: NSObject {
-        @objc func rowTapped(_ sender: NSMenuItem) {}
+        @objc func rowTapped(_: NSMenuItem) {}
     }
 
     private func makeInstance(name: String = "Test VM", status: VMStatus = .running) -> VMInstance {


### PR DESCRIPTION
Closes #704

## Summary

All four Periphery findings, all in `KernovaTests`. Every one is real — none is a false positive, so there is no `periphery:ignore` in this diff.

**Two orphaned seams (2 findings).** `MockFileSystem.fileExistsResult` and `MockRestoreImageCatalogService` are injection points nothing injects, and both gate production branches that consequently have no coverage. `fileExistsResult` is the only way to make the mock report a missing file, which is what `IPSWService.discardExistingImage` checks before trashing — so its skip-the-trash branch is untested. `MockRestoreImageCatalogService` is the only stand-in for `RestoreImageCatalogProviding`, and every test builds `VMCreationViewModel` with the default real `RestoreImageCatalogService`, so the `catalogService` injection point is never exercised with fixture entries. Both are removed rather than backfilled: a test written to justify an existing mock tests the mock, and neither gap clears the severity bar in [docs/REVIEW.md](docs/REVIEW.md) for a follow-up issue — they are coverage gaps on small, evidently-correct branches, not defects.

Deleting `fileExistsResult` leaves `MockFileSystem.fileExists` returning a constant `true`, which is what every existing test already depends on; it no longer takes the lock, since there is no shared state left to read. The `RestoreImageCatalogProviding` protocol itself stays — it is live in production, injected by `VMCreationViewModel` and read by `IPSWSelectionContentViewController`.

**Dead import (1 finding).** `RemindersSettingsViewControllerTests` imports `KernovaTestSupport` but uses nothing from it; its one helper, `makeEphemeralPreferences`, is declared in `KernovaTests/TestHelpers.swift` — the same target. That helper wraps `KernovaTestSupport.makeEphemeralDefaults` internally, but a Swift import is not transitively required at the call site.

**Unused `sender` (1 finding).** `RowTarget.rowTapped` is an empty `@objc` target/action stub reached only through `#selector`. The repo already decided this case: [`.periphery.yml`](.periphery.yml) notes under `retain_unused_protocol_func_params` that `@objc` action `sender` params "are handled at the source: the unused binding is renamed to `_`", and production carries the same shape in 15+ places. Only the internal name changes, so the selector stays `rowTapped:` and the three `#selector` sites are untouched.

## Changes

- `KernovaTests/Mocks/MockFileSystem.swift`
- `KernovaTests/Mocks/MockRestoreImageCatalogService.swift` → `KernovaTests/Mocks/RestoreImageCatalogFixtures.swift`
- `KernovaTests/IPSWServiceDownloadTests.swift`
- `KernovaTests/RemindersSettingsViewControllerTests.swift`
- `KernovaTests/StatusMenuVMSectionTests.swift`

The catalog mock's file is renamed, not deleted: it also declares `makeCatalogEntry`, used ~30 times across four suites, and the old filename named a type it no longer declares. The factory stays in `Mocks/` beside its peer `makeProbedImage` in `MockRestoreImageProbeService.swift`. No `project.pbxproj` edit is needed for the rename — `KernovaTests` is a `PBXFileSystemSynchronizedRootGroup`.

Test-only diff; no production sources touched.

## Test plan

- [x] `make test` — all three test targets pass. Load-bearing: `IPSWServiceDownloadTests.discardExistingDownloadTrashesThenDownloads` and `…CleanupFailureThrows` depend on `fileExists` continuing to report true, and `StatusMenuVMSectionTests`' three `#selector(RowTarget.rowTapped(_:))` sites must still resolve.
- [x] `make lint`
- [x] `periphery scan` (3.7.4, repo `.periphery.yml`) locally — reproduced all four findings verbatim at `89b3a54` before the change, *No unused code detected* after, with no new findings from the renamed parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GijsxiKaETDMVvTwfmTgad