### PR TITLE
fix: Report every file a copy lost, not just the ones lost after the poll

### DIFF
--- a/Kernova/Services/ClipboardPassthroughCoordinator.swift
+++ b/Kernova/Services/ClipboardPassthroughCoordinator.swift
@@ -161,25 +161,20 @@ final class ClipboardPassthroughCoordinator {
         switch ClipboardPasteboardIntake.read(from: pasteboard, allowsBinary: allowsBinary) {
         case .content(let content, let note):
             offer(content, note: note, to: service)
-        case .pendingFiles(let urls):
-            resolveAndForward(urls, allowsBinary: allowsBinary)
-        case .rejected:
-            // Every rejection here is a verdict that the pasteboard holds
-            // nothing shareable — an empty clipboard, a privacy marker, a
-            // text-only transport — so there is no failure to report. The
-            // rejection in `resolveAndForward` is the other kind: items were
-            // there and could not be read.
-            break
+        case .pendingFiles(let urls, let unresolved):
+            resolveAndForward(urls, unresolved: unresolved, allowsBinary: allowsBinary)
+        case .rejected(let message, let unreadable):
+            report(rejection: message, unreadable: unreadable, to: service)
         }
     }
 
     /// Resolves copied files/folders off the main actor (the stat and folder
     /// estimate walk are I/O), then offers them to the current service on the
     /// way back.
