### PR TITLE
fix: Give Debug a stable code identity so privacy grants persist

### DIFF
--- a/Config/Base.xcconfig
+++ b/Config/Base.xcconfig
@@ -2,12 +2,17 @@
 // project XCBuildConfigurations (targets without their own
 // baseConfigurationReference inherit it).
 //
-// DEVELOPMENT_TEAM lives in the gitignored, hand-maintained Local.xcconfig
-// included below (one line: DEVELOPMENT_TEAM = <team>) — see docs/BUILD.md
-// "Signing team".
+// DEVELOPMENT_TEAM and the CODE_SIGN_IDENTITY override live in the
+// gitignored, hand-maintained Local.xcconfig included below — see
+// docs/BUILD.md "Signing identity".
 //
 // `#include?` (with the trailing `?`) is the optional form: it silently
-// no-ops when Local.xcconfig doesn't exist, so a fresh clone builds with no
-// team at all — every target signs ad-hoc in Debug; only the agent's Release
-// Developer ID signing needs the team.
+// no-ops when Local.xcconfig doesn't exist, so a fresh clone builds with
+// neither a team nor a certificate.
+
+// Debug's signing identity. Every Release configuration pins its own at
+// target level, which outranks a project xcconfig, so the Local.xcconfig
+// override below reaches Debug alone.
+CODE_SIGN_IDENTITY = -
+
 #include? "Local.xcconfig"

--- a/Config/Local.xcconfig.example
+++ b/Config/Local.xcconfig.example
@@ -1,5 +1,5 @@
 // Template for the gitignored Config/Local.xcconfig — copy it there and set
-// your team. See docs/BUILD.md "Signing team".
+// your team. See docs/BUILD.md "Signing identity".
 //
 // The team ID is the OU of your signing certificate. On an Apple Development
 // certificate the CN parenthetical is a per-developer identifier that looks
@@ -7,3 +7,9 @@
 //   security find-certificate -c "Developer ID Application" -p \
 //     | openssl x509 -noout -subject
 DEVELOPMENT_TEAM = ABCDE12345
