### PR TITLE
docs: Correct prose that outlived its mechanism

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Ensure shellcheck
         run: command -v shellcheck >/dev/null || brew install shellcheck
 
-      - name: make lint (swift-format --strict + shell lint)
+      - name: make lint
         run: make lint

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -2,7 +2,7 @@
 # (shellcheck searches upward from each script's directory for this file).
 # SC2016 ("Expressions don't expand in single quotes"): disabled repo-wide.
 # The Tools/ scripts' user-facing pass/warn/detail text quotes commands and
-# flags in backticks inside single-quoted strings (e.g. `make fp-reset`,
+# flags in backticks inside single-quoted strings (e.g. `make ghosts`,
 # `--fix`) — display markup, not intended command substitution — and that
 # trips SC2016 on every such line.
 disable=SC2016

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ Persisted formats are current-only — no migration code. Back-compat shims, dec
 
 ### File Operations
 
-Prefer `trash` over `rm` when deleting files.
+Prefer `trash` over `rm` when deleting files. A user-confirmed permanent-delete flow ("Delete Immediately") is the exception and removes outright.
 
 ### Review Feedback Handling
 

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -314,12 +314,11 @@ final class MainWindowController: NSWindowController, NSToolbarDelegate, NSWindo
     /// Re-applies toolbar enablement after any sheet, and recreates the app's
     /// custom toolbar items when the closing sheet is the customize palette.
     ///
