### PR TITLE
refactor: Drive the refusal-burst window from an injected clock

### DIFF
--- a/KernovaKit/Sources/KernovaKit/EngineClock.swift
+++ b/KernovaKit/Sources/KernovaKit/EngineClock.swift
@@ -40,6 +40,32 @@ public func makePlatformEngineClock() -> any EngineClock {
     return MonotonicEngineClock()
 }
 
+/// An `EngineClock` erased to a running seconds reading, for a holder that only
+/// stamps and measures elapsed time.
+///
+/// Carrying no `Instant` type is what makes it storable: holding a clock
+/// otherwise means a generic parameter, which a macOS 12 holder cannot
+/// instantiate on `ContinuousEngineClock` — the constraint the clock-free facade
+/// protocols answer for holders that need a whole clock.
+public struct EngineStopwatch: Sendable {
+    private let read: @Sendable () -> TimeInterval
+
+    /// Starts a stopwatch on `clock`, reading zero at this call.
+    public init<Clock: EngineClock>(_ clock: Clock) {
+        let start = clock.now
+        read = { clock.seconds(from: start, to: clock.now) }
+    }
+
+    /// A stopwatch on the platform-default engine clock.
+    public static func platform() -> EngineStopwatch {
+        func build<C: EngineClock>(_ clock: C) -> EngineStopwatch { EngineStopwatch(clock) }
+        return build(makePlatformEngineClock())
+    }
+
+    /// Seconds elapsed since this stopwatch started.
+    public var elapsed: TimeInterval { read() }
+}
+
 /// `ContinuousClock` as an `EngineClock` — the conformance every macOS 13+
 /// system runs, storing genuine `ContinuousClock.Instant`s.
 @available(macOS 13.0, *)

