### PR TITLE
fix: Focus the guest display on start, resume, and pop in

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		28934EC9D674276AC8786B9A /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		A1000004 /* Kernova.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Kernova.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1000005 /* KernovaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KernovaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000F0 /* DiskTemplates */ = {isa = PBXFileReference; lastKnownFileType = folder; path = DiskTemplates; sourceTree = "<group>"; };
@@ -111,7 +112,6 @@
 		A1000500 /* KernovaMacOSAgentFileProvider.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = KernovaMacOSAgentFileProvider.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1000600 /* KernovaFileProvider.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = KernovaFileProvider.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B62FC33F2FAFDBB1003775B7 /* KernovaKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = KernovaKit; sourceTree = "<group>"; };
-		28934EC9D674276AC8786B9A /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -122,24 +122,24 @@
 			);
 			target = A1000003 /* Kernova */;
 		};
-		A1000308 /* Exceptions for "KernovaMacOSAgent" folder in "KernovaMacOSAgentTests" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				app.kernova.macosagent.plist,
-				Assets.xcassets,
-				AgentAppDelegate.swift,
-				Info.plist,
-				install.command,
-				uninstall.command,
-			);
-			target = A1000303 /* KernovaMacOSAgentTests */;
-		};
 		A100020D /* Exceptions for "KernovaMacOSAgent" folder in "KernovaMacOSAgent" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
 			);
 			target = A1000204 /* KernovaMacOSAgent */;
+		};
+		A1000308 /* Exceptions for "KernovaMacOSAgent" folder in "KernovaMacOSAgentTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AgentAppDelegate.swift,
+				app.kernova.macosagent.plist,
+				Assets.xcassets,
+				Info.plist,
+				install.command,
+				uninstall.command,
+			);
+			target = A1000303 /* KernovaMacOSAgentTests */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -921,7 +921,6 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				REGISTER_APP_GROUPS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Kernova/App/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright 2025–2026 Nicholas Lonsinger. All rights reserved.";
@@ -935,6 +934,7 @@
 				MARKETING_VERSION = 0.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
 			};
@@ -992,8 +992,8 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				SKIP_INSTALL = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
@@ -1006,17 +1006,17 @@
 				CODE_SIGN_ENTITLEMENTS = KernovaMacOSAgent/KernovaMacOSAgent.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 				DEAD_CODE_STRIPPING = YES;
+				EXECUTABLE_NAME = KernovaMacOSAgent;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
 				MARKETING_VERSION = 0.52.0;
-				EXECUTABLE_NAME = KernovaMacOSAgent;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
@@ -1027,22 +1027,22 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = KernovaMacOSAgent/KernovaMacOSAgent.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
-				PROVISIONING_PROFILE_SPECIFIER = "Kernova macOS Agent Developer ID";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
+				CODE_SIGN_STYLE = Manual;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				OTHER_CODE_SIGN_FLAGS = "--timestamp";
-				SKIP_INSTALL = YES;
+				EXECUTABLE_NAME = KernovaMacOSAgent;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
 				MARKETING_VERSION = 0.52.0;
-				EXECUTABLE_NAME = KernovaMacOSAgent;
+				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
+				PROVISIONING_PROFILE_SPECIFIER = "Kernova macOS Agent Developer ID";
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
@@ -1083,7 +1083,6 @@
 				CODE_SIGN_ENTITLEMENTS = KernovaMacOSAgentFileProvider/KernovaMacOSAgentFileProvider.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_DEBUG_DYLIB = NO;
@@ -1099,6 +1098,7 @@
 				MARKETING_VERSION = 0.52.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent.fileprovider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
@@ -1110,14 +1110,12 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = KernovaMacOSAgentFileProvider/KernovaMacOSAgentFileProvider.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
-				PROVISIONING_PROFILE_SPECIFIER = "Kernova macOS Agent File Provider Developer ID";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
-				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				ENABLE_DEBUG_DYLIB = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = KernovaMacOSAgentFileProvider/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
@@ -1128,8 +1126,10 @@
 					"@loader_path/../Frameworks",
 				);
 				MARKETING_VERSION = 0.52.0;
+				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent.fileprovider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Kernova macOS Agent File Provider Developer ID";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
@@ -1142,7 +1142,6 @@
 				CODE_SIGN_ENTITLEMENTS = KernovaFileProvider/KernovaFileProvider.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_DEBUG_DYLIB = NO;
