### PR TITLE
refactor: Remove production symbols kept alive only by their tests

### DIFF
--- a/Kernova/Models/MacOSInstallContext.swift
+++ b/Kernova/Models/MacOSInstallContext.swift
@@ -68,7 +68,7 @@ struct MacOSInstallContext: Codable, Sendable, Equatable {
     /// Honored once: the existing IPSW file and any `.kernovadownload` bundle
     /// are trashed, then the flag is cleared so a retry after a failed install
     /// reuses the freshly-downloaded file rather than trashing it again.
-    var requestedFreshDownload: Bool = false
+    var requestedFreshDownload: Bool
 
     var downloadDestinationURL: URL? {
         downloadDestinationPath.map { URL(fileURLWithPath: $0) }
@@ -98,19 +98,9 @@ struct MacOSInstallContext: Codable, Sendable, Equatable {
         self.build = build
     }
 
-    // Custom decoder so a context missing these keys decodes with
-    // `requestedFreshDownload = false` and a nil bookmark rather than failing.
-    enum CodingKeys: String, CodingKey {
-        case source
-        case downloadDestinationPath
-        case localIPSWPath
-        case localIPSWBookmark
-        case requestedFreshDownload
-        case remoteURL
-        case version
-        case build
-    }
-
+    // Custom `init(from:)` for the non-optional-with-a-default
+    // `requestedFreshDownload`, which synthesis would `decode` rather than
+    // `decodeIfPresent` (see `VMConfiguration.init(from:)`).
     init(from decoder: any Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.source = try c.decode(Source.self, forKey: .source)

--- a/Kernova/Models/VMBootMode.swift
+++ b/Kernova/Models/VMBootMode.swift
@@ -18,11 +18,4 @@ enum VMBootMode: String, Codable, Sendable {
         case .linuxKernel: "Linux Kernel"
         }
     }
-
-    static func validModes(for guestOS: VMGuestOS) -> [VMBootMode] {
-        switch guestOS {
-        case .macOS: [.macOS]
-        case .linux: [.efi, .linuxKernel]
-        }
-    }
 }

--- a/Kernova/Models/VMBundleLayout.swift
+++ b/Kernova/Models/VMBundleLayout.swift
@@ -93,17 +93,6 @@ struct VMBundleLayout: Sendable {
         return DiskSizes(onDiskBytes: onDisk, capacityBytes: capacity)
     }
 
-    /// Actual bytes consumed on disk by a disk image, or `nil` if the file
-    /// doesn't resolve.
-    func diskOnDiskBytes(forRelativePath path: String, isInternal: Bool) -> UInt64? {
-        diskSizes(forRelativePath: path, isInternal: isInternal).onDiskBytes
-    }
-
-    /// Virtual capacity (bytes) of a disk image, or `nil` when it can't be read.
-    func diskCapacityBytes(forRelativePath path: String, isInternal: Bool) -> UInt64? {
-        diskSizes(forRelativePath: path, isInternal: isInternal).capacityBytes
-    }
-
     /// Outcome of inspecting a file's ASIF header for its virtual capacity.
     private enum ASIFCapacity {
         case capacity(UInt64)

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -445,33 +445,7 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         }
     }
 
