### PR TITLE
fix: Escalate a mid-session guest-agent death past .connecting

### DIFF
--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KernovaKit
 import os
 import Virtualization
 
@@ -138,14 +139,24 @@ final class VMInstance {
     var vsockControlService: VsockControlService?
 
     /// `true` when this VM has reached `.running`, the host previously saw a
-    /// guest agent connect (`configuration.lastSeenAgentVersion != nil`), and
-    /// the post-start grace period has elapsed without a fresh `Hello`
-    /// arriving over the control channel.
+    /// guest agent connect (`configuration.lastSeenAgentVersion != nil`), and a
+    /// grace period has elapsed without a `Hello` arriving over the control
+    /// channel.
     ///
     /// Reset on `tearDownSession` and on the next successful Hello.
     var agentExpectedButMissing: Bool = false
 
-    /// Backing task for the post-start agent-arrival watchdog, one-shot per VM session.
+    /// `true` once a `Hello` has arrived on this VM session.
+    ///
+    /// Separates a mid-session agent disappearance from an agent that never
+    /// appeared: only the latter is evidence about what is installed in the
+    /// guest, so only the latter may rewrite persisted agent state.
+    ///
+    /// Reset on `tearDownSession`.
+    private(set) var hasSeenAgentThisSession = false
+
+    /// Backing task for the post-start agent-arrival watchdog, re-armed each
+    /// time the control channel is lost.
     private var agentPostStartTask: Task<Void, Never>?
 
     /// Performs a host-side mutation of this instance's configuration and routes
@@ -366,6 +377,7 @@ final class VMInstance {
         stopSerialReading()
         cancelAgentPostStartWatchdog()
         agentExpectedButMissing = false
+        hasSeenAgentThisSession = false
         serialInputPipe = nil
         serialOutputPipe = nil
         liveRemovableMedia = []
@@ -621,25 +633,7 @@ final class VMInstance {
             }
             // Replace any prior service from a previous reconnect.
             self.vsockControlService?.stop()
-            let service = VsockControlService(
-                channel: channel,
-                label: self.name,
-                policyProvider: { [weak self] in
-                    guard let self else {
-                        return AgentPolicySnapshot(
-                            logForwardingEnabled: false,
-                            clipboardSharingEnabled: false
-                        )
-                    }
-                    return AgentPolicySnapshot(
-                        logForwardingEnabled: self.configuration.agentLogForwardingEnabled,
-                        clipboardSharingEnabled: self.configuration.clipboardSharingEnabled
-                    )
-                },
-                onAgentInfoObserved: { [weak self] info in
-                    self?.recordObservedAgentInfo(info)
-                }
-            )
+            let service = self.makeControlService(for: channel)
             self.vsockControlService = service
             service.start()
         }
@@ -672,6 +666,41 @@ final class VMInstance {
     func admitsFeatureChannel(requiringClipboardStreaming: Bool) -> Bool {
         guard let control = vsockControlService, control.isConnected else { return false }
         return !requiringClipboardStreaming || control.guestSupportsClipboardStreaming
+    }
+
+    /// Builds the control service for one accepted channel, wired to this
+    /// instance's policy, agent-info, guest-suspension and channel-loss hooks.
+    ///
+    /// Every hook reads through `self` lazily, so all four track live
+    /// configuration edits and pause/resume without being re-pushed.
+    func makeControlService(for channel: VsockChannel) -> VsockControlService {
+        VsockControlService(
+            channel: channel,
+            label: name,
+            policyProvider: { [weak self] in
+                guard let self else {
+                    return AgentPolicySnapshot(
+                        logForwardingEnabled: false,
+                        clipboardSharingEnabled: false
+                    )
+                }
+                return AgentPolicySnapshot(
+                    logForwardingEnabled: self.configuration.agentLogForwardingEnabled,
+                    clipboardSharingEnabled: self.configuration.clipboardSharingEnabled
+                )
+            },
+            onAgentInfoObserved: { [weak self] info in
+                self?.recordObservedAgentInfo(info)
+            },
+            isGuestSuspended: { [weak self] in self?.isLivePaused ?? false },
+            onChannelLost: { [weak self] in
+                // The agent went away mid-session. Re-arm the same grace clock
+                // the post-start path uses, so a channel that never comes back
+                // escalates to `.expectedMissing` instead of spinning at
+                // `.connecting` for the rest of the session.
+                self?.startAgentPostStartWatchdog()
+            }
+        )
     }
 
     /// Builds the log-channel listener; each accepted channel replaces any prior
@@ -727,17 +756,22 @@ final class VMInstance {
     /// Starts a one-shot timer that flips `agentExpectedButMissing = true` if
     /// the guest agent doesn't say Hello within `grace`.
     ///
-    /// A no-op unless the guest is macOS, the boot wasn't into Recovery (which
-    /// never runs the agent, so silence there is evidence of nothing), an agent
-    /// has been seen before on this VM, no install is in progress, and no
-    /// watchdog is already armed. Cancelled by any inbound Hello and by
-    /// `tearDownSession`.
+    /// Armed after a start or resume, and again whenever the control channel
+    /// dies under us, so a mid-session disappearance escalates the same way a
+    /// no-show after boot does. A no-op unless the guest is macOS, the VM is
+    /// running (a paused guest isn't executing, so its silence proves nothing),
+    /// the boot wasn't into Recovery (which never runs the agent), an agent has
+    /// been seen before on this VM, the agent isn't already connected, no
+    /// install is in progress, and no watchdog is already armed. Cancelled by
+    /// any inbound Hello, by a pause, and by `tearDownSession`.
     func startAgentPostStartWatchdog(
         afterRecoveryBoot: Bool = false, grace: Duration = VMInstance.defaultAgentPostStartGrace
     ) {
         guard configuration.guestOS == .macOS else { return }
         guard !afterRecoveryBoot else { return }
+        guard status == .running else { return }
         guard configuration.lastSeenAgentVersion != nil else { return }
+        guard vsockControlService?.agentVersion == nil else { return }
         guard installState == nil else { return }
         guard agentPostStartTask == nil else { return }
 
@@ -757,13 +791,17 @@ final class VMInstance {
                     "Guest agent expected (last seen \(self.configuration.lastSeenAgentVersion ?? "?", privacy: .public)) but never reconnected for '\(self.name, privacy: .public)' — surfacing reinstall affordance"
                 )
                 self.agentExpectedButMissing = true
-                // A previously-installed agent disappearing outranks the nudge
-                // the user silenced — reset the dismissal so a future
-                // `.waiting` surfaces normally. The reported guest OS version
-                // goes with it: the agent that vouched for it is gone, and
-                // "Unknown" beats a stale value.
-                if self.configuration.agentInstallNudgeDismissed
-                    || self.configuration.lastSeenGuestOSVersion != nil
+                // An agent that never showed up at all outranks the nudge the
+                // user silenced — reset the dismissal so a future `.waiting`
+                // surfaces normally. The reported guest OS version goes with
+                // it: nothing vouched for it this session, and "Unknown" beats
+                // a stale value. Both stay untouched when the agent did say
+                // Hello earlier in this session: it demonstrably exists, and
+                // reversing a preference nothing restores needs better evidence
+                // than one dropped channel.
+                if !self.hasSeenAgentThisSession,
+                    self.configuration.agentInstallNudgeDismissed
+                        || self.configuration.lastSeenGuestOSVersion != nil
                 {
                     self.performConfigurationMutation {
                         $0.agentInstallNudgeDismissed = false
@@ -802,6 +840,7 @@ final class VMInstance {
         // before the changed guards below.
         cancelAgentPostStartWatchdog()
         agentExpectedButMissing = false
+        hasSeenAgentThisSession = true
         // Skip the no-op write: a `config.json` rewrite on every Hello would
         // re-fire `VMDirectoryWatcher` reconcile.
         let agentVersionChanged = configuration.lastSeenAgentVersion != info.agentVersion

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -155,9 +155,25 @@ final class VMInstance {
     /// Reset on `tearDownSession`.
     private(set) var hasSeenAgentThisSession = false
 
-    /// Backing task for the post-start agent-arrival watchdog, re-armed each
-    /// time the control channel is lost.
+    /// `true` when this session cold-booted into macOS Recovery, which never
+    /// runs the guest agent — so agent silence is evidence of nothing for the
+    /// whole session, not just at the moment of boot.
+    ///
+    /// Set by `VirtualizationService` at cold boot; reset on `tearDownSession`.
+    var bootedIntoRecovery = false
+
+    /// Backing task for the agent-arrival watchdog, re-armed each time the
+    /// control channel is lost.
     private var agentPostStartTask: Task<Void, Never>?
+
+    /// Bumped by every arm and every cancel, so a watchdog task that finished
+    /// sleeping just before a cancel-and-re-arm can tell it has been disowned.
+    ///
+    /// A task holds the generation it was armed with; only the current one may
+    /// act. Without it, the slot check is an ABA test that a stale task passes
+    /// against a *successor's* task — firing `.expectedMissing` before that
+    /// successor's grace elapsed, and clearing its slot on the way out.
+    private var agentPostStartGeneration: UInt64 = 0
 
     /// Performs a host-side mutation of this instance's configuration and routes
     /// it through the view model's `updateConfiguration` pipeline (persist +
@@ -378,6 +394,7 @@ final class VMInstance {
         cancelAgentPostStartWatchdog()
         agentExpectedButMissing = false
         hasSeenAgentThisSession = false
+        bootedIntoRecovery = false
         serialInputPipe = nil
         serialOutputPipe = nil
         liveRemovableMedia = []
@@ -636,6 +653,13 @@ final class VMInstance {
             let service = self.makeControlService(for: channel)
             self.vsockControlService = service
             service.start()
+            // Any accepted channel that never completes its Hello is on a
+            // clock. Replacing a live service settles the old one as
+            // owner-requested, so `onChannelLost` does not fire and nothing
+            // else would arm here — and an agent that connects but cannot
+            // handshake (a half-finished update) is exactly when the reinstall
+            // affordance is wanted. Idempotent; the Hello cancels it.
+            self.startAgentPostStartWatchdog()
         }
         controlHost.attach(to: socketDevice)
         vsockControlListenerHost = controlHost
@@ -756,27 +780,28 @@ final class VMInstance {
     /// Starts a one-shot timer that flips `agentExpectedButMissing = true` if
     /// the guest agent doesn't say Hello within `grace`.
     ///
-    /// Armed after a start or resume, and again whenever the control channel
-    /// dies under us, so a mid-session disappearance escalates the same way a
-    /// no-show after boot does. A no-op unless the guest is macOS, the VM is
-    /// running (a paused guest isn't executing, so its silence proves nothing),
-    /// the boot wasn't into Recovery (which never runs the agent), an agent has
-    /// been seen before on this VM, the agent isn't already connected, no
-    /// install is in progress, and no watchdog is already armed. Cancelled by
-    /// any inbound Hello, by a pause, and by `tearDownSession`.
-    func startAgentPostStartWatchdog(
-        afterRecoveryBoot: Bool = false, grace: Duration = VMInstance.defaultAgentPostStartGrace
-    ) {
+    /// Armed after a start, a hot resume, or an accepted control channel, and
+    /// again whenever the control channel dies under us, so a mid-session
+    /// disappearance escalates the same way a no-show after boot does. A no-op
+    /// unless the guest is macOS, the VM is running (a paused guest isn't
+    /// executing, so its silence proves nothing), the session didn't boot into
+    /// Recovery (which never runs the agent), an agent has been seen before on
+    /// this VM, the agent isn't already connected, no install is in progress,
+    /// and no watchdog is already armed. Cancelled by any inbound Hello, by a
+    /// pause, and by `tearDownSession`.
+    func startAgentPostStartWatchdog(grace: Duration = VMInstance.defaultAgentPostStartGrace) {
         guard configuration.guestOS == .macOS else { return }
-        guard !afterRecoveryBoot else { return }
+        guard !bootedIntoRecovery else { return }
         guard status == .running else { return }
         guard configuration.lastSeenAgentVersion != nil else { return }
         guard vsockControlService?.agentVersion == nil else { return }
         guard installState == nil else { return }
         guard agentPostStartTask == nil else { return }
 
+        agentPostStartGeneration &+= 1
+        let generation = agentPostStartGeneration
         Self.logger.debug(
-            "Agent post-start watchdog armed for '\(self.name, privacy: .public)' (grace=\(grace, privacy: .public))"
+            "Agent arrival watchdog armed for '\(self.name, privacy: .public)' (grace=\(grace, privacy: .public))"
         )
         agentPostStartTask = Task { [weak self] in
             do {
@@ -785,7 +810,7 @@ final class VMInstance {
                 return
             }
             guard let self else { return }
-            guard self.agentPostStartTask != nil else { return }
+            guard self.agentPostStartGeneration == generation else { return }
             if self.vsockControlService?.agentVersion == nil {
                 Self.logger.notice(
                     "Guest agent expected (last seen \(self.configuration.lastSeenAgentVersion ?? "?", privacy: .public)) but never reconnected for '\(self.name, privacy: .public)' — surfacing reinstall affordance"
@@ -813,10 +838,13 @@ final class VMInstance {
         }
     }
 
-    /// Cancels the post-start watchdog if armed.
+    /// Cancels the agent-arrival watchdog if armed.
     ///
     /// Does not clear `agentExpectedButMissing` — callers do that explicitly.
     func cancelAgentPostStartWatchdog() {
+        // Bumping disowns a task whose sleep already elapsed, which a bare
+        // `cancel()` cannot reach.
+        agentPostStartGeneration &+= 1
         agentPostStartTask?.cancel()
         agentPostStartTask = nil
     }

--- a/Kernova/Services/AgentStatus.swift
+++ b/Kernova/Services/AgentStatus.swift
@@ -23,20 +23,22 @@ enum AgentStatus: Equatable, Sendable {
     case unresponsive(version: String)
 
     /// The host has seen the agent connect on this VM before
-    /// (`VMConfiguration.lastSeenAgentVersion` is set), but the post-start
-    /// grace period elapsed without a fresh `Hello`.
+    /// (`VMConfiguration.lastSeenAgentVersion` is set), but a grace period
+    /// elapsed with no `Hello` — after the VM started or resumed, or after the
+    /// control channel died mid-session.
     ///
     /// Synthesized only at `VMInstance.agentStatus`; `VsockControlService`,
     /// which has no access to persisted state, never returns it.
     case expectedMissing(expected: String)
 
     /// Live session for a VM that has had an agent connect before
-    /// (`VMConfiguration.lastSeenAgentVersion` is set), but no `Hello` has
-    /// arrived yet on this session.
+    /// (`VMConfiguration.lastSeenAgentVersion` is set), with no handshaken
+    /// control channel right now — the agent has yet to arrive, or arrived and
+    /// then went away.
     ///
-    /// Resolves to `.current` once the handshake completes, or to
-    /// `.expectedMissing` if the post-start watchdog fires. Synthesized only at
-    /// `VMInstance.agentStatus`; `VsockControlService` never returns it.
+    /// Resolves to `.current` once a handshake completes, or to
+    /// `.expectedMissing` if the agent-arrival watchdog fires. Synthesized only
+    /// at `VMInstance.agentStatus`; `VsockControlService` never returns it.
     case connecting(expected: String)
 
     var isConnecting: Bool {

--- a/Kernova/Services/VirtualizationService.swift
+++ b/Kernova/Services/VirtualizationService.swift
@@ -220,6 +220,10 @@ final class VirtualizationService {
         do {
             try await vm.pause()
             instance.status = .paused
+            // The grace clock only means something while the guest is executing
+            // — a frozen guest cannot say Hello, so letting it run would blame
+            // the agent for the pause.
+            instance.cancelAgentPostStartWatchdog()
             Self.logger.notice("Paused VM '\(instance.name, privacy: .public)'")
         } catch {
             Self.logger.error(
@@ -255,6 +259,11 @@ final class VirtualizationService {
                 throw VirtualizationError.noSaveFile
             }
 
+            // Both branches land a guest that is executing again: a hot resume
+            // whose channel died while paused, and a cold restore that has yet
+            // to see its first Hello, each need the grace clock the start path
+            // arms. A no-op while the agent is connected.
+            instance.startAgentPostStartWatchdog()
             Self.logger.notice("Resumed VM '\(instance.name, privacy: .public)'")
         } catch {
             Self.logger.error(

--- a/Kernova/Services/VirtualizationService.swift
+++ b/Kernova/Services/VirtualizationService.swift
@@ -41,7 +41,7 @@ final class VirtualizationService {
             // the agent before gets no Hello within the grace period. No-op for
             // fresh VMs (no `lastSeenAgentVersion`), for Linux, and for recovery
             // boots, which never run the agent.
-            instance.startAgentPostStartWatchdog(afterRecoveryBoot: bootIntoRecovery)
+            instance.startAgentPostStartWatchdog()
             if bootIntoRecovery {
                 Self.logger.notice("Started VM '\(instance.name, privacy: .public)' in recovery mode")
             } else {
@@ -101,8 +101,10 @@ final class VirtualizationService {
     /// plumbing, and starts the machine — one cold-boot attempt.
     private func coldBoot(_ instance: VMInstance, bootIntoRecovery: Bool) async throws {
         // Per attempt, not once per start: the lock-contention retry loop tears the
-        // session down — releasing these scopes — between attempts.
+        // session down — releasing these scopes — between attempts, and that
+        // teardown resets the Recovery flag this re-sets below.
         instance.openRuntimeFileAccess()
+        instance.bootedIntoRecovery = bootIntoRecovery
         let result = try await buildConfiguration(for: instance)
         instance.serialInputPipe = result.serialInputPipe
         instance.serialOutputPipe = result.serialOutputPipe
@@ -252,18 +254,23 @@ final class VirtualizationService {
                 try await vm.resume()
                 instance.status = .running
                 instance.removeSaveFile()
+                // The guest is executing again, and this is the same session
+                // that was paused — so `bootedIntoRecovery` still governs, and
+                // a channel that died during the pause gets its grace clock
+                // back. A no-op while the agent is connected.
+                instance.startAgentPostStartWatchdog()
             } else if instance.hasSaveFile {
+                // Deliberately arms nothing: a restore resumes whatever guest
+                // state was frozen, which may be a Recovery session that never
+                // runs the agent, and no host-side flag survives the save to
+                // say which. The accept path arms once a control channel
+                // actually shows up.
                 try await restoreOrColdBoot(instance)
                 instance.status = .running
             } else {
                 throw VirtualizationError.noSaveFile
             }
 
-            // Both branches land a guest that is executing again: a hot resume
-            // whose channel died while paused, and a cold restore that has yet
-            // to see its first Hello, each need the grace clock the start path
-            // arms. A no-op while the agent is connected.
-            instance.startAgentPostStartWatchdog()
             Self.logger.notice("Resumed VM '\(instance.name, privacy: .public)'")
         } catch {
             Self.logger.error(

--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -24,13 +24,24 @@ struct ObservedAgentInfo: Equatable, Sendable {
 /// The listener is installed for every macOS guest with a
 /// `VZVirtioSocketDevice`, independent of any feature toggle, and carries the
 /// bidirectional `Hello` handshake plus a `Heartbeat` stream where extended
-/// peer silence means the peer is hung. One instance manages one channel for
+/// peer silence — while the guest is executing — means the peer is hung. One
+/// instance manages one channel for
 /// one accepted connection and stops itself once that channel dies, whether the
 /// peer closed it or the watchdog did; `stop()` is idempotent and terminal, so
 /// a reconnect is served by a fresh instance.
 @MainActor
 @Observable
 final class VsockControlService {
+    /// Why the service settled, which decides whether the owner hears about it.
+    enum StopReason {
+        /// The channel died underneath us — the peer closed it, or the liveness
+        /// watchdog terminated it for silence.
+        case channelLost
+        /// The owner asked for the teardown: a session teardown, or a fresh
+        /// connection replacing this one.
+        case ownerRequested
+    }
+
     // MARK: - Observable state
 
     /// `true` once the guest agent has sent its `Hello`; reset when the
@@ -75,6 +86,16 @@ final class VsockControlService {
     ///
     /// Fire-and-forget — this service does not care whether the host persists the value.
     private let onAgentInfoObserved: (@MainActor (ObservedAgentInfo) -> Void)?
+
+    /// Reports whether the guest is frozen (the VM is live-paused).
+    ///
+    /// Read at every liveness tick and before every outbound heartbeat, so it
+    /// tracks pause/resume without the owner having to push transitions in.
+    private let isGuestSuspended: (@MainActor () -> Bool)?
+
+    /// Notified once when the channel dies on its own, never on an
+    /// owner-requested `stop()`.
+    private let onChannelLost: (@MainActor () -> Void)?
 
     private var consumeTask: Task<Void, Never>?
     private var outboundHeartbeatTask: Task<Void, Never>?
@@ -138,7 +159,9 @@ final class VsockControlService {
         unresponsiveAfter: Duration = .seconds(15),
         terminateAfter: Duration = .seconds(30),
         policyProvider: (@MainActor () -> AgentPolicySnapshot)? = nil,
-        onAgentInfoObserved: (@MainActor (ObservedAgentInfo) -> Void)? = nil
+        onAgentInfoObserved: (@MainActor (ObservedAgentInfo) -> Void)? = nil,
+        isGuestSuspended: (@MainActor () -> Bool)? = nil,
+        onChannelLost: (@MainActor () -> Void)? = nil
     ) {
         // The two-stage watchdog requires `unresponsiveAfter < terminateAfter`:
         // reversed, `terminateAfter` fires first and `.unresponsive` is never
@@ -158,6 +181,8 @@ final class VsockControlService {
         self.livenessTickInterval = min(heartbeatInterval, unresponsiveAfter / 3)
         self.policyProvider = policyProvider
         self.onAgentInfoObserved = onAgentInfoObserved
+        self.isGuestSuspended = isGuestSuspended
+        self.onChannelLost = onChannelLost
     }
 
     // MARK: - Lifecycle
@@ -175,7 +200,7 @@ final class VsockControlService {
             }
             // The channel is gone once `consume` returns; settle so the
             // heartbeat and liveness tasks stop running against a dead socket.
-            self?.stop()
+            self?.stop(reason: .channelLost)
         }
 
         let heartbeatInterval = self.heartbeatInterval
@@ -207,13 +232,24 @@ final class VsockControlService {
         Self.logger.info("Vsock control service started for '\(self.label, privacy: .public)'")
     }
 
-    /// Tears the service down and resets the handshake state.
+    /// Tears the service down at the owner's request and resets the handshake
+    /// state.
+    ///
+    /// The owner is not called back — it already knows. Involuntary channel
+    /// death routes through `stop(reason: .channelLost)` instead.
+    func stop() {
+        stop(reason: .ownerRequested)
+    }
+
+    /// Tears the service down and resets the handshake state, telling the owner
+    /// when the channel died rather than being closed on purpose.
     ///
     /// Safe to call from inside the tasks it cancels: `Task.cancel()` only sets
     /// the cancellation flag, so a caller running inside the liveness or consume
     /// task runs this method to completion and then unwinds at its own next
-    /// cancellation check.
-    func stop() {
+    /// cancellation check. The `hasStopped` latch makes `onChannelLost` fire at
+    /// most once, and never after an owner teardown has already settled.
+    private func stop(reason: StopReason) {
         guard !hasStopped else { return }
         hasStopped = true
         consumeTask?.cancel()
@@ -230,6 +266,11 @@ final class VsockControlService {
         guestSupportsClipboardStreamingStorage = false
         guestSupportsClipboardDirTreeStorage = false
         Self.logger.info("Vsock control service stopped for '\(self.label, privacy: .public)'")
+        // Last, so the owner observes fully-settled state — notably a nil
+        // `agentVersion` — from inside the callback.
+        if case .channelLost = reason {
+            onChannelLost?()
+        }
     }
 
     // MARK: - Outbound
@@ -290,6 +331,11 @@ final class VsockControlService {
     }
 
     private func sendHeartbeat() {
+        // A frozen guest drains nothing, and `VsockChannel.writeFramed` parks in
+        // a blocking `write(2)` once the peer's receive buffer fills — here, on
+        // the main actor. Send nothing while the guest is suspended.
+        guard !(isGuestSuspended?() ?? false) else { return }
+
         let nonce = nextHeartbeatNonce
         nextHeartbeatNonce += 1
 
@@ -318,12 +364,23 @@ final class VsockControlService {
             // `agentStatus` already reports `.waiting`.
             return
         }
+        // A live-paused guest is frozen, not silent: it cannot answer, so
+        // host-side elapsed time says nothing about the agent's health. Hold
+        // the clock at now for as long as it stays frozen, so the deadline the
+        // guest is judged against runs only while it is executing. This is also
+        // what survives host sleep: the VM is auto-paused for it, but
+        // `ContinuousClock` keeps advancing across it.
+        if isGuestSuspended?() ?? false {
+            lastInboundFrame = ContinuousClock.now
+            isUnresponsive = false
+            return
+        }
         let elapsed = ContinuousClock.now - last
         if elapsed > terminateAfter {
             Self.logger.warning(
                 "Control channel for '\(self.label, privacy: .public)' silent for \(elapsed.formatted(.units(allowed: [.seconds])), privacy: .public) — closing"
             )
-            stop()
+            stop(reason: .channelLost)
         } else if elapsed > unresponsiveAfter {
             if !isUnresponsive {
                 Self.logger.warning(

--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -372,7 +372,10 @@ final class VsockControlService {
         // `ContinuousClock` keeps advancing across it.
         if isGuestSuspended?() ?? false {
             lastInboundFrame = ContinuousClock.now
-            isUnresponsive = false
+            // Guarded like the branches below: an unconditional write to an
+            // `@Observable` property notifies on every tick, and a pause can
+            // last hours.
+            if isUnresponsive { isUnresponsive = false }
             return
         }
         let elapsed = ContinuousClock.now - last

--- a/Kernova/Views/Sidebar/AgentStatusPopoverContentViewController.swift
+++ b/Kernova/Views/Sidebar/AgentStatusPopoverContentViewController.swift
@@ -205,7 +205,7 @@ final class AgentStatusPopoverContentViewController: NSViewController {
                 "\(vmName) is running guest agent \(installed). Kernova bundles \(bundled). Mounting the installer presents it as a disk inside the VM — open it in Finder and run install.command."
         case .connecting(let expected):
             return
-                "Waiting for guest agent \(expected) on \(vmName) to reconnect after boot. If it doesn't connect within a couple of minutes, you'll see a 'didn't reconnect' indicator with reinstall steps."
+                "Waiting for guest agent \(expected) on \(vmName) to connect. If it doesn't within a couple of minutes, you'll see a 'didn't reconnect' indicator with reinstall steps."
         case .current(let version):
             return "\(vmName) is connected with guest agent \(version)."
         case .unresponsive(let version):
@@ -213,7 +213,7 @@ final class AgentStatusPopoverContentViewController: NSViewController {
                 "\(vmName) (guest agent \(version)) stopped responding to heartbeats. The control connection will reset automatically; if it persists, restart the agent inside the VM."
         case .expectedMissing(let expected):
             return
-                "\(vmName) had guest agent \(expected) installed previously, but it didn't connect after this boot. The agent's LaunchAgent may be unloaded, or it may have been uninstalled inside the VM. Reinstalling presents the installer as a disk — open it in Finder and run install.command."
+                "\(vmName) had guest agent \(expected) installed previously, but it isn't connected now. The agent's LaunchAgent may be unloaded, or it may have been uninstalled inside the VM. Reinstalling presents the installer as a disk — open it in Finder and run install.command."
         }
     }
 

--- a/KernovaTests/AgentStatusPopoverContentViewControllerTests.swift
+++ b/KernovaTests/AgentStatusPopoverContentViewControllerTests.swift
@@ -53,6 +53,21 @@ struct AgentStatusPopoverContentViewControllerTests {
         }
     }
 
+    @Test("Body copy for a missing agent describes no particular cause")
+    func absentAgentCopyIsCauseAgnostic() {
+        // Both states are reached after a mid-session death as well as after a
+        // boot, so neither may claim a boot happened (#706). The escalation the
+        // `.connecting` copy promises is what the re-armed watchdog delivers.
+        let connecting = AgentStatusPopoverContentViewController.bodyText(
+            for: .connecting(expected: "0.9.2"), vmName: "TestVM")
+        #expect(!connecting.contains("boot"))
+        #expect(connecting.contains("didn't reconnect"))
+
+        let missing = AgentStatusPopoverContentViewController.bodyText(
+            for: .expectedMissing(expected: "0.9.2"), vmName: "TestVM")
+        #expect(!missing.contains("boot"))
+    }
+
     @Test("Don't show again button visibility tracks hasDismissAction")
     func dismissButtonVisibility() {
         let vc = AgentStatusPopoverContentViewController()

--- a/KernovaTests/VMInstanceAgentReconnectTests.swift
+++ b/KernovaTests/VMInstanceAgentReconnectTests.swift
@@ -49,7 +49,11 @@ struct VMInstanceAgentReconnectTests {
     }
 
     /// Installs a production-wired control service on `instance` over a socket
-    /// pair, and returns the guest end for the test to drive.
+    /// pair, mirroring what the accept closure in `startVsockServices()` does,
+    /// and returns the guest end for the test to drive.
+    ///
+    /// Every step the accept closure takes, in its order — settle whatever is
+    /// installed, build, install, start, arm.
     private func attachControlService(to instance: VMInstance) throws -> VsockChannel {
         let (guestFd, hostFd) = try makeRawSocketPair()
         let guest = VsockChannel(fileDescriptor: guestFd)
@@ -57,9 +61,11 @@ struct VMInstanceAgentReconnectTests {
         guest.start()
         host.start()
 
+        instance.vsockControlService?.stop()
         let service = instance.makeControlService(for: host)
         instance.vsockControlService = service
         service.start()
+        instance.startAgentPostStartWatchdog()
         return guest
     }
 
@@ -94,6 +100,39 @@ struct VMInstanceAgentReconnectTests {
         #expect(instance.agentStatus == .connecting(expected: version))
     }
 
+    @Test("A replacement channel that never handshakes still escalates")
+    func wedgedReplacementChannelStillEscalates() async throws {
+        // Replacing a live service settles the old one as owner-requested, so
+        // `onChannelLost` stays silent — the accept path's own arm is the only
+        // thing standing between a connect-but-never-Hello agent (a
+        // half-finished update) and a spinner that never resolves.
+        let version = try bundledAgentVersion()
+        let instance = makeInstance(agentVersion: version)
+        let first = try attachControlService(to: instance)
+        defer {
+            instance.cancelAgentPostStartWatchdog()
+            instance.stopVsockServices()
+            first.close()
+        }
+
+        try first.send(makeGuestHello(agentVersion: version))
+        try await waitForChange { instance.vsockControlService?.agentVersion != nil }
+        #expect(instance.agentPostStartTaskForTesting == nil)
+
+        // A second connection arrives while the first is still healthy, then
+        // wedges: open, but never a valid Hello.
+        let second = try attachControlService(to: instance)
+        defer { second.close() }
+        #expect(instance.agentStatus == .connecting(expected: version))
+        #expect(instance.agentPostStartTaskForTesting != nil)
+
+        // Re-arm short to watch that clock actually run out.
+        instance.cancelAgentPostStartWatchdog()
+        instance.startAgentPostStartWatchdog(grace: .milliseconds(200))
+        await instance.agentPostStartTaskForTesting?.value
+        #expect(instance.agentStatus == .expectedMissing(expected: version))
+    }
+
     @Test("An owner teardown of the control service arms nothing")
     func ownerTeardownArmsNothing() async throws {
         let version = try bundledAgentVersion()
@@ -113,11 +152,16 @@ struct VMInstanceAgentReconnectTests {
         #expect(instance.agentPostStartTaskForTesting == nil)
     }
 
-    @Test("A live-paused VM keeps its channel and never escalates")
-    func livePausedVMKeepsItsChannel() async throws {
-        // The trap #706 called out: the liveness watchdog terminates a silent
-        // channel, a paused guest is silent by definition, and the re-arm would
-        // then put a "didn't reconnect" warning on a VM the user merely paused.
+    @Test("Pausing a VM disturbs neither the control channel nor the agent badge")
+    func pausingLeavesTheAgentBadgeAlone() async throws {
+        // Scoped to what a production-cadence service can show in a short
+        // window: pausing tears nothing down synchronously and arms no grace
+        // clock, so the badge a user sees does not flinch when they pause.
+        //
+        // It does NOT cover the deadline being held while frozen — the first
+        // liveness tick is 5 s away at production cadences. That property needs
+        // injected windows and lives in
+        // `VsockControlServiceTests.suspendedGuestSurvivesTerminateWindow`.
         let version = try bundledAgentVersion()
         let instance = makeInstance(agentVersion: version)
         let guest = try attachControlService(to: instance)
@@ -133,11 +177,9 @@ struct VMInstanceAgentReconnectTests {
         instance.status = .paused
         #expect(instance.isLivePaused)
 
-        // RATIONALE: negative assertion ("prove neither the channel teardown
-        // nor the watchdog fired") — a fixed observation window, per
-        // docs/TESTING.md "Async waits in tests". The service runs production
-        // liveness windows, so this only has to outlast a mistaken immediate
-        // teardown, not the 30 s terminate deadline.
+        // RATIONALE: negative assertion ("prove nothing was torn down or
+        // armed") — a fixed observation window, per docs/TESTING.md "Async
+        // waits in tests".
         try await Task.sleep(for: .milliseconds(500))
         #expect(instance.vsockControlService?.isConnected == true)
         #expect(instance.agentPostStartTaskForTesting == nil)

--- a/KernovaTests/VMInstanceAgentReconnectTests.swift
+++ b/KernovaTests/VMInstanceAgentReconnectTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import KernovaKit
+import KernovaTestSupport
+import Testing
+
+@testable import Kernova
+
+/// The #706 mid-session escalation, end to end over a real control channel:
+/// `VMInstance.makeControlService(for:)` wires the hooks the accept path
+/// installs, so an agent that disappears mid-session escalates past
+/// `.connecting` instead of spinning there for the rest of the session.
+@Suite("VMInstance agent reconnect escalation")
+@MainActor
+struct VMInstanceAgentReconnectTests {
+    // MARK: - Helpers
+
+    /// The version both the persisted `lastSeenAgentVersion` and the guest's
+    /// `Hello` report, so a connected agent renders `.current` rather than
+    /// `.outdated` against whatever the host bundles.
+    private func bundledAgentVersion() throws -> String {
+        try #require(KernovaMacOSAgentInfo.bundledVersion)
+    }
+
+    private func makeInstance(agentVersion: String, status: VMStatus = .running) -> VMInstance {
+        var config = VMConfiguration(name: "Reconnect VM", guestOS: .macOS, bootMode: .macOS)
+        config.lastSeenAgentVersion = agentVersion
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(config.id.uuidString, isDirectory: true)
+        let instance = VMInstance(configuration: config, bundleURL: bundleURL, status: status)
+        // `agentStatus` synthesis keys off a live VZVirtualMachine, which no CI
+        // host can create.
+        instance.hasLiveVirtualMachineOverrideForTesting = true
+        return instance
+    }
+
+    private func makeGuestHello(agentVersion: String) -> Frame {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.hello = Kernova_V1_Hello.with {
+            $0.serviceVersion = 1
+            $0.capabilities = KernovaCapability.controlChannelDefaults
+            $0.agentInfo = Kernova_V1_AgentInfo.with {
+                $0.os = "macOS"
+                $0.osVersion = "26.0"
+                $0.agentVersion = agentVersion
+            }
+        }
+        return frame
+    }
+
+    /// Installs a production-wired control service on `instance` over a socket
+    /// pair, and returns the guest end for the test to drive.
+    private func attachControlService(to instance: VMInstance) throws -> VsockChannel {
+        let (guestFd, hostFd) = try makeRawSocketPair()
+        let guest = VsockChannel(fileDescriptor: guestFd)
+        let host = VsockChannel(fileDescriptor: hostFd)
+        guest.start()
+        host.start()
+
+        let service = instance.makeControlService(for: host)
+        instance.vsockControlService = service
+        service.start()
+        return guest
+    }
+
+    // MARK: - Tests
+
+    @Test("An agent that disappears mid-session re-arms the watchdog")
+    func channelLossRearmsTheWatchdog() async throws {
+        let version = try bundledAgentVersion()
+        let instance = makeInstance(agentVersion: version)
+        let guest = try attachControlService(to: instance)
+        defer {
+            instance.cancelAgentPostStartWatchdog()
+            instance.stopVsockServices()
+            guest.close()
+        }
+
+        try guest.send(makeGuestHello(agentVersion: version))
+        try await waitForChange { instance.vsockControlService?.agentVersion != nil }
+        #expect(instance.agentStatus == .current(version: version))
+        #expect(instance.hasSeenAgentThisSession)
+        // A connected agent is nothing to wait for.
+        #expect(instance.agentPostStartTaskForTesting == nil)
+
+        // The guest agent quits. Before #706 the status parked at `.connecting`
+        // with nothing left to escalate it.
+        guest.close()
+        try await waitForChange { instance.vsockControlService?.isConnected == false }
+
+        // `onChannelLost` runs inside the settle, so the re-arm is already done
+        // by the time the settle is observable.
+        #expect(instance.agentPostStartTaskForTesting != nil)
+        #expect(instance.agentStatus == .connecting(expected: version))
+    }
+
+    @Test("An owner teardown of the control service arms nothing")
+    func ownerTeardownArmsNothing() async throws {
+        let version = try bundledAgentVersion()
+        let instance = makeInstance(agentVersion: version)
+        let guest = try attachControlService(to: instance)
+        defer {
+            instance.cancelAgentPostStartWatchdog()
+            guest.close()
+        }
+
+        try guest.send(makeGuestHello(agentVersion: version))
+        try await waitForChange { instance.vsockControlService?.agentVersion != nil }
+
+        // `stopVsockServices()` is the session teardown path; arming a grace
+        // clock against a VM being shut down would be pure noise.
+        instance.stopVsockServices()
+        #expect(instance.agentPostStartTaskForTesting == nil)
+    }
+
+    @Test("A live-paused VM keeps its channel and never escalates")
+    func livePausedVMKeepsItsChannel() async throws {
+        // The trap #706 called out: the liveness watchdog terminates a silent
+        // channel, a paused guest is silent by definition, and the re-arm would
+        // then put a "didn't reconnect" warning on a VM the user merely paused.
+        let version = try bundledAgentVersion()
+        let instance = makeInstance(agentVersion: version)
+        let guest = try attachControlService(to: instance)
+        defer {
+            instance.cancelAgentPostStartWatchdog()
+            instance.stopVsockServices()
+            guest.close()
+        }
+
+        try guest.send(makeGuestHello(agentVersion: version))
+        try await waitForChange { instance.vsockControlService?.agentVersion != nil }
+
+        instance.status = .paused
+        #expect(instance.isLivePaused)
+
+        // RATIONALE: negative assertion ("prove neither the channel teardown
+        // nor the watchdog fired") — a fixed observation window, per
+        // docs/TESTING.md "Async waits in tests". The service runs production
+        // liveness windows, so this only has to outlast a mistaken immediate
+        // teardown, not the 30 s terminate deadline.
+        try await Task.sleep(for: .milliseconds(500))
+        #expect(instance.vsockControlService?.isConnected == true)
+        #expect(instance.agentPostStartTaskForTesting == nil)
+        #expect(instance.agentExpectedButMissing == false)
+        #expect(instance.agentStatus == .current(version: version))
+    }
+
+    @Test("A channel lost while live-paused still arms nothing")
+    func livePausedChannelLossArmsNothing() async throws {
+        // Belt and braces for the same trap: even if the channel does go away
+        // during a pause — the guest agent crashed before the freeze, say — the
+        // `.running` guard keeps the grace clock off until the VM is executing.
+        let version = try bundledAgentVersion()
+        let instance = makeInstance(agentVersion: version)
+        let guest = try attachControlService(to: instance)
+        defer {
+            instance.cancelAgentPostStartWatchdog()
+            instance.stopVsockServices()
+            guest.close()
+        }
+
+        try guest.send(makeGuestHello(agentVersion: version))
+        try await waitForChange { instance.vsockControlService?.agentVersion != nil }
+
+        instance.status = .paused
+        guest.close()
+        try await waitForChange { instance.vsockControlService?.isConnected == false }
+
+        #expect(instance.agentPostStartTaskForTesting == nil)
+
+        // Resuming is what starts the clock — and the resumed VM is exactly the
+        // case that must escalate.
+        instance.status = .running
+        instance.startAgentPostStartWatchdog(grace: .milliseconds(200))
+        await instance.agentPostStartTaskForTesting?.value
+        #expect(instance.agentStatus == .expectedMissing(expected: version))
+    }
+}

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -838,19 +838,33 @@ struct VMInstanceTests {
         #expect(instance.agentExpectedButMissing == false)
     }
 
-    @Test("Watchdog is a no-op after a recovery boot")
+    @Test("Watchdog is a no-op for the whole of a recovery-booted session")
     func watchdogNoopAfterRecoveryBoot() async throws {
         // Recovery never runs the agent, so its silence proves nothing — the
         // "didn't reconnect" badge would be false and clearing the stored guest
-        // OS version would erase a value that is not in doubt.
+        // OS version would erase a value that is not in doubt. Session state,
+        // not a per-call flag: a pause/resume inside a Recovery session reaches
+        // the same arm site with no idea a Recovery boot happened.
         let instance = makeMacOSInstanceWithAgentInstalled(
             lastSeenGuestOSVersion: "Version 26.0 (Build 25A123)")
+        instance.bootedIntoRecovery = true
 
-        instance.startAgentPostStartWatchdog(
-            afterRecoveryBoot: true, grace: Self.testWatchdogGrace)
+        instance.startAgentPostStartWatchdog(grace: Self.testWatchdogGrace)
         try await Task.sleep(for: Self.testWatchdogGrace * 3)
         #expect(instance.agentExpectedButMissing == false)
         #expect(instance.configuration.lastSeenGuestOSVersion == "Version 26.0 (Build 25A123)")
+        #expect(instance.configuration.agentInstallNudgeDismissed == false)
+    }
+
+    @Test("tearDownSession clears the recovery-boot flag")
+    func tearDownSessionClearsRecoveryFlag() {
+        // Per-session, like the rest of the watchdog state: the next boot is
+        // free to be an ordinary one.
+        let instance = makeMacOSInstanceWithAgentInstalled()
+        instance.bootedIntoRecovery = true
+
+        instance.tearDownSession()
+        #expect(!instance.bootedIntoRecovery)
     }
 
     @Test("Watchdog is a no-op while macOS install is in progress")

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -1,6 +1,8 @@
 import Testing
 import Foundation
 import AppKit
+import KernovaKit
+import KernovaTestSupport
 @testable import Kernova
 
 @Suite("VMInstance Tests")
@@ -718,7 +720,9 @@ struct VMInstanceTests {
     //
     // The watchdog flips `agentExpectedButMissing` after a grace period when:
     //   - The guest is macOS,
+    //   - The VM is `.running` (a frozen guest can't answer),
     //   - `lastSeenAgentVersion` is set (so we have a baseline expectation),
+    //   - No agent is connected on the control channel already,
     //   - No `installState` is in progress, and
     //   - No Hello arrives during the grace window.
     // Tests inject a millisecond-scale grace so the suite stays fast.
@@ -744,6 +748,22 @@ struct VMInstanceTests {
         let instance = VMInstance(configuration: config, bundleURL: bundleURL, status: .running)
         instance.installState = installState
         return instance
+    }
+
+    /// Guest-side `Hello` for tests that drive a real `VsockControlService`.
+    private func makeGuestHelloFrame(agentVersion: String) -> Frame {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.hello = Kernova_V1_Hello.with {
+            $0.serviceVersion = 1
+            $0.capabilities = KernovaCapability.controlChannelDefaults
+            $0.agentInfo = Kernova_V1_AgentInfo.with {
+                $0.os = "macOS"
+                $0.osVersion = "26.0"
+                $0.agentVersion = agentVersion
+            }
+        }
+        return frame
     }
 
     // Sized past macos-26 GitHub Actions MainActor jitter, which far exceeds
@@ -847,6 +867,50 @@ struct VMInstanceTests {
         #expect(instance.agentExpectedButMissing == false)
     }
 
+    @Test(
+        "Watchdog is a no-op unless the VM is running",
+        arguments: [
+            VMStatus.paused, .saving, .restoring, .stopped,
+        ])
+    func watchdogNoopUnlessRunning(status: VMStatus) async throws {
+        // A live-paused guest is frozen: it cannot say Hello, so a grace clock
+        // running against it would blame the agent for the user's pause. The
+        // control channel settles for silence at the same time, which is what
+        // re-arms the watchdog — hence the guard rather than caller discipline.
+        let instance = makeMacOSInstanceWithAgentInstalled()
+        instance.status = status
+
+        instance.startAgentPostStartWatchdog(grace: Self.testWatchdogGrace)
+        #expect(instance.agentPostStartTaskForTesting == nil)
+        try await Task.sleep(for: Self.testWatchdogGrace * 3)
+        #expect(instance.agentExpectedButMissing == false)
+    }
+
+    @Test("Watchdog is a no-op while the agent is connected")
+    func watchdogNoopWhileAgentConnected() async throws {
+        // Re-arm sites (resume, and the control channel dying) fire without
+        // checking whether an agent is already talking; nothing to wait for
+        // means nothing to arm.
+        let instance = makeMacOSInstanceWithAgentInstalled()
+        let (guestFd, hostFd) = try makeRawSocketPair()
+        let guest = VsockChannel(fileDescriptor: guestFd)
+        let host = VsockChannel(fileDescriptor: hostFd)
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let control = VsockControlService(channel: host, label: "watchdog-test")
+        instance.vsockControlService = control
+        control.start()
+        defer { control.stop() }
+
+        try guest.send(makeGuestHelloFrame(agentVersion: "0.9.2"))
+        try await waitForChange { control.agentVersion != nil }
+
+        instance.startAgentPostStartWatchdog(grace: Self.testWatchdogGrace)
+        #expect(instance.agentPostStartTaskForTesting == nil)
+    }
+
     @Test("startAgentPostStartWatchdog is idempotent when already armed")
     func watchdogIdempotent() async throws {
         let instance = makeMacOSInstanceWithAgentInstalled()
@@ -923,6 +987,52 @@ struct VMInstanceTests {
         await instance.agentPostStartTaskForTesting?.value
         #expect(instance.agentExpectedButMissing == true)
         #expect(persistCallCount == 0)
+    }
+
+    @Test("A mid-session firing leaves the nudge dismissal and guest OS version alone")
+    func watchdogPreservesPersistedStateAfterAMidSessionDeath() async throws {
+        // The clearing exists for an agent that never showed up: nothing
+        // vouched for the stored OS version, and the install nudge should come
+        // back. After a Hello this session both facts are backed by evidence
+        // the session produced, and `agentInstallNudgeDismissed` is a user
+        // preference nothing restores — a dropped channel is not enough to
+        // reverse it.
+        let instance = makeMacOSInstanceWithAgentInstalled()
+        instance.configuration.agentInstallNudgeDismissed = true
+
+        var persistCallCount = 0
+        instance.onUpdateConfiguration = { mutate in
+            mutate(&instance.configuration)
+            persistCallCount += 1
+        }
+
+        instance.recordObservedAgentInfo(
+            ObservedAgentInfo(agentVersion: "0.9.2", osVersion: "Version 26.0 (Build 25A123)"))
+        #expect(instance.hasSeenAgentThisSession)
+        let persistsAfterHello = persistCallCount
+
+        // The agent goes away mid-session and never comes back.
+        instance.startAgentPostStartWatchdog(grace: Self.testWatchdogGrace)
+        await instance.agentPostStartTaskForTesting?.value
+
+        // The badge still escalates — that is the whole point of #706.
+        #expect(instance.agentExpectedButMissing == true)
+        #expect(instance.agentStatus == .expectedMissing(expected: "0.9.2"))
+        #expect(instance.configuration.agentInstallNudgeDismissed == true)
+        #expect(instance.configuration.lastSeenGuestOSVersion == "Version 26.0 (Build 25A123)")
+        #expect(persistCallCount == persistsAfterHello)
+    }
+
+    @Test("tearDownSession clears hasSeenAgentThisSession")
+    func tearDownSessionClearsSeenAgentFlag() {
+        // The flag is per-session: the next boot's no-show must be free to
+        // rewrite persisted agent state again.
+        let instance = makeMacOSInstanceWithAgentInstalled()
+        instance.recordObservedAgentInfo(ObservedAgentInfo(agentVersion: "0.9.2", osVersion: "26.0"))
+        #expect(instance.hasSeenAgentThisSession)
+
+        instance.tearDownSession()
+        #expect(!instance.hasSeenAgentThisSession)
     }
 
     @Test("tearDownSession clears agentExpectedButMissing and cancels the watchdog")

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -102,7 +102,9 @@ struct VsockControlServiceTests {
         unresponsiveAfter: Duration? = nil,
         terminateAfter: Duration? = nil,
         policyProvider: (@MainActor () -> AgentPolicySnapshot)? = nil,
-        onAgentInfoObserved: (@MainActor (ObservedAgentInfo) -> Void)? = nil
+        onAgentInfoObserved: (@MainActor (ObservedAgentInfo) -> Void)? = nil,
+        isGuestSuspended: (@MainActor () -> Bool)? = nil,
+        onChannelLost: (@MainActor () -> Void)? = nil
     ) -> VsockControlService {
         VsockControlService(
             channel: channel,
@@ -112,7 +114,9 @@ struct VsockControlServiceTests {
             unresponsiveAfter: unresponsiveAfter ?? Self.watchdogDisabledUnresponsive,
             terminateAfter: terminateAfter ?? Self.watchdogDisabledTerminate,
             policyProvider: policyProvider,
-            onAgentInfoObserved: onAgentInfoObserved
+            onAgentInfoObserved: onAgentInfoObserved,
+            isGuestSuspended: isGuestSuspended,
+            onChannelLost: onChannelLost
         )
     }
 
@@ -591,6 +595,231 @@ struct VsockControlServiceTests {
         #expect(service.lifecycleTasksForTesting.isEmpty)
     }
 
+    // MARK: - Live-paused guest
+
+    @Test("A suspended guest is never judged silent, however long the pause runs")
+    func suspendedGuestSurvivesTerminateWindow() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        // A live-paused VM is frozen by design: the guest cannot answer a
+        // heartbeat, so the pre-#706 behavior — terminate for silence — blamed
+        // the agent for the user's pause.
+        // Short windows are safe here in a way they are not elsewhere in this
+        // suite: the property under test is that the deadline never advances
+        // while suspended, so a stalled runner cannot produce a false failure.
+        let suspension = SuspensionFlag()
+        let service = makeService(
+            channel: host,
+            bundledAgentVersion: "0.9.0",
+            heartbeatInterval: .milliseconds(50),
+            unresponsiveAfter: .milliseconds(100),
+            terminateAfter: .milliseconds(200),
+            isGuestSuspended: { suspension.isSuspended }
+        )
+        service.start()
+        defer { service.stop() }
+
+        _ = try await nextFrame(from: guest)  // host hello
+        try guest.send(makeGuestHello(agentVersion: "0.9.0"))
+        try await waitForChange { service.isConnected }
+
+        suspension.isSuspended = true
+
+        // RATIONALE: negative assertion ("prove the watchdog never fired") —
+        // a fixed observation window, per docs/TESTING.md "Async waits in tests".
+        // Four terminate windows with the guest sending nothing at all.
+        try await Task.sleep(for: .milliseconds(800))
+        #expect(service.isConnected)
+        #expect(service.agentStatus == .current(version: "0.9.0"))
+    }
+
+    @Test("Suspension defers the liveness deadline rather than disabling it")
+    func resumedGuestGetsAFreshWindow() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let suspension = SuspensionFlag()
+        let service = makeService(
+            channel: host,
+            bundledAgentVersion: "0.9.0",
+            heartbeatInterval: .milliseconds(50),
+            unresponsiveAfter: .milliseconds(100),
+            terminateAfter: .milliseconds(200),
+            isGuestSuspended: { suspension.isSuspended }
+        )
+        service.start()
+        defer { service.stop() }
+
+        _ = try await nextFrame(from: guest)  // host hello
+        try guest.send(makeGuestHello(agentVersion: "0.9.0"))
+        try await waitForChange { service.isConnected }
+
+        // RATIONALE: negative assertion ("prove the watchdog didn't fire during
+        // the pause") — a fixed observation window, per docs/TESTING.md "Async
+        // waits in tests". Three terminate windows, guest sending nothing.
+        suspension.isSuspended = true
+        try await Task.sleep(for: .milliseconds(600))
+        #expect(service.isConnected)
+
+        // Resuming hands the guest a window it can still miss: nothing has been
+        // heard from it, so the deadline starts running again and expires.
+        suspension.isSuspended = false
+        try await waitForChange { !service.isConnected }
+        #expect(service.agentStatus == .waiting)
+    }
+
+    @Test("No heartbeat is written to a suspended guest")
+    func noHeartbeatWhileSuspended() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        // `VsockChannel.writeFramed` parks in a blocking `write(2)` once the
+        // peer's receive buffer fills, on the main actor — and a frozen guest
+        // drains nothing. Sending to one is a main-thread hang waiting to
+        // happen, so nothing may go out.
+        //
+        // The collector owns the guest's inbound stream for the whole test:
+        // `nextFrame` would consume from the same single-consumer stream and
+        // race it for frames.
+        let collector = FrameCollector(channel: guest)
+        defer { collector.cancel() }
+
+        let suspension = SuspensionFlag()
+        let service = makeService(
+            channel: host,
+            bundledAgentVersion: "0.9.0",
+            heartbeatInterval: .milliseconds(50),
+            isGuestSuspended: { suspension.isSuspended }
+        )
+        service.start()
+        defer { service.stop() }
+
+        try guest.send(makeGuestHello(agentVersion: "0.9.0"))
+        try await waitForChange { service.isConnected }
+        // Prove the sender is genuinely running before freezing it, so a
+        // silent-for-another-reason service can't pass this test.
+        try await collector.received.wait { collector.count >= 2 }
+
+        // Snapshot the baseline only after a settle window: a heartbeat written
+        // just before the flip flipped is still in flight through the socket and
+        // the collector's task, and counting it against the frozen guest would
+        // be a false failure.
+        suspension.isSuspended = true
+        try await Task.sleep(for: .milliseconds(150))
+        let baseline = collector.count
+
+        // RATIONALE: negative assertion ("prove no frame arrived") — a fixed
+        // observation window, per docs/TESTING.md "Async waits in tests". Spans
+        // many heartbeat intervals.
+        try await Task.sleep(for: .milliseconds(400))
+        #expect(
+            collector.count == baseline,
+            "Expected no outbound frames while the guest was suspended; got \(collector.count - baseline)"
+        )
+    }
+
+    // MARK: - onChannelLost
+
+    @Test("onChannelLost fires when the liveness watchdog terminates a silent channel")
+    func channelLostOnLivenessTerminate() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let lost = ChannelLostRecorder()
+        let service = makeService(
+            channel: host,
+            bundledAgentVersion: "0.9.0",
+            heartbeatInterval: .milliseconds(100),
+            unresponsiveAfter: .milliseconds(200),
+            terminateAfter: .milliseconds(500),
+            onChannelLost: { lost.record() }
+        )
+        lost.sampleAgentVersion = { [weak service] in service?.agentVersion }
+        service.start()
+        defer { service.stop() }
+
+        _ = try await nextFrame(from: guest)  // host hello
+        // No wait on `isConnected` in between: with a terminate window this
+        // short the settle can beat the observation, and the callback — not the
+        // connected state — is what this test is about.
+        try guest.send(makeGuestHello(agentVersion: "0.9.0"))
+
+        try await lost.changed.wait { lost.count == 1 }
+        // The callback runs on fully-settled state, which is what lets
+        // `VMInstance` re-arm its agent watchdog on a nil `agentVersion`
+        // instead of no-oping against the stale one.
+        #expect(lost.sampledAgentVersions == [nil])
+    }
+
+    @Test("onChannelLost fires when the peer closes the channel")
+    func channelLostOnPeerClose() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+
+        let lost = ChannelLostRecorder()
+        let service = makeService(
+            channel: host,
+            bundledAgentVersion: "0.9.0",
+            onChannelLost: { lost.record() }
+        )
+        lost.sampleAgentVersion = { [weak service] in service?.agentVersion }
+        service.start()
+        defer { service.stop() }
+
+        _ = try await nextFrame(from: guest)  // host hello
+        try guest.send(makeGuestHello(agentVersion: "0.9.0"))
+        try await waitForChange { service.isConnected }
+
+        // The guest agent quits mid-session: EOF unwinds the consume loop.
+        guest.close()
+
+        try await lost.changed.wait { lost.count == 1 }
+        #expect(lost.sampledAgentVersions == [nil])
+    }
+
+    @Test("onChannelLost stays silent for an owner-requested stop()")
+    func channelLostSkippedForOwnerStop() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        // Session teardown and the accept path's replace-the-previous-service
+        // both route here. The owner already knows, and telling it the channel
+        // "died" would arm a watchdog against a VM it is shutting down.
+        let lost = ChannelLostRecorder()
+        let service = makeService(
+            channel: host,
+            bundledAgentVersion: "0.9.0",
+            onChannelLost: { lost.record() }
+        )
+        service.start()
+
+        _ = try await nextFrame(from: guest)  // host hello
+        try guest.send(makeGuestHello(agentVersion: "0.9.0"))
+        try await waitForChange { service.isConnected }
+
+        service.stop()
+        #expect(!service.isConnected)
+
+        // RATIONALE: negative assertion ("prove the callback never fired") —
+        // a fixed observation window, per docs/TESTING.md "Async waits in
+        // tests". The consume task also unwinds in here, and its settle must
+        // not fire the callback either: the owner's stop() latched first.
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(lost.count == 0)
+    }
+
     // MARK: - Lifecycle
 
     @Test("stop() is idempotent and resets state")
@@ -924,4 +1153,60 @@ private final class ObservedRecorder {
         values.append(value)
         changed.notify()
     }
+}
+
+/// Stand-in for `VMInstance.isLivePaused`, flipped by the test to freeze and
+/// thaw the guest.
+@MainActor
+private final class SuspensionFlag {
+    var isSuspended = false
+}
+
+/// Counts `onChannelLost` invocations, sampling service state at callback time.
+///
+/// `sampleAgentVersion` is assigned after the service exists, since the thing
+/// worth sampling is the service the recorder is wired into.
+@MainActor
+private final class ChannelLostRecorder {
+    private(set) var count = 0
+    private(set) var sampledAgentVersions: [String?] = []
+
+    var sampleAgentVersion: (@MainActor () -> String?)?
+
+    /// Fires on every `record`; await it instead of polling `count`.
+    let changed = AsyncGate()
+
+    func record() {
+        count += 1
+        sampledAgentVersions.append(sampleAgentVersion.flatMap { $0() })
+        changed.notify()
+    }
+}
+
+/// Records every frame arriving on a channel, for negative assertions about
+/// outbound traffic.
+@MainActor
+private final class FrameCollector {
+    private(set) var count = 0
+    private var consumeTask: Task<Void, Never>?
+
+    /// Fires on every recorded frame; await it instead of polling `count`.
+    let received = AsyncGate()
+
+    init(channel: VsockChannel) {
+        consumeTask = Task { @MainActor [weak self] in
+            do {
+                for try await _ in channel.incoming {
+                    self?.count += 1
+                    self?.received.notify()
+                }
+            } catch {
+                // The stream errored — recording stops, and the count so far
+                // is what the assertion reads.
+            }
+        }
+    }
+
+    func cancel() { consumeTask?.cancel() }
+    deinit { consumeTask?.cancel() }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,9 +122,12 @@ The vsock stack (macOS guests only):
   measurements: [research/2026-07-13-vsock-transport-throughput.md](research/2026-07-13-vsock-transport-throughput.md).
 - `VsockControlService` — `@MainActor` `@Observable` owner of the always-on control channel:
   `Hello`/`Heartbeat` exchange, a liveness watchdog, the observed `agentVersion`, and `PolicyUpdate`
-  pushes carrying an `AgentPolicySnapshot` (built by a closure that reads the current
-  configuration, so a reconnect picks up live toggles). Installed for every macOS guest with a
-  socket device, independent of clipboard sharing.
+  pushes carrying an `AgentPolicySnapshot`. `VMInstance.makeControlService(for:)` builds it with
+  four closures that read the instance lazily, so a reconnect picks up live toggles and a
+  pause/resume needs nothing re-pushed: current policy, observed agent info, whether the guest is
+  frozen (which suspends both the heartbeat and the liveness deadline), and a channel-loss
+  notification that re-arms `VMInstance`'s agent-arrival watchdog. Installed for every macOS guest
+  with a socket device, independent of clipboard sharing.
 - `VsockGuestLogService` — forwards guest `LogRecord` frames into the `app.kernova.guest` subsystem.
 
 The log and clipboard listeners are gated on their configuration toggles and re-evaluated at


### PR DESCRIPTION
Closes #706

## Problem

`VsockControlService` tears itself down when the control channel dies (#703, #707), so `agentStatus` drops to `.waiting` and `AgentStatus.synthesize` renders `.connecting(expected:)`. That is right while the agent is reconnecting, but nothing could ever escalate past it mid-session: `startAgentPostStartWatchdog` is one-shot per session, guarded on `agentPostStartTask == nil` and cancelled by the first `Hello`, with a single call site in `VirtualizationService.start()`.

The consequence is worse than stale copy. `SidebarVMRowCellView.visibleAgentStatus` keeps surfacing `.connecting`, so the spinner runs forever; `GuestAgentDiskMenuItem.model` returns `isEnabled: false` for `.connecting` and `ClipboardContentViewController.applyStatus` hides the action button — leaving the user **no affordance to mount the installer** for exactly the failure being reported.

## Approach

The issue named the trap: naively re-arming whenever the service settles fires `.expectedMissing` on a VM the user merely paused, because a live-paused guest is frozen and the liveness watchdog terminates its channel for silence by design. This handles it in two independent layers, so the paused case is excluded by construction rather than by caller discipline:

1. **The liveness watchdog stops running against a frozen guest.** `VsockControlService` takes an injected `isGuestSuspended` closure (wired to `VMInstance.isLivePaused`) and, while it reports `true`, holds `lastInboundFrame` at now instead of measuring elapsed silence. Pausing no longer kills the channel, so there is nothing to escalate from. The same predicate gates `sendHeartbeat()` — `VsockChannel.writeFramed` parks in a blocking `write(2)` when the peer's receive buffer fills, on the main actor, and a frozen guest drains nothing; the 30 s liveness teardown is what accidentally prevents that today.

2. **The watchdog refuses to arm unless the VM is `.running`.** Plus a second guard for "an agent is already connected", so every arm site can fire unconditionally.

Re-arming is driven by a new `onChannelLost` callback, fired from a private `stop(reason:)` only for `.channelLost` — the liveness terminate branch and the consume loop's EOF. An owner-requested `stop()` (session teardown, or the accept path replacing a prior service) reports nothing, so a VM being shut down never arms a grace clock. The callback runs after the state reset, which is what lets the re-arm see a nil `agentVersion` rather than no-oping against the stale one.

### The nudge-preference clobber

The watchdog's config mutation clears `agentInstallNudgeDismissed` (a user preference nothing restores) alongside `lastSeenGuestOSVersion`. Its premise, stated in its own comment, is that the agent that vouched for those values is gone and never showed up — true after a boot no-show, false after a mid-session death, where the session itself produced the evidence. New `VMInstance.hasSeenAgentThisSession` (set in `recordObservedAgentInfo`, reset in `tearDownSession`) scopes the mutation to sessions where no `Hello` ever arrived. `agentExpectedButMissing` still latches unconditionally — the badge escalates either way. Boot behavior is byte-for-byte unchanged, and the two existing tests covering it pass unmodified.

### Copy

`.connecting` dropped "after boot" and now promises an escalation that actually arrives on both paths. `.expectedMissing` lost "after this boot" for the same reason — the mid-session escalation makes it newly reachable without one.

## Deviations from the issue

- **Re-arm trigger.** The issue says "whenever `VsockControlService` settles"; this arms only on involuntary loss. Distinguishing the two at the source beats relying on every caller to clean up after.
- **Two guards the issue doesn't mention.** `.running` and agent-not-connected are what make the re-arm safe by construction; the `.running` guard alone already blocks the live-paused false positive.
- **Preference scoping** is "no `Hello` this session", not "boot path only" — the mutation's actual premise, and it threads no new parameter through the arm sites.
- **Heartbeat suspension is mandatory, not optional.** The issue names only the liveness watchdog; removing its teardown without gating the send re-exposes a main-actor-parking blocking write on a long pause.
- **Scope addition.** `VirtualizationService.pause()`/`resume()` cancel and arm, and the accept path arms too. The hot-resume arm is a second entry point for the same defect; the cold-restore branch deliberately arms nothing (see Review round).
- **Simplified from the plan.** An earlier design carried the suspension one liveness tick past the resume to grant a full fresh window. Dropped: because the clock is refreshed on every suspended tick, the first post-wake tick already sees the auto-paused VM, so the carry bought one tick interval (5 s of a 30 s budget) for extra state and an untested branch.

## Rejected alternatives

- `SuspendingClock` for the liveness measurement — fixes host sleep, not VM pause.
- Reading `VZVirtualMachine.state` instead of `isLivePaused` — untestable; CI hosts lack the virtualization entitlement, which is why `hasLiveVirtualMachineOverrideForTesting` exists.
- A second associated value on `.connecting` to distinguish boot from mid-session — the badge is identical and copy true in both cases is cheaper.

## Deferred

`VMInstance` writes `agentInstallNudgeDismissed` through `performConfigurationMutation` rather than `VMLibraryViewModel.setAgentInstallNudgeDismissed`, whose doc comment calls itself "the single write path". A real divergence, but the view model is not reachable from `VMInstance`, so consolidating it is a separate change.

## Test plan

- [x] `make build`
- [x] `make test` — full suite, run twice
- [x] `make lint`
- [x] New `VMInstanceAgentReconnectTests` drives a production-wired control service over a real socket pair: channel loss re-arms the watchdog and renders `.connecting`, owner teardown arms nothing, a live-paused VM keeps its channel and stays `.current`, and a channel lost while paused arms nothing until the resume.
- [x] `VsockControlServiceTests`: a suspended guest survives four terminate windows; suspension defers the deadline rather than disabling it; no frame is written to a frozen guest; `onChannelLost` fires once on liveness terminate and once on peer close, and never on an owner `stop()`.
- [x] `VMInstanceTests`: watchdog no-ops for every non-`.running` status and while the agent is connected; a mid-session firing leaves the nudge dismissal, the guest OS version, and the persist count untouched while still latching `agentExpectedButMissing`.


## Review round

Three findings from review, all fixed in `201ccc8`:

- **Recovery context was lost on resume.** `Start in Recovery Mode` → Pause → Resume reached the new arm site with no idea a Recovery boot had happened, so after 120 s the watchdog reported `.expectedMissing` on a guest that never runs the agent — and, no Hello having arrived that session, also cleared `agentInstallNudgeDismissed` and `lastSeenGuestOSVersion`. Exactly the clobber this issue asked to prevent, reintroduced through a new door. Fixed by making it session state (`VMInstance.bootedIntoRecovery`, set at cold boot, reset on teardown) rather than a per-call parameter, so every arm site is covered by construction. The `afterRecoveryBoot:` parameter is gone.
- **A wedged replacement channel never escalated.** Replacing a live service settles the old one as owner-requested, so `onChannelLost` stays silent and nothing armed. An agent that connects but never completes its Hello — a half-finished update, which is precisely when the reinstall affordance is wanted — spun at `.connecting` forever. The accept path now arms; the Hello cancels it.
- **The re-arm made the task slot an ABA test.** `guard agentPostStartTask != nil` was safe only while the watchdog was one-shot. A task whose sleep elapsed just before a cancel-and-re-arm would pass that guard against its *successor's* slot, fire with none of the successor's grace spent, and clear it on the way out. The task now carries a generation that both arming and cancelling bump. No test: the window is between `Task.sleep` returning and the body resuming on the MainActor, which can't be produced deterministically without a production seam, and a test that can't reach it would only look like coverage.

Also from review: `checkLiveness` was writing `isUnresponsive = false` unconditionally in the suspended branch. On an `@Observable` class that notifies on every write, so a live-paused VM woke every observer of `agentStatus` each liveness tick for the whole pause. Guarded like the two branches below it.

### Walked back

`resume()`'s cold-restore branch no longer arms. A restore resumes whatever guest state was frozen — possibly a Recovery session — and no host-side flag survives the save to say which, so arming there trades the mid-session gap for a false `.expectedMissing`. That branch keeps its pre-change behavior, and the accept-path arm covers it as soon as a control channel appears.

### Dismissed

Nothing. Both Codex findings and both built-in-review findings were confirmed against the code and fixed.
