### PR TITLE
chore: Add a Config/Local.xcconfig template

### DIFF
--- a/Config/Local.xcconfig.example
+++ b/Config/Local.xcconfig.example
@@ -1,0 +1,9 @@
+// Template for the gitignored Config/Local.xcconfig — copy it there and set
+// your team. See docs/BUILD.md "Signing team".
+//
+// The team ID is the OU of your signing certificate. On an Apple Development
+// certificate the CN parenthetical is a per-developer identifier that looks
+// like a team ID but isn't, so read OU rather than the name:
+//   security find-certificate -c "Developer ID Application" -p \
+//     | openssl x509 -noout -subject
+DEVELOPMENT_TEAM = ABCDE12345


### PR DESCRIPTION
## Summary

`Config/Local.xcconfig` is gitignored and hand-maintained, so nothing in the tree shows its shape. Since #720 deleted `Tools/bootstrap-team.sh` and `make bootstrap`, the file is now created entirely by hand, and `docs/BUILD.md` describes it only as "one line: `DEVELOPMENT_TEAM = <team>`" with nothing to copy. This adds the template beside where the real file gets created.

## The one fact worth writing down

The team ID is the **OU** of the signing certificate, not the CN parenthetical. Those agree on a Developer ID Application certificate and disagree on an Apple Development one, where the parenthetical is a per-developer identifier that reads exactly like a team ID:

```
Apple Development: Nicholas Lonsinger (WN57KR9TLZ)          <- not the team
Developer ID Application: Nicholas Lonsinger (8MT4P4GZL2)   <- OU=8MT4P4GZL2
```

Neither `docs/BUILD.md` nor `docs/RELEASING.md` says how to derive the value, and the template is what you are looking at when you need it. The `security find-certificate | openssl x509` command in it was run against a real keychain before it went in.

## Route taken

- **No `.gitignore` change** — the rule names `Config/Local.xcconfig` exactly, so `.example` is tracked as-is (`git check-ignore` exits 1).
- **No `.worktreeinclude` entry** — that list carries *gitignored* files into worktrees; a tracked file arrives through git.
- **No doc edit** — anyone told by `README.md` or `docs/BUILD.md` to create `Config/Local.xcconfig` lands in `Config/` and sees the template beside it, so a pointer would duplicate discovery that already works. Easy to add one to BUILD.md's "Signing team" if preferred.
- **Nothing restated from another layer** — `Config/Base.xcconfig` owns the `#include?` optional-form story and `docs/BUILD.md` owns which target consumes the team; the template links rather than repeating.

## Test plan

- [x] `make lint`
- [x] `git check-ignore Config/Local.xcconfig.example` exits 1
- [x] Agent Release signing settings still resolve after the accompanying header trim to the real `Config/Local.xcconfig` — gitignored, so not in this diff: `DEVELOPMENT_TEAM = 8MT4P4GZL2`, `CODE_SIGN_STYLE = Manual`, `PROVISIONING_PROFILE_SPECIFIER = Kernova macOS Agent Developer ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AUYtqTZnsvjvZ7XdjH3vx