--- a/KernovaKit/Sources/KernovaTestSupport/TestEngineClock.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/TestEngineClock.swift
@@ -1,0 +1,106 @@
+import Foundation
+import KernovaKit
+
+/// Manually advanced `EngineClock` for deterministic timing tests: time moves
+/// only through `advance(by:)`, which resumes every parked sleeper whose
+/// deadline it reaches, in deadline order.
+///
+/// Await `onSleep` to know a sleeper has parked before advancing — advancing
+/// first leaves it parked past its own deadline.
+public final class TestEngineClock: EngineClock, @unchecked Sendable {
+    /// A point on the test timeline: seconds since the clock's zero.
+    public struct Instant: Comparable, Sendable {
+        let offset: TimeInterval
+
+        /// Orders instants by their offset on the test timeline.
+        public static func < (lhs: Instant, rhs: Instant) -> Bool {
+            lhs.offset < rhs.offset
+        }
+    }
+
+    private struct Sleeper {
+        let id: UInt64
+        let deadline: TimeInterval
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private let lock = NSLock()
+    private var current: TimeInterval = 0
+    private var sleepers: [Sleeper] = []
+    private var nextID: UInt64 = 1
+    /// Sleep ids cancelled before their continuation parked.
+    private var preCancelled: Set<UInt64> = []
+    private var onSleepStorage: (@Sendable (TimeInterval) -> Void)?
+
+    /// Creates a clock at time zero with no sleepers.
+    public init() {}
+
+    /// Fired (on the sleeping task's thread) each time a sleeper parks, with
+    /// its interval — the event a test awaits before advancing the clock.
+    public var onSleep: (@Sendable (TimeInterval) -> Void)? {
+        get { lock.withLock { onSleepStorage } }
+        set { lock.withLock { onSleepStorage = newValue } }
+    }
+
+    /// The current manual time.
+    public var now: Instant { lock.withLock { Instant(offset: current) } }
+
+    /// Seconds from `start` to `end`; negative when `end` precedes `start`.
+    public func seconds(from start: Instant, to end: Instant) -> TimeInterval {
+        end.offset - start.offset
+    }
+
+    /// Parks until `advance(by:)` reaches the deadline, throwing
+    /// `CancellationError` on task cancellation.
+    public func sleep(for interval: TimeInterval) async throws {
+        let id: UInt64 = lock.withLock {
+            defer { nextID += 1 }
+            return nextID
+        }
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                enum Disposition { case parked, elapsed, cancelled }
+                let disposition: Disposition = lock.withLock {
+                    if preCancelled.remove(id) != nil { return .cancelled }
+                    guard interval > 0 else { return .elapsed }
+                    sleepers.append(
+                        Sleeper(id: id, deadline: current + interval, continuation: continuation))
+                    return .parked
+                }
+                switch disposition {
+                case .parked: onSleep?(interval)
+                case .elapsed: continuation.resume()
+                case .cancelled: continuation.resume(throwing: CancellationError())
+                }
+            }
+        } onCancel: {
+            self.cancelSleeper(id)
+        }
+    }
+
+    /// Advances the test timeline, resuming every sleeper whose deadline is
+    /// reached, in `(deadline, park order)` order.
+    public func advance(by interval: TimeInterval) {
+        let due: [Sleeper] = lock.withLock {
+            current += interval
+            let reached = current
+            let ready = sleepers.filter { $0.deadline <= reached }
+                .sorted { ($0.deadline, $0.id) < ($1.deadline, $1.id) }
+            sleepers.removeAll { $0.deadline <= reached }
+            return ready
+        }
+        for sleeper in due { sleeper.continuation.resume() }
+    }
+
+    private func cancelSleeper(_ id: UInt64) {
+        let continuation: CheckedContinuation<Void, any Error>? = lock.withLock {
+            if let index = sleepers.firstIndex(where: { $0.id == id }) {
+                return sleepers.remove(at: index).continuation
+            }
+            preCancelled.insert(id)
+            return nil
+        }
+        continuation?.resume(throwing: CancellationError())
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/EngineClockTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/EngineClockTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KernovaTestSupport
 import Testing
 
 @testable import KernovaKit
@@ -22,5 +23,73 @@ struct EngineClockTests {
             try await ContinuousEngineClock().sleep(for: 0)
         }
         await #expect(throws: CancellationError.self) { try await task.value }
+    }
+}
+
+@Suite("TestEngineClock")
+struct TestEngineClockTests {
+    /// Starts a sleeper on `clock` and returns once it has parked — advancing
+    /// before then would miss it.
+    private func parkedSleeper(on clock: TestEngineClock, for interval: TimeInterval) async throws
+        -> Task<Void, any Error>
+    {
+        let gate = AsyncGate()
+        let parkedFor = Box<TimeInterval?>(nil)
+        clock.onSleep = { parked in
+            parkedFor.value = parked
+            gate.notify()
+        }
+        let sleeper = Task { try await clock.sleep(for: interval) }
+        try await gate.wait { parkedFor.value != nil }
+        #expect(parkedFor.value == interval)
+        return sleeper
+    }
+
+    @Test("A parked sleeper resumes on the advance that reaches its deadline")
+    func advanceResumesAParkedSleeper() async throws {
+        let clock = TestEngineClock()
+        let sleeper = try await parkedSleeper(on: clock, for: 5)
+        clock.advance(by: 5)
+        try await sleeper.value
+    }
+
+    @Test("Cancelling a parked sleeper throws")
+    func cancellingAParkedSleeperThrows() async throws {
+        let clock = TestEngineClock()
+        let sleeper = try await parkedSleeper(on: clock, for: 5)
+        sleeper.cancel()
+        await #expect(throws: CancellationError.self) { try await sleeper.value }
+    }
+
+    @Test("Sleep on an already-cancelled task throws instead of parking")
+    func sleepThrowsWhenCancelledBeforeParking() async {
+        let clock = TestEngineClock()
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            try await clock.sleep(for: 5)
+        }
+        await #expect(throws: CancellationError.self) { try await task.value }
+    }
+
+    @Test("Elapsed seconds come only from advance(by:)")
+    func secondsMeasureTheManualTimeline() {
+        let clock = TestEngineClock()
+        let start = clock.now
+        clock.advance(by: 2.5)
+        #expect(clock.seconds(from: start, to: clock.now) == 2.5)
+        #expect(clock.seconds(from: clock.now, to: start) == -2.5)
+    }
+}
+
+@Suite("EngineStopwatch")
+struct EngineStopwatchTests {
+    @Test("Reads zero at the instant it starts, then tracks the clock it erases")
+    func tracksTheClockItErases() {
+        let clock = TestEngineClock()
+        clock.advance(by: 10)
+        let stopwatch = EngineStopwatch(clock)
+        #expect(stopwatch.elapsed == 0)
+        clock.advance(by: 2.5)
+        #expect(stopwatch.elapsed == 2.5)
     }
 }

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -79,7 +79,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// One paste gesture fires one data provider per promised item, so its
     /// refusals arrive as a burst and are worth one message; a paste made after
     /// the window is a second gesture and is owed its own answer.
-    static let defaultRefusalBurstWindow: TimeInterval = 2
+    static let refusalBurstWindow: TimeInterval = 2
 
     /// What the paste progress readout calls the machine the bytes come from —
     /// the guest can't learn the host's actual computer name over the control
@@ -89,8 +89,8 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     private let client: any VsockReconnecting
     private let pasteboard: Pasteboard
 
-    /// How long one reported refusal silences the rest of its burst.
-    private let refusalBurstWindow: TimeInterval
+    /// Measures the refusal-burst window.
+    private let refusalStopwatch: EngineStopwatch
 
     /// Aggregates what this side streams to the host into the status item's
     /// readout.