-    /// RATIONALE: AppKit bakes the section-specific glass treatment into a
-    /// bordered item's view at creation, and a customization drag across the
-    /// sidebar tracking separator reuses the existing instance without firing
-    /// toolbarWillAddItem or toolbarDidRemoveItem (verified empirically), so a
-    /// moved item keeps the wrong treatment. Reinserting at the same index routes
-    /// through the delegate factory.
+    /// AppKit bakes the section-specific glass treatment into a bordered item's
+    /// view at creation, and a customization drag across the sidebar tracking
+    /// separator reuses the existing instance without firing toolbarWillAddItem
+    /// or toolbarDidRemoveItem, so a moved item keeps the wrong treatment.
+    /// Reinserting at the same index routes through the delegate factory.
     func windowDidEndSheet(_ notification: Notification) {
         // Every sheet, not just the palette: item enablement is applied from the
         // observation with `autovalidates` off, so a refresh that lands while a

--- a/Kernova/App/VMToolbarManager.swift
+++ b/Kernova/App/VMToolbarManager.swift
@@ -463,9 +463,8 @@ final class VMToolbarManager: NSObject {
         item.action = action
         item.toolTip = toolTip
         item.isBordered = true
-        // RATIONALE: the update methods own enabled state; with autovalidation
-        // on, AppKit would force isEnabled=true and fight the manual updates,
-        // producing a visible flicker when switching between stopped VMs.
+        // Autovalidation fights the update methods' writes visibly here: the
+        // items flicker when switching between stopped VMs (docs/TOOLBAR.md).
         item.autovalidates = false
         return item
     }

--- a/Kernova/Services/DownloadService.swift
+++ b/Kernova/Services/DownloadService.swift
@@ -310,8 +310,6 @@ final class DownloadService: Sendable {
         let bundleURL = Self.resumeBundleURL(for: destinationURL)
         do {
             if permanently {
-                // RATIONALE: the user-confirmed "Delete Immediately" path; the deliberate
-                // exception to AGENTS.md's "prefer trash over rm" guideline.
                 try fileSystem.removeItem(at: bundleURL)
             } else {
                 try fileSystem.trashItem(at: bundleURL)

--- a/Kernova/Services/HostClipboardPublisher.swift
+++ b/Kernova/Services/HostClipboardPublisher.swift
@@ -118,12 +118,9 @@ final class HostClipboardPublisher {
         }
 
         let pasteboard = writePasteboard
-        // RATIONALE: `.currentHostOnly` keeps guest content — host-owned data on
-        // arrival — from being re-advertised to the user's other Apple-Account
-        // devices over Universal Clipboard (docs/CLIPBOARD.md §10). The option is
-        // per-write state, reset by every `prepareForNewContents`/`clearContents`,
-        // so it is applied at this single publication choke point rather than once
-        // at init.
+        // `.currentHostOnly` (docs/CLIPBOARD.md §10) is per-write state, reset by
+        // every `prepareForNewContents`/`clearContents`, so it is applied at this
+        // single publication choke point rather than once at init.
         pasteboard.prepareForNewContents(with: .currentHostOnly)
         guard pasteboard.writeObjects(items) else {
             // The write failed, so the providers were never retained.

--- a/Kernova/Services/VMStorageService.swift
+++ b/Kernova/Services/VMStorageService.swift
@@ -132,9 +132,6 @@ struct VMStorageService: Sendable {
         guard FileManager.default.fileExists(atPath: bundleURL.path(percentEncoded: false)) else {
             throw VMStorageError.bundleNotFound(bundleURL)
         }
-        // RATIONALE: The user-confirmed "Delete Immediately" path (menu item →
-        // confirm sheet → here) is the deliberate exception to AGENTS.md's
-        // "prefer trash over rm" rule.
         try FileManager.default.removeItem(at: bundleURL)
         Self.logger.notice("Permanently deleted VM bundle: \(bundleURL.lastPathComponent, privacy: .public)")
     }

--- a/Kernova/Utilities/AppPreferences.swift
+++ b/Kernova/Utilities/AppPreferences.swift
@@ -15,13 +15,14 @@ struct AppPreferences {
         self.defaults = defaults
     }
 
+    /// The literal `UserDefaults` key strings.
+    ///
+    /// Renaming one orphans the value every existing install has already stored
+    /// under the old string, so each key stays as written — including where its
+    /// namespacing reads inconsistently against its neighbours.
     private enum Keys {
         static let alwaysShowAdvancedOptions = "alwaysShowAdvancedOptions"
         static let expandedSidebarSections = "KernovaSidebarExpandedSections"
-        // RATIONALE: these two deliberately keep unnamespaced key strings — the
-        // ones existing users' persisted selection and order are already stored
-        // under. Not a namespacing inconsistency to "fix": changing them drops
-        // that saved state.
         static let lastSelectedVMID = "lastSelectedVMID"
         static let vmOrder = "vmOrder"
         // Deliberately inverted relative to `keepInMenuBarOnQuit` — see that

--- a/Kernova/Utilities/NSWindowExtensions.swift
+++ b/Kernova/Utilities/NSWindowExtensions.swift
@@ -4,11 +4,11 @@ extension NSWindow {
     /// Creates a window hosting `contentViewController` whose content size is
     /// exactly `contentSize`.
     ///
-    /// RATIONALE: assigning `contentViewController` resizes the window to the
-    /// content view's Auto Layout fitting size, which for a flexible content view
-    /// is far smaller than the intended initial size — and `minSize`, set
-    /// afterwards, then clamps the window up to *that*. Re-establishing the size
-    /// after the assignment is the only ordering that sticks.
+    /// Assigning `contentViewController` resizes the window to the content view's
+    /// Auto Layout fitting size, which for a flexible content view is far smaller
+    /// than the intended initial size — and `minSize`, set afterwards, then clamps
+    /// the window up to *that*. Re-establishing the size after the assignment is
+    /// the only ordering that sticks.
     static func withStableContentSize(
         _ contentSize: NSSize,
         styleMask: NSWindow.StyleMask,

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -965,9 +965,6 @@ final class VMLibraryViewModel {
                 try SecurityScopedBookmark.withResolvedURL(bookmark: bookmark, fallback: url) {
                     target in
                     if permanently {
-                        // RATIONALE: the user-confirmed "Delete Immediately" path — the
-                        // deliberate exception to AGENTS.md's "Prefer `trash` over `rm`"
-                        // guideline.
                         try fileSystem.removeItem(at: target)
                     } else {
                         try fileSystem.trashItem(at: target)

--- a/KernovaKit/Proto/kernova.proto
+++ b/KernovaKit/Proto/kernova.proto
@@ -22,6 +22,11 @@ message Frame {
   // protocol (`ClipboardStreamBegin`/`ClipboardChunk`/`ClipboardStreamEnd`).
   // Never reuse — reserved for wire history.
   reserved 22;
+
+  // 29 was `ClipboardTreeFetch`, which pulled a directory representation's
+  // placeholder tree one node at a time (a listing, or one child file).
+  // Retired with the File Provider placeholder mechanism it fed: a directory
+  // rep now rides the plain-file stream path as a request-time archive.
   reserved 29;
 
   oneof payload {
@@ -52,6 +57,7 @@ message Frame {
     ClipboardStreamAck clipboard_stream_ack = 27;
     ClipboardStreamAbort clipboard_stream_abort = 28;
 
+    // 29 retired (see `reserved` above).
     LogRecord log_record = 30;
   }
 }
@@ -59,8 +65,8 @@ message Frame {
 // Sent by both sides immediately after a vsock connection is accepted.
 //
 // Each side advertises its protocol version, the capabilities it supports,
-// and identifying information for diagnostics. Capability strings use a dotted
-// namespace (e.g. "clipboard.text", "clipboard.image.png", "log.records.v1").
+// and identifying information for diagnostics. `KernovaCapability` owns the
+// tag list both sides advertise and recognize.
 message Hello {
   // Bumps when the service-level protocol changes within a given
   // `protocol_version`. Independent from `Frame.protocol_version`.

--- a/KernovaKit/Proto/kernova.proto
+++ b/KernovaKit/Proto/kernova.proto
@@ -44,7 +44,9 @@ message Frame {
 
     ClipboardOffer clipboard_offer = 20;
     ClipboardRequest clipboard_request = 21;
+
     // 22 retired (see `reserved` above).
+
     ClipboardRelease clipboard_release = 23;
 
     // Chunk-streamed clipboard data. One streamed representation per
@@ -58,6 +60,7 @@ message Frame {
     ClipboardStreamAbort clipboard_stream_abort = 28;
 
     // 29 retired (see `reserved` above).
+
     LogRecord log_record = 30;
   }
 }

--- a/KernovaKit/Sources/KernovaKit/ClipboardFileStaging.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileStaging.swift
@@ -195,8 +195,7 @@ public final class ClipboardFileStaging: @unchecked Sendable {
 
         let dir = try directory(for: generation)
         let url = Self.uniqueDestination(in: dir, filename: filename)
-        // `F_NOCACHE` keeps a multi-GB transfer from evicting the page cache —
-        // the DTS-preferred behavior for streaming large files.
+        // `F_NOCACHE` keeps a multi-GB transfer from evicting the page cache.
         FileManager.default.createFile(atPath: url.path, contents: nil)
         let handle = try FileHandle(forWritingTo: url)
         _ = fcntl(handle.fileDescriptor, F_NOCACHE, 1)

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
@@ -10,10 +10,8 @@ import Foundation
 /// Swift-concurrency cooperative thread. Per-transfer state is guarded by each
 /// transfer's `NSCondition`; the transfer table is guarded by `lock`.
 ///
-/// RATIONALE: Apple DTS sanctions a synchronous read on a dedicated GCD queue as
-/// the fallback to `DispatchIO`, and `F_NOCACHE` recovers the page-cache behavior
-/// DTS prefers for streaming large files. The blocking read is deliberate: the
-/// dedicated queue is what keeps it off the cooperative pool.
+/// The blocking read is deliberate rather than a `DispatchIO` port left undone —
+/// the dedicated queue is what makes it safe.
 public final class ClipboardStreamSender: @unchecked Sendable {
     private let channel: VsockChannel
     private let chunkSize: Int

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
@@ -10,8 +10,8 @@ import Foundation
 /// Swift-concurrency cooperative thread. Per-transfer state is guarded by each
 /// transfer's `NSCondition`; the transfer table is guarded by `lock`.
 ///
-/// The blocking read is deliberate rather than a `DispatchIO` port left undone —
-/// the dedicated queue is what makes it safe.
+/// The blocking read is deliberate rather than a `DispatchIO` port left undone:
+/// the per-transfer queue is what keeps it off the cooperative pool.
 public final class ClipboardStreamSender: @unchecked Sendable {
     private let channel: VsockChannel
     private let chunkSize: Int

--- a/KernovaKit/Sources/KernovaKit/Generated/kernova.pb.swift
+++ b/KernovaKit/Sources/KernovaKit/Generated/kernova.pb.swift
@@ -101,7 +101,6 @@ public nonisolated struct Kernova_V1_Frame: Sendable {
     set {payload = .clipboardRequest(newValue)}
   }
 
-  /// 22 retired (see `reserved` above).
   public var clipboardRelease: Kernova_V1_ClipboardRelease {
     get {
       if case .clipboardRelease(let v)? = payload {return v}
@@ -154,7 +153,6 @@ public nonisolated struct Kernova_V1_Frame: Sendable {
     set {payload = .clipboardStreamAbort(newValue)}
   }
 
-  /// 29 retired (see `reserved` above).
   public var logRecord: Kernova_V1_LogRecord {
     get {
       if case .logRecord(let v)? = payload {return v}
@@ -178,7 +176,6 @@ public nonisolated struct Kernova_V1_Frame: Sendable {
     case policyUpdate(Kernova_V1_PolicyUpdate)
     case clipboardOffer(Kernova_V1_ClipboardOffer)
     case clipboardRequest(Kernova_V1_ClipboardRequest)
-    /// 22 retired (see `reserved` above).
     case clipboardRelease(Kernova_V1_ClipboardRelease)
     /// Chunk-streamed clipboard data. One streamed representation per
     /// `transfer_id`: Begin announces it, a series of Chunks carries the bytes,
@@ -189,7 +186,6 @@ public nonisolated struct Kernova_V1_Frame: Sendable {
     case clipboardStreamEnd(Kernova_V1_ClipboardStreamEnd)
     case clipboardStreamAck(Kernova_V1_ClipboardStreamAck)
     case clipboardStreamAbort(Kernova_V1_ClipboardStreamAbort)
-    /// 29 retired (see `reserved` above).
     case logRecord(Kernova_V1_LogRecord)
 
   }

--- a/KernovaKit/Sources/KernovaKit/Generated/kernova.pb.swift
+++ b/KernovaKit/Sources/KernovaKit/Generated/kernova.pb.swift
@@ -154,6 +154,7 @@ public nonisolated struct Kernova_V1_Frame: Sendable {
     set {payload = .clipboardStreamAbort(newValue)}
   }
 
+  /// 29 retired (see `reserved` above).
   public var logRecord: Kernova_V1_LogRecord {
     get {
       if case .logRecord(let v)? = payload {return v}
@@ -188,6 +189,7 @@ public nonisolated struct Kernova_V1_Frame: Sendable {
     case clipboardStreamEnd(Kernova_V1_ClipboardStreamEnd)
     case clipboardStreamAck(Kernova_V1_ClipboardStreamAck)
     case clipboardStreamAbort(Kernova_V1_ClipboardStreamAbort)
+    /// 29 retired (see `reserved` above).
     case logRecord(Kernova_V1_LogRecord)
 
   }
@@ -198,8 +200,8 @@ public nonisolated struct Kernova_V1_Frame: Sendable {
 /// Sent by both sides immediately after a vsock connection is accepted.
 ///
 /// Each side advertises its protocol version, the capabilities it supports,
-/// and identifying information for diagnostics. Capability strings use a dotted
-/// namespace (e.g. "clipboard.text", "clipboard.image.png", "log.records.v1").
+/// and identifying information for diagnostics. `KernovaCapability` owns the
+/// tag list both sides advertise and recognize.
 public nonisolated struct Kernova_V1_Hello: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for

--- a/KernovaKit/Sources/KernovaTestSupport/EphemeralDefaults.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/EphemeralDefaults.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-// Shared ephemeral-`UserDefaults` test helpers for the test bundles that
-// exercise a `UserDefaults`-backed preferences wrapper.
+// Ephemeral-`UserDefaults` test helpers for the test bundle that exercises a
+// `UserDefaults`-backed preferences wrapper.
 
 // MARK: - makeEphemeralDefaults
 

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -926,12 +926,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             return (types: item.map { $0.type }, provider: provider)
         }
 
-        // RATIONALE: `.currentHostOnly` keeps the continuity-pasteboard
-        // advertiser from fetching the promised flavors at offer time — on the
-        // sync path, producing `public.file-url` materializes the whole file with
-        // zero user interaction (docs/CLIPBOARD.md §3). The option is per-write
-        // state, reset by every prepare/clear, so it is applied at this single
-        // publication choke point.
+        // `.currentHostOnly` (docs/CLIPBOARD.md §3) is per-write state, reset by
+        // every prepare/clear, so it is applied at this single publication choke
+        // point.
         pasteboard.prepareForNewContents(with: .currentHostOnly)
         let written = pasteboard.writeItems(writes)
         lastPasteboardChangeCount = pasteboard.changeCount

--- a/KernovaMacOSAgentTests/TestHelpers.swift
+++ b/KernovaMacOSAgentTests/TestHelpers.swift
@@ -6,9 +6,8 @@ import KernovaTestSupport
 
 // Bundle-specific test helpers for KernovaMacOSAgentTests. The event-driven/
 // poll wait primitives (`AsyncGate`, `waitUntil`, `TestFailure`) and the
-// ephemeral-`UserDefaults` helpers (`makeEphemeralDefaults`,
-// `withEphemeralDefaults`) live in the shared `KernovaTestSupport` package
-// product — see its doc comments.
+// blocking-bridge GCD hop (`offCooperativePool`) live in the shared
+// `KernovaTestSupport` package product — see its doc comments.
 
 // MARK: - Socket / channel factories
 

--- a/KernovaTests/DownloadServiceTests.swift
+++ b/KernovaTests/DownloadServiceTests.swift
@@ -1256,10 +1256,14 @@ final class StubURLProtocol: URLProtocol, @unchecked Sendable {
         }
     }
 
-    // RATIONALE: URLProtocol is instantiated per-request by URLSession on an
-    // internal queue; the test sets `handler` before kicking off the download
-    // and clears it after, so the global isn't racy in practice. Marking it
-    // nonisolated(unsafe) sidesteps Sendable diagnostics for the closure.
+    /// The response shape for the case in flight, set before a download starts.
+    ///
+    /// Belongs to `DownloadServiceTests` alone: the handler is a global, Swift Testing
+    /// runs suites in parallel, and that suite's `.serialized` orders only its own
+    /// cases — a second suite driving this class would clobber it, which is why the
+    /// other URL-stubbing suites each declare their own `URLProtocol`.
+    /// `nonisolated(unsafe)`: URLSession instantiates the protocol per request on a
+    /// session-internal queue, so no actor can own this.
     nonisolated(unsafe) static var handler: ((URLRequest) -> StubResponse)?
 
     override class func canInit(with request: URLRequest) -> Bool { true }

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -8,7 +8,7 @@ struct VMConfigurationTests {
     ///
     /// Pass extra comma-separated JSON fields via `extraFields` to add or override entries.
     private static func makeBaseJSON(
-        name: String = "Old VM",
+        name: String = "Base VM",
         extraFields: String = ""
     ) -> String {
         let extra = extraFields.isEmpty ? "" : ",\n            \(extraFields)"
@@ -185,7 +185,7 @@ struct VMConfigurationTests {
         decoder.dateDecodingStrategy = .iso8601
         let config = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
 
-        #expect(config.name == "Old VM")
+        #expect(config.name == "Base VM")
         #expect(config.genericMachineIdentifierData == nil)
         #expect(config.macAddress == nil)
     }
@@ -569,8 +569,8 @@ struct VMConfigurationTests {
         #expect(decoded.installContext?.localIPSWPath == "/tmp/macOS-26.ipsw")
     }
 
-    @Test("Legacy config.json without installContext key decodes as nil")
-    func legacyConfigWithoutInstallContextDecodesAsNil() throws {
+    @Test("A config omitting installContext decodes it as nil")
+    func configOmittingInstallContextDecodesNil() throws {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let config = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
@@ -638,12 +638,8 @@ struct VMConfigurationTests {
         #expect(jsonObject["linuxInstallContext"] == nil)
     }
 
-    @Test("Pre-existing config.json with installContext missing requestedFreshDownload decodes cleanly")
-    func legacyInstallContextWithoutRequestedFreshDownloadDecodes() throws {
-        // Wire-shape from before `requestedFreshDownload` was added — Codable
-        // must tolerate the missing field and default it to `false` so users
-        // who created VMs on an older build don't have their install state
-        // become un-decodable.
+    @Test("An installContext omitting requestedFreshDownload decodes it as false")
+    func installContextOmittingRequestedFreshDownloadDecodesFalse() throws {
         let baseFields = """
             "installContext": {
                 "source": "downloadLatest",
@@ -900,8 +896,6 @@ struct VMConfigurationTests {
 
     @Test("Configs missing the clipboardPassthroughEnabled key default it off")
     func clipboardPassthroughMissingKeyUsesDefault() throws {
-        // `makeBaseJSON` predates the passthrough key — the shape of a config
-        // saved before passthrough existed. It must fall through to `false`.
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let decoded = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
@@ -941,11 +935,8 @@ struct VMConfigurationTests {
         #expect(decoded.agentLogForwardingEnabled == true)
     }
 
-    @Test("Missing agentLogForwardingEnabled decodes as false (existing-VM migration)")
+    @Test("A config omitting agentLogForwardingEnabled decodes it as false")
     func missingAgentLogForwardingEnabledDecodesFalse() throws {
-        // Older configs predate the field — they must still decode, with the
-        // new flag defaulting to off so existing VMs don't suddenly forward
-        // logs without the user opting in.
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let config = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
@@ -985,11 +976,8 @@ struct VMConfigurationTests {
         #expect(decoded.lastSeenAgentVersion == "0.9.2")
     }
 
-    @Test("Missing lastSeenAgentVersion decodes as nil (existing-VM migration)")
+    @Test("A config omitting lastSeenAgentVersion decodes it as nil")
     func missingLastSeenAgentVersionDecodesNil() throws {
-        // Older configs predate the field — they must still decode, with the
-        // optional defaulting to nil so the post-start watchdog doesn't
-        // misfire on VMs that have never connected an agent.
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let config = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
@@ -1029,11 +1017,8 @@ struct VMConfigurationTests {
         #expect(decoded.lastSeenGuestOSVersion == "Version 26.0 (Build 25A123)")
     }
 
-    @Test("Missing lastSeenGuestOSVersion decodes as nil (existing-VM migration)")
+    @Test("A config omitting lastSeenGuestOSVersion decodes it as nil")
     func missingLastSeenGuestOSVersionDecodesNil() throws {
-        // Older configs predate the field — they must still decode, with the
-        // optional defaulting to nil so the VM reads "Unknown" until an agent
-        // reports.
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let config = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
@@ -1073,11 +1058,8 @@ struct VMConfigurationTests {
         #expect(decoded.agentInstallNudgeDismissed == true)
     }
 
-    @Test("Missing agentInstallNudgeDismissed decodes as false (existing-VM migration)")
+    @Test("A config omitting agentInstallNudgeDismissed decodes it as false")
     func missingAgentInstallNudgeDismissedDecodesFalse() throws {
-        // Older configs predate the field — they must still decode, with the
-        // flag defaulting to off so the install nudge keeps surfacing for
-        // VMs the user has never actively dismissed.
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let config = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2401,7 +2401,7 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.instances[0].status == .initialBoot)
     }
 
-    @Test("loadVMs assigns .stopped when no installContext (back-compat)")
+    @Test("loadVMs assigns .stopped when no installContext")
     func loadVMsAssignsStoppedWithoutInstallContext() {
         let storage = MockVMStorageService()
         let config = VMConfiguration(name: "Installed VM", guestOS: .linux, bootMode: .efi)

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ doctor: ## Check the local toolchain (macOS, Xcode, Swift, swift-format) and rep
 # git worktrees left behind by torn-down worktrees (the post-checkout hook
 # sweeps registrations and arenas on new checkouts; this reports whatever
 # remains) — plus LIVE on-disk Kernova.app copies (Trash, DerivedData) that
-# outrank the installed /Applications copy in the LaunchServices/PluginKit
+# outrank the installed /Applications copy in the LaunchServices
 # CFBundleVersion election (#454). `ghosts` only reports; `clean-ghosts` also
 # unregisters/kills/prunes/evicts, prompting only for live competing copies.
 ghosts: ## Report stale/competing Kernova Launch Services, process, and worktree registrations

--- a/Tools/doctor.sh
+++ b/Tools/doctor.sh
@@ -9,8 +9,8 @@
 # failed (optional/tooling checks only warn). That makes it usable both as a
 # human sanity check and as a scriptable gate in CI.
 #
-# Requirements checked here mirror README.md "Requirements" and the toolchain
-# the Makefile actually invokes (e.g. `xcrun swift-format`).
+# Requirements checked here mirror the toolchain the Makefile actually invokes
+# (e.g. `xcrun swift-format`).
 
 set -uo pipefail
 

--- a/Tools/ghosts.sh
+++ b/Tools/ghosts.sh
@@ -47,7 +47,7 @@ usage='Usage: Tools/ghosts.sh [--fix | --sweep | --evict <dir>]'
 case "${1:-}" in
     '') ;;
     --fix) FIX=1 ;;
-    --sweep | --sweep-ls) SWEEP=1 ;;
+    --sweep) SWEEP=1 ;;
     --evict)
         EVICT=1
         EVICT_DIR="${2:-}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -236,11 +236,11 @@ NSSplitViewController (MainWindowController)
 └── Detail:  DetailContainerViewController  (owns DetailAlertsPresenter)
     ├── VMDisplayBackingView (layered on top; VZVirtualMachineView + overlays)
     └── DetailEmptyStateView ⇆ VMDetailRouterViewController  (routes via DetailRoute.resolve)
-            ├── VMSettingsViewController                   (stopped / error / running-settings)
-            ├── InitialBootBannerView + VMSettingsViewController
-            ├── DetailStatusPlaceholderViewController      (preparing / transition)
-            ├── MacOSInstallProgressViewController         (installing)
-            └── VMDisplayPlaceholderContentViewController  (external / suspended / unavailable)
+            ├── VMSettingsViewController                    (stopped / running-settings)
+            ├── DetailBannerView + VMSettingsViewController (initial boot / error)
+            ├── DetailStatusPlaceholderViewController       (preparing / transition)
+            ├── GuestSetupProgressViewController            (setup)
+            └── VMDisplayPlaceholderContentViewController   (external / suspended / unavailable)
 
 VMCreationWizardViewController (modal sheet, presented by DetailContainerViewController)
 ├── OSSelectionContentViewController
@@ -349,7 +349,7 @@ kernel resources until relaunch — hence one owner (`RuntimeFileAccess`) and on
 
 - **KernovaMacOSAgent** — `Kernova Guest Agent.app`, the `.accessory` menu-bar app that runs inside
   macOS guests, holding three independent vsock connections to the host (control, log forwarding,
-  clipboard). It is not embedded as a bundle: a build phase `ditto`-copies it into
+  clipboard). It is not embedded as a bundle: the `Package Guest Agent DMG` build phase produces
   `Contents/Resources/KernovaMacOSAgent.dmg`, so it must already carry its final Developer ID
   signature when the DMG is baked — export-time re-signing cannot reach inside a DMG resource
   ([RELEASING.md](RELEASING.md)); version bumps are in [BUILD.md](BUILD.md).

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -87,7 +87,9 @@ State *the constraint that makes this form required here*, never *what the code 
 
 ## Periphery directives
 
-When the dead-code scan flags a symbol that is alive through machinery its symbol graph cannot see, annotate the declaration with `// periphery:ignore - <reason>` instead of deleting it. The invisible paths: protocol witnesses invoked by compiler-emitted code (string interpolation, `Codable`), members reached through type inference on argument labels, declarations referenced only from a test target the scan does not index, and symbols intentionally retained for API symmetry.
+When the dead-code scan flags a symbol that is alive through machinery its symbol graph cannot see, annotate the declaration with `// periphery:ignore - <reason>` instead of deleting it. The invisible paths: protocol witnesses invoked by compiler-emitted code (string interpolation, `Codable`), members reached through type inference on argument labels, parameters carried for their type rather than their name (`isolated (any Actor)?`), and symbols intentionally retained for API symmetry.
+
+The scan indexes the test targets, so a reference from a test counts as usage: a production symbol only tests call is never flagged, and finding one is a manual job.
 
 Annotate freely here, unlike a `RATIONALE:` — the scan re-raises the symbol deterministically on every run, and the reason is a statement about this codebase's own wiring that any reader can verify.
 
@@ -95,14 +97,19 @@ Annotate freely here, unlike a `RATIONALE:` — the scan re-raises the symbol de
 - **Fix** when the finding is real — delete the symbol, or demote `public` to `internal` if only the access level is redundant.
 - **Dismiss** never applies: every annotation carries a reason, since silently retained symbols become a maintenance hazard.
 
-**Format** — put the directive **between** the doc comment and the declaration so DocC still associates the doc with the symbol, and keep the reason in the same comment block, with no blank line after the directive:
+**Format** — put the directive **between** the doc comment and the declaration so DocC still associates the doc with the symbol, and keep the reason in the same comment block, with no blank line after the directive. `periphery:ignore:parameters <names>` scopes it to those parameters instead of the whole declaration:
 
 ```swift
-/// `true` when no buffered bytes remain.
-// periphery:ignore - Used by `VsockFrameTests` via `@testable import`,
-// which Periphery's scheme-based scan doesn't currently index for the
-// SwiftPM package test target.
-var isEmpty: Bool { buffer.count == readOffset }
+/// Suspends until the next `notify()`, an immediate hit, or the `deadline`
+/// backstop — whichever comes first.
+// `isolation` uses the Swift `isolated` keyword to pin this helper to the
+// caller's actor, so it is intentionally never referenced by name.
+// periphery:ignore:parameters isolation
+private func armOnce(
+    deadline: ContinuousClock.Instant,
+    isolation: isolated (any Actor)?,
+    predicate: () -> Bool
+) async {
 ```
 
 Audit with `grep -r "periphery:ignore"` and drop any whose machinery has since become visible to Periphery. Prefer per-symbol annotations over re-toggling broad config flags like `retain_public` — see `.periphery.yml`.


### PR DESCRIPTION
## Summary

A sweep of documentation, comments and test names that describe mechanisms the code no longer has. Nothing here changes behavior: the only Swift edits are comments, `@Test` display names, two test function names, and regenerated proto bindings whose diff is doc comments.

Two of the corrections were load-bearing enough to be worth calling out:

- **docs/REVIEW.md listed a Periphery limitation that does not exist.** "Declarations referenced only from a test target the scan does not index" was named as an invisible path, and the worked example was a `periphery:ignore` on `VsockFrame.isEmpty` that has never been in the tree. The scan builds all three schemes and the test plan enrolls all three test targets — findings inside `KernovaTests`, `KernovaKitTests` and `KernovaMacOSAgentTests` appear in the scan-tracker issues. The doc now states the inverse fact, which is the one that costs something to not know: a test reference counts as usage, so a production symbol only tests call is never flagged and has to be found by hand. The example is now the real `periphery:ignore:parameters isolation` annotation in `KernovaTestSupport/AsyncWaits.swift`.
- **docs/ARCHITECTURE.md credited the guest-agent DMG to `ditto`.** The `Package Guest Agent DMG` phase uses `ditto` only to stage the app into a scratch folder; `hdiutil create` (UDRW) → `hdiutil convert` (UDTO) → `mv` produce the image. The doc now names the phase and leaves the how to the phase's own script, per the one-layer rule.

## Changes

**Docs**

- `docs/REVIEW.md` — false invisible path removed, inverse fact stated, fictional example replaced with the real annotation and a note on the `:parameters` variant.
- `docs/ARCHITECTURE.md` — detail-router tree: `DetailBannerView` replaces the nonexistent `InitialBootBannerView`; `GuestSetupProgressViewController` replaces the nonexistent `MacOSInstallProgressViewController`; the error route moves onto the banner row, since `.error` renders `DetailBannerView.error` over the settings form. DMG mechanism corrected as above.
- `AGENTS.md` — the File Operations rule now carries the user-confirmed "Delete Immediately" exception that three separate `RATIONALE:` comments were each restating.

**Wire protocol**

- `kernova.proto` — field 29 (`ClipboardTreeFetch`, deleted with the File Provider dirtree mechanism) gets the history note and oneof breadcrumb field 22 already had. `Hello.capabilities` pointed at three example tags (`clipboard.text`, `clipboard.image.png`, `log.records.v1`) that no side has ever advertised; it now points at `KernovaCapability`, which owns the list. Regenerated with `Tools/regen-proto.sh`.

**Tooling**

- `Makefile` — "LaunchServices/PluginKit" → "LaunchServices"; the app ships no extensions and this was the tree's only PluginKit mention.
- `.shellcheckrc` — the SC2016 justification cited `make fp-reset`, a deleted target; now `make ghosts`, which is a live instance of the construct.
- `Tools/doctor.sh` — dropped the cross-reference to a README "Requirements" section that no longer exists.
- `Tools/ghosts.sh` — removed the unreachable `--sweep-ls` alias (absent from the header, the usage string, and every caller).
- `.github/workflows/lint.yml` — step renamed to plain `make lint`; the old name listed two of the three stages. The job id is untouched, since the required-checks ruleset matches on it.

**`RATIONALE:` trims (eleven; none added)**

Each failed docs/REVIEW.md's four conditions — mostly condition 3 (no re-checkable evidence) or condition 2 (a better home). The technical content survives as ordinary comments wherever it was not already stated in a deeper layer; the per-annotation list is in the commit body. The three "Delete Immediately" ones are the clearest case: identical prose at three call sites, all pointing at an AGENTS.md rule, which now states the exception itself. `KernovaMacOSAgent/uninstall.command`'s annotation is untouched — it carries a Launch Services fact nothing else states.

**Tests (names and comments only)**

`VMConfigurationTests` framed the `decodeIfPresent ?? default` cases as migration coverage ("Older configs predate the field", "existing-VM migration", a `makeBaseJSON` default name of "Old VM"). AGENTS.md's Persisted Data rule means there are no migrations to cover — these tests pin a decode contract, and they now say so. One premise was also simply wrong: `legacyConfigWithoutInstallContextDecodesAsNil` treated a nil `installContext` as a legacy shape, but nil is the normal state of every installed VM and every Linux guest, which is what that fixture is.

## Test plan

- [x] `make lint` — swift-format `--strict`, shellcheck, `Tools/check-docs.sh`
- [x] `make test` — full test plan, `** TEST SUCCEEDED **`; the renamed cases run and pass
- [x] `Tools/regen-proto.sh` run with `protoc-gen-swift` built from the swift-protobuf revision pinned in `Package.resolved` (1.38.0), mirroring what `proto-drift` does on CI; a re-run leaves no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2KKh7BzcebB2Xts95rjyF