### PR TITLE
feat: Name the latest-download IPSW for its probed version and build

### DIFF
--- a/Kernova/Models/LatestRestoreImage.swift
+++ b/Kernova/Models/LatestRestoreImage.swift
@@ -11,4 +11,9 @@ struct LatestRestoreImage: Sendable, Equatable {
     var version: String
     /// Apple build identifier, e.g. `"25F84"`.
     var build: String
+
+    /// The filename the download lands on, derived from ``url``.
+    var suggestedFilename: String {
+        RestoreImageFilename.destination(for: url)
+    }
 }

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -111,7 +111,8 @@ final class VMCreationViewModel {
     /// What "Download Latest" will fetch, once ``loadLatestImageDetails()`` has
     /// answered; `nil` until then, and after a lookup that failed.
     ///
-    /// Display only, on the terms ``LatestRestoreImage`` states.
+    /// A preview on the terms ``LatestRestoreImage`` states, read for display
+    /// and to name the download destination.
     private(set) var latestImage: LatestRestoreImage?
 
     /// How large ``latestImage`` is, when the server reported a size.
@@ -131,8 +132,9 @@ final class VMCreationViewModel {
     private(set) var lastPastedImage: ProbedRestoreImage?
     /// Always inside Downloads — there is no custom-destination picker.
     ///
-    /// A pinned pick names the file through ``RestoreImageFilename``;
-    /// "Download Latest" keeps the fixed default.
+    /// Every download source names the file through ``RestoreImageFilename``;
+    /// "Download Latest" starts on the fixed fallback and adopts the looked-up
+    /// image's name once ``loadLatestImageDetails()`` answers.
     var ipswDownloadPath: String = VMCreationViewModel.defaultIPSWDownloadPath {
         didSet {
             if ipswDownloadPath != confirmedOverwritePath {
@@ -311,8 +313,8 @@ final class VMCreationViewModel {
         ipswDownloadPath = Self.downloadPath(forFilename: image.suggestedFilename)
     }
 
-    /// Commits the "Download Latest" source, returning the destination to the
-    /// fixed filename that source has always resolved to at install time.
+    /// Commits the "Download Latest" source, naming the destination for the
+    /// image the lookup found — or the fixed fallback while none has answered.
     ///
     /// The one operation that drops both sheet seeds: choosing to install
     /// whatever is newest retracts the earlier "install *this* build" answers.
@@ -320,7 +322,8 @@ final class VMCreationViewModel {
         ipswSelection = .downloadLatest
         lastCatalogPick = nil
         lastPastedImage = nil
-        ipswDownloadPath = Self.defaultIPSWDownloadPath
+        ipswDownloadPath = Self.downloadPath(
+            forFilename: latestImage?.suggestedFilename ?? RestoreImageFilename.fallback)
     }
 
     /// Commits a panel-picked file together with the grant minted for it, which
@@ -332,7 +335,8 @@ final class VMCreationViewModel {
     // MARK: - Latest Image Lookup
 
     /// Looks up what "Download Latest" would fetch, so the wizard can name the
-    /// version, build and size that source otherwise leaves unsaid.
+    /// version, build, size and destination filename that source otherwise
+    /// leaves unsaid.
     ///
     /// Idempotent: calls while a lookup runs join it, calls after one succeeded
     /// do nothing, and one that failed retries on the next call — a wizard the
@@ -365,6 +369,12 @@ final class VMCreationViewModel {
             guard let self else { return }
             self.latestImage = image
             self.latestImageSizeBytes = sizeBytes
+            // Only while the source is still current — a pick made while the
+            // lookup ran named its own destination.
+            if self.ipswSelection == .downloadLatest {
+                self.ipswDownloadPath = Self.downloadPath(
+                    forFilename: image.suggestedFilename)
+            }
         }
         latestImageTask = task
         return task
@@ -468,13 +478,14 @@ final class VMCreationViewModel {
         ipswSelection = .localFile(path: ipswDownloadPath, bookmark: nil)
     }
 
-    /// The build the wizard is currently promising, or `nil` when the source
-    /// names no particular image.
-    var pinnedBuild: String? {
+    /// The build the wizard is currently promising — a pinned pick's, or the
+    /// looked-up latest one — or `nil` while no particular image is named.
+    var expectedBuild: String? {
         switch ipswSelection {
         case .catalogVersion(let entry): entry.build
         case .customURL(let image): image.build
-        case .downloadLatest, .localFile: nil
+        case .downloadLatest: latestImage?.build
+        case .localFile: nil
         }
     }
 
@@ -523,8 +534,8 @@ final class VMCreationViewModel {
                     ?? "That restore image can't install on this Mac.")
         }
 
-        if let pinnedBuild, pinnedBuild != inspected.build {
-            return .mismatch(expected: pinnedBuild, found: inspected)
+        if let expectedBuild, expectedBuild != inspected.build {
+            return .mismatch(expected: expectedBuild, found: inspected)
         }
 
         useExistingDownloadFile()

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -469,13 +469,18 @@ final class VMCreationViewModel {
         confirmedOverwritePath = ipswDownloadPath
     }
 
-    /// Adopts the file already sitting at the download destination.
+    /// Adopts the file at `path`, which the caller inspected or the user
+    /// explicitly accepted.
+    ///
+    /// The caller supplies the path it showed the user rather than this reading
+    /// ``ipswDownloadPath``, which the latest-image lookup can move while a
+    /// decision is pending.
     ///
     /// No bookmark: the file was adopted without a panel, so there is no grant
     /// to capture — and none is needed, the Downloads location being
     /// entitlement-covered.
-    func useExistingDownloadFile() {
-        ipswSelection = .localFile(path: ipswDownloadPath, bookmark: nil)
+    func useExistingDownloadFile(at path: String) {
+        ipswSelection = .localFile(path: path, bookmark: nil)
     }
 
     /// The build the wizard is currently promising — a pinned pick's, or the
@@ -503,8 +508,9 @@ final class VMCreationViewModel {
         case cancelled
     }
 
-    /// Checks the file sitting at the download destination, and adopts it only
-    /// if it is the image the wizard is promising.
+    /// Checks the file at `path` — the caller's snapshot of the destination it
+    /// showed the user — and adopts it only if it is the image the wizard is
+    /// promising.
     ///
     /// Without this, "Use Existing File" takes whatever is at the path. A file
     /// that is a *valid but different* macOS installs silently — the same
@@ -512,10 +518,15 @@ final class VMCreationViewModel {
     /// a stale or hand-placed file reintroduces.
     ///
     /// Reading a multi-gigabyte image takes seconds, in which the user can pick
-    /// another source or leave the step: a cancelled call returns
-    /// ``ExistingFileVerdict/cancelled`` having changed nothing.
-    func adoptExistingDownloadFile() async -> ExistingFileVerdict {
-        let url = URL(fileURLWithPath: ipswDownloadPath)
+    /// another source or leave the step — a cancelled call returns
+    /// ``ExistingFileVerdict/cancelled`` having changed nothing — and the
+    /// latest-image lookup can move ``ipswDownloadPath`` and ``expectedBuild``:
+    /// both the verdict and any adoption describe the file the user was asked
+    /// about, so the path comes in as the caller's snapshot and the build is
+    /// snapshotted before the inspection.
+    func adoptExistingDownloadFile(at path: String) async -> ExistingFileVerdict {
+        let expectedBuild = expectedBuild
+        let url = URL(fileURLWithPath: path)
         let inspected: InspectedRestoreImage
         do {
             inspected = try await localImageInspector.inspect(url)
@@ -538,7 +549,7 @@ final class VMCreationViewModel {
             return .mismatch(expected: expectedBuild, found: inspected)
         }
 
-        useExistingDownloadFile()
+        useExistingDownloadFile(at: path)
         return .adopted(inspected)
     }
 

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -238,21 +238,21 @@ final class VMLifecycleCoordinator {
                     )
                     instance.status = .installing
 
-                    // A catalog pick or a checked URL names its image at wizard
-                    // time, so the install downloads that build however long it
-                    // sits unstarted. Only "Download Latest" resolves here.
+                    // Local because a moved latest destination lapses it below.
+                    var requestedFreshDownload = context.requestedFreshDownload
+
+                    // A catalog pick or a checked URL names its image and its
+                    // destination at wizard time, so the install downloads that
+                    // build however long it sits unstarted. Only "Download
+                    // Latest" resolves here, and its destination follows the
+                    // answer.
                     let remoteURL: URL
+                    let downloadDestination: URL
                     if context.source.usesPinnedURL {
                         guard let pinnedURL = context.remoteURL else {
                             throw IPSWError.noDownloadURL
                         }
                         remoteURL = pinnedURL
-                    } else {
-                        remoteURL = try await ipswService.fetchLatestRestoreImage().url
-                    }
-
-                    let downloadDestination: URL
-                    if context.source.usesPinnedURL {
                         // A persisted destination outside Downloads (a hand-edited
                         // config.json) can never be written and has no picker to
                         // re-point it, so the invariant is enforced at use time.
@@ -264,18 +264,31 @@ final class VMLifecycleCoordinator {
                             )
                         }
                     } else {
+                        remoteURL = try await ipswService.fetchLatestRestoreImage().url
                         downloadDestination = latestDownloadDestination(
                             persisted: persistedDestination, resolvedURL: remoteURL)
                         if downloadDestination != persistedDestination {
                             Self.logger.notice(
                                 "installMacOS: resolved latest image names the download '\(downloadDestination.lastPathComponent, privacy: .public)'"
                             )
+                            // "Download & Replace" was confirmed against the
+                            // wizard's destination; a destination that moved
+                            // names a file the user never saw, so the intent
+                            // lapses rather than retargets.
+                            requestedFreshDownload = false
+                            // A moved destination also means the fetch changed
+                            // builds, so the old path's partial download can
+                            // never be resumed — discard its sidecar before the
+                            // only pointer to it moves.
+                            ipswService.discardResumeData(
+                                at: persistedDestination, permanently: false)
                             // Keep the persisted path on the file the download
                             // actually writes, so resume across relaunches and
                             // delete-time cleanup stay keyed to it.
                             instance.performConfigurationMutation {
                                 $0.installContext?.downloadDestinationPath =
                                     downloadDestination.path(percentEncoded: false)
+                                $0.installContext?.requestedFreshDownload = false
                             }
                         }
                     }
@@ -286,7 +299,7 @@ final class VMLifecycleCoordinator {
                     // could delete bytes another VM is streaming into the same
                     // bundle. The flag clears before the download so a retry
                     // after a partial-install failure reuses what it fetched.
-                    if context.requestedFreshDownload {
+                    if requestedFreshDownload {
                         // `downloadDestinationPath` survives through `config.json`
                         // on disk, so a stray edit could otherwise have us
                         // trashing an arbitrary file.
@@ -310,7 +323,7 @@ final class VMLifecycleCoordinator {
                     try await ipswService.downloadRestoreImage(
                         from: remoteURL,
                         to: downloadDestination,
-                        discardsExistingDownload: context.requestedFreshDownload
+                        discardsExistingDownload: requestedFreshDownload
                     ) { progress in
                         instance.installState?.currentPhase = .downloading(progress)
                     }

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -172,6 +172,20 @@ final class VMLifecycleCoordinator {
         return downloads.appendingPathComponent(filename)
     }
 
+    /// The destination a "Download Latest" install writes to, named by the URL
+    /// the install just resolved.
+    ///
+    /// The persisted path is only the wizard's preview of that answer: the
+    /// newest build can move between wizard and Start, and only a name derived
+    /// from the URL actually fetched keeps ``RestoreImageFilename``'s per-build
+    /// identity honest for the file the bytes land in. Falls back to the
+    /// persisted path when normalization is disabled.
+    func latestDownloadDestination(persisted: URL, resolvedURL: URL) -> URL {
+        guard let downloads = downloadsDirectory else { return persisted }
+        return downloads.appendingPathComponent(
+            RestoreImageFilename.destination(for: resolvedURL))
+    }
+
     /// Whether `candidate` names a file sitting directly in the Downloads
     /// directory, which the directory itself does not.
     ///
@@ -217,15 +231,53 @@ final class VMLifecycleCoordinator {
                     guard let persistedDestination = context.downloadDestinationURL else {
                         throw IPSWError.noDownloadURL
                     }
-                    // A persisted destination outside Downloads (a hand-edited
-                    // config.json) can never be written and has no picker to
-                    // re-point it, so the invariant is enforced at use time.
-                    let downloadDestination = normalizedDownloadDestination(
-                        for: persistedDestination, remoteURL: context.remoteURL)
-                    if downloadDestination != persistedDestination {
-                        Self.logger.notice(
-                            "installMacOS: persisted download destination is outside Downloads; using the derived destination instead"
-                        )
+
+                    instance.installState = MacOSInstallState(
+                        hasDownloadStep: true,
+                        currentPhase: .downloading(.zero)
+                    )
+                    instance.status = .installing
+
+                    // A catalog pick or a checked URL names its image at wizard
+                    // time, so the install downloads that build however long it
+                    // sits unstarted. Only "Download Latest" resolves here.
+                    let remoteURL: URL
+                    if context.source.usesPinnedURL {
+                        guard let pinnedURL = context.remoteURL else {
+                            throw IPSWError.noDownloadURL
+                        }
+                        remoteURL = pinnedURL
+                    } else {
+                        remoteURL = try await ipswService.fetchLatestRestoreImage().url
+                    }
+
+                    let downloadDestination: URL
+                    if context.source.usesPinnedURL {
+                        // A persisted destination outside Downloads (a hand-edited
+                        // config.json) can never be written and has no picker to
+                        // re-point it, so the invariant is enforced at use time.
+                        downloadDestination = normalizedDownloadDestination(
+                            for: persistedDestination, remoteURL: remoteURL)
+                        if downloadDestination != persistedDestination {
+                            Self.logger.notice(
+                                "installMacOS: persisted download destination is outside Downloads; using the derived destination instead"
+                            )
+                        }
+                    } else {
+                        downloadDestination = latestDownloadDestination(
+                            persisted: persistedDestination, resolvedURL: remoteURL)
+                        if downloadDestination != persistedDestination {
+                            Self.logger.notice(
+                                "installMacOS: resolved latest image names the download '\(downloadDestination.lastPathComponent, privacy: .public)'"
+                            )
+                            // Keep the persisted path on the file the download
+                            // actually writes, so resume across relaunches and
+                            // delete-time cleanup stay keyed to it.
+                            instance.performConfigurationMutation {
+                                $0.installContext?.downloadDestinationPath =
+                                    downloadDestination.path(percentEncoded: false)
+                            }
+                        }
                     }
 
                     // Honor "Download & Replace" intent ONCE: the download
@@ -253,25 +305,6 @@ final class VMLifecycleCoordinator {
                         instance.performConfigurationMutation {
                             $0.installContext?.requestedFreshDownload = false
                         }
-                    }
-
-                    instance.installState = MacOSInstallState(
-                        hasDownloadStep: true,
-                        currentPhase: .downloading(.zero)
-                    )
-                    instance.status = .installing
-
-                    // A catalog pick or a checked URL names its image at wizard
-                    // time, so the install downloads that build however long it
-                    // sits unstarted. Only "Download Latest" resolves here.
-                    let remoteURL: URL
-                    if context.source.usesPinnedURL {
-                        guard let pinnedURL = context.remoteURL else {
-                            throw IPSWError.noDownloadURL
-                        }
-                        remoteURL = pinnedURL
-                    } else {
-                        remoteURL = try await ipswService.fetchLatestRestoreImage().url
                     }
 
                     try await ipswService.downloadRestoreImage(

--- a/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import UniformTypeIdentifiers
+import os
 
 /// Step 2 of the creation wizard for macOS guests: choose where the IPSW restore
 /// image comes from, show which image that is and where it lands, and surface
@@ -10,6 +11,9 @@ import UniformTypeIdentifiers
 /// shell observes the model separately to keep its Next button in sync.
 @MainActor
 final class IPSWSelectionContentViewController: NSViewController {
+    private static let logger = Logger(
+        subsystem: "app.kernova", category: "IPSWSelectionContentViewController")
+
     private let creationVM: VMCreationViewModel
 
     private var radios: [IPSWSource: NSButton] = [:]
@@ -27,6 +31,9 @@ final class IPSWSelectionContentViewController: NSViewController {
         case unusable(message: String)
     }
     private var existingFileNotice: ExistingFileNotice?
+    /// The destination ``existingFileNotice`` describes, set with it; a notice
+    /// whose path the latest-image lookup has moved away from is stale.
+    private var existingFileNoticePath: String?
     /// In-flight inspection, so a second click can't race the first.
     private var adoptTask: Task<Void, Never>?
     /// Redraws the badge once the model's latest-image lookup lands.
@@ -272,10 +279,15 @@ final class IPSWSelectionContentViewController: NSViewController {
     private func addDownloadBanners(version: String?) {
         let subject = version.map { "macOS \($0)" }
         // A verdict on the existing file supersedes the plain overwrite
-        // warning — it says something more specific about the same file.
+        // warning — it says something more specific about the same file. One
+        // for a destination the lookup has since moved away from describes a
+        // file that no longer matters, so it drops instead of rendering.
         if let notice = existingFileNotice {
-            addExistingFileNotice(notice)
-            return
+            if existingFileNoticePath == creationVM.ipswDownloadPath {
+                addExistingFileNotice(notice)
+                return
+            }
+            clearExistingFileNotice()
         }
         if creationVM.shouldShowOverwriteWarning {
             let useExisting = NSButton(
@@ -364,11 +376,13 @@ final class IPSWSelectionContentViewController: NSViewController {
     /// IPSW can't stand in for the version the wizard is showing.
     @objc private func useExistingTapped() {
         guard adoptTask == nil else { return }
+        let path = creationVM.ipswDownloadPath
         existingFileNotice = .checking
+        existingFileNoticePath = path
         rebuildConditional()
         adoptTask = Task { [weak self] in
             guard let self else { return }
-            let verdict = await self.creationVM.adoptExistingDownloadFile()
+            let verdict = await self.creationVM.adoptExistingDownloadFile(at: path)
             switch verdict {
             case .cancelled:
                 // The canceller dropped this task and the notice already, and a
@@ -388,8 +402,13 @@ final class IPSWSelectionContentViewController: NSViewController {
 
     /// Adopts the file the mismatch banner described, on the user's say-so.
     @objc private func useExistingAnywayTapped() {
-        creationVM.useExistingDownloadFile()
-        existingFileNotice = nil
+        guard let path = existingFileNoticePath else {
+            Self.logger.fault("Use It Anyway tapped with no notice path")
+            assertionFailure("A mismatch banner is showing, so its path must be set")
+            return
+        }
+        creationVM.useExistingDownloadFile(at: path)
+        clearExistingFileNotice()
         refresh()
     }
 
@@ -405,6 +424,7 @@ final class IPSWSelectionContentViewController: NSViewController {
         adoptTask?.cancel()
         adoptTask = nil
         existingFileNotice = nil
+        existingFileNoticePath = nil
     }
 
     // MARK: - Panels

--- a/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
+++ b/Kernova/Views/Creation/IPSWSelectionContentViewController.swift
@@ -221,11 +221,10 @@ final class IPSWSelectionContentViewController: NSViewController {
                 conditionalContainer.addArrangedSubview(
                     makeWizardPathBadge(path: creationVM.ipswDownloadPath))
             }
-            // `version: nil` even once the lookup lands: this source pins no
-            // build and shares one destination filename, so the file already
-            // sitting there may be any image, and naming the version the badge
-            // shows would describe that file wrongly.
-            addDownloadBanners(version: nil)
+            // The subject follows the lookup: until it lands the destination is
+            // the shared fallback filename, whose occupant may be any image;
+            // once it lands, the destination is per-build like a pinned pick's.
+            addDownloadBanners(version: creationVM.latestImage?.version)
         case .catalogVersion(let entry):
             addPinnedImageBadge(
                 parts: [

--- a/KernovaTests/Mocks/MockIPSWService.swift
+++ b/KernovaTests/Mocks/MockIPSWService.swift
@@ -12,20 +12,11 @@ final class MockIPSWService: IPSWProviding, @unchecked Sendable {
     var lastDiscardResumeDataURL: URL?
     var lastDiscardResumeDataPermanently: Bool?
 
-    private static let mockRestoreImageURL: URL = {
-        guard let url = URL(string: "https://example.com/restore.ipsw") else {
-            assertionFailure("MockIPSWService: failed to construct mock restore image URL")
-            return URL(filePath: "/")
-        }
-        return url
-    }()
-
     var fetchError: (any Error)?
     var downloadError: (any Error)?
 
     /// Returned on success; defaults to a plausible newest release.
-    var fetchResult = LatestRestoreImage(
-        url: MockIPSWService.mockRestoreImageURL, version: "26.5.2", build: "25F84")
+    var fetchResult = makeLatestImage()
 
     func fetchLatestRestoreImage() async throws -> LatestRestoreImage {
         fetchCallCount += 1
@@ -51,4 +42,25 @@ final class MockIPSWService: IPSWProviding, @unchecked Sendable {
         lastDiscardResumeDataURL = destinationURL
         lastDiscardResumeDataPermanently = permanently
     }
+}
+
+/// Builds the answer a latest-image lookup returns, defaulted so a test names
+/// only what it cares about.
+///
+/// The default URL follows Apple's own convention, so the filename it derives
+/// is the readable `UniversalMac_<version>_<build>_Restore.ipsw` rather than a
+/// digest — pass `urlString` to exercise the off-convention path.
+func makeLatestImage(
+    version: String = "26.5.2",
+    build: String = "25F84",
+    urlString: String? = nil
+) -> LatestRestoreImage {
+    let resolved =
+        urlString
+        ?? "https://updates.cdn-apple.com/fullrestores/UniversalMac_\(version)_\(build)_Restore.ipsw"
+    return LatestRestoreImage(
+        url: URL(string: resolved) ?? URL(fileURLWithPath: "/"),
+        version: version,
+        build: build
+    )
 }

--- a/KernovaTests/Mocks/MockIPSWService.swift
+++ b/KernovaTests/Mocks/MockIPSWService.swift
@@ -58,9 +58,10 @@ func makeLatestImage(
     let resolved =
         urlString
         ?? "https://updates.cdn-apple.com/fullrestores/UniversalMac_\(version)_\(build)_Restore.ipsw"
-    return LatestRestoreImage(
-        url: URL(string: resolved) ?? URL(fileURLWithPath: "/"),
-        version: version,
-        build: build
-    )
+    guard let url = URL(string: resolved) else {
+        assertionFailure("makeLatestImage: could not build a URL from '\(resolved)'")
+        return LatestRestoreImage(
+            url: URL(fileURLWithPath: "/"), version: version, build: build)
+    }
+    return LatestRestoreImage(url: url, version: version, build: build)
 }

--- a/KernovaTests/Mocks/MockMacOSInstallService.swift
+++ b/KernovaTests/Mocks/MockMacOSInstallService.swift
@@ -5,6 +5,7 @@ import Foundation
 @MainActor
 final class MockMacOSInstallService: MacOSInstallProviding {
     var installCallCount = 0
+    var lastRestoreImageURL: URL?
 
     var installError: (any Error)?
 
@@ -14,6 +15,7 @@ final class MockMacOSInstallService: MacOSInstallProviding {
         progressHandler: @MainActor @Sendable @escaping (Double) -> Void
     ) async throws {
         installCallCount += 1
+        lastRestoreImageURL = restoreImageURL
         if let error = installError { throw error }
         // Mirror the real `MacOSInstallService` post-install state: VM
         // released (via `guestDidStop` → `resetToStopped` in production

--- a/KernovaTests/RestoreImageProbeTests.swift
+++ b/KernovaTests/RestoreImageProbeTests.swift
@@ -123,6 +123,23 @@ struct ProbedRestoreImageTests {
     }
 }
 
+@Suite("LatestRestoreImage Tests")
+struct LatestRestoreImageTests {
+    @Test("The destination is Apple's filename for the URL the lookup returned")
+    func suggestedFilename() {
+        #expect(
+            makeLatestImage(version: "26.5.2", build: "25F84").suggestedFilename
+                == "UniversalMac_26.5.2_25F84_Restore.ipsw")
+    }
+
+    @Test("An off-convention URL gets a generated name, never the shared fallback")
+    func suggestedFilenameForOffConventionURL() {
+        let image = makeLatestImage(urlString: "https://example.com/restore.ipsw")
+        #expect(image.suggestedFilename.hasSuffix(".ipsw"))
+        #expect(image.suggestedFilename != RestoreImageFilename.fallback)
+    }
+}
+
 @Suite("RestoreImageFilename Tests")
 struct RestoreImageFilenameTests {
     @Test("A plain .ipsw filename passes through")

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -453,7 +453,7 @@ struct VMCreationViewModelTests {
         let vm = VMCreationViewModel()
         vm.ipswDownloadPath = "/usr/bin/true"
 
-        vm.useExistingDownloadFile()
+        vm.useExistingDownloadFile(at: vm.ipswDownloadPath)
 
         #expect(vm.ipswSelection == .localFile(path: "/usr/bin/true", bookmark: nil))
     }
@@ -800,7 +800,7 @@ struct VMCreationViewModelTests {
         let vm = VMCreationViewModel()
         vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
         let destination = vm.ipswDownloadPath
-        vm.useExistingDownloadFile()
+        vm.useExistingDownloadFile(at: destination)
 
         #expect(vm.ipswSelection == .localFile(path: destination, bookmark: nil))
     }
@@ -810,7 +810,7 @@ struct VMCreationViewModelTests {
         let vm = VMCreationViewModel()
         let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
         vm.selectCatalogEntry(entry)
-        vm.useExistingDownloadFile()
+        vm.useExistingDownloadFile(at: vm.ipswDownloadPath)
 
         #expect(vm.ipswSource == .localFile)
         #expect(vm.lastCatalogPick == entry)
@@ -919,7 +919,7 @@ struct VMCreationViewModelTests {
         vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
         let destination = vm.ipswDownloadPath
 
-        let verdict = await vm.adoptExistingDownloadFile()
+        let verdict = await vm.adoptExistingDownloadFile(at: destination)
 
         #expect(verdict == .adopted(inspector.inspectResult))
         #expect(vm.ipswSelection == .localFile(path: destination, bookmark: nil))
@@ -935,7 +935,7 @@ struct VMCreationViewModelTests {
         let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
         vm.selectCatalogEntry(entry)
 
-        let verdict = await vm.adoptExistingDownloadFile()
+        let verdict = await vm.adoptExistingDownloadFile(at: vm.ipswDownloadPath)
 
         #expect(verdict == .mismatch(expected: "24G90", found: inspector.inspectResult))
         // The wrong-image install this exists to prevent.
@@ -949,7 +949,7 @@ struct VMCreationViewModelTests {
         let vm = VMCreationViewModel(localImageInspector: inspector)
         vm.selectCatalogEntry(makeCatalogEntry())
 
-        let verdict = await vm.adoptExistingDownloadFile()
+        let verdict = await vm.adoptExistingDownloadFile(at: vm.ipswDownloadPath)
 
         #expect(
             verdict
@@ -966,7 +966,7 @@ struct VMCreationViewModelTests {
         let vm = VMCreationViewModel(localImageInspector: inspector)
         vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
 
-        let verdict = await vm.adoptExistingDownloadFile()
+        let verdict = await vm.adoptExistingDownloadFile(at: vm.ipswDownloadPath)
 
         #expect(
             verdict
@@ -984,7 +984,7 @@ struct VMCreationViewModelTests {
         vm.selectDownloadLatest()
 
         #expect(vm.expectedBuild == nil)
-        let verdict = await vm.adoptExistingDownloadFile()
+        let verdict = await vm.adoptExistingDownloadFile(at: vm.ipswDownloadPath)
 
         #expect(verdict == .adopted(inspector.inspectResult))
         #expect(vm.ipswSource == .localFile)
@@ -1001,7 +1001,7 @@ struct VMCreationViewModelTests {
             ipswService: MockIPSWService())
         await vm.loadLatestImageDetails()?.value
 
-        let verdict = await vm.adoptExistingDownloadFile()
+        let verdict = await vm.adoptExistingDownloadFile(at: vm.ipswDownloadPath)
 
         // The wrong-image install a per-build destination prevents for the
         // download, which a hand-placed file at that destination reintroduces.
@@ -1021,7 +1021,7 @@ struct VMCreationViewModelTests {
         await vm.loadLatestImageDetails()?.value
         let destination = vm.ipswDownloadPath
 
-        let verdict = await vm.adoptExistingDownloadFile()
+        let verdict = await vm.adoptExistingDownloadFile(at: destination)
 
         #expect(verdict == .adopted(inspector.inspectResult))
         #expect(vm.ipswSelection == .localFile(path: destination, bookmark: nil))
@@ -1036,7 +1036,9 @@ struct VMCreationViewModelTests {
                 urlString: "https://example.com/image.ipsw", version: nil, build: nil))
 
         #expect(vm.expectedBuild == nil)
-        #expect(await vm.adoptExistingDownloadFile() == .adopted(inspector.inspectResult))
+        #expect(
+            await vm.adoptExistingDownloadFile(at: vm.ipswDownloadPath)
+                == .adopted(inspector.inspectResult))
     }
 
     @Test("An inspection cancelled mid-flight adopts nothing")
@@ -1047,13 +1049,55 @@ struct VMCreationViewModelTests {
         let entry = makeCatalogEntry(version: "15.6.1", build: "24G90")
         vm.selectCatalogEntry(entry)
 
-        let adopt = Task { await vm.adoptExistingDownloadFile() }
+        let destination = vm.ipswDownloadPath
+        let adopt = Task { await vm.adoptExistingDownloadFile(at: destination) }
         try await inspector.waitUntilInspecting()
         adopt.cancel()
         inspector.release()
 
         #expect(await adopt.value == .cancelled)
         #expect(vm.ipswSelection == .catalogVersion(entry))
+    }
+
+    @Test("Adoption inspects and commits the path it was handed, not the live destination")
+    func adoptUsesTheCallersPath() async {
+        let inspector = MockLocalRestoreImageInspector()
+        let vm = VMCreationViewModel(localImageInspector: inspector)
+        // The destination as the caller showed it to the user.
+        let snapshot = "/tmp/kernova-snapshot-\(UUID().uuidString).ipsw"
+        #expect(snapshot != vm.ipswDownloadPath)
+
+        let verdict = await vm.adoptExistingDownloadFile(at: snapshot)
+
+        #expect(verdict == .adopted(inspector.inspectResult))
+        #expect(inspector.lastInspectedURL?.path(percentEncoded: false) == snapshot)
+        #expect(vm.ipswSelection == .localFile(path: snapshot, bookmark: nil))
+    }
+
+    @Test("A destination that moves mid-inspection changes neither the file adopted nor the build")
+    func adoptIgnoresADestinationThatMovesMidInspection() async throws {
+        let inspector = SuspendingMockLocalRestoreImageInspector()
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(),
+            localImageInspector: inspector,
+            ipswService: MockIPSWService())
+        let destination = vm.ipswDownloadPath
+
+        let adopt = Task { await vm.adoptExistingDownloadFile(at: destination) }
+        try await inspector.waitUntilInspecting()
+        // The lookup lands during the seconds the read takes, moving both the
+        // destination and the build "Download Latest" promises.
+        await vm.loadLatestImageDetails()?.value
+        #expect(vm.ipswDownloadPath != destination)
+        #expect(vm.expectedBuild == "25F84")
+        inspector.release()
+
+        // The verdict answers the question that was asked: the file read is the
+        // file adopted, and a build that arrived afterwards is not held against
+        // it — a mismatch here would name a build the user never saw, about a
+        // file at a path nothing inspected.
+        #expect(await adopt.value == .adopted(inspector.inspectResult))
+        #expect(vm.ipswSelection == .localFile(path: destination, bookmark: nil))
     }
 
     @Test("expectedBuild names the build each source is promising")
@@ -1174,7 +1218,7 @@ struct VMCreationViewModelTests {
 /// Inspector stand-in that stays inside `inspect` until the test releases it,
 /// the way a multi-gigabyte image keeps the real one busy for seconds.
 final class SuspendingMockLocalRestoreImageInspector: LocalRestoreImageInspecting, @unchecked Sendable {
-    private let inspectResult = InspectedRestoreImage(
+    let inspectResult = InspectedRestoreImage(
         version: "15.6.1", build: "24G90", isSupportedOnThisHost: true)
     private let gate = AsyncGate()
     private let lock = NSLock()

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -696,13 +696,63 @@ struct VMCreationViewModelTests {
         #expect(first != vm.ipswDownloadPath)
     }
 
-    @Test("Returning to Download Latest restores the fixed destination")
+    @Test("Returning to Download Latest takes the fixed destination until the lookup answers")
     func downloadLatestRestoresDefaultDestination() {
         let vm = VMCreationViewModel()
         vm.selectCatalogEntry(makeCatalogEntry())
         vm.selectDownloadLatest()
 
         #expect(vm.ipswSelection == .downloadLatest)
+        #expect(vm.ipswDownloadPath == VMCreationViewModel.defaultIPSWDownloadPath)
+    }
+
+    @Test("The looked-up image names Download Latest's destination")
+    func downloadLatestUsesTheLookedUpFilename() async {
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(), ipswService: MockIPSWService())
+
+        await vm.loadLatestImageDetails()?.value
+
+        // The lookup landing on the live source moves the destination itself,
+        // so the wizard names the file it is about to write.
+        let expected = VMCreationViewModel.downloadPath(
+            forFilename: "UniversalMac_26.5.2_25F84_Restore.ipsw")
+        #expect(vm.ipswDownloadPath == expected)
+        #expect(vm.ipswDownloadPath != VMCreationViewModel.defaultIPSWDownloadPath)
+
+        // And a later re-pick names the same file, the answer being in hand.
+        vm.selectCatalogEntry(makeCatalogEntry())
+        vm.selectDownloadLatest()
+        #expect(vm.ipswDownloadPath == expected)
+    }
+
+    @Test("A lookup landing after another source was picked leaves that pick's destination")
+    func lateLookupLeavesAnotherSourcesDestination() async {
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(), ipswService: MockIPSWService())
+
+        // The pick happens while the lookup is in flight: nothing has awaited,
+        // so the completion runs strictly after it.
+        let lookup = vm.loadLatestImageDetails()
+        vm.selectCatalogEntry(makeCatalogEntry(version: "15.6.1", build: "24G90"))
+        await lookup?.value
+
+        #expect(vm.latestImage?.build == "25F84")
+        #expect(
+            vm.ipswDownloadPath
+                == VMCreationViewModel.downloadPath(
+                    forFilename: "UniversalMac_15.6.1_24G90_Restore.ipsw"))
+    }
+
+    @Test("A failed lookup leaves the destination on the fixed fallback")
+    func failedLookupKeepsTheFallbackDestination() async {
+        let ipswService = MockIPSWService()
+        ipswService.fetchError = URLError(.notConnectedToInternet)
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(), ipswService: ipswService)
+
+        await vm.loadLatestImageDetails()?.value
+
         #expect(vm.ipswDownloadPath == VMCreationViewModel.defaultIPSWDownloadPath)
     }
 
@@ -925,7 +975,7 @@ struct VMCreationViewModelTests {
         #expect(vm.ipswSource == .catalogVersion)
     }
 
-    @Test("Download Latest pins no build, so any usable image is adopted")
+    @Test("Download Latest names no build before the lookup answers, so any usable image is adopted")
     func downloadLatestAdoptsAnyUsableImage() async {
         let inspector = MockLocalRestoreImageInspector()
         inspector.inspectResult = InspectedRestoreImage(
@@ -933,11 +983,48 @@ struct VMCreationViewModelTests {
         let vm = VMCreationViewModel(localImageInspector: inspector)
         vm.selectDownloadLatest()
 
-        #expect(vm.pinnedBuild == nil)
+        #expect(vm.expectedBuild == nil)
         let verdict = await vm.adoptExistingDownloadFile()
 
         #expect(verdict == .adopted(inspector.inspectResult))
         #expect(vm.ipswSource == .localFile)
+    }
+
+    @Test("Once the lookup lands, a file of another build is reported, not adopted")
+    func downloadLatestRefusesAnotherBuildOnceTheLookupLands() async {
+        let inspector = MockLocalRestoreImageInspector()
+        inspector.inspectResult = InspectedRestoreImage(
+            version: "14.2", build: "23C64", isSupportedOnThisHost: true)
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(),
+            localImageInspector: inspector,
+            ipswService: MockIPSWService())
+        await vm.loadLatestImageDetails()?.value
+
+        let verdict = await vm.adoptExistingDownloadFile()
+
+        // The wrong-image install a per-build destination prevents for the
+        // download, which a hand-placed file at that destination reintroduces.
+        #expect(verdict == .mismatch(expected: "25F84", found: inspector.inspectResult))
+        #expect(vm.ipswSelection == .downloadLatest)
+    }
+
+    @Test("A file of the looked-up build is adopted")
+    func downloadLatestAdoptsTheLookedUpBuild() async {
+        let inspector = MockLocalRestoreImageInspector()
+        inspector.inspectResult = InspectedRestoreImage(
+            version: "26.5.2", build: "25F84", isSupportedOnThisHost: true)
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(),
+            localImageInspector: inspector,
+            ipswService: MockIPSWService())
+        await vm.loadLatestImageDetails()?.value
+        let destination = vm.ipswDownloadPath
+
+        let verdict = await vm.adoptExistingDownloadFile()
+
+        #expect(verdict == .adopted(inspector.inspectResult))
+        #expect(vm.ipswSelection == .localFile(path: destination, bookmark: nil))
     }
 
     @Test("A URL pick with no parsed build pins nothing to compare against")
@@ -948,7 +1035,7 @@ struct VMCreationViewModelTests {
             makeProbedImage(
                 urlString: "https://example.com/image.ipsw", version: nil, build: nil))
 
-        #expect(vm.pinnedBuild == nil)
+        #expect(vm.expectedBuild == nil)
         #expect(await vm.adoptExistingDownloadFile() == .adopted(inspector.inspectResult))
     }
 
@@ -969,19 +1056,24 @@ struct VMCreationViewModelTests {
         #expect(vm.ipswSelection == .catalogVersion(entry))
     }
 
-    @Test("pinnedBuild names the build each source is promising")
-    func pinnedBuildTracksTheSource() {
-        let vm = VMCreationViewModel()
-        #expect(vm.pinnedBuild == nil)
+    @Test("expectedBuild names the build each source is promising")
+    func expectedBuildTracksTheSource() async {
+        let vm = VMCreationViewModel(
+            probeService: MockRestoreImageProbeService(), ipswService: MockIPSWService())
+        #expect(vm.expectedBuild == nil)
 
         vm.selectCatalogEntry(makeCatalogEntry(build: "24G90"))
-        #expect(vm.pinnedBuild == "24G90")
+        #expect(vm.expectedBuild == "24G90")
 
         vm.selectPastedImage(makeProbedImage(build: "25G72"))
-        #expect(vm.pinnedBuild == "25G72")
+        #expect(vm.expectedBuild == "25G72")
 
+        // "Whatever is newest" names nothing until the lookup says what that is.
         vm.selectDownloadLatest()
-        #expect(vm.pinnedBuild == nil)
+        #expect(vm.expectedBuild == nil)
+
+        await vm.loadLatestImageDetails()?.value
+        #expect(vm.expectedBuild == "25F84")
     }
 
     @Test("Switching between pinned sources keeps both picks; Download Latest clears them")
@@ -1009,7 +1101,7 @@ struct VMCreationViewModelTests {
         // Only the live source carries a payload, so no reader can reach the
         // catalog entry while the URL source is current.
         #expect(vm.ipswSelection == .customURL(image))
-        #expect(vm.pinnedBuild == "25G72")
+        #expect(vm.expectedBuild == "25G72")
         // The seed survives so the version picker re-opens on the old pick.
         #expect(vm.lastCatalogPick == entry)
     }
@@ -1076,20 +1168,6 @@ struct VMCreationViewModelTests {
 
         #expect(vm.latestImage?.version == "26.5.2")
         #expect(vm.latestImageSizeBytes == nil)
-    }
-
-    @Test("The looked-up image pins nothing: any usable file at the destination is adopted")
-    func latestImageLookupPinsNoBuild() async {
-        let vm = VMCreationViewModel(
-            probeService: MockRestoreImageProbeService(), ipswService: MockIPSWService())
-
-        await vm.loadLatestImageDetails()?.value
-
-        // Naming a build here would make a file of a different build a
-        // mismatch, at a destination this source shares with every other
-        // Download Latest.
-        #expect(vm.latestImage != nil)
-        #expect(vm.pinnedBuild == nil)
     }
 }
 

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -440,6 +440,11 @@ struct VMLifecycleCoordinatorTests {
         #expect(
             instance.configuration.installContext?.downloadDestinationPath
                 == expected.path(percentEncoded: false))
+        // The old path's partial belongs to a build this install is no longer
+        // fetching, and moving the only pointer to it would strand it.
+        #expect(ipswService.discardResumeDataCallCount == 1)
+        #expect(ipswService.lastDiscardResumeDataURL == persisted)
+        #expect(ipswService.lastDiscardResumeDataPermanently == false)
     }
 
     @Test("installMacOS with a catalog context downloads the pinned URL, never the latest")
@@ -586,15 +591,14 @@ struct VMLifecycleCoordinatorTests {
         let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: temp)
         let instance = makeInstance()
 
-        // The install writes the file the resolved image names, whatever the
-        // wizard persisted, so that is what the replacement covers.
+        // The persisted destination is the one the resolved image derives, so
+        // the file the user confirmed replacing is the file the download writes.
         let destination = temp.appendingPathComponent(
             RestoreImageFilename.destination(for: ipswService.fetchResult.url))
 
         let context = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: temp.appendingPathComponent(RestoreImageFilename.fallback)
-                .path(percentEncoded: false),
+            downloadDestinationPath: destination.path(percentEncoded: false),
             requestedFreshDownload: true
         )
         instance.configuration.installContext = context
@@ -608,6 +612,48 @@ struct VMLifecycleCoordinatorTests {
         #expect(ipswService.discardResumeDataCallCount == 0)
     }
 
+    @Test("A latest destination that moved lapses Download & Replace rather than retargeting it")
+    func installMacOSLatestFreshDownloadLapsesOnAMovedDestination() async {
+        // "Download & Replace" was confirmed in the wizard against the
+        // destination shown there. When the install resolves a newer image, the
+        // file at the derived destination is one the user never saw, so
+        // honoring the flag would trash bytes nobody agreed to lose.
+        // Read on the failure path: a successful install clears the context.
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("freshDownloadMoved-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: temp)
+        ipswService.downloadError = IPSWError.downloadFailed(URLError(.notConnectedToInternet))
+        let instance = makeInstance()
+
+        let persisted = temp.appendingPathComponent(RestoreImageFilename.fallback)
+        let context = MacOSInstallContext(
+            source: .downloadLatest,
+            downloadDestinationPath: persisted.path(percentEncoded: false),
+            requestedFreshDownload: true
+        )
+        instance.configuration.installContext = context
+        instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
+
+        await #expect(throws: IPSWError.self) {
+            try await coordinator.installMacOS(on: instance, context: context)
+        }
+
+        let derived = temp.appendingPathComponent(
+            RestoreImageFilename.destination(for: ipswService.fetchResult.url))
+        #expect(ipswService.lastDownloadDestinationURL == derived)
+        #expect(ipswService.lastDownloadDiscardsExisting == false)
+        // The lapse spares the file at the *derived* destination; the sidecar
+        // left at the path being abandoned is still discarded.
+        #expect(ipswService.discardResumeDataCallCount == 1)
+        #expect(ipswService.lastDiscardResumeDataURL == persisted)
+        // The lapse is persisted with the re-pointed path, so the retry Start
+        // that reads this context does not resurrect the confirmation.
+        #expect(
+            instance.configuration.installContext?.downloadDestinationPath
+                == derived.path(percentEncoded: false))
+        #expect(instance.configuration.installContext?.requestedFreshDownload == false)
+    }
+
     @Test("installMacOS clears requestedFreshDownload before the download runs")
     func installMacOSFreshDownloadClearsTheFlagOnce() async {
         // A download that fails leaves the context for the retry Start — with
@@ -619,10 +665,13 @@ struct VMLifecycleCoordinatorTests {
         ipswService.downloadError = IPSWError.downloadFailed(URLError(.notConnectedToInternet))
         let instance = makeInstance()
 
+        // Honored, not lapsed: the persisted destination is already the one the
+        // resolved image derives.
         let context = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: temp.appendingPathComponent("RestoreImage.ipsw")
-                .path(percentEncoded: false),
+            downloadDestinationPath: temp.appendingPathComponent(
+                RestoreImageFilename.destination(for: ipswService.fetchResult.url)
+            ).path(percentEncoded: false),
             requestedFreshDownload: true
         )
         instance.configuration.installContext = context
@@ -641,9 +690,16 @@ struct VMLifecycleCoordinatorTests {
         // The download reports that it could not clear the way for the
         // replacement; the install must fail rather than install the file the
         // user asked to replace.
-        let (coordinator, _, installService, ipswService, _) = makeCoordinator()
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("freshDownloadTrashFails-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, installService, ipswService, _) = makeCoordinator(
+            downloadsDirectory: temp)
+        // The destination the resolved image derives, so the replacement is
+        // actually requested and can fail.
+        let destination = temp.appendingPathComponent(
+            RestoreImageFilename.destination(for: ipswService.fetchResult.url))
         ipswService.downloadError = IPSWError.freshDownloadCleanupFailed(
-            path: "/tmp/cannot-trash.ipsw",
+            path: destination.path(percentEncoded: false),
             underlying: NSError(
                 domain: NSCocoaErrorDomain,
                 code: NSFileWriteNoPermissionError,
@@ -654,7 +710,7 @@ struct VMLifecycleCoordinatorTests {
         let instance = makeInstance()
         let context = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: "/tmp/cannot-trash.ipsw",
+            downloadDestinationPath: destination.path(percentEncoded: false),
             requestedFreshDownload: true
         )
         instance.configuration.installContext = context
@@ -717,8 +773,9 @@ struct VMLifecycleCoordinatorTests {
 
         let context = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: temp.appendingPathComponent("RestoreImage.ipsw")
-                .path(percentEncoded: false)
+            downloadDestinationPath: temp.appendingPathComponent(
+                RestoreImageFilename.destination(for: ipswService.fetchResult.url)
+            ).path(percentEncoded: false)
         )
         instance.configuration.installContext = context
         instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
@@ -726,20 +783,26 @@ struct VMLifecycleCoordinatorTests {
         try await coordinator.installMacOS(on: instance, context: context)
 
         // Nothing at the destination is disturbed: the download resumes or
-        // skips over whatever is already there.
+        // skips over whatever is already there. The destination did not move
+        // either, so there is no superseded sidecar to discard.
         #expect(ipswService.lastDownloadDiscardsExisting == false)
         #expect(ipswService.discardResumeDataCallCount == 0)
     }
 
     @Test("installMacOS preserves IPSW resume data when download is cancelled")
     func installMacOSCancelPreservesResumeData() async {
-        let (coordinator, _, _, ipswService, _) = makeCoordinator()
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cancelResumeData-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: temp)
         ipswService.downloadError = CancellationError()
         let instance = makeInstance()
+        // The destination the resolved image derives, so the cancel is the only
+        // thing that could reach the partial sitting there.
         let context = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: FileManager.default.temporaryDirectory
-                .appendingPathComponent("cancel-test-restore.ipsw").path(percentEncoded: false)
+            downloadDestinationPath: temp.appendingPathComponent(
+                RestoreImageFilename.destination(for: ipswService.fetchResult.url)
+            ).path(percentEncoded: false)
         )
 
         await #expect(throws: CancellationError.self) {
@@ -753,7 +816,9 @@ struct VMLifecycleCoordinatorTests {
 
     @Test("installMacOS preserves IPSW resume data on NSURLErrorCancelled")
     func installMacOSURLCancelPreservesResumeData() async {
-        let (coordinator, _, _, ipswService, _) = makeCoordinator()
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("urlCancelResumeData-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: temp)
         ipswService.downloadError = NSError(
             domain: NSURLErrorDomain,
             code: NSURLErrorCancelled,
@@ -762,8 +827,9 @@ struct VMLifecycleCoordinatorTests {
         let instance = makeInstance()
         let context = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: FileManager.default.temporaryDirectory
-                .appendingPathComponent("url-cancel-test-restore.ipsw").path(percentEncoded: false)
+            downloadDestinationPath: temp.appendingPathComponent(
+                RestoreImageFilename.destination(for: ipswService.fetchResult.url)
+            ).path(percentEncoded: false)
         )
 
         await #expect(throws: CancellationError.self) {

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -384,21 +384,62 @@ struct VMLifecycleCoordinatorTests {
         #expect(installService.installCallCount == 1)
     }
 
-    @Test("installMacOS with downloadLatest context calls fetch and download")
+    @Test("installMacOS with downloadLatest context downloads the resolved image, named after it")
     func installMacOSDownload() async throws {
-        let (coordinator, _, installService, ipswService, _) = makeCoordinator()
+        let downloads = FileManager.default.temporaryDirectory
+            .appendingPathComponent("installLatest-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, installService, ipswService, _) = makeCoordinator(
+            downloadsDirectory: downloads)
         let instance = makeInstance()
+        // What the wizard persisted: the fallback name it shows before its own
+        // lookup answers.
+        let persisted = downloads.appendingPathComponent(RestoreImageFilename.fallback)
         let context = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: FileManager.default.temporaryDirectory
-                .appendingPathComponent("test-restore.ipsw").path(percentEncoded: false)
+            downloadDestinationPath: persisted.path(percentEncoded: false)
         )
 
         try await coordinator.installMacOS(on: instance, context: context)
 
+        let expected = downloads.appendingPathComponent(
+            RestoreImageFilename.destination(for: ipswService.fetchResult.url))
         #expect(ipswService.fetchCallCount == 1)
         #expect(ipswService.downloadCallCount == 1)
+        #expect(ipswService.lastDownloadRemoteURL == ipswService.fetchResult.url)
+        #expect(ipswService.lastDownloadDestinationURL == expected)
         #expect(installService.installCallCount == 1)
+        #expect(installService.lastRestoreImageURL == expected)
+    }
+
+    @Test("A latest install re-points the persisted destination at the file it downloads")
+    func installMacOSLatestPersistsTheDerivedDestination() async {
+        // The persisted path is what a resume across relaunches and a delete's
+        // sidecar cleanup are keyed to, so it has to name the file the bytes
+        // land in. Read on the failure path: a successful install clears the
+        // context before anything can inspect it.
+        let downloads = FileManager.default.temporaryDirectory
+            .appendingPathComponent("latestDestination-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: downloads)
+        ipswService.downloadError = IPSWError.downloadFailed(URLError(.notConnectedToInternet))
+        let instance = makeInstance()
+        let persisted = downloads.appendingPathComponent(RestoreImageFilename.fallback)
+        let context = MacOSInstallContext(
+            source: .downloadLatest,
+            downloadDestinationPath: persisted.path(percentEncoded: false)
+        )
+        instance.configuration.installContext = context
+        instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
+
+        await #expect(throws: IPSWError.self) {
+            try await coordinator.installMacOS(on: instance, context: context)
+        }
+
+        let expected = downloads.appendingPathComponent(
+            RestoreImageFilename.destination(for: ipswService.fetchResult.url))
+        #expect(ipswService.lastDownloadDestinationURL == expected)
+        #expect(
+            instance.configuration.installContext?.downloadDestinationPath
+                == expected.path(percentEncoded: false))
     }
 
     @Test("installMacOS with a catalog context downloads the pinned URL, never the latest")
@@ -512,13 +553,18 @@ struct VMLifecycleCoordinatorTests {
 
     @Test("installMacOS throws CancellationError on cancel and preserves installContext")
     func installMacOSCancelPreservesContext() async {
-        let (coordinator, _, _, ipswService, _) = makeCoordinator()
+        let downloads = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cancelPreservesContext-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: downloads)
         ipswService.downloadError = CancellationError()
         let instance = makeInstance()
+        // Already naming the file the resolved image derives, so nothing but the
+        // cancel can touch the context.
         let originalContext = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: FileManager.default.temporaryDirectory
-                .appendingPathComponent("cancel-preserves-context.ipsw").path(percentEncoded: false)
+            downloadDestinationPath: downloads.appendingPathComponent(
+                RestoreImageFilename.destination(for: ipswService.fetchResult.url)
+            ).path(percentEncoded: false)
         )
         instance.configuration.installContext = originalContext
         instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
@@ -540,11 +586,15 @@ struct VMLifecycleCoordinatorTests {
         let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: temp)
         let instance = makeInstance()
 
-        let destination = temp.appendingPathComponent("RestoreImage.ipsw")
+        // The install writes the file the resolved image names, whatever the
+        // wizard persisted, so that is what the replacement covers.
+        let destination = temp.appendingPathComponent(
+            RestoreImageFilename.destination(for: ipswService.fetchResult.url))
 
         let context = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: destination.path(percentEncoded: false),
+            downloadDestinationPath: temp.appendingPathComponent(RestoreImageFilename.fallback)
+                .path(percentEncoded: false),
             requestedFreshDownload: true
         )
         instance.configuration.installContext = context
@@ -622,20 +672,26 @@ struct VMLifecycleCoordinatorTests {
     }
 
     @Test("installMacOS rejects requestedFreshDownload on a non-IPSW path")
-    func installMacOSFreshDownloadRejectsNonIPSWPath() async {
+    func installMacOSFreshDownloadRejectsNonIPSWPath() async throws {
         // The non-IPSW file sits inside the (injected) Downloads directory —
-        // an out-of-Downloads path would be normalized to the default
-        // destination before this guard is reached.
+        // an out-of-Downloads path would be normalized to the pinned image's
+        // filename before this guard is reached. A pinned source is what keeps
+        // such a path: "Download Latest" always names its destination from the
+        // URL it resolved, which is always an `.ipsw`.
         let temp = FileManager.default.temporaryDirectory
             .appendingPathComponent("rejectNonIPSW-\(UUID().uuidString)", isDirectory: true)
         let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: temp)
         let instance = makeInstance()
         // Path doesn't end in .ipsw — guard must fire before any trash attempt.
         let context = MacOSInstallContext(
-            source: .downloadLatest,
+            source: .catalogVersion,
             downloadDestinationPath: temp.appendingPathComponent("important.doc")
                 .path(percentEncoded: false),
-            requestedFreshDownload: true
+            requestedFreshDownload: true,
+            remoteURL: try #require(
+                URL(
+                    string:
+                        "https://updates.cdn-apple.com/x/UniversalMac_15.6.1_24G90_Restore.ipsw"))
         )
         instance.configuration.installContext = context
         instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
@@ -719,13 +775,18 @@ struct VMLifecycleCoordinatorTests {
 
     @Test("installMacOS preserves IPSW resume data on non-cancel download failure")
     func installMacOSFailurePreservesResumeData() async {
-        let (coordinator, _, _, ipswService, _) = makeCoordinator()
+        let downloads = FileManager.default.temporaryDirectory
+            .appendingPathComponent("networkFailure-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, _, ipswService, _) = makeCoordinator(downloadsDirectory: downloads)
         ipswService.downloadError = IPSWError.downloadFailed(URLError(.notConnectedToInternet))
         let instance = makeInstance()
+        // Already naming the file the resolved image derives, so the retry
+        // context that survives is the one that went in.
         let originalContext = MacOSInstallContext(
             source: .downloadLatest,
-            downloadDestinationPath: FileManager.default.temporaryDirectory
-                .appendingPathComponent("network-fail-restore.ipsw").path(percentEncoded: false)
+            downloadDestinationPath: downloads.appendingPathComponent(
+                RestoreImageFilename.destination(for: ipswService.fetchResult.url)
+            ).path(percentEncoded: false)
         )
         instance.configuration.installContext = originalContext
         instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
@@ -892,6 +953,70 @@ struct VMLifecycleCoordinatorTests {
                 #expect(normalized.pathExtension.lowercased() == "ipsw", "not an IPSW for \(context)")
             }
         }
+    }
+
+    // MARK: - Latest Download Destination
+
+    @Test("latestDownloadDestination names the download after the URL the install resolved")
+    func latestDestinationFollowsTheResolvedURL() throws {
+        let downloads = FileManager.default.temporaryDirectory
+            .appendingPathComponent("latestFollowsURL-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, _, _, _) = makeCoordinator(downloadsDirectory: downloads)
+        let persisted = downloads.appendingPathComponent(RestoreImageFilename.fallback)
+        let resolved = try #require(
+            URL(
+                string:
+                    "https://updates.cdn-apple.com/fullrestores/UniversalMac_26.5.2_25F84_Restore.ipsw"
+            ))
+
+        let destination = coordinator.latestDownloadDestination(
+            persisted: persisted, resolvedURL: resolved)
+
+        #expect(
+            destination
+                == downloads.appendingPathComponent("UniversalMac_26.5.2_25F84_Restore.ipsw"))
+    }
+
+    @Test("An off-convention latest URL still lands on a name unique to it")
+    func latestDestinationForOffConventionURL() throws {
+        let downloads = FileManager.default.temporaryDirectory
+            .appendingPathComponent("latestOffConvention-\(UUID().uuidString)", isDirectory: true)
+        let (coordinator, _, _, _, _) = makeCoordinator(downloadsDirectory: downloads)
+        let persisted = downloads.appendingPathComponent(RestoreImageFilename.fallback)
+        let resolved = try #require(URL(string: "https://example.com/restore.ipsw"))
+
+        let destination = coordinator.latestDownloadDestination(
+            persisted: persisted, resolvedURL: resolved)
+
+        #expect(
+            destination
+                == downloads.appendingPathComponent(RestoreImageFilename.unique(for: resolved)))
+        // Sharing the fallback would let an unrelated image already sitting
+        // there satisfy this download.
+        #expect(destination != persisted)
+    }
+
+    @Test("With normalization disabled the persisted destination is what the install writes")
+    func latestDestinationKeepsPersistedWithoutDownloads() throws {
+        // No Downloads directory at all — the one state that leaves a persisted
+        // path unexamined, so the `makeCoordinator` fallback is bypassed here.
+        let coordinator = VMLifecycleCoordinator(
+            virtualizationService: MockVirtualizationService(),
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService(),
+            usbDeviceService: MockUSBDeviceService(),
+            downloadsDirectory: nil
+        )
+        let persisted = URL(fileURLWithPath: "/Users/Shared/RestoreImage.ipsw")
+        let resolved = try #require(
+            URL(
+                string:
+                    "https://updates.cdn-apple.com/fullrestores/UniversalMac_26.5.2_25F84_Restore.ipsw"
+            ))
+
+        #expect(
+            coordinator.latestDownloadDestination(persisted: persisted, resolvedURL: resolved)
+                == persisted)
     }
 
     /// A path with `..` collapsed and any trailing separator dropped, so a


### PR DESCRIPTION
## Summary
- "Download Latest" downloaded to a fixed `RestoreImage.ipsw` while the catalog and pasted-URL sources name the file for the image it carries. The wizard already looks up what this source will fetch (`VZMacOSRestoreImage.latestSupported`, surfaced as version/build/size on the badge), and Apple's latest URL follows the same `UniversalMac_<version>_<build>_Restore.ipsw` convention — so the source now derives its destination through the same `RestoreImageFilename` helper as the others.
- Two layers, matching the source's "preview, not a pin" semantics: the wizard adopts the looked-up image's filename once the lookup answers (keeping the fixed fallback until then, e.g. offline), and the install re-derives the name from the URL it actually resolves at Start — the newest build can move in between — persisting the corrected path so download resume and delete-time cleanup stay keyed to the real file. Pinned sources are untouched.
- Per-build naming makes existing-file reuse honest for this source, the same way it already is for pinned picks: a pre-existing file of the same build is correctly reused instead of a stale `RestoreImage.ipsw` of unknown vintage standing in, "Use Existing File" now verifies the file against the looked-up build (`pinnedBuild` → `expectedBuild`), and the overwrite/resume banners name the version.

## Review fixes
Three review passes (built-in medium, Codex, Codex adversarial) converged on the consequences of the destination becoming movable; all confirmed findings are fixed on the branch:
- **Consent stays on the file it was given for**: "Download & Replace" lapses when the install resolves a different destination than the wizard showed, instead of trashing a file the user never confirmed replacing.
- **No orphaned partial downloads**: when the resolved build moves the destination, the superseded path's `.kernovadownload` sidecar is discarded before the persisted pointer is re-written — restoring the self-healing the fixed path used to get from `loadResumeMetadata`. Closes #709.
- **Adoption is path-exact**: `adoptExistingDownloadFile(at:)` / `useExistingDownloadFile(at:)` take the caller's snapshot, and the expected build is captured before the inspection await, so a lookup landing mid-inspection can no longer commit an uninspected path.
- **No stale conflict banners**: the existing-file verdict is keyed to the path it describes and drops when the lookup moves the destination.

Dismissed under docs/REVIEW.md's bar (with the reviewers' own concurrence where they self-verified): silent reuse of a pre-existing per-build file when the lookup lands after the Boot step (right build by construction — the same deliberate skip-existing semantics the install already applies when a file appears between wizard and Start), the triplicated one-line `suggestedFilename` sugar (derivation logic is single-sourced in `RestoreImageFilename`), and two self-healing adversarial-timing races in the adoption UI flow.

## Changes
- `Kernova/Models/LatestRestoreImage.swift` — `suggestedFilename`, matching the other two source models
- `Kernova/ViewModels/VMCreationViewModel.swift` — destination naming on selection and on lookup completion; `expectedBuild`; path-explicit adoption API
- `Kernova/ViewModels/VMLifecycleCoordinator.swift` — `latestDownloadDestination(persisted:resolvedURL:)`; `installMacOS` derives the latest destination from the resolved URL, persists it, lapses stale replace-consent, and discards the superseded sidecar
- `Kernova/Views/Creation/IPSWSelectionContentViewController.swift` — download banners name the looked-up version; conflict notice keyed to its path
- `KernovaTests/` — coverage for the lookup-driven naming, install-time derivation and persistence, consent lapse, sidecar discard, adoption race, failed-lookup fallback, and stricter adoption; mock factories

## Test plan
- [x] `make lint`
- [x] `make test` — full suite green (2,083 tests)

Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwUXkAWUwCz8bcobTixwi6