### PR TITLE
fix: Name every Linux ISO download for its URL, not for the mirror

### DIFF
--- a/Kernova/Models/CustomLinuxImage.swift
+++ b/Kernova/Models/CustomLinuxImage.swift
@@ -24,19 +24,16 @@ struct CustomLinuxImage: Codable, Sendable, Equatable {
         SafeFilename.sanitized(url.lastPathComponent, requiring: "iso") ?? "the installer image"
     }
 
-    /// The filename this image's download lands on, after every condition
+    /// The name ``url`` gives the image, after every condition
     /// ``make(urlText:checksumText:)`` checked is checked again.
     ///
     /// Re-checked at use time because the value reaching here comes off a
     /// `config.json` a user can edit — the same reason `LinuxImageResolveService`
     /// re-admits a catalog entry before contacting its mirror.
     ///
-    /// The name is unique to ``url`` rather than taken from it. A link ending
-    /// in a name the user already has in Downloads would otherwise resolve to
-    /// that file, which `DownloadService` adopts as the download in place of
-    /// fetching anything — installing an image the user never chose when there
-    /// is no digest, and trashing their file when there is one.
-    func destinationFilename() throws -> String {
+    /// Nothing is named from this: the download lands on
+    /// ``LinuxImageFilename/destination(for:)``.
+    func admittedFilename() throws -> String {
         if let sha256, !ChecksumManifest.isSHA256(sha256) {
             throw LinuxImageURLError.malformedChecksum
         }
@@ -55,18 +52,14 @@ struct CustomLinuxImage: Codable, Sendable, Equatable {
         guard url.host() != nil else {
             throw LinuxImageURLError.malformedURL
         }
-        // A direct link to a named `.iso` is what makes the generated name
-        // recognizable and the destination an ISO, which is what the
-        // replace-existing guard in the download pipeline keys on.
-        guard SafeFilename.sanitized(url.lastPathComponent, requiring: "iso") != nil else {
+        // A direct link to a named `.iso` is what holds a pasted URL to naming
+        // an image rather than a landing page, and what gives the generated
+        // destination a stem the user can recognize.
+        guard let filename = SafeFilename.sanitized(url.lastPathComponent, requiring: "iso") else {
             throw LinuxImageURLError.notAnISOLink
         }
-        return UniqueDownloadFilename.make(
-            for: url, fileExtension: "iso", defaultStem: Self.defaultStem)
+        return filename
     }
-
-    /// Stem of a generated filename when the URL's own last component yields none.
-    private static let defaultStem = "LinuxImage"
 
     /// The image `urlText` and `checksumText` name, or the first reason they
     /// name none.
@@ -78,7 +71,7 @@ struct CustomLinuxImage: Codable, Sendable, Equatable {
         guard let url = URL(string: urlText.trimmingCharacters(in: .whitespacesAndNewlines))
         else { throw LinuxImageURLError.malformedURL }
         let image = CustomLinuxImage(url: url, sha256: sha256)
-        _ = try image.destinationFilename()
+        _ = try image.admittedFilename()
         return image
     }
 

--- a/Kernova/Models/LinuxImageFilename.swift
+++ b/Kernova/Models/LinuxImageFilename.swift
@@ -19,6 +19,16 @@ enum LinuxImageFilename {
             for: url, fileExtension: "iso", defaultStem: defaultStem)
     }
 
+    /// The name the source gave the ISO this app downloaded to `filename`, or
+    /// `nil` when `filename` is not one ``destination(for:)`` produced.
+    ///
+    /// What a file in Downloads answers about where it came from: only a name
+    /// carrying a discriminator is one of this app's downloads, and only such a
+    /// file is what a later download would find and adopt.
+    static func sourceFilename(of filename: String) -> String? {
+        UniqueDownloadFilename.sourceFilename(of: filename, fileExtension: "iso")
+    }
+
     /// Stem of a generated filename when the URL's own last component yields none.
     private static let defaultStem = "LinuxImage"
 }

--- a/Kernova/Models/LinuxImageFilename.swift
+++ b/Kernova/Models/LinuxImageFilename.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Turns a Linux installer image's URL into the filename its download lands on.
+///
+/// Every source — a catalog entry resolved against its mirror's manifest, a URL
+/// the user pasted — names its destination here, so no name a mirror or a
+/// hand-edited `config.json` chose reaches the filesystem.
+enum LinuxImageFilename {
+    /// The download destination's filename for the ISO at `url`.
+    ///
+    /// Always unique to `url`, never the name the source gave the file.
+    /// Downloads holds everything the user has ever fetched and `DownloadService`
+    /// adopts a completed file at the destination as the download, so a
+    /// source-chosen name can land on a file the user already has — installed in
+    /// place of the image chosen when nothing is verified, and trashed for
+    /// failing a digest that was never its own when something is.
+    static func destination(for url: URL) -> String {
+        UniqueDownloadFilename.make(
+            for: url, fileExtension: "iso", defaultStem: defaultStem)
+    }
+
+    /// Stem of a generated filename when the URL's own last component yields none.
+    private static let defaultStem = "LinuxImage"
+}

--- a/Kernova/Models/LinuxInstallContext.swift
+++ b/Kernova/Models/LinuxInstallContext.swift
@@ -24,17 +24,12 @@ struct LinuxInstallContext: Codable, Sendable, Equatable {
     /// file — which for a catalog entry is only at download time, the mirror
     /// being the one to say which point release it is serving.
     ///
+    /// Always a name ``LinuxImageFilename`` derived, so there is never a file
+    /// here the user put there and no replace-existing prompt to show.
+    ///
     /// A sibling `.kernovadownload` bundle at this location holds in-progress
     /// download state and enables resume across app restarts.
     var downloadDestinationPath: String?
-
-    /// `true` when the user confirmed replacing the image already at the
-    /// destination.
-    ///
-    /// Honored once: the existing ISO and any `.kernovadownload` bundle are
-    /// trashed, then the flag is cleared so a retry after a failed attempt
-    /// reuses the freshly-downloaded file rather than trashing it again.
-    var requestedFreshDownload: Bool = false
 
     var downloadDestinationURL: URL? {
         downloadDestinationPath.map { URL(fileURLWithPath: $0) }
@@ -59,14 +54,9 @@ struct LinuxInstallContext: Codable, Sendable, Equatable {
         }
     }
 
-    init(
-        source: Source,
-        downloadDestinationPath: String? = nil,
-        requestedFreshDownload: Bool = false
-    ) {
+    init(source: Source, downloadDestinationPath: String? = nil) {
         self.source = source
         self.downloadDestinationPath = downloadDestinationPath
-        self.requestedFreshDownload = requestedFreshDownload
     }
 
     // MARK: - Codable
@@ -84,7 +74,6 @@ struct LinuxInstallContext: Codable, Sendable, Equatable {
         case remoteURL
         case sha256
         case downloadDestinationPath
-        case requestedFreshDownload
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -99,7 +88,6 @@ struct LinuxInstallContext: Codable, Sendable, Equatable {
             try c.encodeIfPresent(image.sha256, forKey: .sha256)
         }
         try c.encodeIfPresent(downloadDestinationPath, forKey: .downloadDestinationPath)
-        try c.encode(requestedFreshDownload, forKey: .requestedFreshDownload)
     }
 
     init(from decoder: any Decoder) throws {
@@ -115,7 +103,5 @@ struct LinuxInstallContext: Codable, Sendable, Equatable {
         }
         downloadDestinationPath = try c.decodeIfPresent(
             String.self, forKey: .downloadDestinationPath)
-        requestedFreshDownload =
-            try c.decodeIfPresent(Bool.self, forKey: .requestedFreshDownload) ?? false
     }
 }

--- a/Kernova/Models/ResolvedLinuxImage.swift
+++ b/Kernova/Models/ResolvedLinuxImage.swift
@@ -8,8 +8,11 @@ import Foundation
 struct ResolvedLinuxImage: Sendable, Equatable {
     /// Where the ISO is served from.
     var isoURL: URL
-    /// The ISO's filename, checked to be one visible path component so it can
-    /// be appended to a download directory.
+    /// The name the source gives the ISO, checked to be one visible path
+    /// component.
+    ///
+    /// Shown, logged and named in a checksum failure — never written. What the
+    /// bytes land on is ``destinationFilename``.
     var filename: String
     /// The digest to check the download against, as 64 lowercase hex
     /// characters, or `nil` when the source published none and there is nothing
@@ -17,4 +20,10 @@ struct ResolvedLinuxImage: Sendable, Equatable {
     var sha256: String?
     /// The ISO's length in bytes, as the mirror reports it.
     var sizeBytes: UInt64
+
+    /// The filename the download lands on, unique to ``isoURL`` on the terms
+    /// ``LinuxImageFilename`` states.
+    var destinationFilename: String {
+        LinuxImageFilename.destination(for: isoURL)
+    }
 }

--- a/Kernova/Models/UniqueDownloadFilename.swift
+++ b/Kernova/Models/UniqueDownloadFilename.swift
@@ -33,6 +33,35 @@ enum UniqueDownloadFilename {
         return "\(stem(of: url.lastPathComponent) ?? defaultStem)-\(discriminator).\(fileExtension)"
     }
 
+    /// The name the source gave a file ``make(for:fileExtension:defaultStem:)``
+    /// named, or `nil` when `filename` carries no discriminator.
+    ///
+    /// The discriminator is a digest and cannot be inverted, so only the stem
+    /// comes back — which is what says where the file came from. A stem long
+    /// enough to have been truncated comes back truncated, so a source name
+    /// past ``maximumStemLength`` is not recognized.
+    static func sourceFilename(of filename: String, fileExtension: String) -> String? {
+        guard let stem = stem(of: filename, requiring: fileExtension) else { return nil }
+        // `-<discriminator>`, with at least one character of source name ahead
+        // of it — a name that is nothing but a discriminator names no source.
+        let suffixLength = discriminatorBytes * 2 + 1
+        guard stem.count > suffixLength else { return nil }
+        let source = stem.dropLast(suffixLength)
+        let suffix = stem.dropFirst(source.count)
+        guard suffix.first == "-",
+            suffix.dropFirst().allSatisfy({ $0.isASCII && $0.isHexDigit && !$0.isUppercase })
+        else { return nil }
+        return "\(source).\(fileExtension)"
+    }
+
+    /// The part of `candidate` before a `.<fileExtension>` it must end in.
+    private static func stem(of candidate: String, requiring fileExtension: String) -> String? {
+        guard let name = SafeFilename.sanitized(candidate, requiring: fileExtension) else {
+            return nil
+        }
+        return String(name.dropLast(fileExtension.count + 1))
+    }
+
     /// The part of `candidate` before its extension, or `nil` when `candidate`
     /// is not usable as a filename at all.
     private static func stem(of candidate: String) -> String? {

--- a/Kernova/Services/LinuxImageResolveService.swift
+++ b/Kernova/Services/LinuxImageResolveService.swift
@@ -99,7 +99,7 @@ final class LinuxImageResolveService: LinuxImageResolving {
     }
 
     func resolve(_ image: CustomLinuxImage) async throws -> ResolvedLinuxImage {
-        let filename = try image.destinationFilename()
+        let filename = try image.admittedFilename()
         let sizeBytes: UInt64
         do {
             sizeBytes = try await sizeProbe.size(of: image.url)

--- a/Kernova/ViewModels/VMCreationViewModel.swift
+++ b/Kernova/ViewModels/VMCreationViewModel.swift
@@ -498,10 +498,10 @@ final class VMCreationViewModel {
     /// so a pick made under EFI does not follow a switch to Linux-kernel boot
     /// onto a VM that never boots an installer.
     ///
-    /// A catalog pick gets no destination: the mirror names the file, and only
-    /// a resolution just before the download can say what that name is. A URL
-    /// names its own destination, which the check just admitted, so it is known
-    /// here.
+    /// A catalog pick gets no destination: only a resolution just before the
+    /// download knows which URL the mirror is serving, and the destination is
+    /// named for that URL. A pasted URL is known from the moment it is
+    /// admitted, so its destination is too.
     func buildLinuxInstallContext() -> LinuxInstallContext? {
         guard selectedBootMode == .efi else { return nil }
         switch linuxSelection {
@@ -510,8 +510,8 @@ final class VMCreationViewModel {
         case .customURL(let image, _):
             return LinuxInstallContext(
                 source: .customURL(image),
-                downloadDestinationPath: (try? image.destinationFilename())
-                    .map(Self.downloadPath(forFilename:)))
+                downloadDestinationPath: Self.downloadPath(
+                    forFilename: LinuxImageFilename.destination(for: image.url)))
         case .localISO, nil:
             return nil
         }

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -401,14 +401,22 @@ final class VMLifecycleCoordinator {
     // MARK: - Linux Installer Image
 
     /// Where a resolved Linux image is written: inside Downloads, under the
-    /// name the mirror just gave it.
+    /// name ``LinuxImageFilename`` derives for the URL it resolved to.
     ///
     /// Never built from the persisted path, which comes out of a `config.json`
-    /// a user can edit: only the name this resolution produced describes the
-    /// bytes about to land. Falls back to the persisted path when
-    /// normalization is disabled, and is `nil` only when there is neither.
+    /// a user can edit, and never from a name the source chose: only a name
+    /// this app derived is safe to append to a directory holding everything the
+    /// user has ever downloaded.
+    ///
+    /// Falls back to the persisted path when normalization is disabled, and
+    /// only while it still names an ISO — the download writes over this path,
+    /// and a digest failure trashes it, so an edit pointing it at an arbitrary
+    /// file names no destination at all.
     func linuxDownloadDestination(persisted: URL?, filename: String) -> URL? {
-        guard let downloads = downloadsDirectory else { return persisted }
+        guard let downloads = downloadsDirectory else {
+            guard persisted?.pathExtension.lowercased() == "iso" else { return nil }
+            return persisted
+        }
         return downloads.appendingPathComponent(filename)
     }
 
@@ -444,22 +452,26 @@ final class VMLifecycleCoordinator {
                     image = try await linuxImageResolveService.resolve(custom)
                 }
 
-                // `image.filename`, never `isoURL.lastPathComponent`: the
-                // resolution already checked the name is one visible path
-                // component, and re-deriving it from the URL percent-decodes it
-                // back into a value that can walk out of Downloads.
+                // `image.destinationFilename`, never the name the source gave
+                // the ISO: Downloads holds everything the user has ever
+                // fetched, and a file already sitting under the source's name
+                // is one the download would adopt in place of fetching, or
+                // trash for failing a digest that was never its own.
                 guard
                     let downloadDestination = linuxDownloadDestination(
-                        persisted: context.downloadDestinationURL, filename: image.filename)
+                        persisted: context.downloadDestinationURL,
+                        filename: image.destinationFilename)
                 else {
-                    throw DownloadError.invalidDownloadDestination(path: image.filename)
+                    throw DownloadError.invalidDownloadDestination(
+                        path: context.downloadDestinationURL?.path(percentEncoded: false)
+                            ?? image.destinationFilename)
                 }
 
                 if let persisted = context.downloadDestinationURL,
                     persisted != downloadDestination
                 {
                     Self.logger.notice(
-                        "downloadLinuxImage: the mirror now names the image '\(downloadDestination.lastPathComponent, privacy: .public)'"
+                        "downloadLinuxImage: the resolution moved to '\(image.filename, privacy: .public)', downloading to '\(downloadDestination.lastPathComponent, privacy: .public)'"
                     )
                     // The partial at the abandoned path belongs to an image
                     // this download is no longer fetching, so discard it before
@@ -483,29 +495,14 @@ final class VMLifecycleCoordinator {
                         totalBytes: Int64(clamping: image.sizeBytes),
                         bytesPerSecond: 0))
 
-                // Honored ONCE, and the flag clears before the download so a
-                // retry after a later failure reuses what it fetched.
-                let requestedFreshDownload = context.requestedFreshDownload
-                if requestedFreshDownload {
-                    // The destination can come from a persisted path when
-                    // normalization is disabled, so a stray edit could
-                    // otherwise have the download trashing an arbitrary file.
-                    guard downloadDestination.pathExtension.lowercased() == "iso" else {
-                        Self.logger.error(
-                            "downloadLinuxImage: refusing to honor requestedFreshDownload for non-ISO destination '\(downloadDestination.path(percentEncoded: false), privacy: .public)'"
-                        )
-                        throw DownloadError.invalidDownloadDestination(
-                            path: downloadDestination.path(percentEncoded: false))
-                    }
-                    instance.performConfigurationMutation {
-                        $0.linuxInstallContext?.requestedFreshDownload = false
-                    }
-                }
-
+                // Never replaces: the destination is named for this URL, so a
+                // file already there is what a prior attempt at this same image
+                // fetched, and adopting it is right — the verify step below
+                // holds it to the same digest a fresh download would face.
                 try await downloadService.download(
                     from: image.isoURL,
                     to: downloadDestination,
-                    discardsExistingDownload: requestedFreshDownload,
+                    discardsExistingDownload: false,
                     expectedSizeBytes: image.sizeBytes
                 ) { progress in
                     instance.setupState?.progress = .download(progress)
@@ -531,7 +528,8 @@ final class VMLifecycleCoordinator {
                     }
                 }
 
-                attachInstallerImage(at: downloadDestination, to: instance)
+                attachInstallerImage(
+                    at: downloadDestination, named: image.filename, to: instance)
                 instance.setupState = nil
                 // The VM entered `.installing` for the pipeline and nothing
                 // else takes it out — unlike a macOS install, no VZ session ran
@@ -585,15 +583,21 @@ final class VMLifecycleCoordinator {
     /// Attaches the fetched installer image ahead of the VM's main disk and
     /// clears the pending download intent.
     ///
+    /// `filename` is the name the source gave the ISO, which is what the disk
+    /// is labelled with — the file it was written to carries a discriminator
+    /// suffix no user would recognize.
+    ///
     /// The bookmark is minted without a panel — Downloads is covered by the
     /// downloads entitlement — and it is worth minting because, unlike an IPSW
     /// consumed by an install, this attachment outlives the setup and has to
     /// track the file if the user later moves it.
-    private func attachInstallerImage(at destination: URL, to instance: VMInstance) {
+    private func attachInstallerImage(
+        at destination: URL, named filename: String, to instance: VMInstance
+    ) {
         let installer = StorageDisk(
             path: destination.path(percentEncoded: false),
             readOnly: true,
-            label: destination.deletingPathExtension().lastPathComponent,
+            label: (filename as NSString).deletingPathExtension,
             bookmark: SecurityScopedBookmark.make(for: destination)
         )
         let layout = VMBundleLayout(bundleURL: instance.bundleURL)

--- a/Kernova/Views/Creation/LinuxImageCatalogSheetContentViewController.swift
+++ b/Kernova/Views/Creation/LinuxImageCatalogSheetContentViewController.swift
@@ -342,16 +342,39 @@ final class LinuxImageCatalogSheetContentViewController: NSViewController {
 
     /// IDs of the entries `filenames` holds an image for.
     ///
+    /// Each name has to answer twice. Reading it back through
+    /// ``LinuxImageFilename/sourceFilename(of:)`` says which image it is, and an
+    /// ISO the user fetched themselves — sitting under the mirror's own name,
+    /// with no discriminator — is not one of this app's downloads at all.
+    /// Naming it again off *this* entry's directory says the download it came
+    /// from was this entry's: an identically-named ISO fetched from another
+    /// mirror or pasted as a URL carries a different discriminator, so choosing
+    /// this row would fetch the whole image again.
+    ///
+    /// Which point release the mirror serves *now* is a question only a
+    /// resolution answers, and this sheet reaches no network — so the column
+    /// states which images are on disk, never that the next download will skip.
+    ///
     /// A completed download is the only thing that can match: an interrupted one
     /// keeps its bytes in a `.kernovadownload` bundle beside the destination,
-    /// which the entry's `.iso`-anchored glob does not take.
+    /// which is not an `.iso` name at all.
     private static func downloadedEntryIDs(
         among entries: [LinuxImageCatalogEntry], in filenames: [String]
     ) -> Set<String> {
-        Set(
+        let downloaded = filenames.compactMap { filename in
+            LinuxImageFilename.sourceFilename(of: filename)
+                .map { (onDisk: filename, published: $0) }
+        }
+        return Set(
             entries.compactMap { entry -> String? in
                 guard let glob = ISOFilenameGlob(entry.isoPattern) else { return nil }
-                return filenames.contains(where: glob.matches) ? entry.id : nil
+                let held = downloaded.contains { image in
+                    glob.matches(image.published)
+                        && LinuxImageFilename.destination(
+                            for: entry.directoryURL.appendingPathComponent(image.published))
+                            == image.onDisk
+                }
+                return held ? entry.id : nil
             })
     }
 

--- a/Kernova/Views/Creation/LinuxImageURLSheetContentViewController.swift
+++ b/Kernova/Views/Creation/LinuxImageURLSheetContentViewController.swift
@@ -327,12 +327,12 @@ final class LinuxImageURLSheetContentViewController: NSViewController {
             makeWizardBadge(
                 symbolName: "checkmark.seal.fill",
                 text: [
-                    image.isoURL.lastPathComponent, DataFormatters.formatBytes(image.sizeBytes),
+                    image.filename, DataFormatters.formatBytes(image.sizeBytes),
                 ].joined(separator: "  ·  "),
                 // The destination, which carries a suffix unique to this link so
                 // it can never land on a file the user already has.
                 secondaryText: wizardAbbreviateWithTilde(
-                    VMCreationViewModel.downloadPath(forFilename: image.filename))
+                    VMCreationViewModel.downloadPath(forFilename: image.destinationFilename))
             )
         ]
         if image.sha256 == nil {

--- a/Kernova/Views/Creation/ReviewContentViewController.swift
+++ b/Kernova/Views/Creation/ReviewContentViewController.swift
@@ -190,13 +190,12 @@ final class ReviewContentViewController: NSViewController {
                             "Verification", wizardVerificationSummary(sha256: image.sha256)))
                     // The destination carries a suffix unique to this link, so
                     // it names a file only this pick can ever write.
-                    if let destination = try? image.destinationFilename() {
-                        rows.append(
-                            valueRow(
-                                "Save to",
-                                wizardAbbreviateWithTilde(
-                                    VMCreationViewModel.downloadPath(forFilename: destination))))
-                    }
+                    rows.append(
+                        valueRow(
+                            "Save to",
+                            wizardAbbreviateWithTilde(
+                                VMCreationViewModel.downloadPath(
+                                    forFilename: LinuxImageFilename.destination(for: image.url)))))
                 case .localISO(let path, _):
                     rows.append(valueRow("ISO", URL(fileURLWithPath: path).lastPathComponent))
                 case nil:

--- a/KernovaTests/CustomLinuxImageTests.swift
+++ b/KernovaTests/CustomLinuxImageTests.swift
@@ -69,49 +69,6 @@ struct CustomLinuxImageTests {
         }
     }
 
-    // MARK: - Destination
-
-    @Test("The destination is unique to the URL, not the name the URL gives")
-    func destinationIsUniquePerURL() throws {
-        // A link ending in a name the user already has in Downloads would
-        // otherwise resolve to their file, which the download adopts in place
-        // of fetching — installing an image they never chose.
-        let first = try CustomLinuxImage.make(
-            urlText: "https://one.example/alpine.iso", checksumText: "")
-        let second = try CustomLinuxImage.make(
-            urlText: "https://two.example/alpine.iso", checksumText: "")
-
-        let firstName = try first.destinationFilename()
-        let secondName = try second.destinationFilename()
-
-        #expect(firstName != secondName)
-        #expect(firstName != "alpine.iso")
-        #expect(firstName.hasPrefix("alpine-"))
-        #expect(firstName.hasSuffix(".iso"))
-        // The display name stays the one in the link the user pasted.
-        #expect(first.displayName == "alpine.iso")
-    }
-
-    @Test("One URL always names the same destination, so a download stays resumable")
-    func destinationIsStableForOneURL() throws {
-        let image = try CustomLinuxImage.make(
-            urlText: "https://mirror.example/alpine-3.22-aarch64.iso", checksumText: "")
-
-        #expect(try image.destinationFilename() == (try image.destinationFilename()))
-    }
-
-    @Test("A URL that names no usable stem still yields an .iso destination")
-    func destinationFallsBackToADefaultStem() throws {
-        // Not reachable through `make`, which refuses a link naming no `.iso`;
-        // this pins the fallback the generator carries anyway.
-        let name = UniqueDownloadFilename.make(
-            for: URL(string: "https://mirror.example/")!, fileExtension: "iso",
-            defaultStem: "LinuxImage")
-
-        #expect(name.hasPrefix("LinuxImage-"))
-        #expect(name.hasSuffix(".iso"))
-    }
-
     @Test("Text that names no host is not a URL")
     func refusesMalformedURL() {
         for text in ["", "   ", "not a url", "https:///alpine.iso"] {
@@ -121,7 +78,7 @@ struct CustomLinuxImageTests {
         }
     }
 
-    @Test("A link that doesn't end in an .iso filename names no destination")
+    @Test("A link that doesn't end in an .iso filename is not admitted")
     func refusesNonISOLink() {
         for text in [
             "https://mirror.example/downloads/",
@@ -140,6 +97,7 @@ struct CustomLinuxImageTests {
             urlText: "https://mirror.example/alpine-3.22-aarch64.iso?mirror=eu", checksumText: "")
 
         #expect(image.displayName == "alpine-3.22-aarch64.iso")
+        #expect(try image.admittedFilename() == "alpine-3.22-aarch64.iso")
     }
 
     @Test("A percent-encoded name that decodes to a path is refused")
@@ -160,17 +118,17 @@ struct CustomLinuxImageTests {
         #expect(throws: LinuxImageURLError.insecureURL) {
             try CustomLinuxImage(
                 url: URL(string: "http://mirror.example/alpine.iso")!, sha256: nil
-            ).destinationFilename()
+            ).admittedFilename()
         }
         #expect(throws: LinuxImageURLError.malformedChecksum) {
             try CustomLinuxImage(
                 url: URL(string: "https://mirror.example/alpine.iso")!, sha256: "deadbeef"
-            ).destinationFilename()
+            ).admittedFilename()
         }
         #expect(throws: LinuxImageURLError.notAnISOLink) {
             try CustomLinuxImage(
                 url: URL(string: "https://mirror.example/alpine.img")!, sha256: nil
-            ).destinationFilename()
+            ).admittedFilename()
         }
     }
 }

--- a/KernovaTests/LinuxImageCatalogSheetContentViewControllerTests.swift
+++ b/KernovaTests/LinuxImageCatalogSheetContentViewControllerTests.swift
@@ -38,6 +38,17 @@ struct LinuxImageCatalogSheetContentViewControllerTests {
         return vc
     }
 
+    /// The Downloads name a completed download leaves behind.
+    ///
+    /// Built the way the pipeline builds it — the resolved ISO URL through
+    /// ``LinuxImageFilename`` — rather than spelled out, so a test never asserts
+    /// against a discriminator it invented.
+    private func downloadedName(
+        of published: String, from entry: LinuxImageCatalogEntry
+    ) -> String {
+        LinuxImageFilename.destination(for: entry.directoryURL.appendingPathComponent(published))
+    }
+
     /// The text the sheet renders in `column` for the row at `row`.
     private func cellText(
         _ vc: LinuxImageCatalogSheetContentViewController, row: Int, column identifier: String
@@ -125,16 +136,55 @@ struct LinuxImageCatalogSheetContentViewControllerTests {
 
     @Test("The Status column names only the images already in Downloads")
     func statusNamesDownloadedImages() throws {
-        let vc = makeSheet(downloads: ["debian-13.1.0-arm64-netinst.iso"])
+        let debian = try #require(entries.last)
+        let vc = makeSheet(
+            downloads: [downloadedName(of: "debian-13.1.0-arm64-netinst.iso", from: debian)])
 
         #expect(try cellText(vc, row: 0, column: "status").isEmpty)
         #expect(try cellText(vc, row: 2, column: "status") == "In Downloads")
     }
 
+    @Test("An ISO the user fetched themselves does not read as In Downloads")
+    func statusIgnoresImagesThisAppDidNotDownload() throws {
+        // Under the mirror's own name, so no download will ever find or adopt
+        // it — saying it is there would promise a fast path that is not there.
+        let vc = makeSheet(downloads: ["debian-13.1.0-arm64-netinst.iso"])
+
+        #expect(try cellText(vc, row: 2, column: "status").isEmpty)
+    }
+
+    @Test("The same image fetched from another mirror does not read as In Downloads")
+    func statusIgnoresTheSameImageFromAnotherURL() throws {
+        // Same published filename, different directory, so the discriminator
+        // differs and choosing this row downloads the whole ISO again.
+        let elsewhere = makeLinuxCatalogEntry(
+            directoryURLString: "https://mirror.example/debian-cd/current/arm64/iso-cd/")
+        let vc = makeSheet(
+            downloads: [downloadedName(of: "debian-13.1.0-arm64-netinst.iso", from: elsewhere)])
+
+        #expect(try cellText(vc, row: 2, column: "status").isEmpty)
+    }
+
+    @Test("A pasted-URL download does not read as In Downloads for a catalog row")
+    func statusIgnoresACustomURLDownload() throws {
+        // The URL source names its destination the same way, so a link ending
+        // in a catalog image's filename lands on a name whose stem matches that
+        // row's glob — and whose discriminator says it came from elsewhere.
+        let pasted = try #require(
+            URL(string: "https://example.com/debian-13.1.0-arm64-netinst.iso"))
+        let vc = makeSheet(downloads: [LinuxImageFilename.destination(for: pasted)])
+
+        #expect(try cellText(vc, row: 2, column: "status").isEmpty)
+    }
+
     @Test("A half-finished download does not read as In Downloads")
     func statusIgnoresPartialDownloads() throws {
-        let vc = makeSheet(
-            downloads: ["ubuntu-26.04.1-desktop-arm64.iso.kernovadownload"])
+        // The bundle replaces the destination's extension rather than following
+        // it, so nothing about a partial download reads as an `.iso`.
+        let ubuntu = try #require(entries.first)
+        let complete = downloadedName(of: "ubuntu-26.04.1-desktop-arm64.iso", from: ubuntu)
+        let partial = (complete as NSString).deletingPathExtension + ".kernovadownload"
+        let vc = makeSheet(downloads: [partial])
 
         #expect(try cellText(vc, row: 0, column: "status").isEmpty)
     }
@@ -142,8 +192,10 @@ struct LinuxImageCatalogSheetContentViewControllerTests {
     @Test("Downloads is read once, however many rows render and filters run")
     func downloadsAreEnumeratedOncePerSheet() throws {
         var reads = 0
+        let debian = try #require(entries.last)
         let vc = makeSheet(
-            downloads: ["debian-13.1.0-arm64-netinst.iso"], onDownloadsRead: { reads += 1 })
+            downloads: [downloadedName(of: "debian-13.1.0-arm64-netinst.iso", from: debian)],
+            onDownloadsRead: { reads += 1 })
 
         for row in 0..<3 { _ = try cellText(vc, row: row, column: "status") }
         for term in ["u", "ub", "ubu"] {

--- a/KernovaTests/LinuxImageFilenameTests.swift
+++ b/KernovaTests/LinuxImageFilenameTests.swift
@@ -50,4 +50,37 @@ struct LinuxImageFilenameTests {
         #expect(name.hasPrefix("LinuxImage-"))
         #expect(name.hasSuffix(".iso"))
     }
+
+    // MARK: - Reading a destination back
+
+    @Test("A destination this app generated names the image the source published")
+    func sourceFilenameRecoversTheSourceName() throws {
+        let iso = try url(
+            "https://cdimage.debian.org/debian-cd/current/arm64/iso-cd/debian-13.6.0-arm64-netinst.iso"
+        )
+
+        #expect(
+            LinuxImageFilename.sourceFilename(of: LinuxImageFilename.destination(for: iso))
+                == "debian-13.6.0-arm64-netinst.iso")
+    }
+
+    @Test(
+        "A name this app did not generate belongs to no source",
+        arguments: [
+            // The mirror's own name, as a user's own fetch would leave it.
+            "debian-13.6.0-arm64-netinst.iso",
+            // A discriminator that is not eight lowercase hex characters.
+            "debian-1a2b3c4.iso",
+            "debian-1a2b3c4de.iso",
+            "debian-1A2B3C4D.iso",
+            "debian-nothexes.iso",
+            // Nothing in front of the discriminator to name a source.
+            "-1a2b3c4d.iso",
+            // Not an ISO, so not an image at all — a resume bundle among them.
+            "debian-13.6.0-arm64-netinst-1a2b3c4d.kernovadownload",
+            "debian-1a2b3c4d.img",
+        ])
+    func sourceFilenameRefusesForeignNames(candidate: String) {
+        #expect(LinuxImageFilename.sourceFilename(of: candidate) == nil)
+    }
 }

--- a/KernovaTests/LinuxImageFilenameTests.swift
+++ b/KernovaTests/LinuxImageFilenameTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("LinuxImageFilename Tests")
+struct LinuxImageFilenameTests {
+    private func url(_ text: String) throws -> URL {
+        try #require(URL(string: text))
+    }
+
+    @Test("The destination is unique to the URL, not the name the URL gives")
+    func destinationIsUniquePerURL() throws {
+        // A source naming its ISO after a file the user already has in
+        // Downloads would otherwise resolve to their file, which the download
+        // adopts in place of fetching — installing an image they never chose
+        // when nothing is verified, and trashing their file when something is.
+        let first = LinuxImageFilename.destination(for: try url("https://one.example/alpine.iso"))
+        let second = LinuxImageFilename.destination(for: try url("https://two.example/alpine.iso"))
+
+        #expect(first != second)
+        #expect(first != "alpine.iso")
+        #expect(first.hasPrefix("alpine-"))
+        #expect(first.hasSuffix(".iso"))
+    }
+
+    @Test("A path a source could name is never reproduced in the destination")
+    func destinationIsOneComponent() throws {
+        // `URL.lastPathComponent` percent-decodes, so this arrives as
+        // `../../evil.iso` — a stem the generator refuses in favor of its
+        // default.
+        let escaping = LinuxImageFilename.destination(
+            for: try url("https://mirror.example/a%2F..%2F..%2Fevil.iso"))
+
+        #expect(!escaping.contains("/"))
+        #expect(escaping.hasPrefix("LinuxImage-"))
+    }
+
+    @Test("One URL always names the same destination, so a download stays resumable")
+    func destinationIsStableForOneURL() throws {
+        let iso = try url("https://mirror.example/alpine-3.22-aarch64.iso")
+
+        #expect(LinuxImageFilename.destination(for: iso) == LinuxImageFilename.destination(for: iso))
+    }
+
+    @Test("A URL that names no usable stem still yields an .iso destination")
+    func destinationFallsBackToADefaultStem() throws {
+        let name = LinuxImageFilename.destination(for: try url("https://mirror.example/"))
+
+        #expect(name.hasPrefix("LinuxImage-"))
+        #expect(name.hasSuffix(".iso"))
+    }
+}

--- a/KernovaTests/LinuxImageResolveTests.swift
+++ b/KernovaTests/LinuxImageResolveTests.swift
@@ -435,6 +435,11 @@ struct LinuxImageResolveServiceTests {
         let image = try await makeService().resolve(ubuntuEntry)
 
         #expect(image.filename == "ubuntu-24.04.4-desktop-arm64.iso")
+        // The mirror names the image; it does not name the file that image is
+        // written to, which carries a suffix unique to the URL resolved.
+        #expect(image.destinationFilename != image.filename)
+        #expect(image.destinationFilename.hasPrefix("ubuntu-24.04.4-desktop-arm64-"))
+        #expect(image.destinationFilename.hasSuffix(".iso"))
         #expect(
             image.sha256 == "0be6df929cb47d4f188ab94d1fdedc75aa947d1fe7d4a17fb70f65c130699a44")
         #expect(
@@ -599,11 +604,12 @@ struct LinuxImageResolveServiceTests {
         let image = try await makeService().resolve(pasted)
 
         #expect(image.isoURL == pasted.url)
+        #expect(image.filename == "alpine-3.22-aarch64.iso")
         // The destination is unique to the URL, so it can never land on a file
         // the user happens to already have under the link's own name.
-        #expect(image.filename == (try pasted.destinationFilename()))
-        #expect(image.filename != "alpine-3.22-aarch64.iso")
-        #expect(image.filename.hasSuffix(".iso"))
+        #expect(image.destinationFilename != image.filename)
+        #expect(image.destinationFilename.hasPrefix("alpine-3.22-aarch64-"))
+        #expect(image.destinationFilename.hasSuffix(".iso"))
         #expect(image.sha256 == digest)
         #expect(image.sizeBytes == 1_073_741_824)
         // No manifest is read: the URL names the file outright.

--- a/KernovaTests/LinuxInstallContextTests.swift
+++ b/KernovaTests/LinuxInstallContextTests.swift
@@ -20,8 +20,7 @@ struct LinuxInstallContextTests {
                 makeLinuxCatalogEntry(
                     id: "ubuntu-desktop-26.04", distribution: "Ubuntu Desktop",
                     version: "26.04 LTS")),
-            downloadDestinationPath: "/Users/test/Downloads/ubuntu-26.04-desktop-arm64.iso",
-            requestedFreshDownload: true
+            downloadDestinationPath: "/Users/test/Downloads/ubuntu-26.04-desktop-arm64-1a2b3c4d.iso"
         )
 
         #expect(try roundTrip(context) == context)

--- a/KernovaTests/ReviewContentViewControllerTests.swift
+++ b/KernovaTests/ReviewContentViewControllerTests.swift
@@ -174,7 +174,7 @@ struct ReviewContentViewControllerTests {
         #expect(findLabel(withText: "Verified with your checksum", in: vc.view) != nil)
         // The URL names its own destination, so unlike a catalog pick the whole
         // path is known here — carrying a suffix unique to this link.
-        let destination = try #require(try? image.destinationFilename())
+        let destination = LinuxImageFilename.destination(for: image.url)
         #expect(destination != "alpine-3.22-aarch64.iso")
         #expect(
             findLabel(

--- a/KernovaTests/VMCreationViewModelTests.swift
+++ b/KernovaTests/VMCreationViewModelTests.swift
@@ -621,7 +621,6 @@ struct VMCreationViewModelTests {
         // The mirror names the file, and only a resolution just before the
         // download can say what that name is.
         #expect(context.downloadDestinationPath == nil)
-        #expect(!context.requestedFreshDownload)
     }
 
     @Test("buildLinuxInstallContext snapshots a URL pick with its checksum and destination")
@@ -641,7 +640,7 @@ struct VMCreationViewModelTests {
         // A fixed URL names its own destination, so unlike a catalog pick it is
         // known before the VM is created — and it is unique to the link, so it
         // can never land on a file the user already has.
-        let destination = try #require(try? image.destinationFilename())
+        let destination = LinuxImageFilename.destination(for: image.url)
         #expect(destination != "alpine-3.22-aarch64.iso")
         #expect(
             context.downloadDestinationPath
@@ -740,7 +739,6 @@ struct VMCreationViewModelTests {
         #expect(context.source == .localFile)
         #expect(context.localIPSWPath == "/tmp/macOS-26.ipsw")
         #expect(context.downloadDestinationPath == nil)
-        #expect(!context.requestedFreshDownload)
     }
 
     @Test("buildInstallContext carries a local pick's bookmark")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2588,8 +2588,12 @@ struct VMLibraryViewModelTests {
 
     /// A resolved image nothing on this Mac can already be sitting at, so a
     /// dispatch test never reads a file out of the real Downloads folder.
+    ///
+    /// The URL is what varies: the destination is named for it, not for the
+    /// name the source gives the ISO.
     private func makeUnusedResolvedImage() -> ResolvedLinuxImage {
-        makeResolvedLinuxImage(filename: "kernova-test-\(UUID().uuidString).iso")
+        makeResolvedLinuxImage(
+            isoURLString: "https://mirror.example/kernova-test-\(UUID().uuidString).iso")
     }
 
     /// A stopped Linux VM with a pending catalog download, registered in

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -938,7 +938,7 @@ struct VMLifecycleCoordinatorTests {
             on: instance, context: LinuxInstallContext(source: .catalogEntry(entry)))
 
         let expected = fixture.downloads.appendingPathComponent(
-            fixture.resolveService.resolveResult.filename)
+            fixture.resolveService.resolveResult.destinationFilename)
         #expect(fixture.resolveService.resolveCallCount == 1)
         #expect(fixture.resolveService.lastResolvedEntry == entry)
         #expect(fixture.downloadService.lastDownloadRemoteURL == fixture.resolveService.resolveResult.isoURL)
@@ -955,7 +955,9 @@ struct VMLifecycleCoordinatorTests {
         #expect(disks[0].path == expected.path(percentEncoded: false))
         #expect(disks[0].readOnly)
         #expect(disks[0].kind == .usbMassStorage)
-        #expect(disks[0].label == expected.deletingPathExtension().lastPathComponent)
+        // Labelled for the image the mirror published, not for the
+        // discriminated filename the bytes landed in.
+        #expect(disks[0].label == "debian-13.6.0-arm64-netinst")
         #expect(disks[1].label == "Main Disk")
         #expect(disks[1].isInternal)
 
@@ -1000,7 +1002,7 @@ struct VMLifecycleCoordinatorTests {
         }
 
         let expected = fixture.downloads.appendingPathComponent(
-            fixture.resolveService.resolveResult.filename)
+            fixture.resolveService.resolveResult.destinationFilename)
         #expect(
             instance.configuration.linuxInstallContext?.downloadDestinationPath
                 == expected.path(percentEncoded: false))
@@ -1022,7 +1024,7 @@ struct VMLifecycleCoordinatorTests {
         try await fixture.coordinator.downloadLinuxImage(on: instance, context: context)
 
         let expected = fixture.downloads.appendingPathComponent(
-            fixture.resolveService.resolveResult.filename)
+            fixture.resolveService.resolveResult.destinationFilename)
         #expect(fixture.downloadService.lastDownloadDestinationURL == expected)
         // The partial at the abandoned path can never be resumed, so it goes
         // before the only pointer to it moves.
@@ -1038,7 +1040,9 @@ struct VMLifecycleCoordinatorTests {
             persisted: URL(fileURLWithPath: "/Users/Shared/old.iso"), filename: "debian.iso")
         #expect(derived == fixture.downloads.appendingPathComponent("debian.iso"))
 
-        // With normalization disabled the persisted path is all there is.
+        // With normalization disabled the persisted path is all there is, and
+        // it is taken only while it still names an ISO: the download writes
+        // over it and a digest failure trashes it.
         let unnormalized = VMLifecycleCoordinator(
             virtualizationService: MockVirtualizationService(),
             installService: MockMacOSInstallService(),
@@ -1051,6 +1055,10 @@ struct VMLifecycleCoordinatorTests {
             unnormalized.linuxDownloadDestination(persisted: persisted, filename: "debian.iso")
                 == persisted)
         #expect(unnormalized.linuxDownloadDestination(persisted: nil, filename: "debian.iso") == nil)
+        #expect(
+            unnormalized.linuxDownloadDestination(
+                persisted: URL(fileURLWithPath: "/Users/Shared/notes.txt"), filename: "debian.iso")
+                == nil)
     }
 
     @Test("A checksum mismatch trashes the image, discards its bundle, and keeps the context")
@@ -1065,11 +1073,13 @@ struct VMLifecycleCoordinatorTests {
         let instance = makeLinuxInstance(context: context)
 
         let expected = fixture.downloads.appendingPathComponent(
-            fixture.resolveService.resolveResult.filename)
+            fixture.resolveService.resolveResult.destinationFilename)
         do {
             try await fixture.coordinator.downloadLinuxImage(on: instance, context: context)
             Issue.record("Expected checksumMismatch")
         } catch DownloadError.checksumMismatch(let filename, let expected, let actual) {
+            // The name the mirror published, which is what the user is shown —
+            // not the discriminated name the bytes were written to.
             #expect(filename == fixture.resolveService.resolveResult.filename)
             // The digest the manifest stated, against what the bytes hash to.
             #expect(expected == fixture.resolveService.resolveResult.sha256)
@@ -1094,7 +1104,7 @@ struct VMLifecycleCoordinatorTests {
         // when a completed file with no resumable bundle is already there.
         fixture.downloadService.downloadedContents = nil
         let destination = fixture.downloads.appendingPathComponent(
-            fixture.resolveService.resolveResult.filename)
+            fixture.resolveService.resolveResult.destinationFilename)
         try Data("not the image the mirror published".utf8).write(to: destination)
 
         let context = LinuxInstallContext(source: .catalogEntry(makeLinuxCatalogEntry()))
@@ -1108,24 +1118,50 @@ struct VMLifecycleCoordinatorTests {
         #expect(instance.configuration.storageDisks == nil)
     }
 
-    @Test("downloadLinuxImage forwards requestedFreshDownload and clears it before downloading")
-    func downloadLinuxImageForwardsFreshDownload() async throws {
+    @Test("A file already in Downloads under the mirror's own name is never touched")
+    func downloadLinuxImageLeavesACollidingFileAlone() async throws {
         let fixture = try makeLinuxFixture()
         defer { try? FileManager.default.removeItem(at: fixture.downloads) }
-        // Read on the failure path: a successful run clears the whole context.
-        fixture.downloadService.downloadError = DownloadError.downloadFailed(
-            URLError(.notConnectedToInternet))
-        let context = LinuxInstallContext(
-            source: .catalogEntry(makeLinuxCatalogEntry()), requestedFreshDownload: true)
+        // The mirror names its ISO after a file the user already has. Nothing
+        // the mirror chooses may decide which file is downloaded over, adopted
+        // in place of a download, or trashed for failing a digest.
+        let resolved = fixture.resolveService.resolveResult
+        let usersFile = fixture.downloads.appendingPathComponent(resolved.filename)
+        let usersBytes = Data("the user's own ISO".utf8)
+        try usersBytes.write(to: usersFile)
+        let context = LinuxInstallContext(source: .catalogEntry(makeLinuxCatalogEntry()))
+        let instance = makeLinuxInstance(context: context)
+
+        try await fixture.coordinator.downloadLinuxImage(on: instance, context: context)
+
+        let written = fixture.downloads.appendingPathComponent(resolved.destinationFilename)
+        #expect(fixture.downloadService.lastDownloadDestinationURL == written)
+        #expect(try Data(contentsOf: usersFile) == usersBytes)
+        #expect(fixture.fileSystem.trashedURLs.isEmpty)
+        #expect(
+            instance.configuration.storageDisks?.first?.path
+                == written.path(percentEncoded: false))
+    }
+
+    @Test("A digest failure trashes only the file the download wrote")
+    func downloadLinuxImageMismatchSparesACollidingFile() async throws {
+        let fixture = try makeLinuxFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.downloads) }
+        fixture.resolveService.resolveResult = makeResolvedLinuxImage(
+            sha256: String(repeating: "a", count: 64))
+        let resolved = fixture.resolveService.resolveResult
+        let usersFile = fixture.downloads.appendingPathComponent(resolved.filename)
+        try Data("the user's own ISO".utf8).write(to: usersFile)
+        let context = LinuxInstallContext(source: .catalogEntry(makeLinuxCatalogEntry()))
         let instance = makeLinuxInstance(context: context)
 
         await #expect(throws: DownloadError.self) {
             try await fixture.coordinator.downloadLinuxImage(on: instance, context: context)
         }
 
-        #expect(fixture.downloadService.lastDownloadDiscardsExisting == true)
-        // Spent once, so the retry resumes the partial instead of trashing it.
-        #expect(instance.configuration.linuxInstallContext?.requestedFreshDownload == false)
+        #expect(
+            fixture.fileSystem.trashedURLs
+                == [fixture.downloads.appendingPathComponent(resolved.destinationFilename)])
     }
 
     @Test("downloadLinuxImage throws CancellationError from the resolve step and keeps the context")
@@ -1232,7 +1268,7 @@ struct VMLifecycleCoordinatorTests {
         #expect(fixture.resolveService.lastResolvedCustomImage?.sha256 == fixture.digest)
         #expect(fixture.resolveService.lastResolvedEntry == nil)
         let expected = fixture.downloads.appendingPathComponent(
-            fixture.resolveService.resolveResult.filename)
+            fixture.resolveService.resolveResult.destinationFilename)
         #expect(fixture.downloadService.lastDownloadDestinationURL == expected)
         #expect(instance.configuration.storageDisks?.first?.path == expected.path(percentEncoded: false))
         #expect(instance.configuration.linuxInstallContext == nil)
@@ -1286,7 +1322,7 @@ struct VMLifecycleCoordinatorTests {
 
         // Left in place it would satisfy the skip-existing fast path forever.
         let expected = fixture.downloads.appendingPathComponent(
-            fixture.resolveService.resolveResult.filename)
+            fixture.resolveService.resolveResult.destinationFilename)
         #expect(fixture.fileSystem.trashedURLs == [expected])
         #expect(instance.configuration.storageDisks == nil)
         // The intent survives for the next Start, its destination now persisted.


### PR DESCRIPTION
Closes #727

## Summary

The Linux download destination came from the resolved manifest entry, so a mirror named the file that landed in `~/Downloads`. Two disposal paths act on whatever sits at that name: a digest mismatch trashes it, and `DownloadBundle.finalize` permanently removes a file that appears there between the skip-existing check and finalization. A mirror naming its image after a file the user already has could therefore get that file trashed or replaced — and, where no digest is published, get the user's own file installed in place of the image they chose.

Every Linux ISO now downloads to a name derived from the URL it resolved to, through the `UniqueDownloadFilename` discriminator that already ships. Nothing a mirror or a hand-edited `config.json` chose reaches the filesystem, so a collision with a user's file is no longer expressible.

## The route taken

The pasted-URL source already generated its destination this way (`CustomLinuxImage.destinationFilename()`); only the catalog source passed the mirror's name straight through. Rather than uniquify the catalog name in the resolve service and leave two spellings of one rule, the naming moved into `LinuxImageFilename` — the Linux counterpart to the existing `RestoreImageFilename` — and both sources go through it.

That made the split on `ResolvedLinuxImage` worth making explicit:

| | Was | Now |
|---|---|---|
| `filename` | catalog: mirror's name; URL: generated name | the name the source gives the ISO, both paths |
| `destinationFilename` | — | computed from `isoURL`, the only thing written |

Computed rather than stored, so a `ResolvedLinuxImage` cannot be constructed with a source-named destination.

Keeping `filename` honest pays for itself in what the user sees: the checksum-mismatch alert names the image the mirror published rather than a hex-suffixed filename, and the attached installer disk is labelled `debian-13.6.0-arm64-netinst` instead of `debian-13.6.0-arm64-netinst-1a2b3c4d`. The wizard's "Save to" row still shows the real destination — that one is about where the bytes go.

## `requestedFreshDownload`

Deleted, along with the honored-once block in `downloadLinuxImage` (per the follow-up on #727, the flag had to be either wired to a prompt or removed with the block).

`VMCreationViewModel.buildLinuxInstallContext` never set it, so the block — including its non-ISO refusal — was unreachable in the shipped flow. Wiring it to a prompt was the alternative, and it has nothing to prompt about: with the destination named for the URL, a file already there is what a prior attempt at this same image fetched. Adopting it is correct, and the verify step holds it to the same digest a fresh download would face. The macOS path keeps its flag, its wizard warning, and its `Downloading.discardsExistingDownload` argument — its destinations are app-derived but predictable, so an existing file there plausibly is the user's own.

## The picker's "In Downloads" column

Renaming the destination broke a shipped column, and three reviews converged on it. The distribution picker globs Downloads filenames against `entry.isoPattern`, which the discriminated name can never satisfy — so the column went blank for exactly the images this app downloaded, while still firing on a file the user fetched themselves, which no download will now find or adopt.

Each name is now read back through the naming rule (`sourceFilename`, the partial inverse of `destination`) and then re-derived against that entry's own `directoryURL`. Both halves are load-bearing: the read-back rejects a user's own ISO, and the round-trip rejects an identically-named image fetched from a different mirror or pasted as a URL, whose discriminator differs and which a download would not adopt either.

What the column still cannot say is whether the *next* download will skip — which point release the mirror serves now is only a resolution's answer, and the sheet reaches no network. That imprecision predates this change (the old glob had it too) and is recorded on `downloadedEntryIDs` rather than fixed: the column states what is on disk.

## Rejected alternatives

- **Refuse the fast path when the existing file predates the download attempt** (the issue's other candidate). Timestamps are the wrong primitive here — it does not stop a mirror from naming its ISO after the user's file, only from adopting one, and it leaves the trash-on-mismatch path fully exposed.
- **Uniquify inside `LinuxImageResolveService.resolve(entry)` and leave `ResolvedLinuxImage` alone.** Smaller diff, but it conflates "what the file is called" with "where it goes" and pushes the hex suffix into the mismatch alert and the disk label.
- **Hard-code the `-<8 hex>` shape in the picker.** Restates in a view a rule that belongs beside the constant generating it.

## Test plan

- [x] `make test` — full suite green (2264 XCTest cases, 123 Swift Testing tests, 0 failures)
- [x] `make lint` — swift-format strict, shell scripts, docs
- [x] A file in Downloads under the mirror's own name is untouched on both the success path and the digest-failure path (`VMLifecycleCoordinatorTests`)
- [x] `LinuxImageFilenameTests` — uniqueness per URL, stability for one URL (so a download stays resumable), single-component output for a percent-encoded escaping name, default stem, round-trip recovery, and seven name shapes it refuses
- [x] Picker column: this app's own download reads "In Downloads"; a user's own ISO, the same image from another mirror, a pasted-URL download, and a partial `.kernovadownload` all do not
- [x] Catalog and pasted-URL resolutions both assert `destinationFilename != filename` (`LinuxImageResolveTests`)

Not exercised against a live mirror — no multi-GB download was run; the naming is verified at the seams the pipeline actually uses.

## Notes

No `RATIONALE:` comments added.

`LinuxInstallContext` drops a persisted field. Per the persisted-data rule this is a removal, not a migration: the key is simply no longer read, and no shim decodes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)