@@ -229,9 +229,10 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         /// index, so a repeated `.fileURL` pull returns the same staged file
         /// instead of re-staging a duplicate.
         var stagedInlineURLs: [Int: URL] = [:]
-        /// When this offer's last refusal was reported, opening the burst window
-        /// that keeps the rest of one paste's provider fires quiet.
-        var lastRefusalReportedAt: MonotonicEngineClock.Instant?
+        /// The `refusalStopwatch` reading when this offer's last refusal was
+        /// reported, opening the burst window that keeps the rest of one paste's
+        /// provider fires quiet.
+        var lastRefusalReportedAt: TimeInterval?
 
         init(generation: UInt64, reps: [Kernova_V1_ClipboardRepresentationInfo]) {
             self.generation = generation
@@ -260,23 +261,23 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// client, and optionally a `freeSpaceProvider` to simulate a full disk, a
     /// `stagingTempRoot` to isolate the staging directory between parallel tests,
     /// an `onProgress` sink to observe the readout the status item renders, an
-    /// `onClipboardNotice` sink to observe refusals, a shortened
-    /// `refusalBurstWindow` so a second paste re-reports without a real-time
-    /// wait, and zeroed reveal/linger delays so a test transfer surfaces while in
-    /// flight.
+    /// `onClipboardNotice` sink to observe refusals, a manually advanced
+    /// `refusalStopwatch` so a second paste crosses the refusal-burst window
+    /// without a real-time wait, and zeroed reveal/linger delays so a test
+    /// transfer surfaces while in flight.
     init(
         pasteboard: Pasteboard, client: any VsockReconnecting,
         freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
         stagingTempRoot: URL = FileManager.default.temporaryDirectory,
         progressRevealDelay: TimeInterval = ClipboardProgressTracker.defaultRevealDelay,
         progressIdleLinger: TimeInterval = ClipboardProgressTracker.defaultIdleLinger,
-        refusalBurstWindow: TimeInterval = VsockGuestClipboardAgent.defaultRefusalBurstWindow,
+        refusalStopwatch: EngineStopwatch = .platform(),
         onProgress: @escaping @Sendable (ClipboardProgressSnapshot?) -> Void = { _ in },
         onClipboardNotice: @escaping @Sendable () -> Void = {}
     ) {
         self.pasteboard = pasteboard
         self.client = client
-        self.refusalBurstWindow = refusalBurstWindow
+        self.refusalStopwatch = refusalStopwatch
         self.onClipboardNotice = onClipboardNotice
         self.progressTracker = ClipboardProgressTracker(
             revealDelay: progressRevealDelay, idleLinger: progressIdleLinger, emit: onProgress)
@@ -1221,9 +1222,8 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// Whether a refusal for `promise` may be reported now, opening the burst
     /// window when it may.
     private func allowsRefusalReport(for promise: InboundPromise) -> Bool {
-        let clock = MonotonicEngineClock()
-        let now = clock.now
-        if let last = promise.lastRefusalReportedAt, clock.seconds(from: last, to: now) < refusalBurstWindow {
+        let now = refusalStopwatch.elapsed
+        if let last = promise.lastRefusalReportedAt, now - last < Self.refusalBurstWindow {
             return false
         }
         promise.lastRefusalReportedAt = now

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -263,7 +263,7 @@ struct VsockGuestClipboardAgentTests {
         freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
         progressRevealDelay: TimeInterval = ClipboardProgressTracker.defaultRevealDelay,
         progressIdleLinger: TimeInterval = ClipboardProgressTracker.defaultIdleLinger,
-        refusalBurstWindow: TimeInterval = VsockGuestClipboardAgent.defaultRefusalBurstWindow,
+        refusalStopwatch: EngineStopwatch = .platform(),
         onProgress: @escaping @Sendable (ClipboardProgressSnapshot?) -> Void = { _ in },
         onClipboardNotice: @escaping @Sendable () -> Void = {}
     ) -> VsockGuestClipboardAgent {
@@ -281,7 +281,7 @@ struct VsockGuestClipboardAgentTests {
             stagingTempRoot: FileManager.default.temporaryDirectory.appendingPathComponent(
                 UUID().uuidString, isDirectory: true),
             progressRevealDelay: progressRevealDelay, progressIdleLinger: progressIdleLinger,
-            refusalBurstWindow: refusalBurstWindow,
+            refusalStopwatch: refusalStopwatch,
             onProgress: onProgress, onClipboardNotice: onClipboardNotice)
     }
 
@@ -2155,11 +2155,13 @@ struct VsockGuestClipboardAgentTests {
         hostChannel.start()
         defer { hostChannel.close() }
 
-        // A burst window short enough that a second paste lands outside it
-        // without the test waiting out the production window.
+        // The production burst window, crossed by advancing the agent's clock
+        // rather than by waiting it out.
+        let clock = TestEngineClock()
         let notices = AtomicInt()
         let agent = makeAgent(
-            pasteboard: pasteboard, agentFd: agentFd, refusalBurstWindow: 0.001,
+            pasteboard: pasteboard, agentFd: agentFd,
+            refusalStopwatch: EngineStopwatch(clock),
             onClipboardNotice: { notices.increment() })
         defer { agent.stop() }
 
@@ -2186,7 +2188,7 @@ struct VsockGuestClipboardAgentTests {
 
         // The offer is still live and the user pastes again — a new gesture, owed
         // its own answer on both surfaces rather than a silent no-op.
-        try await Task.sleep(nanoseconds: 20_000_000)
+        clock.advance(by: VsockGuestClipboardAgent.refusalBurstWindow)
         #expect(await lazyPull(pasteboard, forType: .fileURL).value == nil)
         try await notices.changed.wait { notices.value == 2 }
         let second = try await maybeNextFrame(from: hostChannel)


### PR DESCRIPTION
## Summary

`VsockGuestClipboardAgent.allowsRefusalReport` constructed a `MonotonicEngineClock()` inline and `InboundPromise.lastRefusalReportedAt` was hard-typed to that clock's `Instant`, so the refusal-burst window was the one timing site the clock seam could not drive. `secondPasteOfTheSameOfferReportsAgain` compensated by shortening the window to 1 ms and waiting a real 20 ms `Task.sleep` — the wall-clock wait shape [docs/TESTING.md](docs/TESTING.md) rules out, with no `RATIONALE:` tag.

The window now runs on an injected clock and the test advances it. With time under the test's control the shortened window is no longer needed either, so `refusalBurstWindow` loses its init parameter and the test exercises the production 2 s value.

Closes #753.

## The seam

`VsockGuestClipboardAgent` cannot take a clock generic parameter: it runs at the macOS 12 floor, where a stored property instantiated on `ContinuousEngineClock` is unnameable — the constraint the clock-free facade protocols (`ClipboardStreamReceiving`, `VsockReconnecting`, `VsockGuestControlling`) already answer for holders that need a whole clock. This site needs far less than a whole clock: it stamps an instant and measures seconds since it.

So the injected type is `EngineStopwatch`, an `EngineClock` erased to a running seconds reading. It carries no `Instant`, so a holder stores one with no generic parameter and no availability gate, and `lastRefusalReportedAt` becomes a plain `TimeInterval` reading.

### Rejected alternatives

- **Generic parameter on the agent.** It would push the same problem onto `AgentAppDelegate`, buying a fourth facade protocol for a two-line time check.
- **A bare `@Sendable () -> TimeInterval` in place of `EngineStopwatch`.** Same erasure, but nothing binds the reading to a monotonic source that counts time across VM save/restore — the `EngineClock` contract exists for that.
- **Keeping the injectable `refusalBurstWindow`.** Once the clock is injectable, a shortened window is a second clock racing the test body for no benefit.

## Changes

- `KernovaKit/EngineClock.swift` — new `EngineStopwatch` plus `EngineStopwatch.platform()`, which opens the platform clock existential the same way `makeClipboardStreamReceiver` does
- `KernovaTestSupport/TestEngineClock.swift` — manually advanced `EngineClock`; time moves only through `advance(by:)`, which resumes parked sleepers in deadline order. Reintroduced from the #747 branch, minus the `sleeperCount` accessor nothing used
- `VsockGuestClipboardAgent` — holds an injected `refusalStopwatch`; `lastRefusalReportedAt` is a stopwatch reading; `refusalBurstWindow` drops its init parameter and stays the static constant
- Tests — `secondPasteOfTheSameOfferReportsAgain` advances the clock across the production window in place of the 20 ms sleep; new `TestEngineClock` and `EngineStopwatch` suites cover the reintroduced clock's advance, cancellation, and erasure paths, so nothing here ships unreferenced

## Test plan

- [x] `make test` green
- [x] `make test-package` green, including the new suites
- [x] `KernovaMacOSAgentTests/VsockGuestClipboardAgentTests` green in isolation
- [x] `make lint` green

The full-suite runs on this machine show ~25 unrelated `KernovaTests` cases timing out at ~66 s and passing on retry. That reproduces identically on an unmodified tree under the same load, so it is the known starved-runner pattern, not this diff.

## Notes

- No `RATIONALE:` comments added.
- No agent `MARKETING_VERSION` bump: guest-visible behavior is unchanged, so no running guest needs a reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)