### PR TITLE
docs: Correct three Linux-catalog doc claims the code doesn't support

### DIFF
--- a/Kernova/Models/ChecksumManifest.swift
+++ b/Kernova/Models/ChecksumManifest.swift
@@ -15,9 +15,10 @@ import Foundation
 /// that lists SHA-512 alongside SHA-256 lists both in the one file. Only the
 /// SHA-256 pairs come back.
 ///
-/// Clearsigning is not verified here. The manifest and the ISO come from the
-/// one mirror the redirect chose, so the digest catches a corrupted or wrong
-/// file — not a mirror serving both to match.
+/// The signature is read past, never checked, and the manifest and the ISO are
+/// two independent requests, each following its own redirect. So a digest from
+/// here binds the ISO to whatever the manifest said — enough to catch a
+/// corrupted or wrong file, not a hostile manifest naming a hostile ISO.
 enum ChecksumManifest {
     /// One `(filename, digest)` pair a manifest states.
     struct Row: Sendable, Equatable {

--- a/Kernova/Models/LinuxImageCatalogEntry.swift
+++ b/Kernova/Models/LinuxImageCatalogEntry.swift
@@ -73,12 +73,8 @@ struct LinuxImageCatalogEntry: Codable, Sendable, Identifiable, Equatable {
         return lhs.id < rhs.id
     }
 
-    /// Whether `filename` is an ISO this entry names, by ``isoPattern``.
-    ///
-    /// `fnmatch` with no flags gives the glob exactly the semantics the
-    /// patterns are written for: anchored at both ends, with `*` spanning any
-    /// run of characters — so `debian-13.*-arm64-netinst.iso` takes every point
-    /// release of Debian 13 and nothing else.
+    /// Whether `filename` is an ISO this entry names, matching ``isoPattern``
+    /// as an ``ISOFilenameGlob``.
     func matchesISOFilename(_ filename: String) -> Bool {
         ISOFilenameGlob(isoPattern)?.matches(filename) ?? false
     }

--- a/Kernova/Services/LinuxImageCatalogService.swift
+++ b/Kernova/Services/LinuxImageCatalogService.swift
@@ -89,9 +89,9 @@ struct LinuxImageCatalogService: LinuxImageCatalogProviding {
     /// There is no host allowlist to check the way the macOS catalog checks for
     /// Apple: these images come from each distribution's own mirrors, and a
     /// list of them written here would go stale without anything noticing.
-    /// HTTPS authenticates the mirror the redirect landed on; the SHA-256 that
-    /// same mirror publishes catches a corrupted or wrong file — not a mirror
-    /// serving both to match.
+    /// HTTPS authenticates whichever mirror a redirect landed on, and
+    /// ``ChecksumManifest`` covers what the SHA-256 on top of that does and
+    /// does not establish.
     static func parse(_ data: Data) -> ParseResult {
         guard let document = try? JSONDecoder().decode(LenientCatalog.self, from: data) else {
             return ParseResult(catalog: nil, rejections: [.undecodableDocument])


### PR DESCRIPTION
Closes #737

## Summary

Three `///` comments in the Linux catalog stated properties nothing in the code establishes. Both claims the issue names are load-bearing — the first is the trust rationale a reader weighs when picking up #726, the second is the matching semantics a reader would reason from when editing the glob.

**The same-origin premise.** `ChecksumManifest`'s type doc read "The manifest and the ISO come from the one mirror the redirect chose." They don't. `LinuxImageResolveService.resolve` fetches the manifest over that service's own `URLSession`, following whatever redirect *that* request receives, then hands `isoURL` — built from the same `directoryURL` — to `DownloadService`, which issues its own GET on its own session and follows *that* request's redirect. Two requests, two sessions, two redirect chains; nothing pins them together.

Correcting it also strengthens the claim about what the digest doesn't cover: the old wording bounded the gap at "a mirror serving both to match," which needs one origin to control both responses. With independent requests, a hostile answer to the manifest request alone is enough — it names the digest the ISO is then checked against.

**The `fnmatch` mechanism.** `matchesISOFilename`'s doc read "`fnmatch` with no flags gives the glob exactly the semantics the patterns are written for." The implementation is `ISOFilenameGlob`, an `NSRegularExpression` translation (`([^/]*)` per `*`, `\A`/`\z` anchors), and `fnmatch` appears nowhere in the tree. The two differ on the property the sentence leaned on: without `FNM_PATHNAME`, `fnmatch`'s `*` crosses `/`, while `[^/]*` does not.

## Changes

- `ChecksumManifest` (type doc) — states what the digest binds: the ISO to whatever the manifest said, whichever origin served either.
- `LinuxImageCatalogService.parse` (symbol doc) — carried the same unestablished premise in different words ("the SHA-256 that same mirror publishes … not a mirror serving both to match"). Now routes to `ChecksumManifest`, which owns the trust property.
- `LinuxImageCatalogEntry.matchesISOFilename` (symbol doc) — the `fnmatch` paragraph is deleted rather than rewritten. `ISOFilenameGlob`'s type doc already owns the glob semantics and `isoPattern`'s property doc already restates them; a corrected third copy would be the duplication AGENTS.md's one-layer rule forbids, so the doc links to the glob instead.

## Route taken

The third site is outside the two the issue names. It repeats the same false premise, so fixing only the named two would have left the tree stating the retracted claim in one place and the corrected one in another — worse than either alone. Fixed in the same pass.

`#726`'s description cites the old wording, as the issue notes; its body has been updated to the corrected premise so the two don't disagree.

## Test plan

- [x] `make lint` clean — swift-format `--strict`, shell, docs line cap and links
- [x] `make test` — full suite passes; comments only, no behavior change

## Notes

- No `RATIONALE:` comments added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrKxJCDEAoapux1GvpaeEy