-    private func resolveAndForward(_ urls: [URL], allowsBinary: Bool) {
+    private func resolveAndForward(_ urls: [URL], unresolved: Int, allowsBinary: Bool) {
         Task { @MainActor [weak self] in
             let resolved = await ClipboardPasteboardIntake.read(
-                filesAt: urls, allowsBinary: allowsBinary)
+                filesAt: urls, unresolved: unresolved, allowsBinary: allowsBinary)
             guard let self else { return }
             #if DEBUG
             defer { self.onForwardResolvedForTesting?() }
@@ -189,17 +184,25 @@ final class ClipboardPassthroughCoordinator {
             switch resolved {
             case .content(let content, let note):
                 self.offer(content, note: note, to: service)
-            case .rejected(let message):
-                // Every copied item failed, so nothing is forwarded — the total
-                // of the partial case below, and owed the same report. A
-                // text-only transport is exempt: it rejects *every* file copy by
-                // design, so reporting here would fire on each one.
-                guard allowsBinary else { return }
-                self.reportUnforwarded(message, to: service)
+            case .rejected(let message, let unreadable):
+                self.report(rejection: message, unreadable: unreadable, to: service)
             case .pendingFiles:
                 break
             }
         }
+    }
+
+    /// Raises a rejection only when it means content was there and could not be
+    /// read.
+    ///
+    /// A policy verdict — an empty clipboard, a privacy marker, a text-only
+    /// transport refusing a file copy — leaves nothing to report, and the
+    /// text-only one would otherwise fire on every file the user copies.
+    private func report(
+        rejection message: String, unreadable: Bool, to service: any ClipboardServicing
+    ) {
+        guard unreadable else { return }
+        reportUnforwarded(message, to: service)
     }
 
     /// Offers intake output to the guest, raising the intake's skip note when it

--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -718,8 +718,8 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
         guard let service = instance.clipboardService else { return }
         let allowsBinary = service.supportsBinaryRepresentations
         let result = ClipboardPasteboardIntake.read(from: pasteboard, allowsBinary: allowsBinary)
-        if case .pendingFiles(let urls) = result {
-            resolveAndApply(pendingFiles: urls, allowsBinary: allowsBinary)
+        if case .pendingFiles(let urls, let unresolved) = result {
+            resolveAndApply(pendingFiles: urls, unresolved: unresolved, allowsBinary: allowsBinary)
         } else {
             _ = apply(intake: result)
         }
@@ -727,10 +727,10 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
 
     /// Resolves `.pendingFiles` URLs off the main actor and applies the result
     /// on the way back.
-    private func resolveAndApply(pendingFiles urls: [URL], allowsBinary: Bool) {
+    private func resolveAndApply(pendingFiles urls: [URL], unresolved: Int, allowsBinary: Bool) {
         Task { @MainActor [weak self] in
             let resolved = await ClipboardPasteboardIntake.read(
-                filesAt: urls, allowsBinary: allowsBinary)
+                filesAt: urls, unresolved: unresolved, allowsBinary: allowsBinary)
             _ = self?.apply(intake: resolved)
         }
     }
@@ -749,7 +749,7 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
                 "Took in pasteboard content (\(content.representations.count, privacy: .public) reps, \(content.totalByteCount, privacy: .public) bytes)"
             )
             return true
-        case .rejected(let message):
+        case .rejected(let message, _):
             indicatorView.showTransientMessage(message, style: .warning)
             Self.logger.info("Pasteboard intake rejected: \(message, privacy: .public)")
             return false
@@ -783,10 +783,10 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
         switch result {
         case .content:
             return apply(intake: result)
-        case .pendingFiles(let urls):
+        case .pendingFiles(let urls, let unresolved):
             // Accept the drop now; resolve the files/folders off the main actor
             // (the dragging pasteboard was already consumed synchronously above).
-            resolveAndApply(pendingFiles: urls, allowsBinary: allowsBinary)
+            resolveAndApply(pendingFiles: urls, unresolved: unresolved, allowsBinary: allowsBinary)
             return true
         case .rejected:
             if let receiver = pasteboard.readObjects(forClasses: [NSFilePromiseReceiver.self])?

--- a/Kernova/Views/Clipboard/ClipboardPasteboardIntake.swift
+++ b/Kernova/Views/Clipboard/ClipboardPasteboardIntake.swift
@@ -10,13 +10,20 @@ enum ClipboardIntakeResult: Equatable, Sendable {
     /// its PNG sibling survived).
     case content(ClipboardContent, note: String?)
     /// Nothing usable; `message` says why in user-facing terms.
-    case rejected(message: String)
-    /// One or more files resolved on disk whose bytes still have to be read off
-    /// the main actor via `read(filesAt:)` before they become `.content`.
     ///
-    /// Several URLs, in pasteboard order, for a multi-select copy/drag. Never
-    /// applied directly.
-    case pendingFiles([URL])
+    /// `unreadable` is `true` only when representations were present and could
+    /// not be read — a loss the user is owed a report for. A policy verdict (an
+    /// empty clipboard, a privacy marker, a text-only transport refusing a file)
+    /// is `false`: nothing was there to lose.
+    case rejected(message: String, unreadable: Bool)
+    /// Files whose bytes still have to be read off the main actor via
+    /// `read(filesAt:)` before they become `.content`.
+    ///
+    /// Several URLs, in pasteboard order, for a multi-select copy/drag.
+    /// `unresolved` counts the copied files that no longer exist, so
+    /// `read(filesAt:)` can report them alongside the ones it fails itself.
+    /// Never applied directly.
+    case pendingFiles([URL], unresolved: Int)
 }
 
 /// The single intake path for every host-side gesture that feeds the
@@ -43,7 +50,7 @@ enum ClipboardPasteboardIntake {
     /// text representations are only the file's descriptor and are never returned.
     static func read(from pasteboard: NSPasteboard, allowsBinary: Bool) -> ClipboardIntakeResult {
         guard let items = pasteboard.pasteboardItems, let item = items.first else {
-            return .rejected(message: "The Mac clipboard is empty")
+            return .rejected(message: "The Mac clipboard is empty", unreadable: false)
         }
 
         // Decided from the unfiltered type list, before any representation is
@@ -51,21 +58,29 @@ enum ClipboardPasteboardIntake {
         // can be pasted into the guest, but flagged so the window hides it.
         let disposition = ClipboardSnapshotPolicy.disposition(forTypes: item.types.map(\.rawValue))
         if case .suppress(let reason) = disposition {
-            return .rejected(message: Self.suppressionMessage(for: reason))
+            return .rejected(message: Self.suppressionMessage(for: reason), unreadable: false)
         }
         let isConcealed = disposition == .conceal
 
         // Defer files so the caller reads each off the main actor via
         // `read(filesAt:)` — a large file mustn't block the UI. Only file
         // enumeration spans items; the inline snapshot below stays item-0-scoped.
-        let fileURLs = items.compactMap { existingFileURL(in: $0) }
-        if !fileURLs.isEmpty {
-            return .pendingFiles(fileURLs)
+        var fileURLs: [URL] = []
+        var unresolvedFiles = 0
+        for candidate in items {
+            switch fileURLResolution(in: candidate) {
+            case .resolved(let url): fileURLs.append(url)
+            case .vanished: unresolvedFiles += 1
+            case .notAFile: break
+            }
+        }
+        if !fileURLs.isEmpty || unresolvedFiles > 0 {
+            return .pendingFiles(fileURLs, unresolved: unresolvedFiles)
         }
 
         guard allowsBinary else {
             guard let text = item.string(forType: .string), !text.isEmpty else {
-                return .rejected(message: Self.textOnlyTransportMessage)
+                return .rejected(message: Self.textOnlyTransportMessage, unreadable: false)
             }
             return .content(ClipboardContent(text: text, isConcealed: isConcealed), note: nil)
         }
@@ -75,13 +90,13 @@ enum ClipboardPasteboardIntake {
         // Identity-based skips run before any data is read. A file/promise drag
         // additionally drops the URL/path text fallbacks, so a file drag can never
         // surface its path as text content.
-        let raw: [(uti: String, data: Data)] = item.types.compactMap { type in
+        let qualified = item.types.filter { type in
             guard !ClipboardSnapshotPolicy.shouldSkipBeforeReading(uti: type.rawValue) else {
-                return nil
+                return false
             }
-            if isFileOrPromiseDrag && isPathFallbackType(type.rawValue) {
-                return nil
-            }
+            return !(isFileOrPromiseDrag && isPathFallbackType(type.rawValue))
+        }
+        let raw: [(uti: String, data: Data)] = qualified.compactMap { type in
             guard let data = item.data(forType: type) else { return nil }
             return (uti: type.rawValue, data: data)
         }
@@ -95,7 +110,12 @@ enum ClipboardPasteboardIntake {
         }
 
         guard !outcome.content.isEmpty else {
-            return .rejected(message: "The Mac clipboard has no shareable content")
+            // A qualifying type whose `data(forType:)` came back nil is content
+            // the pasteboard held and would not hand over — a loss, unlike a
+            // snapshot that never had anything shareable in it.
+            return .rejected(
+                message: "The Mac clipboard has no shareable content",
+                unreadable: raw.count < qualified.count)
         }
 
         // `evaluate` builds non-concealed content; re-stamp the concealed flag
@@ -120,12 +140,23 @@ enum ClipboardPasteboardIntake {
         }
     }
 
-    /// A concrete `public.file-url` or a `promised-file-url` that already
-    /// points at an on-disk file.
-    ///
-    /// `nil` when neither resolves to an existing file — e.g. a promise whose
-    /// file hasn't been written yet, which the caller receives asynchronously.
-    private static func existingFileURL(in item: NSPasteboardItem) -> URL? {
+    /// What one pasteboard item contributes to the file enumeration.
+    private enum FileURLResolution {
+        /// A concrete `public.file-url` or a `promised-file-url` that already
+        /// points at an on-disk file.
+        case resolved(URL)
+        /// The item names a `public.file-url` that resolves to nothing today —
+        /// a copy whose file was deleted, renamed, or unmounted since. The
+        /// bytes are gone, so the item is a loss the caller has to count.
+        case vanished
+        /// No concrete file URL: a plain snapshot, or a promise whose file
+        /// hasn't been written yet and which the caller receives asynchronously.
+        case notAFile
+    }
+
+    /// Classifies an item's file URLs, separating a copy that lost its file
+    /// from one that never named a file.
+    private static func fileURLResolution(in item: NSPasteboardItem) -> FileURLResolution {
         let candidates: [NSPasteboard.PasteboardType] = [
             .fileURL,
             NSPasteboard.PasteboardType("com.apple.pasteboard.promised-file-url"),
@@ -135,9 +166,9 @@ enum ClipboardPasteboardIntake {
                 let url = URL(string: string), url.isFileURL,
                 FileManager.default.fileExists(atPath: url.path)
             else { continue }
-            return url
+            return .resolved(url)
         }
-        return nil
+        return item.types.contains(.fileURL) ? .vanished : .notAFile
     }
 
     /// `true` for the types that mark a drag as a file or file promise.
@@ -162,14 +193,18 @@ enum ClipboardPasteboardIntake {
     /// `.directory` source representation carrying a stat-walk size estimate; no
     /// archive is built until a paste requests the rep. An item that fails is
     /// skipped and noted; if *every* item fails, `.rejected`.
+    ///
+    /// `unresolved` is the count `read(from:)` already dropped for having no
+    /// file left on disk, folded into the same note so one report covers every
+    /// item the copy lost on either side of the actor hop.
     nonisolated static func read(
-        filesAt urls: [URL], allowsBinary: Bool
+        filesAt urls: [URL], unresolved: Int = 0, allowsBinary: Bool
     ) async -> ClipboardIntakeResult {
         guard allowsBinary else {
-            return .rejected(message: Self.textOnlyTransportMessage)
+            return .rejected(message: Self.textOnlyTransportMessage, unreadable: false)
         }
         var representations: [ClipboardContent.Representation] = []
-        var skipped = 0
+        var skipped = unresolved
         for url in urls {
             var isDirectory: ObjCBool = false
             guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
@@ -188,8 +223,9 @@ enum ClipboardPasteboardIntake {
         }
         guard !representations.isEmpty else {
             return .rejected(
-                message: urls.count > 1
-                    ? "Couldn't read the dropped items" : "Couldn't read the dropped item")
+                message: skipped > 1
+                    ? "Couldn't read the dropped items" : "Couldn't read the dropped item",
+                unreadable: true)
         }
         let note =
             skipped > 0 ? "Skipped \(skipped) unreadable item\(skipped == 1 ? "" : "s")" : nil

--- a/Kernova/Views/Clipboard/ClipboardPasteboardIntake.swift
+++ b/Kernova/Views/Clipboard/ClipboardPasteboardIntake.swift
@@ -44,7 +44,7 @@ enum ClipboardPasteboardIntake {
     ///
     /// Files already on disk are expanded across *every* item, each becoming its
     /// own filename-tagged representation; the inline snapshot reads item 0 and is
-    /// taken only when no item is a file.
+    /// taken only when no item resolved to a file on disk.
     ///
     /// When a file URL or promise is present but no file is readable, the URL/path
     /// text representations are only the file's descriptor and are never returned.
@@ -67,19 +67,30 @@ enum ClipboardPasteboardIntake {
         // enumeration spans items; the inline snapshot below stays item-0-scoped.
         var fileURLs: [URL] = []
         var unresolvedFiles = 0
-        for candidate in items {
+        var firstItemVanished = false
+        for (index, candidate) in items.enumerated() {
             switch fileURLResolution(in: candidate) {
             case .resolved(let url): fileURLs.append(url)
-            case .vanished: unresolvedFiles += 1
+            case .vanished:
+                unresolvedFiles += 1
+                if index == 0 { firstItemVanished = true }
             case .notAFile: break
             }
         }
-        if !fileURLs.isEmpty || unresolvedFiles > 0 {
+        if !fileURLs.isEmpty {
             return .pendingFiles(fileURLs, unresolved: unresolvedFiles)
         }
+        // No file survived, but an item that lost its file can still carry an
+        // inline flavor to be served from — `HostClipboardPublisher` pairs an
+        // image UTI with `.fileURL` for exactly that fallback. So a vanished
+        // count travels *through* the inline read below rather than
+        // short-circuiting it.
 
         guard allowsBinary else {
-            guard let text = item.string(forType: .string), !text.isEmpty else {
+            // A file copy's path text is the file's descriptor, not content, and
+            // a text-only transport refuses file copies by policy either way.
+            guard unresolvedFiles == 0, let text = item.string(forType: .string), !text.isEmpty
+            else {
                 return .rejected(message: Self.textOnlyTransportMessage, unreadable: false)
             }
             return .content(ClipboardContent(text: text, isConcealed: isConcealed), note: nil)
@@ -110,6 +121,12 @@ enum ClipboardPasteboardIntake {
         }
 
         guard !outcome.content.isEmpty else {
+            guard unresolvedFiles == 0 else {
+                // Every file the copy named is gone and no inline flavor stood in
+                // for one — the same total loss `read(filesAt:)` reports.
+                return .rejected(
+                    message: Self.unreadableItemsMessage(count: unresolvedFiles), unreadable: true)
+            }
             // A qualifying type whose `data(forType:)` came back nil is content
             // the pasteboard held and would not hand over — a loss, unlike a
             // snapshot that never had anything shareable in it.
@@ -118,9 +135,16 @@ enum ClipboardPasteboardIntake {
                 unreadable: raw.count < qualified.count)
         }
 
+        // The inline snapshot is item-0-scoped, so surviving content stands in
+        // for item 0's own vanished file — the dual-flavor image is that case.
+        // Files on the *other* items had nothing to stand in for them.
+        let reportedLosses = unresolvedFiles - (firstItemVanished ? 1 : 0)
+
         // `evaluate` builds non-concealed content; re-stamp the concealed flag
         // when the marker called for it.
-        return .content(outcome.content.withConcealed(isConcealed), note: nil)
+        return .content(
+            outcome.content.withConcealed(isConcealed),
+            note: Self.skipNote(forSkipped: reportedLosses))
     }
 
     /// The user-facing reason a snapshot was dropped wholesale by an
@@ -145,30 +169,50 @@ enum ClipboardPasteboardIntake {
         /// A concrete `public.file-url` or a `promised-file-url` that already
         /// points at an on-disk file.
         case resolved(URL)
-        /// The item names a `public.file-url` that resolves to nothing today —
-        /// a copy whose file was deleted, renamed, or unmounted since. The
-        /// bytes are gone, so the item is a loss the caller has to count.
+        /// The item handed over a concrete `public.file-url` that resolves to
+        /// nothing today — a copy whose file was deleted, renamed, or unmounted
+        /// since. The bytes are gone, so the item is a loss the caller counts.
         case vanished
-        /// No concrete file URL: a plain snapshot, or a promise whose file
-        /// hasn't been written yet and which the caller receives asynchronously.
+        /// No concrete file URL: a plain snapshot, a promise whose file hasn't
+        /// been written yet and which the caller receives asynchronously, or an
+        /// item whose file-URL provider declined to vend one.
         case notAFile
     }
 
     /// Classifies an item's file URLs, separating a copy that lost its file
     /// from one that never named a file.
+    ///
+    /// `.vanished` needs a `public.file-url` that *decoded* and then missed:
+    /// declaring the type is not enough, because a lazy provider may vend no
+    /// URL at all while the item's inline flavors remain readable.
     private static func fileURLResolution(in item: NSPasteboardItem) -> FileURLResolution {
         let candidates: [NSPasteboard.PasteboardType] = [
             .fileURL,
             NSPasteboard.PasteboardType("com.apple.pasteboard.promised-file-url"),
         ]
+        var missedConcreteURL = false
         for type in candidates {
             guard let string = item.string(forType: type),
-                let url = URL(string: string), url.isFileURL,
-                FileManager.default.fileExists(atPath: url.path)
+                let url = URL(string: string), url.isFileURL
             else { continue }
-            return .resolved(url)
+            if FileManager.default.fileExists(atPath: url.path) { return .resolved(url) }
+            // Only `public.file-url` asserts the file exists now; a promise's is
+            // an address for a file still to be written.
+            if type == .fileURL { missedConcreteURL = true }
         }
-        return item.types.contains(.fileURL) ? .vanished : .notAFile
+        // A promise can still deliver through `NSFilePromiseReceiver`, so a
+        // missed URL is not a loss while one is advertised.
+        guard missedConcreteURL, !promisesFile(item) else { return .notAFile }
+        return .vanished
+    }
+
+    /// `true` when the item advertises a file promise, whose asynchronous
+    /// receipt can still produce the file.
+    private static func promisesFile(_ item: NSPasteboardItem) -> Bool {
+        item.types.contains {
+            $0.rawValue.hasPrefix("com.apple.pasteboard.promised-file")
+                || $0.rawValue.hasPrefix("com.apple.NSFilePromise")
+        }
     }
 
     /// `true` for the types that mark a drag as a file or file promise.
@@ -223,13 +267,23 @@ enum ClipboardPasteboardIntake {
         }
         guard !representations.isEmpty else {
             return .rejected(
-                message: skipped > 1
-                    ? "Couldn't read the dropped items" : "Couldn't read the dropped item",
-                unreadable: true)
+                message: Self.unreadableItemsMessage(count: skipped), unreadable: true)
         }
-        let note =
-            skipped > 0 ? "Skipped \(skipped) unreadable item\(skipped == 1 ? "" : "s")" : nil
-        return .content(ClipboardContent(representations: representations), note: note)
+        return .content(
+            ClipboardContent(representations: representations),
+            note: Self.skipNote(forSkipped: skipped))
+    }
+
+    /// The note shown when a copy went through with `count` of its items lost,
+    /// or `nil` when none were.
+    nonisolated private static func skipNote(forSkipped count: Int) -> String? {
+        guard count > 0 else { return nil }
+        return "Skipped \(count) unreadable item\(count == 1 ? "" : "s")"
+    }
+
+    /// The rejection shown when *every* item of a copy was lost.
+    nonisolated private static func unreadableItemsMessage(count: Int) -> String {
+        count > 1 ? "Couldn't read the dropped items" : "Couldn't read the dropped item"
     }
 
     /// Builds a disk-backed `.file` representation from a single file URL via a

--- a/KernovaTests/ClipboardPassthroughCoordinatorTests.swift
+++ b/KernovaTests/ClipboardPassthroughCoordinatorTests.swift
@@ -247,6 +247,61 @@ struct ClipboardPassthroughCoordinatorTests {
         )
     }
 
+    @Test("a file deleted before the poll reads the pasteboard is reported too")
+    func pollSurfacesPrePollLoss() async throws {
+        let h = makeHarness()
+        defer { h.pasteboard.releaseGlobally() }
+
+        let directory = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let kept = directory.appendingPathComponent("kept.txt")
+        let doomed = directory.appendingPathComponent("doomed.txt")
+        try Data("kept".utf8).write(to: kept)
+        try Data("doomed".utf8).write(to: doomed)
+        writeFileURLs([kept, doomed], to: h.pasteboard)
+
+        // The mirror of `pollSurfacesIntakeSkipNote`: deleting *before* the poll
+        // means the intake's existence check drops the item, not the off-actor
+        // stat. The user-visible loss is identical, so the report must be too.
+        try FileManager.default.removeItem(at: doomed)
+        h.coordinator.pollHostClipboard()
+
+        try await h.service.issueReported.wait { h.service.lastTransferIssue != nil }
+        #expect(h.service.grabbed.last?.representations.map(\.filename) == ["kept.txt"])
+        #expect(
+            h.service.lastTransferIssue?.kind
+                == .localFailure(
+                    code: ClipboardErrorCode.forwardItemsSkipped.rawValue,
+                    message: "Skipped 1 unreadable item")
+        )
+    }
+
+    @Test("a copy whose every file vanished before the poll surfaces the rejection")
+    func pollSurfacesPrePollWholeCopyLoss() async throws {
+        let h = makeHarness()
+        defer { h.pasteboard.releaseGlobally() }
+
+        let directory = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let doomed = directory.appendingPathComponent("doomed.txt")
+        try Data("doomed".utf8).write(to: doomed)
+        writeFileURLs([doomed], to: h.pasteboard)
+
+        // A stale clipboard — the copy's file already gone when passthrough
+        // connects and forwards the current clipboard whatever its age.
+        try FileManager.default.removeItem(at: doomed)
+        h.coordinator.pollHostClipboard()
+
+        try await h.service.issueReported.wait { h.service.lastTransferIssue != nil }
+        #expect(h.service.grabbed.isEmpty)
+        #expect(
+            h.service.lastTransferIssue?.kind
+                == .localFailure(
+                    code: ClipboardErrorCode.forwardItemsSkipped.rawValue,
+                    message: "Couldn't read the dropped item")
+        )
+    }
+
     @Test("a text-only transport's blanket file rejection is not reported")
     func pollStaysQuietForTextOnlyTransport() async throws {
         let h = makeHarness()

--- a/KernovaTests/ClipboardPasteboardIntakeTests.swift
+++ b/KernovaTests/ClipboardPasteboardIntakeTests.swift
@@ -53,8 +53,9 @@ struct ClipboardPasteboardIntakeTests {
     private func resolve(
         _ result: ClipboardIntakeResult, allowsBinary: Bool
     ) async -> ClipboardIntakeResult {
-        guard case .pendingFiles(let urls) = result else { return result }
-        return await ClipboardPasteboardIntake.read(filesAt: urls, allowsBinary: allowsBinary)
+        guard case .pendingFiles(let urls, let unresolved) = result else { return result }
+        return await ClipboardPasteboardIntake.read(
+            filesAt: urls, unresolved: unresolved, allowsBinary: allowsBinary)
     }
 
     // MARK: - Generic pasteboard reads
@@ -229,7 +230,7 @@ struct ClipboardPasteboardIntakeTests {
         write([(uti: UTType.png.identifier, data: try makePNG())], to: pasteboard)
 
         guard
-            case .rejected(let message) = ClipboardPasteboardIntake.read(
+            case .rejected(let message, _) = ClipboardPasteboardIntake.read(
                 from: pasteboard, allowsBinary: false)
         else {
             Issue.record("Expected rejection")
@@ -244,11 +245,34 @@ struct ClipboardPasteboardIntakeTests {
         write(
             [(uti: "org.nspasteboard.TransientType", data: Data([1]))], to: pasteboard)
 
-        guard case .rejected = ClipboardPasteboardIntake.read(from: pasteboard, allowsBinary: true)
+        guard
+            case .rejected(_, let unreadable) = ClipboardPasteboardIntake.read(
+                from: pasteboard, allowsBinary: true)
         else {
             Issue.record("Expected rejection")
             return
         }
+        // Nothing qualified, so nothing was lost — a verdict, not a failure.
+        #expect(unreadable == false)
+    }
+
+    @Test("a declared type the pasteboard won't hand over is rejected as unreadable")
+    func unreadableRepresentationRejectedAsLoss() {
+        // A type declared with no data and no owner to provide it: `data(forType:)`
+        // comes back nil, so content the clipboard advertised never crosses.
+        let pasteboard = makeScratchPasteboard()
+        pasteboard.clearContents()
+        pasteboard.declareTypes([NSPasteboard.PasteboardType(UTType.png.identifier)], owner: nil)
+
+        guard
+            case .rejected(let message, let unreadable) = ClipboardPasteboardIntake.read(
+                from: pasteboard, allowsBinary: true)
+        else {
+            Issue.record("Expected rejection")
+            return
+        }
+        #expect(message == "The Mac clipboard has no shareable content")
+        #expect(unreadable)
     }
 
     @Test("a large inline representation is kept (no size cap)")
@@ -290,13 +314,14 @@ struct ClipboardPasteboardIntakeTests {
         // The bytes are NOT read synchronously: read(from:) returns the URLs for
         // the caller to read off the main actor via read(filesAt:).
         guard
-            case .pendingFiles(let pending) = ClipboardPasteboardIntake.read(
+            case .pendingFiles(let pending, let unresolved) = ClipboardPasteboardIntake.read(
                 from: pasteboard, allowsBinary: true)
         else {
             Issue.record("Expected .pendingFiles")
             return
         }
         #expect(pending.map(\.path) == [url.path])
+        #expect(unresolved == 0)
     }
 
     @Test("read(from:) returns every item's file URL as .pendingFiles, in order")
@@ -312,13 +337,94 @@ struct ClipboardPasteboardIntakeTests {
         pasteboard.writeObjects([itemA, itemB])
 
         guard
-            case .pendingFiles(let urls) = ClipboardPasteboardIntake.read(
+            case .pendingFiles(let urls, _) = ClipboardPasteboardIntake.read(
                 from: pasteboard, allowsBinary: true)
         else {
             Issue.record("Expected .pendingFiles")
             return
         }
         #expect(urls.map(\.lastPathComponent) == ["a.txt", "b.txt"])
+    }
+
+    @Test("read(from:) counts a copied file that no longer exists as unresolved")
+    func readFromCountsVanishedFile() throws {
+        // The issue's case: three files copied, one deleted before the poll
+        // reads the pasteboard. The survivors are still forwarded, and the
+        // deleted one is carried as a count instead of being dropped silently.
+        let a = try makeTempFile(name: "a.txt", contents: Data("a".utf8))
+        let gone = try makeTempFile(name: "gone.txt", contents: Data("g".utf8))
+        let b = try makeTempFile(name: "b.txt", contents: Data("b".utf8))
+        let pasteboard = makeScratchPasteboard()
+        pasteboard.clearContents()
+        pasteboard.writeObjects(
+            [a, gone, b].map { url in
+                let item = NSPasteboardItem()
+                item.setString(url.absoluteString, forType: .fileURL)
+                return item
+            })
+        try FileManager.default.removeItem(at: gone)
+
+        guard
+            case .pendingFiles(let urls, let unresolved) = ClipboardPasteboardIntake.read(
+                from: pasteboard, allowsBinary: true)
+        else {
+            Issue.record("Expected .pendingFiles")
+            return
+        }
+        #expect(urls.map(\.lastPathComponent) == ["a.txt", "b.txt"])
+        #expect(unresolved == 1)
+    }
+
+    @Test("read(from:) defers to .pendingFiles even when every copied file is gone")
+    func readFromAllFilesVanished() throws {
+        let gone = try makeTempFile(name: "gone.txt", contents: Data("g".utf8))
+        let pasteboard = makeScratchPasteboard()
+        pasteboard.clearContents()
+        let item = NSPasteboardItem()
+        item.setString(gone.absoluteString, forType: .fileURL)
+        pasteboard.writeObjects([item])
+        try FileManager.default.removeItem(at: gone)
+
+        guard
+            case .pendingFiles(let urls, let unresolved) = ClipboardPasteboardIntake.read(
+                from: pasteboard, allowsBinary: true)
+        else {
+            Issue.record("Expected .pendingFiles")
+            return
+        }
+        #expect(urls.isEmpty)
+        #expect(unresolved == 1)
+    }
+
+    @Test("read(filesAt:) folds the unresolved count into the skip note")
+    func readFilesAtFoldsUnresolvedIntoNote() async throws {
+        let good = try makeTempFile(name: "good.txt", contents: Data("ok".utf8))
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-missing.txt")
+
+        guard
+            case .content(let content, let note) = await ClipboardPasteboardIntake.read(
+                filesAt: [good, missing], unresolved: 2, allowsBinary: true)
+        else {
+            Issue.record("Expected content")
+            return
+        }
+        #expect(content.representations.map(\.filename) == ["good.txt"])
+        // Two dropped before the actor hop plus the one that failed the stat.
+        #expect(note == "Skipped 3 unreadable items")
+    }
+
+    @Test("read(filesAt:) rejects on unresolved alone, with no URLs to stat")
+    func readFilesAtRejectsUnresolvedOnly() async {
+        guard
+            case .rejected(let message, let unreadable) = await ClipboardPasteboardIntake.read(
+                filesAt: [], unresolved: 2, allowsBinary: true)
+        else {
+            Issue.record("Expected rejection")
+            return
+        }
+        #expect(message == "Couldn't read the dropped items")
+        #expect(unreadable)
     }
 
     @Test("read(filesAt:) builds one ordered filename rep per file")
@@ -396,13 +502,16 @@ struct ClipboardPasteboardIntakeTests {
     func readFilesAtTextOnlyRejected() async throws {
         let a = try makeTempFile(name: "a.txt", contents: Data("a".utf8))
         guard
-            case .rejected(let message) = await ClipboardPasteboardIntake.read(
+            case .rejected(let message, let unreadable) = await ClipboardPasteboardIntake.read(
                 filesAt: [a], allowsBinary: false)
         else {
             Issue.record("Expected rejection")
             return
         }
         #expect(message == ClipboardPasteboardIntake.textOnlyTransportMessage)
+        // A policy refusal, not a read failure — the passthrough poll stays
+        // quiet for it rather than firing on every file the user copies.
+        #expect(unreadable == false)
     }
 
     @Test("dragged text file crosses as a disk-backed file representation (name + size)")
@@ -529,7 +638,7 @@ struct ClipboardPasteboardIntakeTests {
         pasteboard.writeObjects([item])
 
         guard
-            case .rejected(let message) = await resolve(
+            case .rejected(let message, _) = await resolve(
                 ClipboardPasteboardIntake.read(from: pasteboard, allowsBinary: false),
                 allowsBinary: false)
         else {

--- a/KernovaTests/ClipboardPasteboardIntakeTests.swift
+++ b/KernovaTests/ClipboardPasteboardIntakeTests.swift
@@ -375,7 +375,7 @@ struct ClipboardPasteboardIntakeTests {
         #expect(unresolved == 1)
     }
 
-    @Test("read(from:) defers to .pendingFiles even when every copied file is gone")
+    @Test("read(from:) reports a copy whose every file is gone and has no inline flavor")
     func readFromAllFilesVanished() throws {
         let gone = try makeTempFile(name: "gone.txt", contents: Data("g".utf8))
         let pasteboard = makeScratchPasteboard()
@@ -386,14 +386,91 @@ struct ClipboardPasteboardIntakeTests {
         try FileManager.default.removeItem(at: gone)
 
         guard
-            case .pendingFiles(let urls, let unresolved) = ClipboardPasteboardIntake.read(
+            case .rejected(let message, let unreadable) = ClipboardPasteboardIntake.read(
                 from: pasteboard, allowsBinary: true)
         else {
-            Issue.record("Expected .pendingFiles")
+            Issue.record("Expected a reported rejection")
             return
         }
-        #expect(urls.isEmpty)
-        #expect(unresolved == 1)
+        // Not "no shareable content", which the poll reads as nothing having
+        // been there: items were there and could not be read.
+        #expect(message == "Couldn't read the dropped item")
+        #expect(unreadable)
+    }
+
+    @Test("a vanished file URL never suppresses the item's inline image")
+    func vanishedFileURLKeepsInlineImage() throws {
+        // `HostClipboardPublisher` pairs an image UTI with `.fileURL` on one
+        // item precisely so the inline bytes can stand in once the staged file
+        // is swept. Classifying the item as a pure loss would defeat that.
+        let png = try makePNG()
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-swept.png")
+        let pasteboard = makeScratchPasteboard()
+        pasteboard.clearContents()
+        let item = NSPasteboardItem()
+        item.setData(png, forType: NSPasteboard.PasteboardType(UTType.png.identifier))
+        item.setString(missing.absoluteString, forType: .fileURL)
+        pasteboard.writeObjects([item])
+
+        guard
+            case .content(let content, let note) = ClipboardPasteboardIntake.read(
+                from: pasteboard, allowsBinary: true)
+        else {
+            Issue.record("Expected the inline image to survive the vanished file URL")
+            return
+        }
+        #expect(content.representations.count == 1)
+        #expect(UTType(content.representations[0].uti)?.conforms(to: .image) == true)
+        // The inline flavor *is* the item's content, so nothing was lost.
+        #expect(note == nil)
+    }
+
+    @Test("a vanished file on another item is still reported alongside item 0's content")
+    func vanishedFileOnLaterItemIsReported() throws {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-gone.txt")
+        let pasteboard = makeScratchPasteboard()
+        pasteboard.clearContents()
+        let textItem = NSPasteboardItem()
+        textItem.setData(Data("hello".utf8), forType: .string)
+        let fileItem = NSPasteboardItem()
+        fileItem.setString(missing.absoluteString, forType: .fileURL)
+        pasteboard.writeObjects([textItem, fileItem])
+
+        guard
+            case .content(_, let note) = ClipboardPasteboardIntake.read(
+                from: pasteboard, allowsBinary: true)
+        else {
+            Issue.record("Expected item 0's text to survive")
+            return
+        }
+        // The inline read is item-0-scoped, so item 1's file had nothing to
+        // stand in for it — a real loss, unlike the dual-flavor case above.
+        #expect(note == "Skipped 1 unreadable item")
+    }
+
+    @Test("a promise advertising a concrete file URL still takes the promise path")
+    func promiseWithConcreteURLStillRejects() {
+        // Declaring `.fileURL` must not divert a promise away from
+        // `NSFilePromiseReceiver`: `handleDrop` reaches that fallback only on a
+        // rejection.
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-unwritten.png")
+        let pasteboard = makeScratchPasteboard()
+        pasteboard.clearContents()
+        let item = NSPasteboardItem()
+        item.setString(missing.absoluteString, forType: .fileURL)
+        item.setString(
+            missing.absoluteString,
+            forType: NSPasteboard.PasteboardType("com.apple.pasteboard.promised-file-url"))
+        pasteboard.writeObjects([item])
+
+        guard case .rejected = ClipboardPasteboardIntake.read(from: pasteboard, allowsBinary: true)
+        else {
+            Issue.record("Expected a rejection so the promise receipt path runs")
+            return
+        }
     }
 
     @Test("read(filesAt:) folds the unresolved count into the skip note")


### PR DESCRIPTION
## Summary

A copied file loses its bytes in one of two places, and only the second was counted. `ClipboardPasteboardIntake.read(from:)` `compactMap`-ed away any item whose file URL no longer resolved, so it never reached `read(filesAt:)` — the stage that counts what it skips and returns `"Skipped N unreadable item(s)"`. The same user-visible loss reported differently depending on microseconds of timing, and the pre-poll case is the more reachable one: a clipboard holding a stale copy is forwarded on the first poll after passthrough connects, which deliberately forwards the *current* clipboard whatever its age.

`read(from:)` now classifies each item and carries the vanished count on `.pendingFiles`, which `read(filesAt:)` seeds its skip count with — so one note covers every item lost on either side of the actor hop, on both consumers (the passthrough poll's transfer issue and the clipboard window's inline message).

Closes #751

## The route taken

**Distinguishing a lost file from a pending promise.** `existingFileURL(in:)` returned `nil` for two unrelated things: an item that never named a file, and an item whose file is gone. Counting every `nil` would have broken the screenshot-thumbnail drag — a promise carries `com.apple.pasteboard.promised-file-url` pointing at a file that legitimately does not exist yet, and `handleDrop` depends on that falling through to `NSFilePromiseReceiver`. So the new `fileURLResolution(in:)` returns `.vanished` only when the item declares a concrete `public.file-url`, which is an assertion that the file exists; an unwritten promise stays `.notAFile`.

**Routing an all-vanished copy through the async stage.** `read(from:)` previously returned `.pendingFiles` only when at least one URL resolved. With none resolving it fell through to the inline snapshot read, where the file-reference types are identity-skipped and the path fallbacks dropped — reaching `"The Mac clipboard has no shareable content"`, a message the poll treats as "nothing was there". It now returns `.pendingFiles([], unresolved: n)`, so the loss lands in `read(filesAt:)` and rejects with the message that already means "items were there and could not be read". The rejection's singular/plural now keys on the total skipped rather than `urls.count`, which is empty in exactly this case.

**The issue's narrower point, decided.** `forwardHostClipboard`'s `.rejected` branch assumed every rejection from `read(from:)` is a verdict that nothing shareable was on the pasteboard — but `"The Mac clipboard has no shareable content"` also arises when every qualifying `data(forType:)` came back nil, which is a loss. Rather than match on the message string, `.rejected` now carries `unreadable:`. `read(from:)` sets it by comparing the count of types that qualified against the count that yielded data, so an empty-data-only snapshot stays a verdict while a pasteboard that would not hand over what it advertised becomes a report.

That also subsumes the coordinator's `guard allowsBinary else { return }`: the text-only transport's blanket file refusal is a policy verdict (`unreadable: false`), so both rejection branches now run the same `report(rejection:unreadable:to:)` rule instead of one branch carrying a special case.

## Rejected alternatives

- **Counting every `nil` from `existingFileURL`.** Simplest reading of the issue, but it classifies an unwritten file promise as a lost file and short-circuits the promise-receipt path — the screenshot thumbnail drag stops working.
- **Matching the rejection message to decide whether to report.** Avoids the API change but makes a user-facing string load-bearing.
- **Leaving the narrower point alone.** It is the same class of bug as the main fix — an uncounted loss — and the fix costs one associated value that the coordinator was already approximating with a branch comment.

## Changes

- `ClipboardPasteboardIntake` — `existingFileURL(in:)` → `fileURLResolution(in:)` (`.resolved`/`.vanished`/`.notAFile`); `read(filesAt:)` gains `unresolved:`; `.rejected` gains `unreadable:`; `.pendingFiles` gains `unresolved:`
- `ClipboardPassthroughCoordinator` — both rejection branches route through one `report(rejection:unreadable:to:)`
- `ClipboardContentViewController` — threads `unresolved` through `resolveAndApply` from the paste and drop paths
- `KernovaTests` — pre-poll loss (partial and total) on the coordinator; the folded note, the unresolved-only rejection, and the unreadable/verdict split on the intake

## Test plan

- [x] `make test` — full suite green
- [x] `make lint`
- [x] Existing `promisedFileURLImage` / `promiseWithoutFileNoPathLeak` still pass, covering the promise paths the `.vanished` scoping protects

🤖 Generated with [Claude Code](https://claude.com/claude-code)