### PR TITLE
fix: Discard the resume bundle when a transfer runs past its ceiling

### DIFF
--- a/Kernova/Services/DownloadService.swift
+++ b/Kernova/Services/DownloadService.swift
@@ -32,9 +32,12 @@ final class DownloadService: Sendable {
     ///
     /// The partial download lives at `<destinationURL minus its extension>.kernovadownload/`;
     /// its `data` file size IS the resume offset, and `Info.plist` holds the
-    /// ETag / Last-Modified used for `If-Range`. The bundle is preserved for a
-    /// later resume on any failure, cancellation included (which throws
-    /// `CancellationError`). A completed file with no bundle beside it is skipped.
+    /// ETag / Last-Modified used for `If-Range`. The bundle survives a failure
+    /// a later attempt can resume past, cancellation included (which throws
+    /// `CancellationError`); one it cannot — a response disagreeing with the
+    /// bytes already on disk, or a body running past `expectedSizeBytes` —
+    /// discards the bundle so the next attempt restarts from zero. A completed
+    /// file with no bundle beside it is skipped.
     ///
     /// Calls are serialized per destination: two callers pinned to the same
     /// remote file share one path and one bundle, so a second caller waits for
@@ -443,7 +446,10 @@ final class DownloadService: Sendable {
     ///
     /// `expectedSizeBytes` bounds the file the caller is willing to land:
     /// `initialOffset` plus everything written is held under it, so a resumed
-    /// transfer spends the same budget the first attempt did.
+    /// transfer spends the same budget the first attempt did. A body running
+    /// past it takes the bundle with it — the offset the transfer stopped at
+    /// is the ceiling, so a preserved bundle would trip this same check on the
+    /// first chunk of every later attempt.
     func streamBytes(
         from chunks: AsyncThrowingStream<Data, any Error>,
         into bundle: DownloadBundle,
@@ -493,8 +499,9 @@ final class DownloadService: Sendable {
                     UInt64(clamping: totalWritten) + UInt64(data.count) > ceiling
                 {
                     Self.logger.error(
-                        "Transfer ran past its expected \(ceiling, privacy: .public) bytes — stopping"
+                        "Transfer ran past its expected \(ceiling, privacy: .public) bytes — stopping and discarding the bundle so the next attempt restarts from zero"
                     )
+                    try? FileManager.default.removeItem(at: bundle.url)
                     throw DownloadError.oversizedTransfer(expectedBytes: ceiling)
                 }
                 try handle.write(contentsOf: data)

--- a/Kernova/Services/DownloadService.swift
+++ b/Kernova/Services/DownloadService.swift
@@ -35,7 +35,7 @@ final class DownloadService: Sendable {
     /// ETag / Last-Modified used for `If-Range`. The bundle survives a failure
     /// a later attempt can resume past, cancellation included (which throws
     /// `CancellationError`); one it cannot — a response disagreeing with the
-    /// bytes already on disk, or a body running past `expectedSizeBytes` —
+    /// bytes already on disk, or a source larger than `expectedSizeBytes` —
     /// discards the bundle so the next attempt restarts from zero. A completed
     /// file with no bundle beside it is skipped.
     ///
@@ -446,10 +446,12 @@ final class DownloadService: Sendable {
     ///
     /// `expectedSizeBytes` bounds the file the caller is willing to land:
     /// `initialOffset` plus everything written is held under it, so a resumed
-    /// transfer spends the same budget the first attempt did. A body running
-    /// past it takes the bundle with it — the offset the transfer stopped at
-    /// is the ceiling, so a preserved bundle would trip this same check on the
-    /// first chunk of every later attempt.
+    /// transfer spends the same budget the first attempt did. A source stating
+    /// a total over the ceiling is stopped before its body moves; one stating
+    /// no total at all — chunked, the shape the ceiling exists for — is stopped
+    /// at the chunk that would cross it. Either way the bundle goes, because a
+    /// source serving more than the ceiling allows leaves no offset a resume
+    /// could finish from.
     func streamBytes(
         from chunks: AsyncThrowingStream<Data, any Error>,
         into bundle: DownloadBundle,
@@ -470,6 +472,20 @@ final class DownloadService: Sendable {
 
         var smoother = DownloadSpeedSmoother()
         var totalWritten = initialOffset
+
+        // A stated total over the ceiling can't fit however its body arrives, so
+        // stop here rather than move the whole ceiling first and abort on the
+        // chunk that crosses it — every Start would spend the transfer again.
+        if let ceiling = expectedSizeBytes, expectedTotal > 0,
+            UInt64(clamping: expectedTotal) > ceiling
+        {
+            Self.logger.error(
+                "Source states \(expectedTotal, privacy: .public) bytes against an expected \(ceiling, privacy: .public) — stopping before its body moves"
+            )
+            Self.emptyAndDiscard(bundle, dataHandle: handle)
+            handleClosed = true
+            throw DownloadError.oversizedTransfer(expectedBytes: ceiling)
+        }
 
         // Emit up front so a resumed download shows its true starting fraction
         // immediately instead of jumping after the first chunk lands.
@@ -499,9 +515,10 @@ final class DownloadService: Sendable {
                     UInt64(clamping: totalWritten) + UInt64(data.count) > ceiling
                 {
                     Self.logger.error(
-                        "Transfer ran past its expected \(ceiling, privacy: .public) bytes — stopping and discarding the bundle so the next attempt restarts from zero"
+                        "Transfer ran past its expected \(ceiling, privacy: .public) bytes — stopping"
                     )
-                    try? FileManager.default.removeItem(at: bundle.url)
+                    Self.emptyAndDiscard(bundle, dataHandle: handle)
+                    handleClosed = true
                     throw DownloadError.oversizedTransfer(expectedBytes: ceiling)
                 }
                 try handle.write(contentsOf: data)
@@ -552,6 +569,41 @@ final class DownloadService: Sendable {
                     totalBytes: expectedTotal,
                     bytesPerSecond: 0
                 )
+            )
+        }
+    }
+
+    /// Empties the bundle's `data` file through the open handle, closes the
+    /// handle, then removes the bundle.
+    ///
+    /// The handle is spent when this returns, whichever steps succeeded.
+    ///
+    /// Three steps because only the first is certain. Removal can be refused —
+    /// permissions, or a volume that won't unlink an open file — and a bundle
+    /// that survives holding zero bytes still resumes from offset 0, which
+    /// sends the next attempt out with no `Range` header. Closing first is what
+    /// gives the removal its best chance on the volumes that refuse.
+    ///
+    /// Removed rather than trashed, unlike `discardResumeData`: these bytes can
+    /// never complete this download, so each Start the user pressed would
+    /// otherwise deposit another multi-GB copy in the Trash.
+    private static func emptyAndDiscard(_ bundle: DownloadBundle, dataHandle: FileHandle) {
+        do {
+            try dataHandle.truncate(atOffset: 0)
+        } catch {
+            Self.logger.warning(
+                "Failed to empty the partial data in '\(bundle.url.lastPathComponent, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+        }
+        try? dataHandle.close()
+        do {
+            try FileManager.default.removeItem(at: bundle.url)
+            Self.logger.notice(
+                "Discarded the bundle at '\(bundle.url.lastPathComponent, privacy: .public)' — the next attempt restarts from zero"
+            )
+        } catch {
+            Self.logger.warning(
+                "Failed to remove the bundle at '\(bundle.url.lastPathComponent, privacy: .public)': \(error.localizedDescription, privacy: .public)"
             )
         }
     }

--- a/KernovaTests/DownloadServiceTests.swift
+++ b/KernovaTests/DownloadServiceTests.swift
@@ -917,16 +917,16 @@ struct DownloadServiceTests {
     @Test("A body running past the size the source stated is stopped at the ceiling")
     func oversizedTransferStopsAtTheCeiling() async throws {
         // What an unbounded body looks like from here: more bytes arriving than
-        // the resolution said the file holds. Left unchecked they fill the
-        // volume, since a chunked response states no length to check against.
+        // the resolution said the file holds, with no stated length to have
+        // caught it up front. Left unchecked they fill the volume.
         let temp = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }
         let destination = temp.appendingPathComponent("installer.iso")
 
         StubURLProtocol.handler = { request in
-            .fullResponse(
+            .unboundedResponse(
                 url: request.url ?? Self.remoteURL,
-                body: Data(repeating: 0x55, count: 8192), etag: "\"v1\"")
+                body: Data(repeating: 0x55, count: 8192))
         }
         defer { StubURLProtocol.handler = nil }
 
@@ -953,7 +953,9 @@ struct DownloadServiceTests {
     @Test("The ceiling is spent by the bytes a resume already has on disk")
     func sizeCeilingCountsResumedBytes() async throws {
         // 3000 bytes are already down and the server sends 2000 more: under the
-        // ceiling on its own, over it once the partial is counted.
+        // ceiling on its own, over it once the partial is counted. The stated
+        // total is the ceiling exactly, so only the per-chunk check can catch
+        // this — the source overruns the range it declared.
         let temp = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }
         let destination = temp.appendingPathComponent("installer.iso")
@@ -969,7 +971,7 @@ struct DownloadServiceTests {
             .partialResponse(
                 url: request.url ?? Self.remoteURL,
                 body: Data(repeating: 0x22, count: 2000),
-                start: 3000, end: 4999, total: 5000)
+                start: 3000, end: 4095, total: 4096)
         }
         defer { StubURLProtocol.handler = nil }
 
@@ -991,6 +993,101 @@ struct DownloadServiceTests {
         #expect(!FileManager.default.fileExists(atPath: destination.path))
         // Discarded, not left at the ceiling for the next attempt to trip over.
         #expect(!bundle.exists)
+    }
+
+    @Test("A stated total over the ceiling stops the attempt before its body moves")
+    func statedTotalOverTheCeilingStopsBeforeTheTransfer() async throws {
+        // The mirror is honest about a size the ceiling can't take. Spending the
+        // whole ceiling first only to abort on the crossing chunk would charge
+        // the user that transfer again on every Start, so nothing moves: the
+        // progress handler never fires, which is what "before its body" means
+        // from outside the service.
+        let temp = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let destination = temp.appendingPathComponent("installer.iso")
+
+        StubURLProtocol.handler = { request in
+            .fullResponse(
+                url: request.url ?? Self.remoteURL,
+                body: Data(repeating: 0x55, count: 8192), etag: "\"v1\"")
+        }
+        defer { StubURLProtocol.handler = nil }
+
+        let progressBox = ProgressRecorder()
+        let service = Self.makeServiceWithStub()
+        do {
+            try await service.download(
+                from: Self.remoteURL,
+                to: destination,
+                expectedSizeBytes: 4096,
+                progressHandler: { [progressBox] progress in
+                    progressBox.record(progress.bytesWritten)
+                }
+            )
+            Issue.record("Expected DownloadError.oversizedTransfer")
+        } catch DownloadError.oversizedTransfer(let expectedBytes) {
+            #expect(expectedBytes == 4096)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(await progressBox.snapshot().isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+        let bundle = DownloadBundle(url: DownloadService.resumeBundleURL(for: destination))
+        #expect(!bundle.exists)
+    }
+
+    @Test("An oversized abort empties the partial even when the bundle can't be removed")
+    func oversizedTransferEmptiesThePartialWhenRemovalFails() async throws {
+        // Removal is the step that can be refused — permissions, or a volume
+        // that won't unlink the open data file. Emptying through the handle we
+        // already hold is what makes the invalidation certain: a bundle left
+        // holding zero bytes resumes from offset 0, so the next attempt asks
+        // for the whole file instead of walking back into the same ceiling.
+        let temp = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let destination = temp.appendingPathComponent("installer.iso")
+        let bundle = DownloadBundle(url: DownloadService.resumeBundleURL(for: destination))
+
+        try bundle.prepareForFreshDownload(
+            with: DownloadBundleMetadata(
+                originalURL: Self.remoteURL, etag: "\"v1\"", lastModified: nil, createdAt: Date()))
+        try Data(repeating: 0x11, count: 4096).write(to: bundle.dataURL)
+
+        let (stream, continuation) = AsyncThrowingStream<Data, any Error>.makeStream()
+        continuation.yield(Data(repeating: 0x22, count: 1000))
+        continuation.finish()
+
+        // Removal fails for real: the bundle directory is read-only for the
+        // duration, so `removeItem` cannot unlink what is inside it.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o500], ofItemAtPath: bundle.url.path(percentEncoded: false))
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700], ofItemAtPath: bundle.url.path(percentEncoded: false))
+        }
+
+        let service = DownloadService()
+        do {
+            try await service.streamBytes(
+                from: stream,
+                into: bundle,
+                startingAt: 4096,
+                expectedTotal: -1,
+                expectedSizeBytes: 4096,
+                progressHandler: { _ in }
+            )
+            Issue.record("Expected DownloadError.oversizedTransfer")
+        } catch DownloadError.oversizedTransfer {
+            // Expected
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(bundle.exists)
+        // Zero bytes: `performDownload` reads this as offset 0 and sends no
+        // `Range`, which is the fresh start the discard was meant to force.
+        #expect(bundle.partialByteCount == 0)
     }
 
     @Test("A retry after an oversized abort starts over instead of tripping the same ceiling")
@@ -1280,6 +1377,15 @@ final class StubURLProtocol: URLProtocol, @unchecked Sendable {
             ]
             return StubResponse(
                 response: makeResponse(url: url, statusCode: 206, headers: headers),
+                body: body, declaresLargerLength: false, failAfterBody: nil)
+        }
+
+        /// A 200 carrying no `Content-Length` — what a chunked source looks like
+        /// from here, and the only shape whose overrun the per-chunk ceiling
+        /// check has to catch.
+        static func unboundedResponse(url: URL, body: Data) -> StubResponse {
+            StubResponse(
+                response: makeResponse(url: url, statusCode: 200, headers: [:]),
                 body: body, declaresLargerLength: false, failAfterBody: nil)
         }
 

--- a/KernovaTests/DownloadServiceTests.swift
+++ b/KernovaTests/DownloadServiceTests.swift
@@ -947,7 +947,7 @@ struct DownloadServiceTests {
 
         #expect(!FileManager.default.fileExists(atPath: destination.path))
         let bundle = DownloadBundle(url: DownloadService.resumeBundleURL(for: destination))
-        #expect(bundle.partialByteCount <= 4096)
+        #expect(!bundle.exists)
     }
 
     @Test("The ceiling is spent by the bytes a resume already has on disk")
@@ -989,7 +989,65 @@ struct DownloadServiceTests {
         }
 
         #expect(!FileManager.default.fileExists(atPath: destination.path))
-        #expect(bundle.partialByteCount == Int64(prefix.count))
+        // Discarded, not left at the ceiling for the next attempt to trip over.
+        #expect(!bundle.exists)
+    }
+
+    @Test("A retry after an oversized abort starts over instead of tripping the same ceiling")
+    func oversizedTransferDiscardsBundleSoTheRetryStartsOver() async throws {
+        // The ceiling and the body are independent requests to the same URL, so
+        // a mirror serving more than the probed size aborts the transfer with
+        // the bundle sitting at the ceiling. Kept, it would send every later
+        // Start back into the same check at the same offset, and the VM could
+        // never finish setup.
+        let temp = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let destination = temp.appendingPathComponent("installer.iso")
+        let bundle = DownloadBundle(url: DownloadService.resumeBundleURL(for: destination))
+
+        try bundle.prepareForFreshDownload(
+            with: DownloadBundleMetadata(
+                originalURL: Self.remoteURL, etag: "\"v1\"", lastModified: nil, createdAt: Date()))
+        try Data(repeating: 0x11, count: 4096).write(to: bundle.dataURL)
+
+        let payload = Data(repeating: 0x33, count: 4096)
+        // A resume is answered by the mirror that overruns; a request carrying
+        // no Range — what an attempt with no bundle behind it sends — gets the
+        // file the ceiling was probed against.
+        StubURLProtocol.handler = { request in
+            guard request.value(forHTTPHeaderField: "Range") == nil else {
+                return .partialResponse(
+                    url: request.url ?? Self.remoteURL,
+                    body: Data(repeating: 0x22, count: 1000),
+                    start: 4096, end: 5095, total: 5096)
+            }
+            return .fullResponse(url: request.url ?? Self.remoteURL, body: payload, etag: "\"v1\"")
+        }
+        defer { StubURLProtocol.handler = nil }
+
+        let service = Self.makeServiceWithStub()
+        do {
+            try await service.download(
+                from: Self.remoteURL,
+                to: destination,
+                expectedSizeBytes: 4096,
+                progressHandler: { _ in }
+            )
+            Issue.record("Expected DownloadError.oversizedTransfer")
+        } catch DownloadError.oversizedTransfer {
+            // Expected
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(!bundle.exists)
+
+        try await service.download(
+            from: Self.remoteURL,
+            to: destination,
+            expectedSizeBytes: 4096,
+            progressHandler: { _ in }
+        )
+        #expect(try Data(contentsOf: destination) == payload)
     }
 
     @Test("A transfer that fits its ceiling, and one with no ceiling at all, both complete")


### PR DESCRIPTION
## Summary

`DownloadService.streamBytes` threw `oversizedTransfer` and left the `.kernovadownload` bundle on disk with the bytes already written. Since the transfer stops at `expectedSizeBytes`, the next Start resumed into the same wall and tripped the check on its first chunk — setup could never complete until the user deleted the bundle by hand.

The bundle now goes before the throw, matching the two sibling unrecoverable paths in `performDownload` (a 206 whose `Content-Range` start disagrees with the requested offset, and a 416 with no usable total). Restarting from zero is what makes the failure recoverable at all: the ceiling comes from `RemoteFileSizeProbe` on one session and the body from `DownloadService`'s own GET on another, and Debian/Fedora/Kali redirect each request independently, so a retry can be answered by a mirror that agrees with the probed size.

Two review findings shaped the rest:

- **The discard was itself best-effort.** `removeItem` ran with the data file's handle still open and its failure was swallowed, so on a volume that refuses to unlink an open file the poisoned bundle survived and the loop stayed shut — while the log claimed otherwise. `emptyAndDiscard` now truncates through that handle, closes it, then removes, logging each failure. Only the first step is certain, and it is enough: a bundle that survives holding zero bytes resumes from offset 0, which sends no `Range` header.
- **Discarding made every retry expensive.** With the bundle gone, a source genuinely larger than its published size costs the full ceiling per attempt instead of failing in one chunk. A *stated* total over the ceiling is knowable from the headers, so the transfer now stops before its body moves. The per-chunk check stays for the case the ceiling exists for — a chunked body stating no length at all.

Closes #735

## Changes

- `DownloadService.streamBytes` — pre-transfer check against `expectedTotal`; both ceiling paths route through the new `emptyAndDiscard(_:dataHandle:)`.
- Doc comments on `download` and `streamBytes` — the bundle survives a failure a later attempt can resume past, not "any failure"; that sentence was already inaccurate for the 206/416 paths.
- `DownloadServiceTests` — a `unboundedResponse` stub (200 with no `Content-Length`) keeps the per-chunk check covering a source only it can catch, `sizeCeilingCountsResumedBytes` states a total at the ceiling for the same reason, and three new tests: the retry after an abort, the pre-transfer stop, and the removal-failure fallback.

## Route

The discard sits at the throw site rather than in a `do`/`catch` around `performDownload`'s status-code switch: `streamBytes` already receives the bundle, owns the ceiling policy, holds the open handle the invalidation needs, and the alternative re-indents ~80 lines of the switch to add one behavior.

Two review findings were dismissed. Routing the removal through the injected `fileSystem` seam would diverge from both sibling unrecoverable paths, which use `FileManager` directly — and every test asserting a bundle is gone depends on that, since the default `MockFileSystem` records removals instead of performing them. Trashing rather than removing would honor AGENTS.md's file-operation preference, but these bytes can never complete the download and each Start the user pressed would deposit another multi-GB copy in the Trash; the helper's doc comment says so.

## Test plan

- [x] `make test` — full suite green
- [x] `make lint`
- [x] Each new test fails with its own fix disabled, and only that test