### PR TITLE
fix: Read Downloads once per distribution picker, not once per row

### DIFF
--- a/Kernova/Models/LinuxImageCatalogEntry.swift
+++ b/Kernova/Models/LinuxImageCatalogEntry.swift
@@ -73,12 +73,6 @@ struct LinuxImageCatalogEntry: Codable, Sendable, Identifiable, Equatable {
         return lhs.id < rhs.id
     }
 
-    /// Whether `filename` is an ISO this entry names, matching ``isoPattern``
-    /// as an ``ISOFilenameGlob``.
-    func matchesISOFilename(_ filename: String) -> Bool {
-        ISOFilenameGlob(isoPattern)?.matches(filename) ?? false
-    }
-
     /// Whether the entry matches a picker search term, over distribution and
     /// version.
     func matches(searchTerm: String) -> Bool {

--- a/Kernova/Views/Creation/LinuxImageCatalogSheetContentViewController.swift
+++ b/Kernova/Views/Creation/LinuxImageCatalogSheetContentViewController.swift
@@ -29,7 +29,8 @@ final class LinuxImageCatalogSheetContentViewController: NSViewController {
     /// The rows currently shown, after the search filter.
     private(set) var visibleEntries: [LinuxImageCatalogEntry]
     private let generatedAt: String?
-    private let isDownloaded: @MainActor (LinuxImageCatalogEntry) -> Bool
+    /// IDs of the entries whose image is already in the user's Downloads folder.
+    private let downloadedIDs: Set<String>
     /// Entry to select once the table exists, from a previous pick.
     private let pendingSelectedID: String?
 
@@ -54,15 +55,16 @@ final class LinuxImageCatalogSheetContentViewController: NSViewController {
 
     /// Builds the picker over `entries`, preselecting `selectedID`.
     ///
-    /// `isDownloaded` reports whether an image for the entry is already in the
-    /// user's Downloads folder, and defaults to matching that folder's contents
-    /// against the entry's glob — the exact filename is a mirror's to decide, so
-    /// there is no single path to probe the way the macOS picker has.
+    /// `downloadsFilenames` lists the user's Downloads folder and defaults to a
+    /// `FileManager` enumeration of it. It is called once, here, and the Status
+    /// column matches the names it returned: the exact ISO filename is a
+    /// mirror's to decide, so there is no single path to probe the way the macOS
+    /// picker has.
     init(
         entries: [LinuxImageCatalogEntry],
         selectedID: String? = nil,
         generatedAt: String? = nil,
-        isDownloaded: (@MainActor (LinuxImageCatalogEntry) -> Bool)? = nil
+        downloadsFilenames: (@MainActor () -> [String])? = nil
     ) {
         // Sorted here so the rows read in catalog order whatever order they
         // arrive in.
@@ -70,7 +72,8 @@ final class LinuxImageCatalogSheetContentViewController: NSViewController {
         self.entries = ordered
         self.visibleEntries = ordered
         self.generatedAt = generatedAt
-        self.isDownloaded = isDownloaded ?? { Self.downloadsHoldsImage(for: $0) }
+        self.downloadedIDs = Self.downloadedEntryIDs(
+            among: ordered, in: downloadsFilenames?() ?? Self.downloadsFolderFilenames())
         self.pendingSelectedID = selectedID
         super.init(nibName: nil, bundle: nil)
     }
@@ -330,18 +333,26 @@ final class LinuxImageCatalogSheetContentViewController: NSViewController {
 
     // MARK: - Helpers
 
-    /// Whether the user's Downloads folder already holds an image this entry
-    /// names.
+    /// The names of everything directly inside the user's Downloads folder, or
+    /// none when it cannot be read.
+    private static func downloadsFolderFilenames() -> [String] {
+        let downloads = VMCreationViewModel.downloadsDirectory.path(percentEncoded: false)
+        return (try? FileManager.default.contentsOfDirectory(atPath: downloads)) ?? []
+    }
+
+    /// IDs of the entries `filenames` holds an image for.
     ///
     /// A completed download is the only thing that can match: an interrupted one
     /// keeps its bytes in a `.kernovadownload` bundle beside the destination,
     /// which the entry's `.iso`-anchored glob does not take.
-    private static func downloadsHoldsImage(for entry: LinuxImageCatalogEntry) -> Bool {
-        let downloads = VMCreationViewModel.downloadsDirectory.path(percentEncoded: false)
-        guard let names = try? FileManager.default.contentsOfDirectory(atPath: downloads) else {
-            return false
-        }
-        return names.contains { entry.matchesISOFilename($0) }
+    private static func downloadedEntryIDs(
+        among entries: [LinuxImageCatalogEntry], in filenames: [String]
+    ) -> Set<String> {
+        Set(
+            entries.compactMap { entry -> String? in
+                guard let glob = ISOFilenameGlob(entry.isoPattern) else { return nil }
+                return filenames.contains(where: glob.matches) ? entry.id : nil
+            })
     }
 
     private func makeHorizontalSeparator() -> NSBox {
@@ -421,7 +432,7 @@ extension LinuxImageCatalogSheetContentViewController: NSTableViewDelegate {
         case Column.size:
             return wizardApproximateSize(entry.approxSizeBytes)
         case Column.status:
-            return isDownloaded(entry) ? "In Downloads" : ""
+            return downloadedIDs.contains(entry.id) ? "In Downloads" : ""
         default:
             return ""
         }

--- a/KernovaTests/LinuxImageCatalogSheetContentViewControllerTests.swift
+++ b/KernovaTests/LinuxImageCatalogSheetContentViewControllerTests.swift
@@ -22,13 +22,17 @@ struct LinuxImageCatalogSheetContentViewControllerTests {
     private func makeSheet(
         entries: [LinuxImageCatalogEntry]? = nil,
         selectedID: String? = nil,
-        downloadedIDs: Set<String> = []
+        downloads: [String] = [],
+        onDownloadsRead: @escaping @MainActor () -> Void = {}
     ) -> LinuxImageCatalogSheetContentViewController {
         let vc = LinuxImageCatalogSheetContentViewController(
             entries: entries ?? self.entries,
             selectedID: selectedID,
             generatedAt: "2026-08-05",
-            isDownloaded: { downloadedIDs.contains($0.id) }
+            downloadsFilenames: {
+                onDownloadsRead()
+                return downloads
+            }
         )
         vc.loadViewIfNeeded()
         return vc
@@ -121,10 +125,33 @@ struct LinuxImageCatalogSheetContentViewControllerTests {
 
     @Test("The Status column names only the images already in Downloads")
     func statusNamesDownloadedImages() throws {
-        let vc = makeSheet(downloadedIDs: ["debian-13"])
+        let vc = makeSheet(downloads: ["debian-13.1.0-arm64-netinst.iso"])
 
         #expect(try cellText(vc, row: 0, column: "status").isEmpty)
         #expect(try cellText(vc, row: 2, column: "status") == "In Downloads")
+    }
+
+    @Test("A half-finished download does not read as In Downloads")
+    func statusIgnoresPartialDownloads() throws {
+        let vc = makeSheet(
+            downloads: ["ubuntu-26.04.1-desktop-arm64.iso.kernovadownload"])
+
+        #expect(try cellText(vc, row: 0, column: "status").isEmpty)
+    }
+
+    @Test("Downloads is read once, however many rows render and filters run")
+    func downloadsAreEnumeratedOncePerSheet() throws {
+        var reads = 0
+        let vc = makeSheet(
+            downloads: ["debian-13.1.0-arm64-netinst.iso"], onDownloadsRead: { reads += 1 })
+
+        for row in 0..<3 { _ = try cellText(vc, row: row, column: "status") }
+        for term in ["u", "ub", "ubu"] {
+            vc.applyFilter(term)
+            _ = try cellText(vc, row: 0, column: "status")
+        }
+
+        #expect(reads == 1)
     }
 
     @Test("Sizes are stated as the approximations they are")

--- a/KernovaTests/LinuxImageCatalogTests.swift
+++ b/KernovaTests/LinuxImageCatalogTests.swift
@@ -82,32 +82,6 @@ struct LinuxImageCatalogEntryTests {
         #expect(!entry.matches(searchTerm: "fedora"))
         #expect(!entry.matches(searchTerm: "24.04"))
     }
-
-    @Test("The ISO glob takes every point release of its version and nothing else")
-    func isoGlobMatchesPointReleases() {
-        let entry = makeLinuxCatalogEntry(isoPattern: "debian-13.*-arm64-netinst.iso")
-        #expect(entry.matchesISOFilename("debian-13.1.0-arm64-netinst.iso"))
-        #expect(entry.matchesISOFilename("debian-13.12.0-arm64-netinst.iso"))
-        #expect(!entry.matchesISOFilename("debian-12.15.0-arm64-netinst.iso"))
-        #expect(!entry.matchesISOFilename("debian-13.1.0-amd64-netinst.iso"))
-    }
-
-    @Test("The glob is anchored at both ends, so a longer name is not a match")
-    func isoGlobIsAnchored() {
-        let entry = makeLinuxCatalogEntry(isoPattern: "ubuntu-26.04*-desktop-arm64.iso")
-        #expect(entry.matchesISOFilename("ubuntu-26.04.1-desktop-arm64.iso"))
-        // A partial download's bundle sits beside the image under a name this
-        // must not take for the image itself.
-        #expect(!entry.matchesISOFilename("ubuntu-26.04.1-desktop-arm64.iso.kernovadownload"))
-        #expect(!entry.matchesISOFilename("old-ubuntu-26.04.1-desktop-arm64.iso"))
-    }
-
-    @Test("A variant the glob doesn't name is excluded")
-    func isoGlobExcludesOtherVariants() {
-        let entry = makeLinuxCatalogEntry(isoPattern: "ubuntu-26.04*-live-server-arm64.iso")
-        #expect(entry.matchesISOFilename("ubuntu-26.04.1-live-server-arm64.iso"))
-        #expect(!entry.matchesISOFilename("ubuntu-26.04.1-live-server-arm64+largemem.iso"))
-    }
 }
 
 @Suite("LinuxImageCatalogService Tests")


### PR DESCRIPTION
## Summary

The distribution picker's Status column re-enumerated the whole Downloads folder — and compiled a fresh `NSRegularExpression` — for every visible row, synchronously on the main actor, on every keystroke in the search field. With `sendsSearchStringImmediately = true` and 9 bundled entries, one keystroke cost up to 9 directory enumerations and 9 regex compiles before the field echoed the character; a Downloads folder holding thousands of files turns that into a visible typing stall.

The picker now takes a Downloads **listing** instead of a per-entry predicate, calls it once when the sheet is built, and resolves the set of entry IDs an image matches there and then. Rendering a row is a set lookup, so neither the enumeration nor the glob compile repeats per row or per keystroke.

## The route taken

The seam could have stayed `(LinuxImageCatalogEntry) -> Bool` with a memoizing default closure, which would have kept the two catalog pickers' initializers symmetric. It was rejected: the caching would live invisibly inside the default, so a future caller injecting a per-entry closure reintroduces the stall silently, and there is no way to assert "Downloads is enumerated once" through the seam. Taking a listing makes the once-only read structural and testable — the shape of the injected value now says what is expensive.

`LinuxImageCatalogEntry.matchesISOFilename` is deleted rather than kept and hoisted around. It compiled a glob per call, which is the shape that made the repetition invisible at the call site, and the picker was its only production caller. `LinuxImageResolveService` — the other place a pattern meets filenames — already builds an `ISOFilenameGlob` once and matches many names against it, so both paths are now on that one pattern rather than a second, trap-shaped API.

The macOS sibling, `RestoreImageCatalogSheetContentViewController`, keeps its per-row `isDownloaded` probe. The divergence is the domain's, not accidental: Apple's filename is known, so that picker probes one path with a `fileExists` stat per row, while a Linux mirror decides its own ISO filename, so this one has to enumerate and glob.

## Changes

- `LinuxImageCatalogSheetContentViewController`: `isDownloaded` becomes `downloadsFilenames`, read once in `init`; `downloadsHoldsImage` splits into `downloadsFolderFilenames` and `downloadedEntryIDs(among:in:)`; the Status column reads the resulting `downloadedIDs` set.
- `LinuxImageCatalogEntry`: drop `matchesISOFilename`.
- Tests: the picker's seam takes filenames; a new test pins that Downloads is read exactly once across row renders and filter passes; the partial-download case (`.kernovadownload` must not read as In Downloads) moves from the deleted entry API to the picker's Status column, where it is now a behavioural assertion rather than a glob-level restatement. The other glob assertions those entry tests carried are already covered by `ISOFilenameGlobTests`.

## Test plan

- [x] `make build`
- [x] `make lint`
- [x] `make test` — full suite green
- [ ] Type into the picker's search field with a large Downloads folder; no stall, and "In Downloads" still marks the right rows

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)