-    // MARK: - Hot-Toggleable Fields
-
-    /// Fields the user may edit while the VM is running.
-    ///
-    /// Changes to these bypass the read-only settings lock. Entries need not
-    /// have a guest-side effect — `applyLivePolicy` checks the fields it pushes
-    /// to the guest directly rather than iterating this list.
-    static let hotToggleFields: [KeyPath<VMConfiguration, Bool> & Sendable] = [
-        \.agentLogForwardingEnabled,
-        \.clipboardSharingEnabled,
-        \.clipboardPassthroughEnabled,
-        \.serialSocketRelayEnabled,
-        \.agentInstallNudgeDismissed,
-        \.displayAutoResizes,
-    ]
-
-    /// Returns `true` if any field that is editable while the VM is running
-    /// differs between `old` and `new`.
-    static func liveEditableFieldsChanged(
-        old: VMConfiguration,
-        new: VMConfiguration
-    ) -> Bool {
-        if hotToggleFields.contains(where: { old[keyPath: $0] != new[keyPath: $0] }) {
-            return true
-        }
-        return removableMediaChanged(old: old, new: new)
-    }
+    // MARK: - Removable Media
 
     static func removableMediaChanged(old: VMConfiguration, new: VMConfiguration) -> Bool {
         (old.removableMedia ?? []) != (new.removableMedia ?? [])

--- a/Kernova/Models/VMStatus.swift
+++ b/Kernova/Models/VMStatus.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The runtime status of a virtual machine.
-enum VMStatus: String, Codable, Sendable {
+enum VMStatus: Sendable {
     case stopped
     case starting
     case running

--- a/Kernova/Services/HostClipboardPublisher.swift
+++ b/Kernova/Services/HostClipboardPublisher.swift
@@ -366,12 +366,6 @@ enum HostPublishOutcome {
     /// `writeObjects` returned false — nothing was placed.
     case writeFailed
 
-    /// `true` only when the write landed on the pasteboard.
-    var didWrite: Bool {
-        if case .written = self { return true }
-        return false
-    }
-
     /// The pasteboard's change count right after a successful write, else `nil`.
     var postWriteChangeCount: Int? {
         if case .written(_, _, let changeCount) = self { return changeCount }

--- a/Kernova/Services/SpiceAgentProtocol.swift
+++ b/Kernova/Services/SpiceAgentProtocol.swift
@@ -174,11 +174,6 @@ enum SpiceMessageBuilder {
         return wrapMessage(type: .clipboard, payload: payload)
     }
 
-    /// Builds a `CLIPBOARD_RELEASE` message.
-    static func buildClipboardRelease() -> Data {
-        wrapMessage(type: .clipboardRelease, payload: Data())
-    }
-
     // MARK: - Private
 
     private static func wrapMessage(type: SpiceAgentMessageType, payload: Data) -> Data {

--- a/Kernova/Utilities/ClipboardContent+AppKit.swift
+++ b/Kernova/Utilities/ClipboardContent+AppKit.swift
@@ -35,12 +35,6 @@ extension ClipboardContent {
         representations.filter { !$0.filename.isEmpty }
     }
 
-    /// The inline representations — alternative encodings of one inline content
-    /// item (text + RTF + image data; the consumer picks the richest).
-    var inlineRepresentations: [Representation] {
-        representations.filter { $0.filename.isEmpty }
-    }
-
     /// The inline rich-text representation best suited to a styled preview, or
     /// `nil` when none is present.
     ///

--- a/Kernova/Utilities/DataFormatters.swift
+++ b/Kernova/Utilities/DataFormatters.swift
@@ -103,11 +103,6 @@ enum DataFormatters {
         return formatted.replacingOccurrences(of: " ", with: "\u{2007}")
     }
 
-    /// Formats a CPU count for display.
-    static func formatCPUCount(_ count: Int) -> String {
-        count == 1 ? "1 core" : "\(count) cores"
-    }
-
     /// Quotes each item with typographic double quotes and joins them with the
     /// locale's list conjunction.
     ///

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -418,14 +418,6 @@ final class VMCreationViewModel {
         return task
     }
 
-    // MARK: - Apply Defaults
-
-    func applyOSDefaults() {
-        cpuCount = selectedOS.defaultCPUCount
-        memoryInGB = selectedOS.defaultMemoryInGB
-        diskSizeInGB = VMGuestOS.defaultDiskSizeInGB
-    }
-
     // MARK: - Overwrite Warning
 
     var ipswDownloadPathFileExists: Bool {

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -93,7 +93,7 @@ final class VMLifecycleCoordinator {
         action: String,
         body: () async throws -> T
     ) async throws -> T {
-        guard activeOperations[instance.id] == nil else {
+        guard !hasActiveOperation(for: instance.id) else {
             Self.logger.warning(
                 "Rejected \(action, privacy: .public) for '\(instance.name, privacy: .public)': operation already in progress"
             )

--- a/Kernova/Views/Detail/GuestSetupProgressViewController.swift
+++ b/Kernova/Views/Detail/GuestSetupProgressViewController.swift
@@ -329,12 +329,6 @@ final class GuestSetupProgressViewController: NSViewController {
         return "\(speed) — \(eta)\u{2007}remaining"
     }
 
-    /// Composes both subtitle lines into one newline-separated string.
-    nonisolated static func detailText(for progress: SetupStepProgress, verb: String) -> String {
-        [detailLine1(for: progress, verb: verb), detailLine2(for: progress)]
-            .compactMap { $0 }.joined(separator: "\n")
-    }
-
     // MARK: - Cancel
 
     @objc private func cancelTapped() {

--- a/KernovaMacOSAgent/VsockHostConnection.swift
+++ b/KernovaMacOSAgent/VsockHostConnection.swift
@@ -129,17 +129,13 @@ final class VsockHostConnection: @unchecked Sendable {
         return false
     }
 
-    /// Appends a frame to the pre-connect ring, dropping oldest entries once the cap is exceeded.
-    func bufferFrame(_ frame: Frame) {
-        lock.withLock { appendToRingLocked(frame) }
-    }
-
-    /// Buffers `frame` unless host policy has meanwhile gone explicitly `.disabled`.
+    /// Appends `frame` to the pre-connect ring unless host policy has meanwhile
+    /// gone explicitly `.disabled`.
     ///
     /// `forwardLog` samples the policy before building the frame, so re-checking
     /// under the same lock hold as the append is what keeps a concurrent
     /// `setEnabled(false)` from leaving this frame behind its own buffer clear.
-    private func bufferFrameUnlessDisabled(_ frame: Frame) {
+    func bufferFrameUnlessDisabled(_ frame: Frame) {
         lock.withLock {
             guard policy != .disabled else { return }
             appendToRingLocked(frame)

--- a/KernovaMacOSAgentTests/VsockHostConnectionTests.swift
+++ b/KernovaMacOSAgentTests/VsockHostConnectionTests.swift
@@ -3,6 +3,9 @@ import Foundation
 import Darwin
 import KernovaKit
 
+/// Tests that seed the ring directly call `bufferFrameUnlessDisabled` on a
+/// fresh connection, whose policy is `.undecided` — the state that buffers, so
+/// they run through the in-lock policy re-check on its appending branch.
 @Suite("VsockHostConnection log buffer")
 struct VsockHostConnectionTests {
     // MARK: - Buffer helpers
@@ -55,7 +58,7 @@ struct VsockHostConnectionTests {
         let cap = VsockHostConnection.logBufferLimit
 
         for i in 0..<total {
-            conn.bufferFrame(makeLogFrame(message: "frame\(i)"))
+            conn.bufferFrameUnlessDisabled(makeLogFrame(message: "frame\(i)"))
         }
 
         #expect(pendingLogCount(conn) == cap)
@@ -69,7 +72,7 @@ struct VsockHostConnectionTests {
         let cap = VsockHostConnection.logBufferLimit
 
         for i in 0..<(cap + 10) {
-            conn.bufferFrame(makeLogFrame(message: "f\(i)"))
+            conn.bufferFrameUnlessDisabled(makeLogFrame(message: "f\(i)"))
         }
 
         #expect(pendingLogCount(conn) == cap)
@@ -83,7 +86,7 @@ struct VsockHostConnectionTests {
         let frameCount = 10
 
         for i in 0..<frameCount {
-            conn.bufferFrame(makeLogFrame(message: "flush\(i)"))
+            conn.bufferFrameUnlessDisabled(makeLogFrame(message: "flush\(i)"))
         }
 
         let (sender, receiver) = try makeChannelPair()
@@ -109,7 +112,7 @@ struct VsockHostConnectionTests {
         let conn = VsockHostConnection()
 
         for i in 0..<5 {
-            conn.bufferFrame(makeLogFrame(message: "m\(i)"))
+            conn.bufferFrameUnlessDisabled(makeLogFrame(message: "m\(i)"))
         }
 
         let (sender, receiver) = try makeChannelPair()
@@ -140,7 +143,7 @@ struct VsockHostConnectionTests {
         // Named frames r00..r19 (zero-padded for sortable string comparison).
         for i in 0..<frameCount {
             let name = String(format: "r%02d", i)
-            conn.bufferFrame(makeLogFrame(message: name + String(repeating: "x", count: 4096)))
+            conn.bufferFrameUnlessDisabled(makeLogFrame(message: name + String(repeating: "x", count: 4096)))
         }
 
         let (senderFd, receiverFd) = try makeRawSocketPair()
@@ -184,7 +187,7 @@ struct VsockHostConnectionTests {
 
         // Preload exactly cap frames: pre0 .. pre255
         for i in 0..<cap {
-            conn.bufferFrame(makeLogFrame(message: "pre\(i)"))
+            conn.bufferFrameUnlessDisabled(makeLogFrame(message: "pre\(i)"))
         }
 
         // Close both ends before flush so every send throws .closed —
@@ -197,7 +200,7 @@ struct VsockHostConnectionTests {
         // Now push 10 more frames: post0 .. post9
         // The cap enforcer must drop the 10 oldest (pre0..pre9).
         for i in 0..<postCount {
-            conn.bufferFrame(makeLogFrame(message: "post\(i)"))
+            conn.bufferFrameUnlessDisabled(makeLogFrame(message: "post\(i)"))
         }
 
         let messages = pendingMessages(conn)
@@ -233,7 +236,7 @@ struct VsockHostConnectionTests {
         // The simplest direct test: after a successful flush, buffer is empty;
         // a subsequent forwardLog that succeeds on the live channel returns true
         // and leaves buffer empty. Drive this by flushing onto a working channel.
-        conn.bufferFrame(makeLogFrame(message: "pre"))
+        conn.bufferFrameUnlessDisabled(makeLogFrame(message: "pre"))
         conn.flushPendingLogs(on: sender)
         _ = try await nextFrame(from: receiver)
         #expect(pendingLogCount(conn) == 0)
@@ -250,7 +253,7 @@ struct VsockHostConnectionTests {
 
         // Put one frame in buffer, then flush onto a dead channel.
         // The send fails and the frame is re-enqueued.
-        conn.bufferFrame(makeLogFrame(message: "initial"))
+        conn.bufferFrameUnlessDisabled(makeLogFrame(message: "initial"))
 
         let (sender, receiver) = try makeChannelPair()
         sender.close()
@@ -284,6 +287,16 @@ struct VsockHostConnectionTests {
         #expect(result == false)
         #expect(pendingLogCount(conn) == 0)
         #expect(conn.isLogForwardingEnabled == false)
+    }
+
+    @Test("Explicitly disabled: bufferFrameUnlessDisabled drops the frame")
+    func explicitlyDisabledDropsBufferedFrame() {
+        let conn = VsockHostConnection()
+        conn.setEnabled(false)
+
+        conn.bufferFrameUnlessDisabled(makeLogFrame(message: "dropped"))
+
+        #expect(pendingLogCount(conn) == 0)
     }
 
     // MARK: - Undecided policy: pre-handshake buffering (#598)

--- a/KernovaTests/ClipboardContentAppKitTests.swift
+++ b/KernovaTests/ClipboardContentAppKitTests.swift
@@ -40,7 +40,9 @@ struct ClipboardContentAppKitTests {
         #expect(content.filePayloads.allSatisfy { !$0.filename.isEmpty })
         // The complement is exactly the inline set — no representation is both,
         // and none is neither.
-        #expect(content.representations.count - content.filePayloads.count == 1)
+        let inline = content.representations.filter { $0.filename.isEmpty }
+        #expect(inline.count == 1)
+        #expect(content.filePayloads.count + inline.count == content.representations.count)
     }
 
     @Test("richTextRepresentation finds an inline RTF rep")

--- a/KernovaTests/ClipboardContentAppKitTests.swift
+++ b/KernovaTests/ClipboardContentAppKitTests.swift
@@ -10,7 +10,7 @@ struct ClipboardContentAppKitTests {
     // `shouldInlineOnPasteboard` moved to KernovaKit (shared by host + guest);
     // its cases live in `ClipboardRepresentationPasteboardTests` in the package.
 
-    // MARK: - filePayloads / inlineRepresentations / richTextRepresentation
+    // MARK: - filePayloads / richTextRepresentation
 
     @Test("filePayloads returns the filename-tagged representations in order")
     func filePayloadsFound() {
@@ -23,22 +23,24 @@ struct ClipboardContentAppKitTests {
         #expect(content.filePayloads.first?.filename == "a.txt")
     }
 
-    @Test("filePayloads is empty and inlineRepresentations holds all when none carry a filename")
+    @Test("filePayloads is empty when no representation carries a filename")
     func filePayloadsAbsent() {
         let content = ClipboardContent(text: "just text")
         #expect(content.filePayloads.isEmpty)
-        #expect(content.inlineRepresentations.count == content.representations.count)
+        #expect(content.representations.allSatisfy { $0.filename.isEmpty })
     }
 
-    @Test("filePayloads and inlineRepresentations partition the representations")
+    @Test("filePayloads and the inline remainder partition the representations")
     func partitionComplementary() {
         let content = ClipboardContent(representations: [
             .init(uti: UTType.plainText.identifier, data: Data("x".utf8), filename: "a.txt"),
             .init(uti: ClipboardContent.utf8TextUTI, data: Data("inline".utf8)),
         ])
         #expect(content.filePayloads.count == 1)
-        #expect(content.inlineRepresentations.count == 1)
-        #expect(content.inlineRepresentations.allSatisfy { $0.filename.isEmpty })
+        #expect(content.filePayloads.allSatisfy { !$0.filename.isEmpty })
+        // The complement is exactly the inline set — no representation is both,
+        // and none is neither.
+        #expect(content.representations.count - content.filePayloads.count == 1)
     }
 
     @Test("richTextRepresentation finds an inline RTF rep")

--- a/KernovaTests/ClipboardPassthroughCoordinatorTests.swift
+++ b/KernovaTests/ClipboardPassthroughCoordinatorTests.swift
@@ -126,7 +126,10 @@ struct ClipboardPassthroughCoordinatorTests {
         // the shared publisher.
         h.service.clipboardContent = ClipboardContent(text: "from guest")
         let outcome = await h.publisher.publish(from: h.service)
-        #expect(outcome.didWrite)
+        guard case .written = outcome else {
+            Issue.record("Expected the publish to land on the pasteboard, got \(outcome)")
+            return
+        }
 
         // The poll must recognize its own write and not offer it back to the guest.
         h.coordinator.pollHostClipboard()

--- a/KernovaTests/DataFormattersTests.swift
+++ b/KernovaTests/DataFormattersTests.swift
@@ -218,16 +218,4 @@ struct DataFormattersTests {
         #expect(DataFormatters.formatDiskSize(2500) == "2.5\u{2007}TB")
         #expect(DataFormatters.formatDiskSize(7500) == "7.5\u{2007}TB")
     }
-
-    // MARK: - formatCPUCount
-
-    @Test("formatCPUCount returns singular for 1 core")
-    func formatCPUCountSingular() {
-        #expect(DataFormatters.formatCPUCount(1) == "1 core")
-    }
-
-    @Test("formatCPUCount returns plural for multiple cores")
-    func formatCPUCountPlural() {
-        #expect(DataFormatters.formatCPUCount(4) == "4 cores")
-    }
 }

--- a/KernovaTests/GuestSetupSubtitleTests.swift
+++ b/KernovaTests/GuestSetupSubtitleTests.swift
@@ -6,15 +6,15 @@ import Testing
 /// Verifies the guest-setup download-progress subtitle holds a stable
 /// horizontal position as it updates (#555).
 ///
-/// The subtitle is one center-aligned wrapping label, so any change in a line's
+/// The subtitle is two center-aligned labels, so any change in a line's
 /// *rendered width* re-centers it and reads as horizontal jitter. These tests
-/// measure the actual rendered width of the assembled lines in the label's own
-/// font and assert the structural invariants that keep it still — rather than
-/// counting characters, which a proportional unit suffix (KB vs MB) would defeat.
+/// measure the actual rendered width of each line in the labels' own font and
+/// assert the structural invariants that keep it still — rather than counting
+/// characters, which a proportional unit suffix (KB vs MB) would defeat.
 @MainActor
 @Suite("Guest setup subtitle width stability")
 struct GuestSetupSubtitleTests {
-    /// The exact font `GuestSetupProgressViewController` gives `detailLabel`.
+    /// The exact font `GuestSetupProgressViewController` gives its detail labels.
     private static let font = NSFont.monospacedDigitSystemFont(
         ofSize: NSFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .regular)
 
@@ -31,11 +31,13 @@ struct GuestSetupSubtitleTests {
     /// The subtitle lines for an estimate of `etaSeconds` at `bytesPerSecond`.
     private func downloadLines(etaSeconds: Int, bytesPerSecond: Double) -> [String] {
         let remaining = Int64((Double(etaSeconds) * bytesPerSecond).rounded())
-        let progress = DownloadProgress(
-            bytesWritten: 0, totalBytes: remaining, bytesPerSecond: bytesPerSecond)
-        return GuestSetupProgressViewController.detailText(
-            for: .download(progress), verb: Self.downloadVerb
-        ).components(separatedBy: "\n")
+        let progress = SetupStepProgress.download(
+            DownloadProgress(
+                bytesWritten: 0, totalBytes: remaining, bytesPerSecond: bytesPerSecond))
+        return [
+            GuestSetupProgressViewController.detailLine1(for: progress, verb: Self.downloadVerb),
+            GuestSetupProgressViewController.detailLine2(for: progress),
+        ].compactMap { $0 }
     }
 
     /// ETA values spanning every unit boundary the H:MM:SS clock can cross.
@@ -65,17 +67,15 @@ struct GuestSetupSubtitleTests {
         // Just above the guard yields a real estimate; just below yields the
         // placeholder. Both render the same "1.0 KB/s" speed, so line 2 must not
         // move as the speed dips across the guard and back.
-        let numeric = GuestSetupProgressViewController.detailText(
+        let numeric = GuestSetupProgressViewController.detailLine2(
             for: .download(
-                DownloadProgress(bytesWritten: 0, totalBytes: 100_100, bytesPerSecond: 1_001)),
-            verb: Self.downloadVerb
-        ).components(separatedBy: "\n")[1]
-        let placeholder = GuestSetupProgressViewController.detailText(
+                DownloadProgress(bytesWritten: 0, totalBytes: 100_100, bytesPerSecond: 1_001)))
+        let placeholder = GuestSetupProgressViewController.detailLine2(
             for: .download(
-                DownloadProgress(bytesWritten: 0, totalBytes: 99_900, bytesPerSecond: 999)),
-            verb: Self.downloadVerb
-        ).components(separatedBy: "\n")[1]
-        #expect(abs(width(numeric) - width(placeholder)) < tolerance)
+                DownloadProgress(bytesWritten: 0, totalBytes: 99_900, bytesPerSecond: 999)))
+        #expect(numeric != nil)
+        #expect(placeholder != nil)
+        #expect(abs(width(numeric ?? "") - width(placeholder ?? "")) < tolerance)
     }
 
     @Test("Line 1 always sets the label box: every line-2 width stays below every line-1 width")
@@ -99,21 +99,11 @@ struct GuestSetupSubtitleTests {
     func installPercentStable() {
         let widths = [0.0, 0.09, 0.10, 0.5, 0.99, 1.0].map {
             width(
-                GuestSetupProgressViewController.detailText(
+                GuestSetupProgressViewController.detailLine1(
                     for: .fraction($0), verb: Self.installVerb))
         }
         let spread = (widths.max() ?? 0) - (widths.min() ?? 0)
         #expect(spread < tolerance, "install percentage width moved by \(spread)pt")
-    }
-
-    @Test("Line 2 is omitted before the first speed sample")
-    func line2AbsentWithoutSpeed() {
-        let lines = GuestSetupProgressViewController.detailText(
-            for: .download(
-                DownloadProgress(bytesWritten: 0, totalBytes: 1_000_000, bytesPerSecond: 0)),
-            verb: Self.downloadVerb
-        ).components(separatedBy: "\n")
-        #expect(lines.count == 1)
     }
 
     // MARK: - Per-line builders (the labels are refreshed on separate cadences)
@@ -137,23 +127,19 @@ struct GuestSetupSubtitleTests {
         #expect(line2?.contains(DataFormatters.etaUnknownPlaceholder) == true)
     }
 
-    @Test("detailText composes exactly line 1, then line 2 when present")
-    func detailTextComposesLines() {
+    @Test("detailLine1 names the step's verb and its percentage for both progress kinds")
+    func line1CarriesVerbAndPercent() {
         let downloading = SetupStepProgress.download(
             DownloadProgress(bytesWritten: 0, totalBytes: 100_000_000, bytesPerSecond: 10_000_000))
-        let line1 = GuestSetupProgressViewController.detailLine1(
+        let downloadLine1 = GuestSetupProgressViewController.detailLine1(
             for: downloading, verb: Self.downloadVerb)
-        let line2 = GuestSetupProgressViewController.detailLine2(for: downloading)
-        #expect(line2 != nil)
-        #expect(
-            GuestSetupProgressViewController.detailText(
-                for: downloading, verb: Self.downloadVerb) == "\(line1)\n\(line2!)")
+        #expect(downloadLine1.hasPrefix(Self.downloadVerb))
+        #expect(downloadLine1.hasSuffix("0%"))
 
-        // A fraction-only step has no line 2, so the composed text is line 1 alone.
         let installing = SetupStepProgress.fraction(0.42)
-        #expect(
-            GuestSetupProgressViewController.detailText(for: installing, verb: Self.installVerb)
-                == GuestSetupProgressViewController.detailLine1(
-                    for: installing, verb: Self.installVerb))
+        let installLine1 = GuestSetupProgressViewController.detailLine1(
+            for: installing, verb: Self.installVerb)
+        #expect(installLine1.hasPrefix(Self.installVerb))
+        #expect(installLine1.hasSuffix("42%"))
     }
 }

--- a/KernovaTests/OSSelectionContentViewControllerTests.swift
+++ b/KernovaTests/OSSelectionContentViewControllerTests.swift
@@ -29,10 +29,8 @@ struct OSSelectionContentViewControllerTests {
         #expect(findButton(titled: "macOS", in: vc.view)?.state == .off)
     }
 
-    @Test("Selecting an OS does not apply OS resource defaults")
-    func selectingDoesNotApplyOSDefaults() {
-        // `applyOSDefaults()` is intentionally never called by the wizard;
-        // changing the OS must leave CPU/memory at their standing values.
+    @Test("Selecting an OS leaves the resource values the user is standing on")
+    func selectingLeavesResourceValues() {
         let vm = VMCreationViewModel()
         let originalCPU = vm.cpuCount
         let originalMemory = vm.memoryInGB

--- a/KernovaTests/SpiceAgentProtocolTests.swift
+++ b/KernovaTests/SpiceAgentProtocolTests.swift
@@ -160,14 +160,6 @@ struct SpiceAgentProtocolTests {
         #expect(String(data: payload, encoding: .utf8) == text)
     }
 
-    @Test("Clipboard release message has empty payload")
-    func buildClipboardRelease() {
-        let message = SpiceMessageBuilder.buildClipboardRelease()
-
-        let dataSize = message.readLittleEndianUInt32(at: VDIChunkHeader.size + 16)
-        #expect(dataSize == 0)
-    }
-
     // MARK: - Parser
 
     @Test("Parser handles announce capabilities from guest")
@@ -443,9 +435,6 @@ struct SpiceAgentProtocolTests {
 
         let data = SpiceMessageBuilder.buildClipboardData(type: .utf8Text, data: Data([0x41]))
         #expect(data.readLittleEndianUInt32(at: 0) == SpiceConstants.serverPort)
-
-        let release = SpiceMessageBuilder.buildClipboardRelease()
-        #expect(release.readLittleEndianUInt32(at: 0) == SpiceConstants.serverPort)
     }
 
     // MARK: - Capability Checking

--- a/KernovaTests/VMBootModeTests.swift
+++ b/KernovaTests/VMBootModeTests.swift
@@ -13,20 +13,6 @@ struct VMBootModeTests {
         #expect(VMBootMode.linuxKernel.displayName == "Linux Kernel")
     }
 
-    // MARK: - Valid Modes
-
-    @Test("validModes for macOS returns only macOS boot mode")
-    func validModesForMacOS() {
-        let modes = VMBootMode.validModes(for: .macOS)
-        #expect(modes == [.macOS])
-    }
-
-    @Test("validModes for Linux returns EFI and linuxKernel")
-    func validModesForLinux() {
-        let modes = VMBootMode.validModes(for: .linux)
-        #expect(modes == [.efi, .linuxKernel])
-    }
-
     // MARK: - Codable Round-Trip
 
     @Test("macOS boot mode round-trips through JSON")

--- a/KernovaTests/VMBundleLayoutTests.swift
+++ b/KernovaTests/VMBundleLayoutTests.swift
@@ -98,14 +98,21 @@ struct VMBundleLayoutTests {
         #expect(layout.hasSaveFile == true)
     }
 
-    // MARK: - diskOnDiskBytes
+    // MARK: - diskSizes.onDiskBytes
 
     private func mainDiskOnDiskBytes(_ layout: VMBundleLayout) -> UInt64? {
-        layout.diskOnDiskBytes(
-            forRelativePath: layout.diskImageURL.lastPathComponent, isInternal: true)
+        layout.diskSizes(
+            forRelativePath: layout.diskImageURL.lastPathComponent, isInternal: true
+        ).onDiskBytes
     }
 
-    @Test("diskOnDiskBytes returns nil when disk image does not exist")
+    private func mainDiskCapacityBytes(_ layout: VMBundleLayout) -> UInt64? {
+        layout.diskSizes(
+            forRelativePath: layout.diskImageURL.lastPathComponent, isInternal: true
+        ).capacityBytes
+    }
+
+    @Test("onDiskBytes is nil when the disk image does not exist")
     func diskOnDiskBytesReturnsNilForMissingFile() {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -113,7 +120,7 @@ struct VMBundleLayoutTests {
         #expect(mainDiskOnDiskBytes(layout) == nil)
     }
 
-    @Test("diskOnDiskBytes returns non-nil for an existing file")
+    @Test("onDiskBytes is non-nil for an existing file")
     func diskOnDiskBytesReturnsSize() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -130,7 +137,7 @@ struct VMBundleLayoutTests {
         #expect(usage! >= 4096)
     }
 
-    @Test("diskOnDiskBytes returns physical allocation less than logical size for sparse files")
+    @Test("onDiskBytes is the physical allocation, below the logical size for sparse files")
     func diskOnDiskBytesReturnsSparseSize() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -153,9 +160,9 @@ struct VMBundleLayoutTests {
         #expect(usage! < logicalSize)
     }
 
-    // MARK: - diskCapacityBytes
+    // MARK: - diskSizes.capacityBytes
 
-    @Test("diskCapacityBytes reads the virtual capacity from a shdw header")
+    @Test("capacityBytes reads the virtual capacity from a shdw header")
     func diskCapacityBytesReadsASIFHeader() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -170,12 +177,10 @@ struct VMBundleLayoutTests {
         withUnsafeBytes(of: &sectorsBE) { header.replaceSubrange(0x30..<0x38, with: $0) }
         try header.write(to: layout.diskImageURL)
 
-        let capacity = layout.diskCapacityBytes(
-            forRelativePath: layout.diskImageURL.lastPathComponent, isInternal: true)
-        #expect(capacity == 50_000_000_000)
+        #expect(mainDiskCapacityBytes(layout) == 50_000_000_000)
     }
 
-    @Test("diskCapacityBytes returns the logical file size for a non-ASIF file")
+    @Test("capacityBytes is the logical file size for a non-ASIF file")
     func diskCapacityBytesLogicalSizeForNonASIF() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -186,12 +191,10 @@ struct VMBundleLayoutTests {
         // A raw image (no `shdw` magic): apparent size *is* the capacity.
         try Data(repeating: 0xAB, count: 0x40).write(to: layout.diskImageURL)
 
-        #expect(
-            layout.diskCapacityBytes(
-                forRelativePath: layout.diskImageURL.lastPathComponent, isInternal: true) == 0x40)
+        #expect(mainDiskCapacityBytes(layout) == 0x40)
     }
 
-    @Test("diskCapacityBytes resolves an external (absolute) path's logical size")
+    @Test("capacityBytes resolves an external (absolute) path's logical size")
     func diskCapacityBytesExternalAbsolutePath() throws {
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(UUID().uuidString).img")
@@ -200,21 +203,21 @@ struct VMBundleLayoutTests {
 
         let layout = VMBundleLayout(bundleURL: FileManager.default.temporaryDirectory)
         #expect(
-            layout.diskCapacityBytes(
-                forRelativePath: fileURL.path(percentEncoded: false), isInternal: false) == 2048)
+            layout.diskSizes(
+                forRelativePath: fileURL.path(percentEncoded: false), isInternal: false
+            )
+            .capacityBytes == 2048)
     }
 
-    @Test("diskCapacityBytes returns nil for a missing file")
+    @Test("capacityBytes is nil for a missing file")
     func diskCapacityBytesNilForMissingFile() {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         let layout = VMBundleLayout(bundleURL: tempDir)
-        #expect(
-            layout.diskCapacityBytes(
-                forRelativePath: layout.diskImageURL.lastPathComponent, isInternal: true) == nil)
+        #expect(mainDiskCapacityBytes(layout) == nil)
     }
 
-    @Test("diskCapacityBytes returns nil for a malformed ASIF rather than its file size")
+    @Test("capacityBytes is nil for a malformed ASIF rather than its file size")
     func diskCapacityBytesNilForMalformedASIF() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -232,12 +235,10 @@ struct VMBundleLayoutTests {
         withUnsafeBytes(of: &sectorsBE) { header.replaceSubrange(0x30..<0x38, with: $0) }
         try header.write(to: layout.diskImageURL)
 
-        #expect(
-            layout.diskCapacityBytes(
-                forRelativePath: layout.diskImageURL.lastPathComponent, isInternal: true) == nil)
+        #expect(mainDiskCapacityBytes(layout) == nil)
     }
 
-    @Test("diskCapacityBytes rejects a sector count that overflows when ×512")
+    @Test("capacityBytes rejects a sector count that overflows when ×512")
     func diskCapacityBytesNilForOverflowingSectorCount() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -254,9 +255,7 @@ struct VMBundleLayoutTests {
         withUnsafeBytes(of: &sectorsBE) { header.replaceSubrange(0x30..<0x38, with: $0) }
         try header.write(to: layout.diskImageURL)
 
-        #expect(
-            layout.diskCapacityBytes(
-                forRelativePath: layout.diskImageURL.lastPathComponent, isInternal: true) == nil)
+        #expect(mainDiskCapacityBytes(layout) == nil)
     }
 
     // MARK: - diskSizes

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -780,28 +780,6 @@ struct VMConfigurationTests {
         #expect(config.displayAutoResizes == true)
     }
 
-    @Test("hotToggleFields covers displayAutoResizes")
-    func displayAutoResizesIsHotToggleable() {
-        #expect(VMConfiguration.hotToggleFields.contains(\.displayAutoResizes))
-
-        var base = VMConfiguration(name: "Test VM", guestOS: .macOS, bootMode: .macOS)
-        var modified = base
-        modified.displayAutoResizes = false
-        #expect(VMConfiguration.liveEditableFieldsChanged(old: base, new: modified))
-
-        // Match-window sizing only applies at boot, so it must not read as live.
-        base.displaySizesToWindow = false
-        modified = base
-        modified.displaySizesToWindow = true
-        #expect(!VMConfiguration.liveEditableFieldsChanged(old: base, new: modified))
-
-        // Nor HiDPI: it picks the density the next boot is configured with.
-        base.displayHiDPI = false
-        modified = base
-        modified.displayHiDPI = true
-        #expect(!VMConfiguration.liveEditableFieldsChanged(old: base, new: modified))
-    }
-
     @Test("displayResolution reads and writes the stored trio")
     func displayResolutionAccessesTheTrio() {
         var config = VMConfiguration(
@@ -1283,29 +1261,20 @@ struct VMConfigurationTests {
         }
     }
 
-    // MARK: - Live-Editable Fields
+    // MARK: - Removable Media Changes
 
-    @Test("liveEditableFieldsChanged detects added removable media item")
-    func liveEditableDetectsAddedRemovableMedia() {
-        let base = VMConfiguration(name: "VM", guestOS: .linux, bootMode: .efi)
-        var modified = base
-        modified.removableMedia = [RemovableMediaItem(path: "/tmp/install.iso", readOnly: true)]
-        #expect(VMConfiguration.liveEditableFieldsChanged(old: base, new: modified))
-        #expect(VMConfiguration.liveEditableFieldsChanged(old: modified, new: base))
-    }
-
-    @Test("liveEditableFieldsChanged detects readOnly flip on a removable media item")
-    func liveEditableDetectsRemovableMediaReadOnlyFlip() {
+    @Test("removableMediaChanged detects a readOnly flip on an existing item")
+    func removableMediaChangedDetectsReadOnlyFlip() {
         let id = UUID()
         var base = VMConfiguration(name: "VM", guestOS: .linux, bootMode: .efi)
         base.removableMedia = [RemovableMediaItem(id: id, path: "/tmp/install.iso", readOnly: true)]
         var modified = base
         modified.removableMedia = [RemovableMediaItem(id: id, path: "/tmp/install.iso", readOnly: false)]
-        #expect(VMConfiguration.liveEditableFieldsChanged(old: base, new: modified))
+        #expect(VMConfiguration.removableMediaChanged(old: base, new: modified))
     }
 
-    @Test("liveEditableFieldsChanged ignores storageDisks changes")
-    func liveEditableIgnoresStorageDisksChanges() {
+    @Test("removableMediaChanged ignores storageDisks changes")
+    func removableMediaChangedIgnoresStorageDisks() {
         // Storage disks are restart-only on VZ (storageDevices is fixed at
         // VM start). The live reconcile flow only acts on removableMedia.
         let base = VMConfiguration(name: "VM", guestOS: .linux, bootMode: .efi)
@@ -1313,22 +1282,7 @@ struct VMConfigurationTests {
         modified.storageDisks = [
             StorageDisk(path: "Disk.asif", readOnly: false, label: "Main Disk", isInternal: true, kind: .virtio)
         ]
-        #expect(!VMConfiguration.liveEditableFieldsChanged(old: base, new: modified))
-    }
-
-    @Test("liveEditableFieldsChanged still covers existing hotToggleFields")
-    func liveEditableCoversHotToggleFields() {
-        var base = VMConfiguration(name: "VM", guestOS: .macOS, bootMode: .macOS)
-        base.clipboardSharingEnabled = false
-        var modified = base
-        modified.clipboardSharingEnabled = true
-        #expect(VMConfiguration.liveEditableFieldsChanged(old: base, new: modified))
-    }
-
-    @Test("liveEditableFieldsChanged returns false for identical configs")
-    func liveEditableReturnsFalseForIdenticalConfigs() {
-        let base = VMConfiguration(name: "VM", guestOS: .linux, bootMode: .efi)
-        #expect(!VMConfiguration.liveEditableFieldsChanged(old: base, new: base))
+        #expect(!VMConfiguration.removableMediaChanged(old: base, new: modified))
     }
 
     @Test("removableMediaChanged detects list mutations")

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -211,40 +211,6 @@ struct VMCreationViewModelTests {
         #expect(vm.effectiveBootMode == .linuxKernel)
     }
 
-    // MARK: - applyOSDefaults
-
-    @Test("applyOSDefaults sets correct values for macOS")
-    func applyOSDefaultsMacOS() {
-        let vm = VMCreationViewModel()
-        vm.selectedOS = .macOS
-        // Set non-default values first
-        vm.cpuCount = 1
-        vm.memoryInGB = 1
-        vm.diskSizeInGB = 1
-
-        vm.applyOSDefaults()
-
-        #expect(vm.cpuCount == VMGuestOS.macOS.defaultCPUCount)
-        #expect(vm.memoryInGB == VMGuestOS.macOS.defaultMemoryInGB)
-        #expect(vm.diskSizeInGB == VMGuestOS.defaultDiskSizeInGB)
-    }
-
-    @Test("applyOSDefaults sets correct values for Linux")
-    func applyOSDefaultsLinux() {
-        let vm = VMCreationViewModel()
-        vm.selectedOS = .linux
-        // Set non-default values first
-        vm.cpuCount = 1
-        vm.memoryInGB = 1
-        vm.diskSizeInGB = 1
-
-        vm.applyOSDefaults()
-
-        #expect(vm.cpuCount == VMGuestOS.linux.defaultCPUCount)
-        #expect(vm.memoryInGB == VMGuestOS.linux.defaultMemoryInGB)
-        #expect(vm.diskSizeInGB == VMGuestOS.defaultDiskSizeInGB)
-    }
-
     // MARK: - buildConfiguration
 
     @Test("buildConfiguration produces configuration with correct fields for Linux EFI")

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -744,18 +744,6 @@ struct VMInstanceTests {
         #expect(instance.vsockClipboardListenerHost == nil)
     }
 
-    @Test("VMConfiguration.hotToggleFields covers all runtime-editable booleans")
-    func hotToggleFieldsCovered() {
-        let fields = VMConfiguration.hotToggleFields
-        #expect(fields.count == 6)
-        #expect(fields.contains(\.agentLogForwardingEnabled))
-        #expect(fields.contains(\.clipboardSharingEnabled))
-        #expect(fields.contains(\.clipboardPassthroughEnabled))
-        #expect(fields.contains(\.serialSocketRelayEnabled))
-        #expect(fields.contains(\.agentInstallNudgeDismissed))
-        #expect(fields.contains(\.displayAutoResizes))
-    }
-
     // MARK: - Agent Post-Start Watchdog
     //
     // The watchdog flips `agentExpectedButMissing` after a grace period when:

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -2100,7 +2100,10 @@ struct VsockClipboardServiceTests {
                 reps: [(uti: "public.data", byteCount: 128, filename: "a.bin", isInline: false)]))
         try await waitForChange { service.clipboardContent.representations.count == 1 }
         let outcome = await publisher.publish(from: service)
-        #expect(outcome.didWrite)
+        guard case .written = outcome else {
+            Issue.record("Expected the publish to land on the pasteboard, got \(outcome)")
+            return
+        }
         #expect(pasteboard.pasteboardItems?.isEmpty == false)
 
         // The guest copies again while the pasteboard still holds our write:
@@ -2151,7 +2154,10 @@ struct VsockClipboardServiceTests {
                     uti: ClipboardContent.utf8TextUTI, data: Data("local".utf8))
             ])
         let outcome = await publisher.publish(from: service)
-        #expect(outcome.didWrite)
+        guard case .written = outcome else {
+            Issue.record("Expected the publish to land on the pasteboard, got \(outcome)")
+            return
+        }
         let countAfterWrite = pasteboard.changeCount
 
         try guest.send(makeTextOffer(generation: 1, text: "guest"))

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -180,8 +180,6 @@ Also here: `LoginItemService` (the `SMAppService.mainApp` wrapper behind the Ope
 rename, and guest-driven `VMInstance.onUpdateConfiguration` callbacks — routes through
 `VMLibraryViewModel.updateConfiguration(of:mutate:)`, which persists and then calls
 `applyLivePolicy`. No control writes `instance.configuration` directly.
-`VMConfiguration.liveEditableFieldsChanged(old:new:)` is the single source of truth for whether a
-change takes effect while the VM runs.
 
 **Removable-media reconcile.** `applyLivePolicy` drops media changes into a coalescing drain that
 calls `applyLiveRemovableMediaChange(for:target:)`.


### PR DESCRIPTION
## Summary

Twelve production symbols had zero callers outside their own tests — the tests were the only thing keeping them compiled. Each is deleted, and where the symbol was a thin wrapper over a real production path, its tests are repointed at that path so the assertions pin behavior the app actually runs.

Two deliberate non-deletions:

- **`VMLifecycleCoordinator.hasActiveOperation(for:)` is adopted instead.** `serialized(_:action:body:)` duplicated the accessor's dictionary lookup inline; it now calls the accessor. The 18 test assertions on it stop being self-referential, and the call site reads better than `activeOperations[instance.id] == nil`.
- **`VsockHostConnection.bufferFrameUnlessDisabled` is promoted `private` → internal.** Production only ever called it; the tests drove the sibling `bufferFrame`, which shared only the private ring append. Deleting `bufferFrame` and pointing the nine ring-buffer tests at the real entry point means they now run through the in-lock policy re-check. A new test covers the previously untested guard: with policy explicitly `.disabled`, the frame is dropped rather than buffered.

Two inert-conformance cleanups in the same theme: `VMStatus` carried a `String` raw value nothing reads and `Codable` nothing encodes, and `MacOSInstallContext` carried an unreachable property default plus a hand-written `CodingKeys` identical to synthesis.

## Changes

**Deleted**

| Symbol | Test handling |
|---|---|
| `VMCreationViewModel.applyOSDefaults()` | 2 tests deleted; the `OSSelectionContentViewController` test that pinned "OS change leaves CPU/memory alone" keeps its assertions, renamed off the deleted method |
| `VMConfiguration.liveEditableFieldsChanged(old:new:)` + `hotToggleFields` | Wrapper-only assertions deleted; the readOnly-flip and storage-disks-are-restart-only cases repointed at `removableMediaChanged`, the predicate production actually calls |
| `VsockHostConnection.bufferFrame(_:)` | 9 tests repointed at `bufferFrameUnlessDisabled`; 1 test added for the disabled-policy drop |
| `GuestSetupProgressViewController.detailText(for:verb:)` | Repointed at `detailLine1` / `detailLine2` individually, matching how the two labels are composed in production |
| `VMBundleLayout.diskOnDiskBytes(...)`, `.diskCapacityBytes(...)` | Repointed at `diskSizes(forRelativePath:isInternal:).onDiskBytes` / `.capacityBytes` |
| `SpiceMessageBuilder.buildClipboardRelease()` | 3 references removed |
| `ClipboardContent.inlineRepresentations` | Partition invariant rewritten as `representations.count - filePayloads.count` |
| `VMBootMode.validModes(for:)` | 2 tests deleted |
| `DataFormatters.formatCPUCount(_:)` | 2 tests deleted |
| `HostPublishOutcome.didWrite` | 3 uses rewritten as `guard case .written` |

**Conformance / boilerplate**

- `VMStatus`: `enum VMStatus: String, Codable, Sendable` → `enum VMStatus: Sendable`. No `rawValue` read, no `init(rawValue:)`, no encode/decode path — all display goes through `displayName`. `Equatable`/`Hashable` synthesize for a payload-free enum, and the three parameterized suites that pass `VMStatus` as `arguments:` only need `Sendable`.
- `MacOSInstallContext`: the `= false` property default is unreachable (both the explicit init and `init(from:)` assign it; the live default is the init parameter's). The hand-written `CodingKeys` matched synthesis exactly — `init(from:)` stays in the type body, so the synthesized enum remains visible. The decoder comment's "nil bookmark rather than failing" clause was false (optionals never fail under `decodeIfPresent`); it now states the one true reason and points at `VMConfiguration.init(from:)`, which owns the full explanation.

**Docs**

- `docs/ARCHITECTURE.md` named `liveEditableFieldsChanged(old:new:)` as "the single source of truth for whether a change takes effect while the VM runs" — a claim no call site backed even before this change. Sentence dropped; the one-door write path it sits under still describes the flow.

Tests were deleted only where the deleted symbol was the assertion's sole subject. One `GuestSetupSubtitleTests` case went with the composer because it had become an exact duplicate of `line2NilWhenNotApplicable`.

## Test plan

- [x] `make build`
- [x] `make test` — full suite, 2163 cases, all passing
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2KKh7BzcebB2Xts95rjyF