### PR TITLE
fix: Keep installer scripts out of the agent bundle and wire Rename menu validation

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -83,7 +83,10 @@
 		A100020D /* Exceptions for "KernovaMacOSAgent" folder in "KernovaMacOSAgent" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				app.kernova.macosagent.plist,
 				Info.plist,
+				install.command,
+				uninstall.command,
 			);
 			target = A1000204 /* KernovaMacOSAgent */;
 		};

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -1728,7 +1728,7 @@ extension VMSettingsViewController {
 
 // MARK: - Actions
 
-extension VMSettingsViewController {
+extension VMSettingsViewController: NSMenuItemValidation {
     @objc private func startRename() {
         guard instance.status.canRename else { return }
         viewModel.renameVMInDetail(instance)
@@ -1736,10 +1736,6 @@ extension VMSettingsViewController {
 
     /// Disables the name field's right-click "Rename" while the VM can't be
     /// renamed (e.g. while running), mirroring the disabled name button.
-    // periphery:ignore - AppKit's menu-validation machinery invokes this
-    // informal-protocol method on the name button's menu target (`self`)
-    // before showing the "Rename" item; that framework-driven call is
-    // invisible to Periphery's symbol graph.
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         if menuItem.action == #selector(startRename) {
             return instance.status.canRename


### PR DESCRIPTION
## Summary

Two independent defects, each verified against build output rather than by reading alone.

**Installer scripts shipped inside the agent app bundle.** A
`PBXFileSystemSynchronizedBuildFileExceptionSet`'s `membershipExceptions` is an
*exclusion* list for the synchronized folder, and the `KernovaMacOSAgent` target's
set (A100020D) carried only `Info.plist`. Everything else in `KernovaMacOSAgent/`
was therefore a build resource, so `app.kernova.macosagent.plist`,
`install.command`, and `uninstall.command` were copied into
`Kernova Guest Agent.app/Contents/Resources/` and installed into every guest.
Nothing read them: the "Package Guest Agent DMG" phase sources all three from
`$(SRCROOT)` onto the DMG root, and `install.command` resolves its siblings from
its own `SCRIPT_DIR` — which is the DMG root, not the nested bundle. The test
target's set (A1000308) already excluded all three, which is what the agent
target's set should have mirrored.

**`validateMenuItem(_:)` was unreachable.** `VMSettingsViewController` conformed to
nothing menu-validation-related, so Swift emitted no ObjC thunk for the method and
AppKit's validation machinery could never find it — confirmed on the pre-fix
object file, which contained zero `validateMenuItem` selectors. The consequence is
user-visible: the name field's right-click "Rename" stayed enabled while the VM
could not be renamed, diverging from the name button beside it, which is correctly
disabled. Declaring `NSMenuItemValidation` is enough; the method already had the
right signature and the class is `@MainActor`, matching the protocol's isolation,
so no concurrency changes were needed.

The comment at `buildGeneralSection` claiming the item "is gated by
`validateMenuItem`" describes the intended behavior — it becomes true with this
change and is left as-is.

## Changes

- `Kernova.xcodeproj/project.pbxproj` — add `app.kernova.macosagent.plist`,
  `install.command`, and `uninstall.command` to exception set A100020D, in the same
  case-insensitive-alphabetical order set A1000308 uses.
- `Kernova/Views/Detail/VMSettingsViewController.swift` — declare
  `NSMenuItemValidation` on the Actions extension and delete the now-obsolete
  `periphery:ignore` annotation (see Notes).

No tests added: the only code change is in a view controller, which AGENTS.md
places outside the unit-test scope.

## Test plan

- [x] `make build` succeeds.
- [x] **Bundle exclusion, empirically:** in a fresh arena,
      `Kernova Guest Agent.app/Contents/Resources/` contains only `AppIcon.icns`,
      `Assets.car`, and `SwiftProtobuf_SwiftProtobuf.bundle`; a recursive `find`
      over the whole bundle matches none of the three files.
- [x] **Delivery path intact:** mounting the built `KernovaMacOSAgent.dmg` shows
      all three files still present at the DMG root alongside the agent app, so
      the installer flow is unchanged.
- [x] **Thunk emitted, empirically:** `otool -oV` on the rebuilt
      `VMSettingsViewController.o` now shows `validateMenuItem:` in the class's
      instance-method list with a real `imp`
      (`…VMSettingsViewControllerC16validateMenuItemySbSo06NSMenuG0CFTo`) plus the
      emitted `NSMenuItemValidation` protocol conformance — where the pre-fix
      object file had none.
- [x] `make test` — `** TEST SUCCEEDED **`, no failures.
- [x] `make lint` — clean (also re-run by the pre-push hook).

## Notes

This change **deletes** a `periphery:ignore` annotation rather than adding one. It
claimed AppKit invoked `validateMenuItem(_:)` as an informal-protocol method
invisible to Periphery's symbol graph; that premise was false — AppKit was not
invoking it at all. With the conformance declared, `.periphery.yml`'s
`retain_objc_accessible: true` retains the method as a protocol witness, which the
file's own comment already names as covering "NSMenuItemValidation conformance", so
no annotation is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2KKh7BzcebB2Xts95rjyF