### PR TITLE
fix: Carry zero-byte files across the clipboard in both directions

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -825,7 +825,7 @@
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
-				MARKETING_VERSION = 0.54.0;
+				MARKETING_VERSION = 0.55.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
@@ -857,7 +857,7 @@
 				INFOPLIST_FILE = KernovaMacOSAgent/Info.plist;
 				INFOPLIST_PREFIX_HEADER = "$(DERIVED_FILE_DIR)/AgentBuildNumber.h";
 				INFOPLIST_PREPROCESS = YES;
-				MARKETING_VERSION = 0.54.0;
+				MARKETING_VERSION = 0.55.0;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;

--- a/Kernova/Services/ClipboardPassthroughCoordinator.swift
+++ b/Kernova/Services/ClipboardPassthroughCoordinator.swift
@@ -70,6 +70,11 @@ final class ClipboardPassthroughCoordinator {
     #if DEBUG
     /// Fires after each inbound auto-publish completes.
     var onInboundPublishedForTesting: (@MainActor () -> Void)?
+
+    /// Fires once the poll's off-actor file resolve has been handled, on every
+    /// outcome — the seam a test needs to observe that a forward produced
+    /// *nothing*, which no other signal announces.
+    var onForwardResolvedForTesting: (@MainActor () -> Void)?
     #endif
 
     private static let logger = Logger(
@@ -159,7 +164,11 @@ final class ClipboardPassthroughCoordinator {
         case .pendingFiles(let urls):
             resolveAndForward(urls, allowsBinary: allowsBinary)
         case .rejected:
-            // Nothing to forward; the intake already logged the reason.
+            // Every rejection here is a verdict that the pasteboard holds
+            // nothing shareable — an empty clipboard, a privacy marker, a
+            // text-only transport — so there is no failure to report. The
+            // rejection in `resolveAndForward` is the other kind: items were
+            // there and could not be read.
             break
         }
     }
@@ -171,29 +180,49 @@ final class ClipboardPassthroughCoordinator {
         Task { @MainActor [weak self] in
             let resolved = await ClipboardPasteboardIntake.read(
                 filesAt: urls, allowsBinary: allowsBinary)
+            guard let self else { return }
+            #if DEBUG
+            defer { self.onForwardResolvedForTesting?() }
+            #endif
             // The live service may have been torn down or replaced during the resolve.
-            guard let service = self?.instance?.clipboardService else { return }
-            if case .content(let content, let note) = resolved {
-                self?.offer(content, note: note, to: service)
+            guard let service = self.instance?.clipboardService else { return }
+            switch resolved {
+            case .content(let content, let note):
+                self.offer(content, note: note, to: service)
+            case .rejected(let message):
+                // Every copied item failed, so nothing is forwarded — the total
+                // of the partial case below, and owed the same report. A
+                // text-only transport is exempt: it rejects *every* file copy by
+                // design, so reporting here would fire on each one.
+                guard allowsBinary else { return }
+                self.reportUnforwarded(message, to: service)
+            case .pendingFiles:
+                break
             }
         }
     }
 
-    /// Offers intake output to the guest, raising the intake's skip note as a
-    /// transfer issue.
+    /// Offers intake output to the guest, raising the intake's skip note when it
+    /// carried one.
     ///
-    /// The window shows that note inline for its own paste/drop gestures; this
-    /// poll has no gesture to answer, so the issue is the only surface the skip
-    /// gets. Raised *after* the grab, which clears the issue on a successful
-    /// offer.
+    /// Raised *after* the grab, which clears the issue on a successful offer.
     private func offer(
         _ content: ClipboardContent, note: String?, to service: any ClipboardServicing
     ) {
         service.clipboardContent = content
         service.grabIfChanged()
         guard let note else { return }
+        reportUnforwarded(note, to: service)
+    }
+
+    /// Raises an intake outcome the user is owed — a partial copy's skip note,
+    /// or the rejection when nothing resolved at all — as a transfer issue.
+    ///
+    /// The window shows these inline for its own paste/drop gestures; this poll
+    /// has no gesture to answer, so the issue is the only surface they get.
+    private func reportUnforwarded(_ note: String, to service: any ClipboardServicing) {
         Self.logger.warning(
-            "Clipboard passthrough forwarded a partial copy for '\(self.instance?.name ?? "?", privacy: .public)': \(note, privacy: .public)"
+            "Clipboard passthrough could not forward every copied item for '\(self.instance?.name ?? "?", privacy: .public)': \(note, privacy: .public)"
         )
         service.reportIssue(.forwardSkippedItems(note: note))
     }

--- a/Kernova/Services/ClipboardPassthroughCoordinator.swift
+++ b/Kernova/Services/ClipboardPassthroughCoordinator.swift
@@ -154,9 +154,8 @@ final class ClipboardPassthroughCoordinator {
     private func forwardHostClipboard(to service: any ClipboardServicing) {
         let allowsBinary = service.supportsBinaryRepresentations
         switch ClipboardPasteboardIntake.read(from: pasteboard, allowsBinary: allowsBinary) {
-        case .content(let content, _):
-            service.clipboardContent = content
-            service.grabIfChanged()
+        case .content(let content, let note):
+            offer(content, note: note, to: service)
         case .pendingFiles(let urls):
             resolveAndForward(urls, allowsBinary: allowsBinary)
         case .rejected:
@@ -174,11 +173,29 @@ final class ClipboardPassthroughCoordinator {
                 filesAt: urls, allowsBinary: allowsBinary)
             // The live service may have been torn down or replaced during the resolve.
             guard let service = self?.instance?.clipboardService else { return }
-            if case .content(let content, _) = resolved {
-                service.clipboardContent = content
-                service.grabIfChanged()
+            if case .content(let content, let note) = resolved {
+                self?.offer(content, note: note, to: service)
             }
         }
+    }
+
+    /// Offers intake output to the guest, raising the intake's skip note as a
+    /// transfer issue.
+    ///
+    /// The window shows that note inline for its own paste/drop gestures; this
+    /// poll has no gesture to answer, so the issue is the only surface the skip
+    /// gets. Raised *after* the grab, which clears the issue on a successful
+    /// offer.
+    private func offer(
+        _ content: ClipboardContent, note: String?, to service: any ClipboardServicing
+    ) {
+        service.clipboardContent = content
+        service.grabIfChanged()
+        guard let note else { return }
+        Self.logger.warning(
+            "Clipboard passthrough forwarded a partial copy for '\(self.instance?.name ?? "?", privacy: .public)': \(note, privacy: .public)"
+        )
+        service.reportIssue(.forwardSkippedItems(note: note))
     }
 
     // MARK: - Guest → host (inbound)

--- a/Kernova/Services/ClipboardServicing.swift
+++ b/Kernova/Services/ClipboardServicing.swift
@@ -32,6 +32,14 @@ protocol ClipboardServicing: AnyObject {
     /// reports a clipboard error; cleared by the next successful transfer.
     var lastTransferIssue: ClipboardTransferIssue? { get }
 
+    /// Records a problem an *automatic* path produced, for `lastTransferIssue`
+    /// to carry.
+    ///
+    /// A window gesture reports its own outcome inline; a passthrough forward has
+    /// no return path, so the issue is the only account it can give. Default
+    /// no-op: a transport that never surfaces an issue drops it.
+    func reportIssue(_ issue: ClipboardTransferIssue)
+
     /// The clipboard transfer currently being shown, or `nil` when none is.
     ///
     /// Aggregate per *operation*, never per file: a multi-file paste fills one bar
@@ -143,6 +151,7 @@ enum CopyToMacDropReason: Sendable, Equatable {
 extension ClipboardServicing {
     func reserveDropDestination() -> URL? { nil }
     func materializeForPreview() async {}
+    func reportIssue(_ issue: ClipboardTransferIssue) {}
     func materializeForCopy() -> [CopyToMacItem] {
         clipboardContent.representations.map { .resolved($0) }
     }

--- a/Kernova/Services/ClipboardTransferIssue.swift
+++ b/Kernova/Services/ClipboardTransferIssue.swift
@@ -124,6 +124,16 @@ extension ClipboardTransferIssue {
             date: Date())
     }
 
+    /// Raised when an automatic passthrough forward left unreadable items out of
+    /// the offer; `note` is the intake's own wording, the same sentence the
+    /// window's own paste/drop gestures show inline.
+    static func forwardSkippedItems(note: String) -> ClipboardTransferIssue {
+        ClipboardTransferIssue(
+            kind: .localFailure(
+                code: ClipboardErrorCode.forwardItemsSkipped.rawValue, message: note),
+            date: Date())
+    }
+
     /// Raised when a copied file's bytes arrived but could not be written to a
     /// file on this Mac for the paste to serve.
     static func pasteFileStagingFailed() -> ClipboardTransferIssue {

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -421,6 +421,10 @@ final class VsockClipboardService: ClipboardServicing {
         retireUnreferencedDropDirectories()
     }
 
+    func reportIssue(_ issue: ClipboardTransferIssue) {
+        lastTransferIssue = issue
+    }
+
     func reserveDropDestination() -> URL? {
         let generation = nextDropGeneration
         nextDropGeneration += 1
@@ -895,14 +899,16 @@ final class VsockClipboardService: ClipboardServicing {
     }
 
     /// A representation excluded from the receive side without reading a byte: a
-    /// transient-marker / raw file-url UTI, or an empty payload.
+    /// transient-marker / raw file-url UTI, or an inline payload with no bytes.
     ///
-    /// A directory rep is exempt from the empty-payload skip: its `byte_count` is
-    /// an estimate of the tree's file bytes (`kernova.proto`), which a tree of
-    /// empty files, bare subdirectories, or nothing at all makes 0 while the
-    /// archive still carries the tree.
+    /// The empty-payload skip is keyed on the *filename*, so it reaches only
+    /// inline reps. A named rep is a file the paste creates, and an empty file is
+    /// content native macOS copies; a folder's `byte_count` is an estimate of the
+    /// tree's file bytes (`kernova.proto`), which a tree of empty files, bare
+    /// subdirectories, or nothing at all makes 0 while the archive still carries
+    /// the tree.
     private static func shouldSkip(_ info: Kernova_V1_ClipboardRepresentationInfo) -> Bool {
-        (info.byteCount == 0 && !info.isDirectory)
+        (info.byteCount == 0 && info.filename.isEmpty)
             || ClipboardSnapshotPolicy.shouldSkipBeforeReading(uti: info.uti)
     }
 

--- a/Kernova/Utilities/DataFormatters.swift
+++ b/Kernova/Utilities/DataFormatters.swift
@@ -5,6 +5,11 @@ enum DataFormatters {
     private nonisolated(unsafe) static let byteFormatter: ByteCountFormatter = {
         let formatter = ByteCountFormatter()
         formatter.countStyle = .file
+        // `allowsNonnumericFormatting` governs the zero case alone, rendering it
+        // "Zero KB"; every other value formats identically either way. An empty
+        // file crosses the clipboard, so its size reads "0 bytes" — the unit
+        // Finder's own Get Info uses for one.
+        formatter.allowsNonnumericFormatting = false
         return formatter
     }()
 

--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -619,7 +619,7 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
                     "Too large to paste into the guest — over the \(ClipboardPasteLimit.displayLimit(instance.effectiveClipboardMaxPasteBytes)) clipboard transfer limit"
             case .pasteTimeout:
                 return "The clipboard transfer to the guest timed out"
-            case .pasteFailed, .copyTooLarge, .pasteIncompleteSet, .none:
+            case .pasteFailed, .copyTooLarge, .pasteIncompleteSet, .forwardItemsSkipped, .none:
                 return "Clipboard transfer failed on the guest side"
             }
         case .localFailure(_, let message):

--- a/Kernova/Views/Clipboard/ClipboardPasteboardIntake.swift
+++ b/Kernova/Views/Clipboard/ClipboardPasteboardIntake.swift
@@ -197,16 +197,19 @@ enum ClipboardPasteboardIntake {
     }
 
     /// Builds a disk-backed `.file` representation from a single file URL via a
-    /// stat (name + size + content UTI), or `nil` when it can't be read or is
-    /// empty (a directory has no `.fileSize`, so it returns `nil` here — the
-    /// folder path builds a source rep instead).
+    /// stat (name + size + content UTI), or `nil` when it can't be read (a
+    /// directory has no `.fileSize`, so it returns `nil` here — the folder path
+    /// builds a source rep instead).
+    ///
+    /// Size gates nothing: native macOS copies a zero-byte file, so one crosses
+    /// at `byteCount == 0`.
     nonisolated private static func fileRepresentation(
         at url: URL
     ) -> ClipboardContent.Representation? {
         guard
             let values = try? url.resourceValues(forKeys: [.contentTypeKey, .fileSizeKey]),
             let type = values.contentType,
-            let fileSize = values.fileSize, fileSize > 0
+            let fileSize = values.fileSize
         else { return nil }
         return ClipboardContent.Representation(
             uti: type.identifier, fileURL: url, byteCount: fileSize,

--- a/KernovaKit/Sources/KernovaKit/ClipboardErrorCode.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardErrorCode.swift
@@ -33,4 +33,11 @@ public enum ClipboardErrorCode: String, CaseIterable, Sendable {
     /// Never crosses the wire: like `copyTooLarge`, the host both refuses and
     /// reports it.
     case pasteIncompleteSet = "clipboard.paste.incomplete.set"
+
+    /// The host could not read every copied item, so the offer forwarded to the
+    /// guest left some out.
+    ///
+    /// Never crosses the wire: like `copyTooLarge`, the host both skips and
+    /// reports it.
+    case forwardItemsSkipped = "clipboard.forward.items.skipped"
 }

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
@@ -210,6 +210,22 @@ public final class ClipboardStreamSender: @unchecked Sendable {
         }
         defer { reader.close() }
 
+        // Retirement is checked per chunk in the loop below, which a zero-byte
+        // payload never enters — so check once here, before anything is
+        // announced. Every transfer then honors an abort or supersession that
+        // landed between `startTransfer` registering it and this queue reaching
+        // it, whatever its size (docs/CLIPBOARD.md §9).
+        let retirement = transfer.retirement()
+        if retirement.retired {
+            notifyPeerOfRetirement(transfer, reason: retirement.reason)
+            return
+        }
+        guard isCurrent(transfer.generation) else {
+            transfer.markAborted(.superseded)
+            notifyPeerOfRetirement(transfer, reason: .superseded)
+            return
+        }
+
         guard
             send(
                 .with {
@@ -236,11 +252,7 @@ public final class ClipboardStreamSender: @unchecked Sendable {
                 offset: offset, chunkSize: nextChunkSize, timeout: noAckTimeout)
             switch outcome {
             case .aborted(let reason):
-                // A local supersede/cancel notifies the peer; an inbound abort
-                // (the peer already gave up) does not echo back.
-                if reason == .superseded {
-                    sendAbort(transfer: transfer, code: "superseded", message: "Offer superseded")
-                }
+                notifyPeerOfRetirement(transfer, reason: reason)
                 return
             case .timedOut:
                 sendAbort(transfer: transfer, code: "ack.timeout", message: "Peer stopped acknowledging")
@@ -252,7 +264,7 @@ public final class ClipboardStreamSender: @unchecked Sendable {
             // Supersession: a newer local copy retired this offer.
             guard isCurrent(transfer.generation) else {
                 transfer.markAborted(.superseded)
-                sendAbort(transfer: transfer, code: "superseded", message: "Offer superseded")
+                notifyPeerOfRetirement(transfer, reason: .superseded)
                 return
             }
 
@@ -310,6 +322,18 @@ public final class ClipboardStreamSender: @unchecked Sendable {
         sendAbort(transferID: transfer.transferID, code: code, message: message)
     }
 
+    /// Tells the peer about a retirement when it is the peer's news.
+    ///
+    /// A local supersede/cancel is; an inbound abort is not, since the peer
+    /// already gave up. The single place that decision is made, shared by the
+    /// pre-Begin check and the chunk loop.
+    private func notifyPeerOfRetirement(
+        _ transfer: OutboundTransfer, reason: OutboundTransfer.AbortReason?
+    ) {
+        guard reason == .superseded else { return }
+        sendAbort(transfer: transfer, code: "superseded", message: "Offer superseded")
+    }
+
     /// Writes a `ClipboardStreamAbort` for `transferID`.
     private func sendAbort(transferID: UInt64, code: String, message: String) {
         _ = send(
@@ -362,6 +386,20 @@ private final class OutboundTransfer: @unchecked Sendable {
     }
 
     enum CreditOutcome { case proceed, aborted(AbortReason?), timedOut }
+
+    /// Whether the transfer has already been retired, and why.
+    ///
+    /// `awaitCredit`'s abort check without the wait, for the payload-independent
+    /// check that runs before the chunk loop.
+    ///
+    /// Reads under `condition`, the lock `markAborted` writes under, so a
+    /// retirement racing this read resolves one way or the other rather than
+    /// tearing.
+    func retirement() -> (retired: Bool, reason: AbortReason?) {
+        condition.lock()
+        defer { condition.unlock() }
+        return (aborted, abortReason)
+    }
 
     /// Blocks until there is credit for a `chunkSize` chunk at `offset`, the
     /// transfer is aborted, or the no-ack deadline elapses without progress.

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
@@ -146,6 +146,31 @@ struct ClipboardStreamTests {
         #expect(harness.collector.abortCount == 0)
     }
 
+    @Test("a superseded zero-byte transfer delivers nothing and tells the peer")
+    func supersededZeroByteTransferDeliversNothing() async throws {
+        let harness = try roomyHarness()
+        defer { harness.tearDown() }
+
+        let source = try tempFile(bytes: Data())
+        defer { try? FileManager.default.removeItem(at: source) }
+        let rep = ClipboardContent.Representation(
+            uti: "public.data", fileURL: source, byteCount: 0, filename: "empty.bin")
+
+        // Every abort and supersession check used to sit inside the chunk loop,
+        // which a zero-byte payload never enters — so an already-retired empty
+        // transfer streamed and reported success anyway. `isCurrent` false at
+        // run time is the deterministic stand-in for a newer copy landing in
+        // the gap between registration and this transfer's queue.
+        harness.sender.startTransfer(
+            transferID: 4, generation: 1, representation: rep, maxAcceptByteCount: .max,
+            isInline: false, isCurrent: { _ in false })
+
+        try await harness.collector.gate.wait { harness.collector.abortCount == 1 }
+        #expect(harness.collector.abortInfos.first?.code == "superseded")
+        #expect(harness.collector.representation(4) == nil)
+        #expect(harness.collector.completedCount == 0)
+    }
+
     @Test("completed transfers report timing metrics for the throughput log line")
     func completedTransfersReportTimingMetrics() async throws {
         let harness = try roomyHarness()

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
@@ -118,6 +118,34 @@ struct ClipboardStreamTests {
         }
     }
 
+    @Test("a zero-byte file payload round-trips: Begin, no chunks, the empty-input digest")
+    func zeroByteFileRoundTrip() async throws {
+        let harness = try roomyHarness()
+        defer { harness.tearDown() }
+
+        let source = try tempFile(bytes: Data())
+        defer { try? FileManager.default.removeItem(at: source) }
+        let rep = ClipboardContent.Representation(
+            uti: "public.data", fileURL: source, byteCount: 0, filename: "empty.bin")
+
+        harness.sender.startTransfer(
+            transferID: 3, generation: 1, representation: rep, maxAcceptByteCount: .max,
+            isInline: false, isCurrent: { _ in true })
+
+        try await harness.collector.gate.wait { harness.collector.representation(3) != nil }
+        let received = try #require(harness.collector.representation(3))
+        let url = try #require(received.fileURL)
+        #expect(try Data(contentsOf: url).isEmpty)
+        #expect(received.byteCount == 0)
+        #expect(received.filename == "empty.bin")
+        if case .file(_, _, let sha256) = received.source {
+            #expect(sha256 == Data(SHA256.hash(data: Data())))
+        } else {
+            Issue.record("Expected a .file representation")
+        }
+        #expect(harness.collector.abortCount == 0)
+    }
+
     @Test("completed transfers report timing metrics for the throughput log line")
     func completedTransfersReportTimingMetrics() async throws {
         let harness = try roomyHarness()

--- a/KernovaMacOSAgent/AgentMenuText.swift
+++ b/KernovaMacOSAgent/AgentMenuText.swift
@@ -39,8 +39,9 @@ enum AgentMenuText {
 
     /// Why a paste of the host's clipboard did not happen, per failure code.
     ///
-    /// `copyTooLarge` and `pasteIncompleteSet` are host-only refusals that never
-    /// reach the guest, so they read as the generic failure.
+    /// `copyTooLarge`, `pasteIncompleteSet`, and `forwardItemsSkipped` are
+    /// host-only outcomes that never reach the guest, so they read as the generic
+    /// failure.
     private static func pasteRefusalDetail(
         _ code: ClipboardErrorCode, pasteLimitBytes: Int?
     ) -> String {
@@ -51,7 +52,8 @@ enum AgentMenuText {
                 "too large to paste — over the \(ClipboardPasteLimit.displayLimit(pasteLimitBytes)) transfer limit"
         case .pasteDiskFull: return "not enough disk space to paste"
         case .pasteTimeout: return "paste timed out"
-        case .pasteFailed, .copyTooLarge, .pasteIncompleteSet: return "paste failed"
+        case .pasteFailed, .copyTooLarge, .pasteIncompleteSet, .forwardItemsSkipped:
+            return "paste failed"
         }
     }
 

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -640,30 +640,43 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// Cheap main-queue metadata check for copied *files and folders*, one per
     /// pasteboard item.
     ///
-    /// A directory is not gated on size (its inode `.fileSize` is meaningless).
-    /// An item inside our own staging root (materialized from a prior inbound
-    /// paste) is skipped so it can't be offered back to the host.
+    /// Size gates nothing: a directory's inode `.fileSize` is meaningless, and a
+    /// zero-byte file is content native macOS copies. An item inside our own
+    /// staging root (materialized from a prior inbound paste) is skipped so it
+    /// can't be offered back to the host — that one is by design, so only the
+    /// unreadable items below are counted and logged.
     private func fileExpansionCandidates() -> [FileCandidate] {
         var candidates: [FileCandidate] = []
+        var unreadable = 0
         for url in pasteboard.itemFileURLs where !staging.isInStagingRoot(url) {
             guard
                 let values = try? url.resourceValues(forKeys: [
                     .contentTypeKey, .isDirectoryKey, .fileSizeKey,
                 ])
-            else { continue }
+            else {
+                unreadable += 1
+                continue
+            }
             if values.isDirectory == true {
                 candidates.append(
                     FileCandidate(
                         url: url, type: values.contentType ?? .folder,
                         filename: url.lastPathComponent, byteCount: 0, isDirectory: true))
             } else {
-                guard let type = values.contentType, let size = values.fileSize, size > 0
-                else { continue }
+                guard let type = values.contentType, let size = values.fileSize else {
+                    unreadable += 1
+                    continue
+                }
                 candidates.append(
                     FileCandidate(
                         url: url, type: type, filename: url.lastPathComponent, byteCount: size,
                         isDirectory: false))
             }
+        }
+        if unreadable > 0 {
+            Self.logger.warning(
+                "Skipped \(unreadable, privacy: .public) unreadable copied item(s) — not offered to the host"
+            )
         }
         return candidates
     }
@@ -1323,15 +1336,17 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// sanitization gate.
     ///
     /// An identity-skip type (transient marker, raw `public.file-url` smuggle) or
-    /// an empty payload is never surfaced, and a `provideData` pull can only
-    /// reach a rep this gate kept.
+    /// an inline payload with no bytes is never surfaced, and a `provideData`
+    /// pull can only reach a rep this gate kept.
     ///
-    /// A directory rep is exempt from the empty-payload skip: its `byte_count` is
-    /// an estimate of the tree's file bytes (`kernova.proto`), which a tree of
-    /// empty files, bare subdirectories, or nothing at all makes 0 while the
-    /// archive still carries the tree.
+    /// The empty-payload skip is keyed on the *filename*, so it reaches only
+    /// inline reps. A named rep is a file the paste creates, and an empty file is
+    /// content native macOS copies; a folder's `byte_count` is an estimate of the
+    /// tree's file bytes (`kernova.proto`), which a tree of empty files, bare
+    /// subdirectories, or nothing at all makes 0 while the archive still carries
+    /// the tree.
     private static func isPromisable(_ info: Kernova_V1_ClipboardRepresentationInfo) -> Bool {
-        (info.byteCount != 0 || info.isDirectory)
+        (info.byteCount != 0 || !info.filename.isEmpty)
             && !ClipboardSnapshotPolicy.shouldSkipBeforeReading(uti: info.uti)
     }
 

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -402,6 +402,51 @@ struct VsockGuestClipboardAgentTests {
         #expect(transfer.end.sha256 == Data(SHA256.hash(data: contents)))
     }
 
+    @Test("outbound copied zero-byte file: offered and streamed as an empty payload")
+    func outboundCopiedZeroByteFileOfferAndStream() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        // Finder copies an empty file, so the guest offers one: the stat gate
+        // keeps the rep at `byteCount == 0` rather than dropping it.
+        let url = try writeTempFile(name: "empty.bin", data: Data())
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        pasteboard.setItem([(type: .fileURL, data: Data(url.absoluteString.utf8))])
+        await MainActor.run { agent.checkClipboardChange() }
+
+        let offerFrame = try await nextFrame(from: hostChannel)
+        guard case .clipboardOffer(let offer) = offerFrame.payload else {
+            throw TestFailure("Expected ClipboardOffer, got \(String(describing: offerFrame.payload))")
+        }
+        let info = try #require(offer.repInfo.first)
+        #expect(offer.repInfo.count == 1)
+        #expect(info.byteCount == 0)
+        #expect(info.filename == "empty.bin")
+        #expect(!info.isInline)
+
+        // The whole stream path survives at zero bytes: Begin, no chunks, End
+        // carrying the empty-input SHA-256.
+        let transferID: UInt64 = (offer.generation << 16) | 0
+        try hostChannel.send(
+            makeRequestFrame(
+                generation: offer.generation, transferID: transferID, uti: info.uti))
+
+        let transfer = try await collectOutboundTransfer(
+            transferID: transferID, from: hostChannel)
+        #expect(transfer.begin.totalBytes == 0)
+        #expect(transfer.begin.filename == "empty.bin")
+        #expect(transfer.bytes.isEmpty)
+        #expect(transfer.end.sha256 == Data(SHA256.hash(data: Data())))
+    }
+
     @Test("serving a host pull publishes an outbound readout, cleared at the terminal")
     func outboundPullPublishesProgress() async throws {
         let pasteboard = FakePasteboard()
@@ -1743,8 +1788,8 @@ struct VsockGuestClipboardAgentTests {
         try await expectNoRequest(from: hostChannel)
     }
 
-    @Test("an inbound zero-byte rep that is not a directory is never promised")
-    func inboundZeroByteNonDirectoryRepIsNotPromised() async throws {
+    @Test("an inbound zero-byte file rep is promised and pastes as a real empty file")
+    func inboundZeroByteFileRepPastesAnEmptyFile() async throws {
         let pasteboard = FakePasteboard()
         let (agentFd, remoteFd) = try makeRawSocketPair()
         let hostChannel = VsockChannel(fileDescriptor: remoteFd)
@@ -1755,15 +1800,49 @@ struct VsockGuestClipboardAgentTests {
         defer { agent.stop() }
         try await startAgentAndWaitForLiveChannel(agent: agent)
 
-        // The empty-payload skip still holds for everything but a directory: a
-        // zero-byte file rep carries nothing a paste could serve.
+        // An empty file is content a native Mac-to-Mac copy carries, so it is a
+        // rep like any other: the empty-payload skip reaches only *inline* reps.
+        let txtUTI = try #require(UTType(filenameExtension: "txt")).identifier
         try hostChannel.send(
             makeOfferFrame(
                 generation: 19,
                 reps: [
-                    RepInfo(
-                        uti: UTType.png.identifier, byteCount: 0, filename: "nothing.png",
-                        isInline: false),
+                    RepInfo(uti: txtUTI, byteCount: 0, filename: "empty.txt", isInline: false)
+                ]))
+
+        try await pasteboard.changed.wait { pasteboard.promisedTypesForTesting == [.fileURL] }
+
+        let pull = lazyPull(pasteboard, forType: .fileURL)
+        try await driveInboundStream(
+            generation: 19, uti: txtUTI, filename: "empty.txt", payload: Data(), isInline: false,
+            on: hostChannel)
+        let urlData = await pull.value
+        let staged = try #require(
+            urlData.flatMap { String(data: $0, encoding: .utf8) }
+                .flatMap(URL.init(string:)))
+        #expect(staged.lastPathComponent == "empty.txt")
+        #expect(try Data(contentsOf: staged).isEmpty)
+    }
+
+    @Test("an inbound zero-byte rep with no filename is never promised")
+    func inboundZeroByteInlineRepIsNotPromised() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        // No filename means no file for a paste to create, so a byte-less rep is
+        // an empty pasteboard flavor and carries nothing.
+        try hostChannel.send(
+            makeOfferFrame(
+                generation: 19,
+                reps: [
+                    RepInfo(uti: UTType.png.identifier, byteCount: 0, isInline: true),
                     .text("keep"),
                 ]))
 

--- a/KernovaTests/ClipboardPassthroughCoordinatorTests.swift
+++ b/KernovaTests/ClipboardPassthroughCoordinatorTests.swift
@@ -37,9 +37,23 @@ struct ClipboardPassthroughCoordinatorTests {
         /// raised in the same step.
         var refusesOverCopyBudget = false
 
+        /// Fires on each `grabIfChanged` / `reportIssue`, so a wait on the poll's
+        /// off-actor file resolve resolves on the event itself.
+        @ObservationIgnored let grabRecorded = AsyncGate()
+        @ObservationIgnored let issueReported = AsyncGate()
+
         func stop() {}
-        func grabIfChanged() { grabbed.append(clipboardContent) }
         func clearBuffer() { clipboardContent = .empty }
+
+        func grabIfChanged() {
+            grabbed.append(clipboardContent)
+            grabRecorded.notify()
+        }
+
+        func reportIssue(_ issue: ClipboardTransferIssue) {
+            lastTransferIssue = issue
+            issueReported.notify()
+        }
 
         func materializeForCopy() -> [CopyToMacItem] {
             guard refusesOverCopyBudget else {
@@ -94,6 +108,25 @@ struct ClipboardPassthroughCoordinatorTests {
         pasteboard.writeObjects([item])
     }
 
+    /// Places one `public.file-url` item per URL, as a Finder ⌘C of several files
+    /// does.
+    private func writeFileURLs(_ urls: [URL], to pasteboard: NSPasteboard) {
+        pasteboard.clearContents()
+        pasteboard.writeObjects(
+            urls.map { url in
+                let item = NSPasteboardItem()
+                item.setString(url.absoluteString, forType: .fileURL)
+                return item
+            })
+    }
+
+    private func makeScratchDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kernova-passthrough-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
     @Test("A host clipboard change is forwarded to the guest on poll")
     func pollForwardsHostChange() {
         let h = makeHarness()
@@ -137,6 +170,55 @@ struct ClipboardPassthroughCoordinatorTests {
         // The poll must recognize its own write and not offer it back to the guest.
         h.coordinator.pollHostClipboard()
         #expect(h.service.grabbed.isEmpty)
+    }
+
+    @Test("a copied zero-byte file is forwarded like any other, with nothing noted")
+    func pollForwardsZeroByteFile() async throws {
+        let h = makeHarness()
+        defer { h.pasteboard.releaseGlobally() }
+
+        let directory = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let empty = directory.appendingPathComponent("empty.txt")
+        try Data().write(to: empty)
+        writeFileURLs([empty], to: h.pasteboard)
+
+        h.coordinator.pollHostClipboard()
+        try await h.service.grabRecorded.wait { !h.service.grabbed.isEmpty }
+
+        #expect(h.service.grabbed.last?.representations.map(\.filename) == ["empty.txt"])
+        #expect(h.service.grabbed.last?.representations.first?.byteCount == 0)
+        #expect(h.service.lastTransferIssue == nil)
+    }
+
+    @Test("a forward the intake could not fully read surfaces the skip as an issue")
+    func pollSurfacesIntakeSkipNote() async throws {
+        let h = makeHarness()
+        defer { h.pasteboard.releaseGlobally() }
+
+        let directory = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let kept = directory.appendingPathComponent("kept.txt")
+        let doomed = directory.appendingPathComponent("doomed.txt")
+        try Data("kept".utf8).write(to: kept)
+        try Data("doomed".utf8).write(to: doomed)
+        writeFileURLs([kept, doomed], to: h.pasteboard)
+
+        // The poll reads the URLs synchronously and stats them on a Task that
+        // cannot start until this method suspends — so deleting here reproduces
+        // exactly the race that leaves a forward carrying fewer files than were
+        // copied, with no gesture to report it back to.
+        h.coordinator.pollHostClipboard()
+        try FileManager.default.removeItem(at: doomed)
+
+        try await h.service.issueReported.wait { h.service.lastTransferIssue != nil }
+        #expect(h.service.grabbed.last?.representations.map(\.filename) == ["kept.txt"])
+        #expect(
+            h.service.lastTransferIssue?.kind
+                == .localFailure(
+                    code: ClipboardErrorCode.forwardItemsSkipped.rawValue,
+                    message: "Skipped 1 unreadable item")
+        )
     }
 
     @Test("A transient-marked snapshot is not forwarded")

--- a/KernovaTests/ClipboardPassthroughCoordinatorTests.swift
+++ b/KernovaTests/ClipboardPassthroughCoordinatorTests.swift
@@ -221,6 +221,63 @@ struct ClipboardPassthroughCoordinatorTests {
         )
     }
 
+    @Test("a forward whose every item went unreadable surfaces the rejection")
+    func pollSurfacesWholeCopyRejection() async throws {
+        let h = makeHarness()
+        defer { h.pasteboard.releaseGlobally() }
+
+        let directory = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let doomed = directory.appendingPathComponent("doomed.txt")
+        try Data("doomed".utf8).write(to: doomed)
+        writeFileURLs([doomed], to: h.pasteboard)
+
+        // The total of the partial case: nothing resolves, so nothing is
+        // forwarded and the guest is left with a copy that never arrived.
+        h.coordinator.pollHostClipboard()
+        try FileManager.default.removeItem(at: doomed)
+
+        try await h.service.issueReported.wait { h.service.lastTransferIssue != nil }
+        #expect(h.service.grabbed.isEmpty)
+        #expect(
+            h.service.lastTransferIssue?.kind
+                == .localFailure(
+                    code: ClipboardErrorCode.forwardItemsSkipped.rawValue,
+                    message: "Couldn't read the dropped item")
+        )
+    }
+
+    @Test("a text-only transport's blanket file rejection is not reported")
+    func pollStaysQuietForTextOnlyTransport() async throws {
+        let h = makeHarness()
+        defer { h.pasteboard.releaseGlobally() }
+        h.service.supportsBinaryRepresentations = false
+
+        let directory = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("notes.txt")
+        try Data("notes".utf8).write(to: file)
+        writeFileURLs([file], to: h.pasteboard)
+
+        // Wait on the resolve *completing*, not on a bounded sleep: the rejection
+        // branch runs on an unstructured Task, so a sleep that outruns a loaded
+        // scheduler would assert "no issue" before the branch that could raise
+        // one had run, and pass for the wrong reason.
+        var resolveCompleted = false
+        let resolved = AsyncGate()
+        h.coordinator.onForwardResolvedForTesting = {
+            resolveCompleted = true
+            resolved.notify()
+        }
+        h.coordinator.pollHostClipboard()
+        try await resolved.wait { resolveCompleted }
+
+        // A Linux guest rejects every file copy by design, so reporting here
+        // would fire on each one rather than on anything the user can act on.
+        #expect(h.service.grabbed.isEmpty)
+        #expect(h.service.lastTransferIssue == nil)
+    }
+
     @Test("A transient-marked snapshot is not forwarded")
     func transientMarkerSkipped() {
         let h = makeHarness()

--- a/KernovaTests/ClipboardPasteboardIntakeTests.swift
+++ b/KernovaTests/ClipboardPasteboardIntakeTests.swift
@@ -340,6 +340,25 @@ struct ClipboardPasteboardIntakeTests {
         #expect(note == nil)
     }
 
+    @Test("read(filesAt:) keeps a zero-byte file — native macOS copies one")
+    func readFilesAtZeroByteFile() async throws {
+        let empty = try makeTempFile(name: "empty.txt", contents: Data())
+        let full = try makeTempFile(name: "full.txt", contents: Data("hi".utf8))
+
+        guard
+            case .content(let content, let note) = await ClipboardPasteboardIntake.read(
+                filesAt: [empty, full], allowsBinary: true)
+        else {
+            Issue.record("Expected content")
+            return
+        }
+        #expect(content.representations.map(\.filename) == ["empty.txt", "full.txt"])
+        #expect(content.representations[0].byteCount == 0)
+        #expect(content.representations[0].fileURL == empty)
+        // An empty file is not an unreadable one, so nothing is noted as skipped.
+        #expect(note == nil)
+    }
+
     @Test("read(filesAt:) skips an unreadable file with a note, keeping the rest")
     func readFilesAtSkipsUnreadable() async throws {
         let good = try makeTempFile(name: "good.txt", contents: Data("ok".utf8))

--- a/KernovaTests/DataFormattersTests.swift
+++ b/KernovaTests/DataFormattersTests.swift
@@ -6,10 +6,10 @@ import Foundation
 struct DataFormattersTests {
     // MARK: - formatBytes
 
-    @Test("formatBytes returns 'Zero KB' for zero bytes")
+    @Test("formatBytes returns '0 bytes' for zero bytes")
     func formatBytesZero() {
         let result = DataFormatters.formatBytes(0)
-        #expect(result == "Zero KB")
+        #expect(result == "0 bytes")
     }
 
     @Test("formatBytes formats kilobytes")

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -2475,6 +2475,39 @@ struct VsockClipboardServiceTests {
         #expect(try Data(contentsOf: #require(secondURL)) == bBytes)
     }
 
+    @Test("a promised zero-byte file rep pastes as a real empty file")
+    func copyPromisedZeroByteFilePastes() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        service.start()
+        defer { service.stop() }
+
+        // The whole stream path survives at zero bytes: Begin, no chunks, End
+        // carrying the empty-input SHA-256.
+        let responder = FakeGuestResponder(guest: guest)
+        defer { responder.cancel() }
+        responder.register(
+            generation: 47, repIndex: 0, uti: "public.data", bytes: Data(), filename: "empty.bin",
+            isInline: false)
+        responder.start()
+
+        try guest.send(
+            makeOffer(
+                generation: 47,
+                reps: [(uti: "public.data", byteCount: 0, filename: "empty.bin", isInline: false)]))
+        try await waitForChange { service.clipboardContent.representations.count == 1 }
+        #expect(service.materializeForCopy().promised.map(\.repIndex) == [0])
+
+        let url = try #require(
+            await offCooperativePool { service.copyToMacFileURL(generation: 47, repIndex: 0) })
+        #expect(url.lastPathComponent == "empty.bin")
+        #expect(try Data(contentsOf: url).isEmpty)
+    }
+
     @Test("a paste-time fire refuses the whole over-budget file set — no piecemeal pastes")
     func copyPasteTimeRefusesOverTotal() async throws {
         let (guest, host) = try makePair()
@@ -3824,8 +3857,8 @@ struct VsockClipboardServiceTests {
         #expect(!reps.contains { $0.uti == "public.file-url" })
     }
 
-    @Test("a zero-byte rep that is not a directory is still filtered from the placeholders")
-    func offerFiltersZeroByteNonDirectoryRep() async throws {
+    @Test("a zero-byte file rep survives the placeholder filter and is promised")
+    func offerKeepsZeroByteFileRep() async throws {
         let (guest, host) = try makePair()
         guest.start()
         host.start()
@@ -3835,13 +3868,42 @@ struct VsockClipboardServiceTests {
         service.start()
         defer { service.stop() }
 
-        // The empty-payload skip still holds for everything but a directory: a
-        // zero-byte file rep carries nothing a paste could serve.
+        // An empty file is content a native Mac-to-Mac copy carries, so it is a
+        // rep like any other: the empty-payload skip reaches only *inline* reps.
         try guest.send(
             makeOffer(
                 generation: 33,
                 reps: [
                     (uti: "public.png", byteCount: 0, filename: "nothing.png", isInline: false),
+                    (uti: "public.png", byteCount: 1024, filename: "shot.png", isInline: false),
+                ]))
+
+        try await waitForChange {
+            service.clipboardContent.representations.map(\.filename)
+                == ["nothing.png", "shot.png"]
+        }
+        #expect(service.clipboardContent.representations[0].byteCount == 0)
+        #expect(service.materializeForCopy().promised.map(\.repIndex) == [0, 1])
+    }
+
+    @Test("a zero-byte rep with no filename is still filtered from the placeholders")
+    func offerFiltersZeroByteInlineRep() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        service.start()
+        defer { service.stop() }
+
+        // No filename means no file for a paste to create, so a byte-less rep is
+        // an empty pasteboard flavor and carries nothing.
+        try guest.send(
+            makeOffer(
+                generation: 33,
+                reps: [
+                    (uti: "public.png", byteCount: 0, filename: "", isInline: true),
                     (uti: "public.png", byteCount: 1024, filename: "shot.png", isInline: false),
                 ]))
 
@@ -3874,13 +3936,13 @@ struct VsockClipboardServiceTests {
         service.clipboardContent = shown
 
         // Every rep of the guest's offer is filtered — an identity-skip type and a
-        // zero-byte non-directory rep.
+        // byte-less inline rep.
         try guest.send(
             makeOffer(
                 generation: 41,
                 reps: [
                     (uti: "org.nspasteboard.TransientType", byteCount: 4, filename: "", isInline: true),
-                    (uti: "public.png", byteCount: 0, filename: "nothing.png", isInline: false),
+                    (uti: "public.png", byteCount: 0, filename: "", isInline: true),
                 ]))
         // Barrier: an error frame after the offer; once it surfaces, handleOffer ran.
         try guest.sendErrorFrame(


### PR DESCRIPTION
## Summary

A copied empty file never crossed the host↔guest clipboard: both producers gated file candidates on `size > 0`, and both receivers exempted only `is_directory` from the empty-payload skip. Native macOS copies a zero-byte file fine, so this failed the round-trip-parity bar in [docs/CLIPBOARD.md](docs/CLIPBOARD.md) §1/§6.

Closes #718.

### The parity fix

Both producer gates lose their `size > 0` clause, and both receive-side predicates key the empty-payload skip on the **filename** rather than `is_directory`:

- A rep carrying a filename is a file the paste creates, so 0 bytes is content.
- A filename-less rep with no bytes is an empty pasteboard flavor and is still filtered.
- The directory exemption folds into this, since a folder rep always carries its name — and a peer offering `is_directory` with an empty filename is now filtered rather than promised as a nameless inline flavor.

The stream path already survives at zero bytes end to end — Begin, no chunks, End carrying the empty-input SHA-256, a committed zero-length staging file — which the new transport-seam test pins.

### The silent-skip fix

The issue's second half, valid independent of the parity decision:

- `ClipboardPassthroughCoordinator` bound the intake `note` to `_`, so a copy the intake could only partly read forwarded silently. Both intake paths now funnel through one `offer(_:note:to:)` choke point that raises the note as a transfer issue. A window gesture reports its own outcome inline; the poll has no gesture to answer, so the issue is the only surface it gets. Raised *after* the grab, which clears the issue on a successful offer.
- The guest's `fileExpansionCandidates` counted and logged nothing when it dropped a candidate. It now logs the items it could not stat — never the staging-root skips, which are deliberate echo suppression.

### Fallout picked up on the way

`ByteCountFormatter` renders zero as `"Zero KB"`, which a zero-byte file's chip now reaches. `allowsNonnumericFormatting = false` governs the zero case alone — every other value formats identically either way — so the size reads `"0 bytes"`, matching what Finder's Get Info calls an empty file.

## Compatibility

No frame changed: `byte_count = 0` was always legal on the wire, and only local filters moved. A mixed pairing degrades to today's behavior in the direction whose end is stale, so no capability gate is needed — the guest agent `MARKETING_VERSION` bump (0.54.0 → 0.55.0) is what makes the guest side reachable.

## Test plan

- [x] `make test` — full suite green
- [x] `KernovaKitTests`: a zero-byte file round-trips through the real sender/receiver
- [x] `KernovaTests`/`KernovaMacOSAgentTests`: both producers offer a copied empty file, both receivers promise it and paste a real empty file, and a byte-less rep with no filename stays filtered
- [x] `ClipboardPassthroughCoordinatorTests`: the skip note surfaces as a `forwardItemsSkipped` issue when a copied file vanishes between the poll's synchronous read and its off-actor stat — the exact race, staged deterministically

## Notes

No `RATIONALE:` comments added. No `ARCHITECTURE.md` edit: `reportIssue(_:)` is a method on an existing protocol, not a changed component boundary. No `CLIPBOARD.md` edit either — §1/§6 already require this, and a "zero-byte files cross" line would describe what was built rather than constrain a future decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)