@@ -1158,6 +1157,7 @@
 				MARKETING_VERSION = 0.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.fileprovider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
@@ -1172,9 +1172,8 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
-				REGISTER_APP_GROUPS = YES;
 				ENABLE_DEBUG_DYLIB = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = KernovaFileProvider/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/KernovaBuildNumber.h";
@@ -1187,6 +1186,7 @@
 				MARKETING_VERSION = 0.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.fileprovider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -1169,6 +1169,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             // the display slot to the main window.
             viewModel.updateConfiguration(of: instance) { $0.displayPreference = .inline }
             instance.displayMode = .inline
+            viewModel.presenter?.focusGuestDisplay(for: instance)
             return
         }
 
@@ -1206,7 +1207,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private func openDisplayWindow(for instance: VMInstance, enterFullscreen: Bool) {
         let vmID = instance.instanceID
 
-        guard displayWindows[vmID] == nil else { return }
+        // Already open (e.g. resuming a live-paused VM from the library):
+        // surface the existing window so keyboard input lands in the guest.
+        if let existing = displayWindows[vmID] {
+            existing.window?.makeKeyAndOrderFront(nil)
+            return
+        }
         ensureRegularActivationIfAgent()
 
         let controller = VMDisplayWindowController(
@@ -1276,6 +1282,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                     } else if !appWasActive {
                         self.showLibraryWindow(bringToFront: false)
                     }
+                    self.viewModel.presenter?.focusGuestDisplay(for: instance)
                     // Reconcile synchronously here, after the restore, rather than
                     // through `scheduleAgentActivationPolicySync()`: the global
                     // `willClose` observer's independent `Task` isn't guaranteed to

--- a/Kernova/App/DetailContainerViewController.swift
+++ b/Kernova/App/DetailContainerViewController.swift
@@ -16,6 +16,14 @@ final class DetailContainerViewController: NSViewController {
     private var activeBackingViewID: UUID?
     private var stateObservation: ObservationLoop?
 
+    /// The VM whose inline guest display should take keyboard focus when it
+    /// appears, set at the moment of a user start, resume, or pop-in.
+    ///
+    /// The request is expired rather than fulfilled as soon as the user is
+    /// looking at or typing in something else, so the display never yanks
+    /// focus later than the action that requested it.
+    private var armedGuestFocusID: UUID?
+
     // MARK: - Detail content layer
 
     private let contentContainer = NSView()
@@ -88,6 +96,7 @@ final class DetailContainerViewController: NSViewController {
         for id in Array(backingViews.keys) {
             removeBackingView(for: id)
         }
+        armedGuestFocusID = nil
     }
 
     // MARK: - Detail content (empty state ⇆ router)
@@ -204,6 +213,13 @@ final class DetailContainerViewController: NSViewController {
     }
 
     private func updateDisplayState() {
+        // A pending focus request survives only while its VM stays selected:
+        // switching VMs mid-boot is user interaction, and fulfilling on a later
+        // re-select would be the late focus steal this exists to prevent.
+        if let armedID = armedGuestFocusID, armedID != viewModel.selectedInstance?.id {
+            armedGuestFocusID = nil
+        }
+
         // Ahead of the early return below: a hidden backing view stays attached and
         // constrained, so a VM whose Settings pane is up still reconfigures its
         // guest on every window resize unless the toggle reaches it here.
@@ -234,6 +250,15 @@ final class DetailContainerViewController: NSViewController {
             instance.status.hasActiveDisplay,
             instance.detailPaneMode == .display
         else {
+            // The armed VM's display is presentable but the user is looking
+            // elsewhere (Settings pane, popped out): the hand-off moment has
+            // passed, so expire the request instead of letting it fire on a
+            // later pane switch.
+            if let selected = viewModel.selectedInstance, armedGuestFocusID == selected.id,
+                selected.virtualMachine != nil, selected.status.hasActiveDisplay
+            {
+                armedGuestFocusID = nil
+            }
             if let currentID = activeBackingViewID, let current = backingViews[currentID] {
                 current.isHidden = true
                 Self.logger.debug("VM display hidden — detail content visible")
@@ -261,6 +286,15 @@ final class DetailContainerViewController: NSViewController {
             transitionText: instance.status.transitionLabel,
             automaticallyReconfiguresDisplay: instance.configuration.displayAutoResizes
         )
+
+        if armedGuestFocusID == instance.id {
+            armedGuestFocusID = nil
+            // A first responder inside a text-editing session means the user
+            // started typing somewhere since the request — leave them be.
+            if let window = view.window, !(window.firstResponder is NSText) {
+                window.makeFirstResponder(backing.machineView)
+            }
+        }
     }
 }
 
@@ -323,6 +357,15 @@ extension DetailContainerViewController: VMLibraryPresenting {
 
     func presentInstallerMounted(vmName: String, purpose: GuestAgentInstallerPurpose) {
         alertsPresenter.presentInstallerMounted(vmName: vmName, purpose: purpose)
+    }
+
+    func focusGuestDisplay(for instance: VMInstance) {
+        guard let window = view.window else { return }
+        if let backing = backingViews[instance.id], !backing.isHidden {
+            window.makeFirstResponder(backing.machineView)
+        } else {
+            armedGuestFocusID = instance.id
+        }
     }
 
     func presentCreationWizard() {

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -111,6 +111,8 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
     override func showWindow(_ sender: Any?) {
         instance.displayMode = enterFullscreen ? .fullscreen : .popOut
         super.showWindow(sender)
+        // Land keyboard focus in the guest, so typing works without a click.
+        window?.makeFirstResponder(backingView.machineView)
         if enterFullscreen {
             window?.toggleFullScreen(nil)
         }

--- a/Kernova/ViewModels/VMLibraryPresenting.swift
+++ b/Kernova/ViewModels/VMLibraryPresenting.swift
@@ -58,4 +58,10 @@ protocol VMLibraryPresenting: AnyObject {
     func presentInstallerMounted(vmName: String, purpose: GuestAgentInstallerPurpose)
     /// Present the VM creation wizard sheet.
     func presentCreationWizard()
+    /// Move keyboard focus into `instance`'s inline guest display, called at
+    /// the moment a user action routes the display there (start, resume, pop
+    /// in). If the display is not up yet, the request holds until it appears —
+    /// but expires the instant focus moves anywhere else, so it never steals
+    /// focus later.
+    func focusGuestDisplay(for instance: VMInstance)
 }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -307,6 +307,16 @@ final class VMLibraryViewModel {
 
     // MARK: - Lifecycle
 
+    /// Surfaces the display a start/resume lands on: the detached window for
+    /// pop-out/fullscreen VMs, else keyboard focus in the inline guest display.
+    private func surfaceDisplay(for instance: VMInstance) {
+        if instance.configuration.displayPreference != .inline {
+            onOpenDisplayWindow?(instance)
+        } else {
+            presenter?.focusGuestDisplay(for: instance)
+        }
+    }
+
     func start(_ instance: VMInstance, bootIntoRecovery: Bool = false) async {
         // Dispatch on installContext, not status, so `.error` retries route through
         // the install pipeline too.
@@ -317,9 +327,7 @@ final class VMLibraryViewModel {
 
         if refuseIfDuplicateMachineIDConflict(instance) { return }
 
-        if instance.configuration.displayPreference != .inline {
-            onOpenDisplayWindow?(instance)
-        }
+        surfaceDisplay(for: instance)
         applyMatchWindowBootResolution(to: instance)
         do {
             try await lifecycle.start(instance, bootIntoRecovery: bootIntoRecovery)
@@ -617,9 +625,7 @@ final class VMLibraryViewModel {
         // own identity.
         if instance.isColdPaused, refuseIfDuplicateMachineIDConflict(instance) { return }
 
-        if instance.configuration.displayPreference != .inline {
-            onOpenDisplayWindow?(instance)
-        }
+        surfaceDisplay(for: instance)
         do {
             try await lifecycle.resume(instance)
         } catch {

--- a/KernovaTests/Mocks/MockVMLibraryPresenting.swift
+++ b/KernovaTests/Mocks/MockVMLibraryPresenting.swift
@@ -26,6 +26,7 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
     private(set) var installerMountedNames: [String] = []
     private(set) var installerMountedPurposes: [GuestAgentInstallerPurpose] = []
     private(set) var creationWizardCount = 0
+    private(set) var focusGuestDisplayInstances: [VMInstance] = []
 
     func presentError(_ message: String, title: String) {
         errors.append(message)
@@ -48,6 +49,9 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
         installerMountedPurposes.append(purpose)
     }
     func presentCreationWizard() { creationWizardCount += 1 }
+    func focusGuestDisplay(for instance: VMInstance) {
+        focusGuestDisplayInstances.append(instance)
+    }
 
     // MARK: - Mirror accessors (read like the former VM flags)
 
@@ -86,5 +90,6 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
         installerMountedNames.removeAll()
         installerMountedPurposes.removeAll()
         creationWizardCount = 0
+        focusGuestDisplayInstances.removeAll()
     }
 }

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -1089,6 +1089,56 @@ struct VMLibraryViewModelTests {
         #expect(instance.status == .running)
     }
 
+    @Test("start of an inline-display VM asks the presenter to focus the guest display")
+    func startRequestsInlineGuestFocus() async {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        viewModel.instances.append(instance)
+
+        await viewModel.start(instance)
+
+        #expect(presenter.focusGuestDisplayInstances.count == 1)
+        #expect(presenter.focusGuestDisplayInstances.last === instance)
+    }
+
+    @Test("start of a pop-out VM opens the display window instead of requesting inline focus")
+    func startPopOutSkipsInlineGuestFocus() async {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        instance.configuration.displayPreference = .popOut
+        viewModel.instances.append(instance)
+
+        await viewModel.start(instance)
+
+        #expect(presenter.focusGuestDisplayInstances.isEmpty)
+    }
+
+    @Test("resume of an inline-display VM asks the presenter to focus the guest display")
+    func resumeRequestsInlineGuestFocus() async {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .paused
+        viewModel.instances.append(instance)
+
+        await viewModel.resume(instance)
+
+        #expect(presenter.focusGuestDisplayInstances.count == 1)
+        #expect(presenter.focusGuestDisplayInstances.last === instance)
+    }
+
+    @Test("resume of a pop-out VM opens the display window instead of requesting inline focus")
+    func resumePopOutSkipsInlineGuestFocus() async {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .paused
+        instance.configuration.displayPreference = .popOut
+        viewModel.instances.append(instance)
+
+        await viewModel.resume(instance)
+
+        #expect(presenter.focusGuestDisplayInstances.isEmpty)
+    }
+
     @Test("save delegates to lifecycle coordinator")
     func saveDelegates() async {
         let (viewModel, _, _, virtService, _) = makeViewModel()


### PR DESCRIPTION
## Summary

Booting, resuming, or popping in a VM left keyboard focus wherever it happened to sit — the library sidebar/toolbar for inline displays, the bare window for pop-outs — so typing reached the guest only after an extra click into the display. Focus now follows the user's action:

- **Pop-out/fullscreen window**: `showWindow` makes the `VZVirtualMachineView` first responder; a start/resume that finds the window already open re-fronts it instead of silently returning (matching `showDisplayWindow`).
- **Inline display**: the focus intent is captured *at the moment of the action* as an armed request keyed by VM ID, fulfilled when the display appears. It expires — rather than firing late — when the user selects another VM, is looking at another pane once the display is presentable, or the first responder is an active text-editing session. A completion-time grab (move focus when the boot finishes) was rejected: a multi-second restore can complete after the user has moved on, and yanking focus then is worse than the original problem. An earlier responder-identity snapshot was also rejected — AppKit's shared field editor makes identity both miss legitimate fulfillments and pass spuriously.
- **Pop In**: both routes issue the same request — the display-window close path and the headless branch of `togglePopOut` (display previously closed while the VM ran).

Reviewed by `/code-review medium`, a Codex review, and an adversarial Codex review (approve); all actionable findings are incorporated above.

## Changes

- `Kernova/App/VMDisplayWindowController.swift` — first-responder grab in `showWindow`
- `Kernova/App/AppDelegate.swift` — front existing display window in `openDisplayWindow`; focus request on both pop-in paths
- `Kernova/ViewModels/VMLibraryViewModel.swift`, `VMLibraryPresenting.swift` — shared `surfaceDisplay(for:)` routing for start/resume; new `focusGuestDisplay(for:)` presenter method
- `Kernova/App/DetailContainerViewController.swift` — `armedGuestFocusID` arm/expire/fulfill logic
- `KernovaTests/` — four display-routing tests on `VMLibraryViewModel`; mock presenter records focus requests
- `Kernova.xcodeproj/project.pbxproj` — Xcode-generated key re-sort, no setting changes

## Test plan

- [x] `make lint` clean
- [x] `make test` full suite: 2110/2110 passing
- [ ] Manual: cold boot, restore, resume (inline + pop-out), Pop In (window + headless), and a mid-boot rename/VM-switch to confirm no late focus steal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3E1rpEJrHkJ1jhFgW9pE4