### PR TITLE
docs: Drop the skill name from the worktree post-merge section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,17 +51,12 @@ ref in the refspec. A PR's head branch must always be the clean
 
 ## Post-merge cleanup in an `EnterWorktree` session
 
-In an `EnterWorktree` session (the usual case), after confirming a merge landed
-(`gh pr view <N> --json state -q .state` → `"MERGED"`), run `/github:freshen-main`
-from the worktree to fast-forward the primary checkout's `main` onto the squash
-commit. Never attempt that fast-forward with raw git — the worktree isolation
-guard refuses ad-hoc `git -C <primary-checkout>` commands, and the skill is the
-sanctioned route. It ships in the
-[github plugin](https://github.com/nicholas-lonsinger/claude-plugins), which
-owns the mechanism and how to read its output.
-
-Working directly in a checkout (no `EnterWorktree` session), follow the
-tool-neutral post-merge steps in AGENTS.md instead.
+AGENTS.md's post-merge steps assume the checkout that holds `main`. An
+`EnterWorktree` session is not it: `main` is checked out in the primary
+checkout, so nothing run from here advances it, and the worktree isolation
+guard refuses ad-hoc `git -C <primary-checkout>` commands. After confirming
+the merge landed (`gh pr view <N> --json state -q .state` → `"MERGED"`),
+fast-forward `main` in that checkout rather than from this worktree.
 
 ## Matching review effort to the diff
 


### PR DESCRIPTION
Follow-up to #740, which introduced the problem this fixes.

## The inconsistency

#740 rewrote the post-merge cleanup section to name `/github:freshen-main` and link the plugin that provides it. That made it the only skill or plugin reference anywhere in the repo — `grep -rn "github:\|plugin"` over `CLAUDE.md`, `AGENTS.md`, and `docs/` returned those two lines and nothing else.

`/github:wait-ci` is at least as load-bearing in the merge workflow and is named nowhere, and it gets used anyway. That is the pattern working as intended: a skill's own `description` frontmatter is what triggers it, and `freshen-main`'s already names the worktree case explicitly. Restating the trigger in a project doc is a second source of truth for when-to-fire, with the usual drift cost — rename the skill, move it between plugins, or read the repo without it installed, and the checked-in doc is wrong.

The justification given in #740 was that a slash command is preferable to a filesystem path in a source-available repo. That answered which *form* of reference to use without establishing that a reference belonged there at all.

## What stays

The section still earns its place, because one fact in it is genuinely this repo's and cannot move to a plugin: AGENTS.md's post-merge steps (`git switch main`, `git pull --ff-only`) assume the checkout that holds `main`, and an `EnterWorktree` session is not that checkout. Without this section, following AGENTS.md from a worktree silently does the wrong thing.

So the rewrite states the constraint and the goal and names no tooling. An agent reads it and its skill description matches. A human reads it and goes to the primary checkout, where the isolation guard was never in play for them.

The closing "working directly in a checkout, follow AGENTS.md instead" paragraph is dropped as redundant — the opening sentence now carries it.

## Test plan

- [x] `bash Tools/check-docs.sh` — line cap and links pass
- [x] `make lint` — clean (also run by the pre-push hook)
- [x] `grep -rn "github:\|plugin"` over `CLAUDE.md`, `AGENTS.md`, `docs/` — no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwHQ2rJv3eF74o7Dg5jRYS