+
+// Signs Debug with your development certificate rather than ad-hoc, giving
+// the app one code identity across rebuilds so macOS privacy grants stick.
+// Drop the line to sign ad-hoc; keep it alongside DEVELOPMENT_TEAM, since
+// automatic signing resolves the certificate through the team.
+CODE_SIGN_IDENTITY = Apple Development

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -690,7 +690,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Kernova/Resources/Kernova.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -748,7 +747,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
@@ -784,7 +782,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = KernovaRelaunchHelper/KernovaRelaunchHelper.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.relaunchhelper;
@@ -877,7 +874,6 @@
 		A100030A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Then open `Kernova.xcodeproj`, select the `Kernova` scheme, and build and run (�
 
 `make doctor` checks that your toolchain, signing, and hooks match what Kernova needs. `make` with no arguments lists every build, test, format, and lint target.
 
-**Debug needs no signing team or Apple account** — every target signs ad-hoc ("Sign to Run Locally"), so a fresh clone builds and runs as-is. **Release** requires a paid membership, a distribution identity (Developer ID, or Apple Distribution for the Mac App Store), and a gitignored `Config/Local.xcconfig` supplying `DEVELOPMENT_TEAM = <team>`; it matters only when cutting a distributable build. The signing story is in [docs/RELEASING.md](docs/RELEASING.md).
+**Debug needs no signing team or Apple account** — it signs ad-hoc ("Sign to Run Locally") by default, so a fresh clone builds and runs as-is. With a development certificate, point Debug at it through a gitignored `Config/Local.xcconfig` off `Config/Local.xcconfig.example` so macOS privacy grants survive a rebuild ([docs/BUILD.md](docs/BUILD.md#signing-identity)). **Release** requires a paid membership and a distribution identity (Developer ID, or Apple Distribution for the Mac App Store); it matters only when cutting a distributable build ([docs/RELEASING.md](docs/RELEASING.md)).
 
 ## Testing
 

--- a/Tools/doctor.sh
+++ b/Tools/doctor.sh
@@ -191,21 +191,33 @@ fi
 
 section 'Signing'
 
-# Debug builds sign ad-hoc and need no team; DEVELOPMENT_TEAM matters only
-# for the agent's Release Developer ID signing, supplied by the gitignored,
-# hand-maintained Config/Local.xcconfig. CI can't catch a broken team here:
-# it builds with CODE_SIGNING_ALLOWED=NO.
+# Debug signs ad-hoc unless the gitignored, hand-maintained
+# Config/Local.xcconfig overrides CODE_SIGN_IDENTITY; the same file supplies
+# DEVELOPMENT_TEAM, which automatic signing resolves the certificate through
+# and the agent's Release Developer ID signing needs. CI can't catch a broken
+# team here: it builds with CODE_SIGNING_ALLOWED=NO.
 local_xcconfig="Config/Local.xcconfig"
 resolved_team=""
+resolved_identity=""
 if [ -f "$local_xcconfig" ]; then
     resolved_team=$(sed -n 's/^[[:space:]]*DEVELOPMENT_TEAM[[:space:]]*=[[:space:]]*\([^[:space:];]*\).*/\1/p' "$local_xcconfig" | head -1)
+    # Unlike the team, an identity name contains spaces, so take the rest of
+    # the line and trim instead of matching a run of non-space characters.
+    resolved_identity=$(sed -n 's/^[[:space:]]*CODE_SIGN_IDENTITY[[:space:]]*=[[:space:]]*//p' "$local_xcconfig" | head -1 | sed 's/[[:space:]]*$//')
 fi
 
 if [ -n "$resolved_team" ]; then
     pass "DEVELOPMENT_TEAM = $resolved_team ($local_xcconfig)"
 else
-    warn "No DEVELOPMENT_TEAM set — fine for Debug (all targets sign ad-hoc)"
+    warn "No DEVELOPMENT_TEAM set — fine for Debug (signs ad-hoc)"
     detail "Release signing needs $local_xcconfig with: DEVELOPMENT_TEAM = <your 10-char team ID>"
+fi
+
+if [ -n "$resolved_identity" ] && [ "$resolved_identity" != "-" ]; then
+    pass "Debug CODE_SIGN_IDENTITY = $resolved_identity ($local_xcconfig)"
+else
+    warn "Debug signs ad-hoc — macOS privacy grants re-prompt after every rebuild"
+    detail "With a development certificate, add to $local_xcconfig: CODE_SIGN_IDENTITY = Apple Development"
 fi
 
 # `security find-identity` lists every codesigning-capable identity in the

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,6 +1,6 @@
 # BUILD.md
 
-Read the relevant section before touching build machinery — hooks and worktree setup, signing-team derivation, test-target topology, DerivedData, build numbers, guest-agent versioning, or LaunchServices cleanup. None of it is needed for a routine `make build` / `make test`; fresh-clone setup is in the [README](../README.md#development-setup).
+Read the relevant section before touching build machinery — hooks and worktree setup, the signing identity, test-target topology, DerivedData, build numbers, guest-agent versioning, or LaunchServices cleanup. None of it is needed for a routine `make build` / `make test`; fresh-clone setup is in the [README](../README.md#development-setup).
 
 ## Git hooks and worktree setup
 
@@ -12,9 +12,15 @@ Read the relevant section before touching build machinery — hooks and worktree
 
 `.worktreeinclude` is the definitive list of local files a worktree inherits. Claude Code and other worktree tools read it natively; the hook is what makes a plain `git worktree add` honor it too. **Literal paths only — no globs.**
 
-## Signing team
+## Signing identity
 
-`DEVELOPMENT_TEAM` is not in the project file, and Debug builds need none — every target signs ad-hoc. The gitignored, hand-maintained `Config/Local.xcconfig` (one line: `DEVELOPMENT_TEAM = <team>`), included by the tracked `Config/Base.xcconfig`, supplies the team to the one consumer left: the guest agent's Release Developer ID signing ([RELEASING.md](RELEASING.md)). Worktrees inherit the file through `.worktreeinclude`.
+Debug signs ad-hoc by default — `Config/Base.xcconfig` sets `CODE_SIGN_IDENTITY = -` — so a fresh clone builds with no Apple account, team, or certificate. The gitignored, hand-maintained `Config/Local.xcconfig`, included by that file and templated by `Config/Local.xcconfig.example`, overrides both that and `DEVELOPMENT_TEAM`. Worktrees inherit it through `.worktreeinclude`.
+
+Set `CODE_SIGN_IDENTITY = Apple Development` there whenever you have a certificate. TCC keys each privacy grant to the app's designated requirement: under a real identity that is `identifier "app.kernova" and anchor apple generic and certificate leaf[subject.CN] = …`, stable across rebuilds, while an ad-hoc signature's is a bare `cdhash`. Every rebuild is then a new app to TCC, and a grant like the Downloads folder re-prompts instead of sticking.
+
+`DEVELOPMENT_TEAM` is what automatic signing resolves that certificate through, and the guest agent's Release Developer ID signing needs it too ([RELEASING.md](RELEASING.md)) — keep the two lines together.
+
+Every Release configuration pins its identity at target level, which outranks a project xcconfig, so the override reaches Debug alone. The guest agent stays ad-hoc in Debug as well: it runs inside the guest, where a host code identity buys nothing.
 
 ## One test invocation, three test targets
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Deep-dive documentation, read on demand. The always-relevant operating guide —
 | [SPEC.md](SPEC.md) | Writing UI or making product decisions — design philosophy and GUI guidelines (layout, typography, spacing, colors, controls) |
 | [CLIPBOARD.md](CLIPBOARD.md) | Touching host↔guest copy/paste — the clipboard subsystem's principles and trade-off rules; authoritative for any clipboard work |
 | [TOOLBAR.md](TOOLBAR.md) | Adding or changing a toolbar item — the macOS 26 glass-platter model (capsule clustering, the 36×36 metric), the constraints on view-backed items, and the sidebar section's collapse rules |
-| [BUILD.md](BUILD.md) | Touching build machinery — git hooks and worktree setup, signing-team derivation, test-target topology, DerivedData and build arenas, build-number derivation, guest-agent versioning, LaunchServices ghost cleanup |
+| [BUILD.md](BUILD.md) | Touching build machinery — git hooks and worktree setup, the signing identity, test-target topology, DerivedData and build arenas, build-number derivation, guest-agent versioning, LaunchServices ghost cleanup |
 | [SANDBOX.md](SANDBOX.md) | Touching entitlements, or auditing what a build is permitted to do — the Mac App Store readiness story and launch model behind the sandbox rules in AGENTS.md |
 | [TESTING.md](TESTING.md) | Writing any test that waits on async state or needs private production state — the async-wait seams, the injected-timeout rule, and test-only exposure patterns |
 | [REVIEW.md](REVIEW.md) | Filing review-debt issues or annotating findings — the full severity bar, issue format and labels, issue hygiene, `RATIONALE:` and `periphery:ignore` formats |


### PR DESCRIPTION
## Summary

Since #720 every target signed ad-hoc in Debug. An ad-hoc signature's designated requirement is a bare `cdhash`, which changes with every build, and TCC keys each privacy grant to that requirement — so every rebuild read as a new app. tccd logged the mismatch against the grant stored under the old identity:

```
Failed to match existing code requirement for subject app.kernova and service kTCCServiceSystemPolicyDownloadsFolder
    identifier "app.kernova" and anchor apple generic and certificate leaf[subject.CN] = "Apple Development: … "
AUTHREQ_PROMPTING: service=kTCCServiceSystemPolicyDownloadsFolder, subject=Sub:{app.kernova}
```

The Downloads-folder prompt then fired at launch and approving it never stuck. `VMLibraryViewModel.init` builds a `VMLifecycleCoordinator`, whose `downloadsDirectory` default resolves `.downloadsDirectory`, so the check runs on the startup path.

Ad-hoc stays the default — a fresh clone still builds with no Apple account, team, or certificate, which is what #720 set out to make possible. The gitignored `Config/Local.xcconfig` now raises it to a real identity for anyone holding a certificate, and Debug carries the stable `identifier "app.kernova" and anchor apple generic and certificate leaf[subject.CN] = …` requirement that grants survive rebuilds under.

Entitlements were never the problem: the built app carries `com.apple.security.app-sandbox` and `com.apple.security.files.downloads.read-write` throughout. The sandbox was satisfied; TCC is the separate gate that broke.

## Changes

- `Config/Base.xcconfig` — `CODE_SIGN_IDENTITY = -` as the project-level default, overridable by the `#include?`d `Config/Local.xcconfig`.
- `Kernova.xcodeproj/project.pbxproj` — dropped the target-level `CODE_SIGN_IDENTITY[sdk=macosx*] = "-"` from the Debug configurations of the app, both test bundles, and the relaunch helper so the xcconfig reaches them. Every Release configuration keeps its own (the app's export re-signs; the agent's is Developer ID), and the guest agent stays ad-hoc in Debug — it runs inside the guest, where a host code identity buys nothing.
- `Config/Local.xcconfig.example` — the `CODE_SIGN_IDENTITY` line and why to keep it alongside `DEVELOPMENT_TEAM`.
- `Tools/doctor.sh` — reports the resolved Debug identity, warning that grants re-prompt when it is ad-hoc.
- `docs/BUILD.md`, `docs/README.md`, `README.md` — "Signing team" becomes "Signing identity" and gains the TCC reasoning.

## Rejected alternative

Deferring the Downloads touch (making `downloadsDirectory` lazy) moves the prompt off the startup path but not out of the app — it would still fire, once per build, whenever an IPSW download runs. It treats the symptom; the identity is the defect.

## Test plan

- [x] `make build` signs Debug with the development certificate; the built app's designated requirement is byte-identical to the one tccd logged as its stored Downloads grant
- [x] `codesign -v --deep --strict` passes on the app with its nested relaunch helper
- [x] Launching the app produces no `kTCCServiceSystemPolicyDownloadsFolder` event, confirmed against a live `log stream` (before the fix, every launch produced one)
- [x] With `Config/Local.xcconfig` moved aside, Debug resolves `CODE_SIGN_IDENTITY = -`, no team, and doctor warns without failing
- [x] App Release (`-`), agent Debug (`-`), and agent Release (`Developer ID Application`, Manual) all unchanged
- [x] `make test`, `make lint`, `make doctor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aSMuzKMKANL5PMRTqGsSd