### PR TITLE
refactor: Move off silently-deprecated AppKit and Virtualization API spellings

### DIFF
--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -103,7 +103,7 @@ struct ConfigurationBuilder: Sendable {
         let layout = VMBundleLayout(bundleURL: bundleURL)
         let platform = VZMacPlatformConfiguration()
 
-        platform.auxiliaryStorage = VZMacAuxiliaryStorage(contentsOf: layout.auxiliaryStorageURL)
+        platform.auxiliaryStorage = VZMacAuxiliaryStorage(url: layout.auxiliaryStorageURL)
 
         if let modelData = config.hardwareModelData,
             let hardwareModel = VZMacHardwareModel(dataRepresentation: modelData)

--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -142,7 +142,7 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
         textView.textContainer?.widthTracksTextView = true
-        textView.textContainer?.containerSize = NSSize(
+        textView.textContainer?.size = NSSize(
             width: 0,
             height: CGFloat.greatestFiniteMagnitude
         )

--- a/Kernova/Views/Clipboard/ClipboardPassthroughBanner.swift
+++ b/Kernova/Views/Clipboard/ClipboardPassthroughBanner.swift
@@ -30,7 +30,7 @@ final class ClipboardPassthroughBanner: NSView {
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         let button = NSButton(title: "Turn Off", target: self, action: #selector(turnOffClicked))
-        button.bezelStyle = .rounded
+        button.bezelStyle = .push
         button.controlSize = .small
         button.setContentHuggingPriority(.required, for: .horizontal)
         button.setContentCompressionResistancePriority(.required, for: .horizontal)

--- a/Kernova/Views/Clipboard/ClipboardRichTextPreviewView.swift
+++ b/Kernova/Views/Clipboard/ClipboardRichTextPreviewView.swift
@@ -23,7 +23,7 @@ final class ClipboardRichTextPreviewView: NSView {
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
         textView.textContainer?.widthTracksTextView = true
-        textView.textContainer?.containerSize = NSSize(
+        textView.textContainer?.size = NSSize(
             width: 0,
             height: CGFloat.greatestFiniteMagnitude
         )

--- a/Kernova/Views/Console/VMDisplayPlaceholderContentViewController.swift
+++ b/Kernova/Views/Console/VMDisplayPlaceholderContentViewController.swift
@@ -293,7 +293,7 @@ private final class DisplayPlaceholderEmptyStateView: NSView {
         buttonRow.setViews(
             actions.map { action in
                 let button = NSButton(title: action.title, target: nil, action: action.selector)
-                button.bezelStyle = .rounded
+                button.bezelStyle = .push
                 button.controlSize = .regular
                 return button
             },

--- a/Kernova/Views/Creation/BootConfigContentViewController.swift
+++ b/Kernova/Views/Creation/BootConfigContentViewController.swift
@@ -217,7 +217,7 @@ final class BootConfigContentViewController: NSViewController, NSTextFieldDelega
         pathLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         let browse = NSButton(title: "Browse…", target: self, action: browseAction)
-        browse.bezelStyle = .rounded
+        browse.bezelStyle = .push
         browse.controlSize = .small
         browse.setContentHuggingPriority(.required, for: .horizontal)
 

--- a/Kernova/Views/Creation/LinuxImageCatalogSheetContentViewController.swift
+++ b/Kernova/Views/Creation/LinuxImageCatalogSheetContentViewController.swift
@@ -230,13 +230,13 @@ final class LinuxImageCatalogSheetContentViewController: NSViewController {
         spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelTapped))
-        cancel.bezelStyle = .rounded
+        cancel.bezelStyle = .push
         cancel.keyEquivalent = "\u{1b}"  // Escape
 
         chooseButton.title = "Choose"
         chooseButton.target = self
         chooseButton.action = #selector(chooseTapped)
-        chooseButton.bezelStyle = .rounded
+        chooseButton.bezelStyle = .push
         chooseButton.keyEquivalent = "\r"  // Return = default action
 
         let stack = NSStackView(views: [note, spacer, cancel, chooseButton])

--- a/Kernova/Views/Creation/RestoreImageCatalogSheetContentViewController.swift
+++ b/Kernova/Views/Creation/RestoreImageCatalogSheetContentViewController.swift
@@ -238,13 +238,13 @@ final class RestoreImageCatalogSheetContentViewController: NSViewController {
         spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelTapped))
-        cancel.bezelStyle = .rounded
+        cancel.bezelStyle = .push
         cancel.keyEquivalent = "\u{1b}"  // Escape
 
         chooseButton.title = "Choose"
         chooseButton.target = self
         chooseButton.action = #selector(chooseTapped)
-        chooseButton.bezelStyle = .rounded
+        chooseButton.bezelStyle = .push
         chooseButton.keyEquivalent = "\r"  // Return = default action
 
         let stack = NSStackView(views: [note, spacer, cancel, chooseButton])

--- a/Kernova/Views/Creation/RestoreImageURLSheetContentViewController.swift
+++ b/Kernova/Views/Creation/RestoreImageURLSheetContentViewController.swift
@@ -171,7 +171,7 @@ final class RestoreImageURLSheetContentViewController: NSViewController {
         checkButton.title = "Check"
         checkButton.target = self
         checkButton.action = #selector(checkTapped)
-        checkButton.bezelStyle = .rounded
+        checkButton.bezelStyle = .push
         checkButton.setContentHuggingPriority(.required, for: .horizontal)
 
         let field = NSStackView(views: [urlField, checkButton])
@@ -222,13 +222,13 @@ final class RestoreImageURLSheetContentViewController: NSViewController {
         spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelTapped))
-        cancel.bezelStyle = .rounded
+        cancel.bezelStyle = .push
         cancel.keyEquivalent = "\u{1b}"  // Escape
 
         useButton.title = "Use"
         useButton.target = self
         useButton.action = #selector(useTapped)
-        useButton.bezelStyle = .rounded
+        useButton.bezelStyle = .push
 
         let stack = NSStackView(views: [note, spacer, cancel, useButton])
         stack.orientation = .horizontal

--- a/Kernova/Views/Creation/VMCreationWizardViewController.swift
+++ b/Kernova/Views/Creation/VMCreationWizardViewController.swift
@@ -158,23 +158,23 @@ final class VMCreationWizardViewController: NSViewController {
         let container = NSView()
 
         cancelButton.title = "Cancel"
-        cancelButton.bezelStyle = .rounded
+        cancelButton.bezelStyle = .push
         cancelButton.target = self
         cancelButton.action = #selector(cancelTapped)
         cancelButton.keyEquivalent = "\u{1B}"  // Escape
 
         backButton.title = "Back"
-        backButton.bezelStyle = .rounded
+        backButton.bezelStyle = .push
         backButton.target = self
         backButton.action = #selector(backTapped)
 
         nextButton.title = "Next"
-        nextButton.bezelStyle = .rounded
+        nextButton.bezelStyle = .push
         nextButton.target = self
         nextButton.action = #selector(nextTapped)
 
         createButton.title = "Create"
-        createButton.bezelStyle = .rounded
+        createButton.bezelStyle = .push
         createButton.target = self
         createButton.action = #selector(createTapped)
 

--- a/Kernova/Views/Detail/DeleteVMSheetContentViewController.swift
+++ b/Kernova/Views/Detail/DeleteVMSheetContentViewController.swift
@@ -498,7 +498,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
         let cancelButton = NSButton(
             title: "Cancel", target: self, action: #selector(cancelTapped(_:))
         )
-        cancelButton.bezelStyle = .rounded
+        cancelButton.bezelStyle = .push
         cancelButton.keyEquivalent = "\u{1B}"  // Escape
 
         // No ellipsis on the action buttons themselves (project HIG: "none on alert
@@ -507,7 +507,7 @@ final class DeleteVMSheetContentViewController: NSViewController {
             title: mode == .immediate ? "Delete Immediately" : "Move to Trash",
             target: self, action: #selector(confirmTapped(_:))
         )
-        confirmButton.bezelStyle = .rounded
+        confirmButton.bezelStyle = .push
         // Trash is recoverable, so confirm is the intentional Return default. Immediate
         // delete is irreversible: no Return default, so a stray Return can't trigger it —
         // the user must click (or press Escape to cancel).

--- a/Kernova/Views/Detail/DetailEmptyStateView.swift
+++ b/Kernova/Views/Detail/DetailEmptyStateView.swift
@@ -37,7 +37,7 @@ final class DetailEmptyStateView: NSView {
         description.maximumNumberOfLines = 0
 
         let button = NSButton(title: "New Virtual Machine", target: self, action: #selector(newVMTapped))
-        button.bezelStyle = .rounded
+        button.bezelStyle = .push
 
         let stack = NSStackView(views: [icon, title, description, button])
         stack.orientation = .vertical

--- a/Kernova/Views/Detail/DiskSizePopoverContentViewController.swift
+++ b/Kernova/Views/Detail/DiskSizePopoverContentViewController.swift
@@ -140,13 +140,13 @@ final class DiskSizePopoverContentViewController: NSViewController {
         let cancelButton = NSButton(
             title: "Cancel", target: self, action: #selector(cancelTapped(_:))
         )
-        cancelButton.bezelStyle = .rounded
+        cancelButton.bezelStyle = .push
         cancelButton.keyEquivalent = "\u{1B}"  // Escape
 
         let createButton = NSButton(
             title: "Create", target: self, action: #selector(createTapped(_:))
         )
-        createButton.bezelStyle = .rounded
+        createButton.bezelStyle = .push
         createButton.keyEquivalent = "\r"
         createButton.setAccessibilityLabel("Create disk")
 

--- a/Kernova/Views/Detail/GuestSetupProgressViewController.swift
+++ b/Kernova/Views/Detail/GuestSetupProgressViewController.swift
@@ -88,7 +88,7 @@ final class GuestSetupProgressViewController: NSViewController {
         detailStack.spacing = Spacing.hairline
 
         cancelButton.title = "Cancel"
-        cancelButton.bezelStyle = .rounded
+        cancelButton.bezelStyle = .push
         cancelButton.target = self
         cancelButton.action = #selector(cancelTapped)
 

--- a/Kernova/Views/Detail/StorageDiskReorderSheetContentViewController.swift
+++ b/Kernova/Views/Detail/StorageDiskReorderSheetContentViewController.swift
@@ -217,7 +217,7 @@ final class StorageDiskReorderSheetContentViewController: NSViewController {
         let done = NSButton(
             title: "Done", target: self, action: #selector(doneTapped(_:))
         )
-        done.bezelStyle = .rounded
+        done.bezelStyle = .push
         done.keyEquivalent = "\r"  // Return = default action
 
         let stack = NSStackView(views: [spacer, done])

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -1025,7 +1025,7 @@ extension VMSettingsViewController {
 
     private func makePushButton(_ title: String, action: Selector) -> NSButton {
         let button = NSButton(title: title, target: self, action: action)
-        button.bezelStyle = .rounded
+        button.bezelStyle = .push
         button.setContentHuggingPriority(.required, for: .horizontal)
         return button
     }

--- a/Kernova/Views/Settings/RemindersSettingsViewController.swift
+++ b/Kernova/Views/Settings/RemindersSettingsViewController.swift
@@ -75,7 +75,7 @@ final class RemindersSettingsViewController: NSViewController {
 
         let resetButton = NSButton(
             title: "Reset All Reminders", target: self, action: #selector(resetAllReminders))
-        resetButton.bezelStyle = .rounded
+        resetButton.bezelStyle = .push
         resetButton.controlSize = .small
         resetButton.setContentHuggingPriority(.required, for: .horizontal)
         let resetCaption = makeGroupedFormCaption(

--- a/Kernova/Views/Shared/GroupedFormStyle.swift
+++ b/Kernova/Views/Shared/GroupedFormStyle.swift
@@ -236,7 +236,7 @@ func makeGroupedFormCaption(_ text: String) -> NSTextField {
 func makeLinkButton(_ title: String, target: AnyObject, action: Selector) -> NSButton {
     let button = NSButton(title: title, target: target, action: action)
     button.isBordered = false
-    button.bezelStyle = .inline
+    button.bezelStyle = .badge
     button.font = .preferredFont(forTextStyle: .caption1)
     button.contentTintColor = .linkColor
     button.setContentHuggingPriority(.required, for: .horizontal)

--- a/Kernova/Views/Sidebar/AgentStatusPopoverContentViewController.swift
+++ b/Kernova/Views/Sidebar/AgentStatusPopoverContentViewController.swift
@@ -138,7 +138,7 @@ final class AgentStatusPopoverContentViewController: NSViewController {
     }
 
     private func configureActionButton() {
-        actionButton.bezelStyle = .rounded
+        actionButton.bezelStyle = .push
         actionButton.keyEquivalent = "\r"
         actionButton.target = self
         actionButton.action = #selector(actionTapped(_:))


### PR DESCRIPTION
## Summary
- Migrates every call site off four `API_TO_BE_DEPRECATED` spellings (no build warning ever fires for these) onto their value/signature-identical replacements, verified against the Xcode 27 beta SDK headers.

## Changes
- `bezelStyle = .rounded` → `.push` at 24 sites across 15 view controllers (`NSBezelStyleRounded` is defined `= NSBezelStylePush`, zero visual change).
- `Kernova/Views/Shared/GroupedFormStyle.swift`: `button.bezelStyle = .inline` → `.badge` (`NSBezelStyleInline = NSBezelStyleBadge`, raw 15).
- `NSTextContainer.containerSize` → `.size` at the two clipboard preview sites (`ClipboardContentViewController.swift`, `ClipboardRichTextPreviewView.swift`) — same property, same `NSSize` expression.
- `Kernova/Services/ConfigurationBuilder.swift`: `VZMacAuxiliaryStorage(contentsOf:)` → `VZMacAuxiliaryStorage(url:)` — non-failable, no throws, signature-identical.
- Left the `hdiutil` usage in the DMG build phase alone: no drop-in `diskutil` replacement exists.

## Test plan
- [x] `make build`
- [x] `make test` (full suite, run twice — clean both times)
- [x] `make lint`
- [x] Final greps for `bezelStyle = .rounded`, `bezelStyle = .inline` (bezelStyle context), `containerSize`, and `VZMacAuxiliaryStorage(contentsOf` all return nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2KKh7BzcebB2Xts95rjyF