### PR TITLE
fix: Stop the control-channel watchdog once it closes a silent channel

### DIFF
--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -25,17 +25,20 @@ struct ObservedAgentInfo: Equatable, Sendable {
 /// `VZVirtioSocketDevice`, independent of any feature toggle, and carries the
 /// bidirectional `Hello` handshake plus a `Heartbeat` stream where extended
 /// peer silence means the peer is hung. One instance manages one channel for
-/// one accepted connection; `stop()` is idempotent.
+/// one accepted connection and stops itself once that channel dies, whether the
+/// peer closed it or the watchdog did; `stop()` is idempotent and terminal, so
+/// a reconnect is served by a fresh instance.
 @MainActor
 @Observable
 final class VsockControlService {
     // MARK: - Observable state
 
-    /// `true` once the guest agent has sent its `Hello`; reset on `stop()`.
+    /// `true` once the guest agent has sent its `Hello`; reset when the
+    /// connection settles.
     private(set) var isConnected: Bool = false
 
     /// The guest-reported `Hello.agent_info.agent_version`, `nil` until that
-    /// `Hello` arrives and again after `stop()`.
+    /// `Hello` arrives and again once the connection settles.
     private(set) var agentVersion: String?
 
     /// `true` when the inbound liveness watchdog has fired but the channel has not yet been torn down.
@@ -76,6 +79,21 @@ final class VsockControlService {
     private var consumeTask: Task<Void, Never>?
     private var outboundHeartbeatTask: Task<Void, Never>?
     private var livenessTask: Task<Void, Never>?
+
+    /// Guards the teardown against re-entry: the liveness watchdog, the consume
+    /// task and the owner can each reach `stop()`, and whichever arrives first
+    /// is the one that settles.
+    private var hasStopped = false
+
+    #if DEBUG
+    /// The tasks `start()` spun up, so a test can await their completion instead
+    /// of polling for the watchdog to fall silent.
+    ///
+    /// Read it before the teardown that clears them.
+    var lifecycleTasksForTesting: [Task<Void, Never>] {
+        [consumeTask, outboundHeartbeatTask, livenessTask].compactMap { $0 }
+    }
+    #endif
 
     /// Instant of the most recent inbound frame of any kind — `Hello` and
     /// `Heartbeat` both count as liveness signals.
@@ -145,7 +163,7 @@ final class VsockControlService {
     // MARK: - Lifecycle
 
     func start() {
-        guard consumeTask == nil else { return }
+        guard consumeTask == nil, !hasStopped else { return }
 
         sendHello()
 
@@ -155,6 +173,9 @@ final class VsockControlService {
             await Self.consume(channel: channel, label: label) { @MainActor frame in
                 self?.handle(frame: frame)
             }
+            // The channel is gone once `consume` returns; settle so the
+            // heartbeat and liveness tasks stop running against a dead socket.
+            self?.stop()
         }
 
         let heartbeatInterval = self.heartbeatInterval
@@ -186,7 +207,15 @@ final class VsockControlService {
         Self.logger.info("Vsock control service started for '\(self.label, privacy: .public)'")
     }
 
+    /// Tears the service down and resets the handshake state.
+    ///
+    /// Safe to call from inside the tasks it cancels: `Task.cancel()` only sets
+    /// the cancellation flag, so a caller running inside the liveness or consume
+    /// task runs this method to completion and then unwinds at its own next
+    /// cancellation check.
     func stop() {
+        guard !hasStopped else { return }
+        hasStopped = true
         consumeTask?.cancel()
         consumeTask = nil
         outboundHeartbeatTask?.cancel()
@@ -294,9 +323,7 @@ final class VsockControlService {
             Self.logger.warning(
                 "Control channel for '\(self.label, privacy: .public)' silent for \(elapsed.formatted(.units(allowed: [.seconds])), privacy: .public) — closing"
             )
-            // Tearing the channel down lets the consume task return and the
-            // listener accept a fresh connection.
-            channel.close()
+            stop()
         } else if elapsed > unresponsiveAfter {
             if !isUnresponsive {
                 Self.logger.warning(
@@ -334,6 +361,10 @@ final class VsockControlService {
     }
 
     private func handle(frame: Frame) {
+        // A frame still buffered in `incoming` when the teardown ran would
+        // otherwise flip `isConnected` back on for a channel whose tasks are
+        // already cancelled.
+        guard !hasStopped else { return }
         guard frame.protocolVersion == 1 else {
             Self.logger.warning(
                 "Dropping frame with unsupported protocol version \(frame.protocolVersion, privacy: .public) for '\(self.label, privacy: .public)'"

--- a/KernovaTests/VMInstanceVsockAdmissionTests.swift
+++ b/KernovaTests/VMInstanceVsockAdmissionTests.swift
@@ -106,4 +106,55 @@ struct VMInstanceVsockAdmissionTests {
         #expect(!instance.admitsFeatureChannel(requiringClipboardStreaming: false))
         #expect(!instance.admitsFeatureChannel(requiringClipboardStreaming: true))
     }
+
+    @Test("A dead control channel withdraws admission, and a reconnect restores it")
+    func settleThenReconnectRestoresAdmission() async throws {
+        let instance = makeInstance()
+        let (firstGuestFd, firstHostFd) = try makeRawSocketPair()
+        let firstGuest = VsockChannel(fileDescriptor: firstGuestFd)
+        let firstHost = VsockChannel(fileDescriptor: firstHostFd)
+        firstGuest.start()
+        firstHost.start()
+        defer { firstGuest.close() }
+
+        let first = VsockControlService(channel: firstHost, label: "admission-test")
+        instance.vsockControlService = first
+        first.start()
+
+        try firstGuest.send(makeGuestHello(streamingCapable: true))
+        try await waitForChange {
+            instance.admitsFeatureChannel(requiringClipboardStreaming: true)
+        }
+
+        // Nobody calls stop() when a guest agent simply disappears — the
+        // service settles itself, and admission drops with it rather than
+        // keeping log and clipboard channels admitted onto a dead channel.
+        firstGuest.close()
+        try await waitForChange {
+            !instance.admitsFeatureChannel(requiringClipboardStreaming: false)
+        }
+        #expect(!instance.admitsFeatureChannel(requiringClipboardStreaming: true))
+
+        // The accept path, as `startVsockServices()` runs it: stop whatever is
+        // installed (a no-op on an already-settled service) and install a fresh
+        // one for the new channel.
+        let (secondGuestFd, secondHostFd) = try makeRawSocketPair()
+        let secondGuest = VsockChannel(fileDescriptor: secondGuestFd)
+        let secondHost = VsockChannel(fileDescriptor: secondHostFd)
+        secondGuest.start()
+        secondHost.start()
+        defer { secondGuest.close() }
+
+        instance.vsockControlService?.stop()
+        let second = VsockControlService(channel: secondHost, label: "admission-test")
+        instance.vsockControlService = second
+        second.start()
+        defer { second.stop() }
+
+        try secondGuest.send(makeGuestHello(streamingCapable: true))
+        try await waitForChange {
+            instance.admitsFeatureChannel(requiringClipboardStreaming: true)
+        }
+        #expect(instance.vsockControlService !== first)
+    }
 }

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -485,8 +485,8 @@ struct VsockControlServiceTests {
         #expect(service.agentStatus == .current(version: "0.9.0"))
     }
 
-    @Test("Silence past terminateAfter closes the host channel")
-    func terminateClosesChannel() async throws {
+    @Test("Silence past terminateAfter settles the service and stops the watchdog")
+    func terminateSettlesTheService() async throws {
         let (guest, host) = try makePair()
         guest.start()
         host.start()
@@ -506,24 +506,88 @@ struct VsockControlServiceTests {
         service.start()
         defer { service.stop() }
 
+        // Captured now: the teardown clears the handles.
+        let lifecycleTasks = service.lifecycleTasksForTesting
+
         _ = try await nextFrame(from: guest)  // host hello
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))
         try await waitForChange { service.isConnected }
 
-        // Wait for a few terminateAfter windows. By then `checkLiveness`
-        // should have fired and called `channel.close()` on the host side.
-        // After teardown, `host.send(...)` raises `VsockChannelError.closed`.
-        // RATIONALE: sanctioned exception-catch poll (docs/TESTING.md "Async
-        // waits in tests") — closure is only detectable by a send raising
-        // `.closed`; the watchdog closes the socket with no signal to await.
-        try await waitUntil {
-            do {
-                try host.send(makeHeartbeat(nonce: 1))
-                return false
-            } catch {
-                return true
-            }
+        // Send nothing further: the watchdog terminates the connection. The
+        // service has to settle rather than re-fire every tick against a frozen
+        // `lastInboundFrame`.
+        try await waitForChange { !service.isConnected }
+
+        // Every periodic task runs to completion — no watchdog tick and no
+        // heartbeat send survives the teardown.
+        for task in lifecycleTasks {
+            await task.value
         }
+        #expect(service.lifecycleTasksForTesting.isEmpty)
+        #expect(service.agentVersion == nil)
+        #expect(service.agentStatus == .waiting)
+        // The channel went with it: the teardown closes before clearing
+        // `isConnected`, so this is ordered, not racy.
+        #expect(throws: VsockChannelError.closed) { try host.send(makeHeartbeat()) }
+    }
+
+    @Test("A channel closed by the peer settles the service")
+    func consumeEndSettlesTheService() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        // Watchdog disabled (the makeService default), so only the consume
+        // path can settle this one.
+        let service = makeService(channel: host, bundledAgentVersion: "0.9.0")
+        service.start()
+        defer { service.stop() }
+
+        let lifecycleTasks = service.lifecycleTasksForTesting
+
+        _ = try await nextFrame(from: guest)  // host hello
+        try guest.send(makeGuestHello(agentVersion: "0.9.0"))
+        try await waitForChange { service.isConnected }
+
+        // The guest agent goes away: EOF unwinds the consume loop, and nobody
+        // calls stop() on the host side until the *next* accept.
+        guest.close()
+
+        try await waitForChange { !service.isConnected }
+        for task in lifecycleTasks {
+            await task.value
+        }
+        #expect(service.agentVersion == nil)
+        #expect(service.agentStatus == .waiting)
+
+        // Settle-then-explicit-stop: the owner still tears down normally.
+        service.stop()
+        #expect(!service.isConnected)
+    }
+
+    @Test("A settled service is terminal — start() does not resurrect it")
+    func settledServiceStaysDown() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let service = makeService(channel: host, bundledAgentVersion: "0.9.0")
+        service.start()
+
+        _ = try await nextFrame(from: guest)  // host hello
+        try guest.send(makeGuestHello(agentVersion: "0.9.0"))
+        try await waitForChange { service.isConnected }
+
+        guest.close()
+        try await waitForChange { !service.isConnected }
+
+        // A reconnect is served by a fresh instance built at accept time, so
+        // restarting this one would only spin tasks against a dead socket.
+        service.start()
+        #expect(!service.isConnected)
+        #expect(service.lifecycleTasksForTesting.isEmpty)
     }
 
     // MARK: - Lifecycle

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -575,6 +575,7 @@ struct VsockControlServiceTests {
 
         let service = makeService(channel: host, bundledAgentVersion: "0.9.0")
         service.start()
+        defer { service.stop() }
 
         _ = try await nextFrame(from: guest)  // host hello
         try guest.send(makeGuestHello(agentVersion: "0.9.0"))


### PR DESCRIPTION
## Summary

`VsockControlService.checkLiveness()` closed a control channel that had gone silent past `terminateAfter` and then left everything else running. `VsockChannel.teardown` early-returns on its closed guard, so every later close was a no-op while the liveness task kept ticking against a frozen `lastInboundFrame` — the host logged "silent for N sec — closing" every 5 s forever, `isConnected` stayed `true` (so `admitsFeatureChannel` kept letting log and clipboard channels onto a dead channel), and each heartbeat threw `.closed`.

The service now settles itself from **either** death path:

- **Liveness timeout** — `checkLiveness()`'s terminate branch calls `stop()` instead of `channel.close()`.
- **Consume loop ending** — the consume task calls `stop()` once `incoming` finishes, which is what was missing on a plain EOF.

A `hasStopped` latch makes the teardown happen exactly once no matter which of the three callers (watchdog, consume task, owner) arrives first. Reconnects are unaffected: the listener host is untouched, and `VMInstance.startVsockServices()`'s accept closure already builds a fresh service per connection, so the settled instance is simply replaced.

Calling `stop()` from inside the tasks it cancels is safe, and that is the load-bearing detail: `Task.cancel()` only sets the cancellation flag, and `stop()` has no suspension point after the self-cancel, so it runs to completion and the caller's loop exits at its own next `Task.isCancelled` check. That contract is now on `stop()`'s doc comment.

Closes #703

## Changes

- `Kernova/Services/VsockControlService.swift` — `hasStopped` latch on `stop()`; `checkLiveness()` and the consume task both reach it. `start()` refuses to restart a stopped service and `handle(frame:)` drops frames buffered past the teardown, so the settled state stays terminal. Adds a `#if DEBUG` `lifecycleTasksForTesting` seam.
- `KernovaTests/VsockControlServiceTests.swift` — `terminateClosesChannel` becomes `terminateSettlesTheService`; new `consumeEndSettlesTheService` and `settledServiceStaysDown`.
- `KernovaTests/VMInstanceVsockAdmissionTests.swift` — new `settleThenReconnectRestoresAdmission`.

Tests await the production tasks' completion (docs/TESTING.md's third seam) rather than asserting on `isConnected` alone — a fix that reset the flag but left the watchdog looping would pass an `isConnected`-only test.

## Deviations from what the issue proposed

- **The latch went on the service, not the channel.** The issue points at `VsockChannel.teardown`'s closed guard; that guard is correct as-is. The missing latch is `hasStopped` on `VsockControlService`, which is what makes the teardown run exactly once across three possible callers.
- **No mirror of the guest's `defer`-based structure.** The issue cites `VsockGuestControlAgent.serve`'s `defer { heartbeatTask.cancel(); livenessTask.cancel() }`. The host's tasks are unstructured and owned by the service rather than by a `serve` frame, so the equivalent is `stop()` reached from both death paths — a `defer` inside the consume task would cover EOF only, missing the liveness timeout that the issue actually observed.
- **Feature channels are deliberately excluded.** `consume` is a private static per service, not shared. `VsockGuestLogService` holds no observable state, and `VsockClipboardService`'s consume task already runs a targeted completion (`receiver.cancelAll()`, `lazyCoordinator.failAll()`); promoting that to a full `stop()` would ref-count down the shared File Provider domain while a paste may still be materializing. Neither runs a periodic task, so neither has this bug.
- **No `VMInstance` change.** `VsockControlService` is `@Observable` and the status UI already tracks `agentStatus`, so the teardown propagates with no wiring. An `onSettled` callback clearing `vmInstance.vsockControlService` would be actively wrong: a settle can land *after* the accept path installed a replacement, and would null out the fresh service.

## Behavior change worth flagging

`agentStatus` goes from a permanent `.unresponsive(version:)` to `.connecting(expected:)` at teardown. Preserving `.unresponsive` was implemented first and then rejected: the watchdog cannot distinguish a hung agent from a **live-paused VM** — a >30 s pause goes silent the same way — so latching a warning-colored "Guest agent unresponsive" badge past teardown asserts a cause the service does not know. A paused VM now gets the gray connecting state and recovers to `.current` on resume.

The cost is that `.connecting`'s popover copy promises a "didn't reconnect" escalation that the one-shot post-start watchdog will not deliver mid-session. Filed as #706 rather than fixed here: re-arming that watchdog naively would fire a false `.expectedMissing` on any live-paused VM and silently clear the user's `agentInstallNudgeDismissed` preference.

## Test plan

- [x] `make build`
- [x] `make test` — all three targets green
- [x] `make lint`