### PR TITLE
chore: Run CI tests ad-hoc signed so the test host is sandboxed

### DIFF
--- a/.github/workflows/xcodebuild-test.yml
+++ b/.github/workflows/xcodebuild-test.yml
@@ -38,7 +38,10 @@ jobs:
 
       # These invocations mirror the Makefile's XCODEBUILD_FLAGS by hand.
       #
-      # CI builds with signing off: the runner has no identity.
+      # Debug signs ad-hoc (Config/Base.xcconfig's CODE_SIGN_IDENTITY = "-"),
+      # which needs no identity or team, so it embeds the app's sandbox
+      # entitlements and the TEST_HOST-hosted unit tests run sandboxed here
+      # exactly as they do locally.
       - name: Build for testing
         run: |
           set -o pipefail
@@ -49,7 +52,6 @@ jobs:
             -derivedDataPath DerivedData/Kernova \
             -configuration Debug \
             -skipPackagePluginValidation \
-            CODE_SIGNING_ALLOWED=NO \
             COMPILER_INDEX_STORE_ENABLE=NO \
             2>&1 | if command -v xcbeautify &>/dev/null; then xcbeautify --renderer github-actions; else cat; fi
 
@@ -64,7 +66,6 @@ jobs:
             -configuration Debug \
             -resultBundlePath artifacts/TestResults.xcresult \
             -skipPackagePluginValidation \
-            CODE_SIGNING_ALLOWED=NO \
             COMPILER_INDEX_STORE_ENABLE=NO \
             2>&1 | if command -v xcbeautify &>/dev/null; then xcbeautify --renderer github-actions; else cat; fi
 

--- a/Kernova/Utilities/SecurityScopedBookmark.swift
+++ b/Kernova/Utilities/SecurityScopedBookmark.swift
@@ -5,9 +5,8 @@ import os
 /// mechanism for persisting a user's open/save-panel grant across launches.
 ///
 /// Runtime behavior here, and in ``ScopedAccess`` and `RuntimeFileAccess`, is
-/// untested by construction: bookmark creation and resolution need a signed,
-/// sandboxed process holding a real panel grant, and CI runs unsigned, where the
-/// sandbox is not enforced at all.
+/// untested by construction: bookmark creation and resolution need a real
+/// open/save-panel grant, which only a user driving the panel can mint.
 ///
 /// Every panel pick site converts its URL through ``capture(_:)`` and stores the
 /// resulting `(path, bookmark)` pair on the model; every access site resolves it

--- a/Tools/doctor.sh
+++ b/Tools/doctor.sh
@@ -194,8 +194,8 @@ section 'Signing'
 # Debug signs ad-hoc unless the gitignored, hand-maintained
 # Config/Local.xcconfig overrides CODE_SIGN_IDENTITY; the same file supplies
 # DEVELOPMENT_TEAM, which automatic signing resolves the certificate through
-# and the agent's Release Developer ID signing needs. CI can't catch a broken
-# team here: it builds with CODE_SIGNING_ALLOWED=NO.
+# and the agent's Release Developer ID signing needs. CI has no Local.xcconfig
+# and signs ad-hoc too, so it can't catch a broken team here either.
 local_xcconfig="Config/Local.xcconfig"
 resolved_team=""
 resolved_identity=""

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,11 +6,10 @@ prerequisites behind it, and the verification checklist. The entitlement story
 is in [SANDBOX.md](SANDBOX.md).
 
 Releasing is **Nicholas-specific** and does not touch CI or the clone-and-run
-story. CI builds Debug with `CODE_SIGNING_ALLOWED=NO`, and the Debug
-configuration signs ad-hoc — anyone can clone and build with no Apple
-account or team. Everything below concerns the **Release** configuration and the
-Developer ID identity (team `8MT4P4GZL2`, bundle id `app.kernova`, Apple
-Silicon only).
+story. The Debug configuration signs ad-hoc — anyone, including CI, can clone
+and build with no Apple account or team. Everything below concerns the
+**Release** configuration and the Developer ID identity (team `8MT4P4GZL2`,
+bundle id `app.kernova`, Apple Silicon only).
 
 ## One-time prerequisites
 


### PR DESCRIPTION
## Summary
- `.github/workflows/xcodebuild-test.yml` passed `CODE_SIGNING_ALLOWED=NO` to both xcodebuild invocations, justified by a comment ("CI builds with signing off: the runner has no identity"). That reason is stale: since #720/#724, Debug builds sign ad-hoc (`CODE_SIGN_IDENTITY = "-"` via `Config/Base.xcconfig:16`, no `DEVELOPMENT_TEAM` anywhere in the project), which needs no identity, keychain, or team.
- The consequence of the flag: the App Sandbox is applied via entitlements at signing time (the app target sets `CODE_SIGN_ENTITLEMENTS`; `KernovaTests` is hosted in the app via `TEST_HOST`), so with signing off CI ran the test host **unsandboxed** while local `make test` runs it **sandboxed** — a coverage gap in a repo whose sandbox rules are load-bearing.

## Changes
- `.github/workflows/xcodebuild-test.yml`: remove `CODE_SIGNING_ALLOWED=NO` from both xcodebuild invocations (build-for-testing and test-without-building); rewrite the stale comment to state what's true now — Debug signs ad-hoc, which embeds the sandbox entitlements so the hosted unit tests run sandboxed in CI exactly as they do locally.
- `Tools/doctor.sh`: the signing-section comment carried the same stale claim ("CI can't catch a broken team here: it builds with `CODE_SIGNING_ALLOWED=NO`"). Restated truthfully — CI has no `Local.xcconfig` and signs ad-hoc too, so it still can't catch a broken local team, but not because of that flag.
- `docs/RELEASING.md`: dropped the now-inaccurate `CODE_SIGNING_ALLOWED=NO` reference; states that Debug (including CI) signs ad-hoc.

## Test plan
- [x] `make test` — passes locally under ad-hoc signing, which is the mechanics CI will now effectively run
- [x] `make lint` — passes
- [ ] The real proof is this PR's own CI run under the new flags. This change deliberately surfaces any test that only passed unsandboxed — none are known today; if CI reveals one, that's a finding to fix, not a reason to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2KKh7BzcebB2Xts95rjyF