### PR TITLE
fix: Keep a restore image whose Last-Modified header is absent

### DIFF
--- a/Kernova/Models/RestoreImageCatalogEntry.swift
+++ b/Kernova/Models/RestoreImageCatalogEntry.swift
@@ -12,8 +12,9 @@ struct RestoreImageCatalogEntry: Codable, Sendable, Identifiable, Equatable {
     var build: String
     var url: URL
     var sizeBytes: UInt64
-    /// The `Last-Modified` Apple's CDN reports for ``url``, in RFC 1123 form.
-    var lastModified: String
+    /// The `Last-Modified` Apple's CDN reports for ``url``, in RFC 1123 form,
+    /// or `nil` when it reported none — the generator omits the key then.
+    var lastModified: String?
     /// Which pass of `Tools/regen-restore-image-catalog.swift` found this image.
     var source: String
 
@@ -24,9 +25,9 @@ struct RestoreImageCatalogEntry: Codable, Sendable, Identifiable, Equatable {
         RestoreImageFilename.destination(for: url)
     }
 
-    /// ``lastModified`` parsed for display, or `nil` if Apple's header did not parse.
+    /// ``lastModified`` parsed for display, or `nil` if it is absent or did not parse.
     var releaseDate: Date? {
-        Self.rfc1123Formatter.date(from: lastModified)
+        lastModified.flatMap { Self.rfc1123Formatter.date(from: $0) }
     }
 
     /// `version` split into numeric components, zero-padded to three.

--- a/KernovaTests/Mocks/RestoreImageCatalogFixtures.swift
+++ b/KernovaTests/Mocks/RestoreImageCatalogFixtures.swift
@@ -8,7 +8,7 @@ func makeCatalogEntry(
     build: String = "24G90",
     urlString: String? = nil,
     sizeBytes: UInt64 = 16_808_427_372,
-    lastModified: String = "Mon, 18 Aug 2025 12:00:00 GMT",
+    lastModified: String? = "Mon, 18 Aug 2025 12:00:00 GMT",
     source: String = "apple-live"
 ) -> RestoreImageCatalogEntry {
     let resolved =

--- a/KernovaTests/RestoreImageCatalogTests.swift
+++ b/KernovaTests/RestoreImageCatalogTests.swift
@@ -108,6 +108,11 @@ struct RestoreImageCatalogEntryTests {
     func releaseDateRejectsGarbage() {
         #expect(makeCatalogEntry(lastModified: "not a date").releaseDate == nil)
     }
+
+    @Test("An absent Last-Modified yields no date, like an unparseable one")
+    func releaseDateAbsent() {
+        #expect(makeCatalogEntry(lastModified: nil).releaseDate == nil)
+    }
 }
 
 @Suite("RestoreImageCatalogService Tests")
@@ -154,6 +159,17 @@ struct RestoreImageCatalogServiceTests {
         let catalog = try #require(result.catalog)
         #expect(catalog.images.map(\.build) == ["24G90"])
         #expect(result.rejections == [.undecodableEntry(index: 0)])
+    }
+
+    @Test("An entry with no Last-Modified key is kept, not dropped")
+    func keepsEntryWithoutLastModified() throws {
+        let noDate = goodEntry.replacingOccurrences(
+            of: "\"lastModified\": \"Mon, 18 Aug 2025 12:00:00 GMT\",", with: "")
+        let result = RestoreImageCatalogService.parse(json(images: noDate))
+        let catalog = try #require(result.catalog)
+        #expect(result.rejections.isEmpty)
+        #expect(catalog.images.map(\.build) == ["24G90"])
+        #expect(catalog.images.first?.releaseDate == nil)
     }
 
     @Test("An undecodable document yields no catalog")


### PR DESCRIPTION
## Summary

`RestoreImageCatalogEntry.lastModified` was declared non-optional with no default, making it a **required decode key**. But the generator writes it conditionally, because the value comes straight off an HTTP response header:

```swift
lastModified: http.value(forHTTPHeaderField: "Last-Modified"),   // :576 — Optional
…
if let lastModified = image.lastModified { row["lastModified"] = lastModified }   // :637
```

So an image Apple serves without a `Last-Modified` header ships without the key, the entry fails to decode, and `LenientEntry` drops it. In Debug the `assertionFailure` traps; in Release it compiles out, so the image disappears from the picker with only an `os_log` fault — the user simply never sees that restore image.

All 66 entries carry the key today, so nothing is broken right now. This closes the exposure, which depends on an external server's headers rather than anything Kernova controls.

The asymmetry that makes it a defect rather than a preference: the model already tolerated an *unparseable* date — `releaseDate`'s doc comment says it returns `nil` "if Apple's header did not parse" — while an *absent* one killed the whole entry. Both now degrade identically: no date shown, image still selectable.

`source` was checked at the same time and is **not** affected: the generator writes it in the unconditional part of the row, so a generated entry cannot lack it.

## Changes

- `Kernova/Models/RestoreImageCatalogEntry.swift` — `lastModified` becomes `String?`; `releaseDate` flat-maps it.
- `KernovaTests/Mocks/RestoreImageCatalogFixtures.swift` — fixture parameter accepts `nil`.
- `KernovaTests/RestoreImageCatalogTests.swift` — two tests: an entry with no `lastModified` key decodes and is kept, and an absent header yields no release date.

## Test plan

- [x] `make build`, `make test` (full suite), `make lint`
- [x] `keepsEntryWithoutLastModified` verified to **fail** against the pre-fix model — the entry was dropped with an `.undecodableEntry` rejection — so it guards the regression rather than passing either way

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2KKh7BzcebB2Xts95rjyF