### PR TITLE
chore: Refresh the macOS restore image catalog

### DIFF
--- a/Kernova/Resources/RestoreImageCatalog.json
+++ b/Kernova/Resources/RestoreImageCatalog.json
@@ -1,12 +1,21 @@
 {
   "device" : "VirtualMac2,1",
-  "generatedAt" : "2026-07-29",
+  "generatedAt" : "2026-08-07",
   "images" : [
+    {
+      "build" : "25G76",
+      "lastModified" : "Mon, 03 Aug 2026 14:26:03 GMT",
+      "sizeBytes" : 19772153977,
+      "source" : "apple-live",
+      "url" : "https://updates.cdn-apple.com/2026SummerFCS/fullrestores/140-83079/25315EF6-AEAB-4588-9774-A3723774C47F/UniversalMac_26.6.1_25G76_Restore.ipsw",
+      "version" : "26.6.1"
+    },
     {
       "build" : "25G72",
       "lastModified" : "Fri, 24 Jul 2026 02:16:52 GMT",
       "sizeBytes" : 19772077142,
-      "source" : "apple-live",
+      "snapshot" : "20260731142234",
+      "source" : "apple-archived",
       "url" : "https://updates.cdn-apple.com/2026SummerFCS/fullrestores/140-65618/10445B26-DE2C-43EC-9149-0A831602E74B/UniversalMac_26.6_25G72_Restore.ipsw",
       "version" : "26.6"
     },

--- a/Tools/regen-restore-image-catalog.swift
+++ b/Tools/regen-restore-image-catalog.swift
@@ -112,17 +112,27 @@ func isSeed(_ build: String) -> Bool {
     return parsed.series == 5 && !parsed.revision.isEmpty
 }
 
+let imageNamePrefix = "UniversalMac_"
+let imageNameSuffix = "_Restore.ipsw"
+
 /// Splits `UniversalMac_<version>_<build>_Restore.ipsw` into its two parts.
 ///
 /// A URL is all steps 3 and 3b have — neither reads a feed entry stating the
 /// version and build, so both take them from the file name Apple assigns.
+/// The affixes are matched at the ends rather than replaced wherever they
+/// occur, so a name carrying anything beyond them yields no version and build
+/// instead of a plausible-looking pair spliced out of the surplus.
 func parseImageName(_ url: URL) -> (version: String, build: String)? {
-    let parts = url.lastPathComponent
-        .replacingOccurrences(of: "UniversalMac_", with: "")
-        .replacingOccurrences(of: "_Restore.ipsw", with: "")
+    let name = url.lastPathComponent
+    guard name.hasPrefix(imageNamePrefix), name.hasSuffix(imageNameSuffix) else { return nil }
+    let parts = name.dropFirst(imageNamePrefix.count).dropLast(imageNameSuffix.count)
         .split(separator: "_")
     guard parts.count == 2 else { return nil }
-    return (String(parts[0]), String(parts[1]))
+    // The crawl index also holds links someone mistyped by hand, such as
+    // `UniversalMac_l3.0_22A380_Restore.ipsw`. A version is digits and dots.
+    let version = String(parts[0])
+    guard !version.isEmpty, version.allSatisfy({ $0.isNumber || $0 == "." }) else { return nil }
+    return (version, String(parts[1]))
 }
 
 let repoRoot = URL(
@@ -432,7 +442,14 @@ if let data = await get(indexURL),
     let rows = try? JSONSerialization.jsonObject(with: data) as? [[String]]
 {
     for row in rows.dropFirst() {
-        guard let raw = row.first, let url = URL(string: raw),
+        // A crawler that lifted this URL out of a page can carry the markup
+        // that followed it into the indexed string, as `…_Restore.ipsw%3Cspan`
+        // and `…_Restore.ipsw&quot;` both show. The image URL is the prefix
+        // through the file name; anything past it belongs to the page, and
+        // keeping it both spoils the build number the name is read for and
+        // asks Apple about an address it never served.
+        guard let raw = row.first, let end = raw.range(of: imageNameSuffix),
+            let url = URL(string: String(raw[..<end.upperBound])),
             url.host == "updates.cdn-apple.com"
         else { continue }
         guard let (version, build) = parseImageName(url) else { continue }


### PR DESCRIPTION
## Summary

Regenerates the restore-image snapshot the creation wizard's **Choose a Version…** picker ships, and repairs a filter in the generator that the refresh exposed.

The catalog gains **macOS 26.6.1 (25G76)**. 26.6 (25G72) is no longer Apple's published build, so its provenance moves from `apple-live` to the archived snapshot that still carries it. No image dropped out; 66 → 67 shipped.

## Changes

**`Kernova/Resources/RestoreImageCatalog.json`** — regenerated via `Tools/regen-restore-image-catalog.swift`.

**`Tools/regen-restore-image-catalog.swift`** — step 3 reads the archive's crawl index, which serves URLs a bot lifted out of a web page with the surrounding markup still attached:

```
UniversalMac_15.5_24F74_Restore.ipsw%3Cspan     ( <span )
UniversalMac_15.6.1_24G90_Restore.ipsw&quot;    ( closing quote )
UniversalMac_26.0_25A5306g_Restore.ipsw)        ( closed a parenthetical )
UniversalMac_26.0_25A5316i_Restore.ipsw)
UniversalMac_26.0_25A5346a_Restore.ipsw&quot;
UniversalMac_l3.0_22A380_Restore.ipsw           ( lowercase L, mistyped by hand )
```

`parseImageName` replaced the two affixes wherever they occurred rather than matching them at the ends, so the tail survived into the build number — and a spoiled build **defeated the seed filter**. `parseBuild` rejects a revision like `g)`, and `isSeed` reads a parse failure as "not a seed", so the guard failed open: three macOS 26.0 betas passed a filter that excludes every one of the ~95 other seeds in the index, and the only thing that stopped them reaching the picker was Apple answering 403 for an address it never served. Each returns 200 once cleaned (18.8 GB, 18.6 GB, 18.1 GB).

The fix truncates an indexed URL at the file name before parsing, anchors the affixes at the string's ends, and requires a version to be digits and dots.

## Why this and not six corrected URLs

Patching the six observed links leaves the parser that mis-reads the seventh. The index grows and its artifacts vary — `%3Cspan`, `&quot;`, `)` are three shapes of the same accident — so the correction belongs where the string is read, not in a table of exceptions.

Correcting them changes nothing in the shipped catalog, which is the point: 15.5 (24F74) and 15.6.1 (24G90) clean up to URLs **byte-identical to entries already shipped** from the feed archive (they were phantom duplicates, distinct only because the garbage changed the build string), the three 26.0 seeds now drop at the seed filter alongside every other seed, and `l3.0` fails the version guard. Regenerating after the fix produced a byte-identical `RestoreImageCatalog.json`.

## The one remaining 403: `26.2 (23C55)`

Broken at the source and not correctable — nothing in the catalog needs changing:

| URL | Result |
|---|---|
| `…089-80477/F7443901-…/UniversalMac_26.2_23C55_Restore.ipsw` | **403** |
| Same directory, correct filename `…_26.2_25C56_…` | **403** — the path is wrong, not just the build |
| `…093-37399/E144C918-…/UniversalMac_26.2_25C56_Restore.ipsw` (shipped) | **200**, 18,741,508,230 bytes |
| `…2023FallFCS/052-15117/DC2EE605-…/UniversalMac_14.2_23C64_Restore.ipsw` (shipped) | **200** |

The "only the build number is mistyped" theory was tested directly and fails: the whole directory 403s, so there is nothing to correct it *to*. The genuine 26.2 lives elsewhere and already ships; 14.2 ships as 23C64, also live. Build 23C55 corresponds to no shipped entry in either version — a fabricated link that a crawler indexed. Its filename is well-formed, so it survives the parser correctly and is reported honestly, alongside the pre-existing `15.2 (24C2101) — HTTP 403` for a withdrawn hardware-spin build whose mainline 15.2 ships fine.

## Test plan

- [x] `swift Tools/regen-restore-image-catalog.swift` — verified all 67 shipped images against Apple's CDN before writing; no build lost, no shrink override needed
- [x] Re-ran after the parser fix — six spoiled candidates gone from the report, `RestoreImageCatalog.json` byte-identical, same provenance counts (live 1 / archived 48 / indexed 17 / unlisted 1)
- [x] `make test` — 2286 passed, 0 failed, including `bundledCatalogIsValid()` against the regenerated resource
- [x] `make lint` — clean (covers `Tools/`)
- [x] Live HEAD checks of every URL discussed above

## Notes

No `RATIONALE:` comments added. No issues closed.
