### PR TITLE
fix: Name the process blocking an arena eviction

### DIFF
--- a/Tools/ghosts.sh
+++ b/Tools/ghosts.sh
@@ -164,29 +164,55 @@ exe_of_pid() {
     lsof -a -p "$1" -d txt -Fn 2>/dev/null | sed -n 's/^n//p' | head -1
 }
 
-# The in-use refusal: one line naming each blocking process, then the way out.
-# Naming the PID is what makes the refusal actionable — the arena path says
-# which folder is stuck, never which running thing to go quit.
+# Whether the app itself is among an arena's holders. Asked with one grep
+# rather than by resolving every PID, because the display list below is capped
+# and can leave the app out — and its quit is the line a reader most needs.
+arena_holds_app() {
+    # shellcheck disable=SC2009
+    ps -axo args= 2>/dev/null | grep -F "$1/" | grep -qF '/Kernova.app/Contents/MacOS/Kernova'
+}
+
+# The in-use refusal: what is holding the arena, and how to clear it. Naming
+# the PID is what makes the refusal actionable — the arena path says which
+# folder is stuck, never which running thing to go quit.
 #
-# When the app itself is the blocker, its AppleScript quit is the one to reach
-# for: it save-suspends running guests before exiting, where a signal drops
-# them unsaved and ⌘Q closes the windows but leaves the app resident, so the
-# arena stays busy and the next run refuses again for the same reason.
-# Callers check arena_in_use first; with no blocker this prints the tail line
-# alone, which is the harmless read on a process that exited in between.
+# Two kinds of holder, labelled apart because the wrong one sends the reader
+# after the wrong process: a binary that lives inside the arena is running
+# from it and dies with the eviction, while a build tool or a log tail merely
+# carries the path in its argv. arena_pids matches argv text, so both land here.
+#
+# Capped: `make clean` evicts the arena Xcode builds into, so a build in flight
+# routes every swift-frontend and ld output path through this — uncapped, the
+# refusal is a screenful and each line costs an lsof. The full count still
+# prints, so a long tail is never silently dropped.
+#
+# Callers check arena_in_use first; with no holder left this prints the tail
+# lines alone, the harmless read on a process that exited in between.
 arena_blocked_lines() {
-    local pid exe is_app=0
+    local dir=$1 pid exe shown=0 total=0 max=5
     while IFS= read -r pid; do
         [ -z "$pid" ] && continue
+        total=$((total + 1))
+        [ "$shown" -ge "$max" ] && continue
+        shown=$((shown + 1))
         exe=$(exe_of_pid "$pid")
-        printf 'still running from inside: PID %s%s\n' "$pid" "${exe:+ (${exe##*/})}"
-        case "$exe" in */Kernova.app/Contents/MacOS/Kernova) is_app=1 ;; esac
-    done < <(arena_pids "$1")
-    if [ "$is_app" = 1 ]; then
-        printf 'quit it, then re-run: %s (save-suspends running VMs)\n' \
-            "osascript -e 'quit app \"Kernova\"'"
+        if [ -n "$exe" ] && [ "${exe#"$dir"/}" != "$exe" ]; then
+            printf 'running from inside: PID %s (%s)\n' "$pid" "${exe##*/}"
+        else
+            printf 'holding it open: PID %s%s\n' "$pid" "${exe:+ (${exe##*/})}"
+        fi
+    done < <(arena_pids "$dir")
+    [ "$total" -gt "$shown" ] && printf 'and %s more\n' "$((total - shown))"
+    if [ "$total" -gt 1 ]; then
+        printf 'quit them (or reboot), then re-run\n'
     else
         printf 'quit it (or reboot), then re-run\n'
+    fi
+    # Additive, never instead of the line above: with a mixed set, quitting the
+    # app alone leaves the arena held and the next run refusing identically.
+    if arena_holds_app "$dir"; then
+        printf 'Kernova quits cleanly with: %s (save-suspends running VMs)\n' \
+            "osascript -e 'quit app \"Kernova\"'"
     fi
 }
 

--- a/Tools/ghosts.sh
+++ b/Tools/ghosts.sh
@@ -164,6 +164,32 @@ exe_of_pid() {
     lsof -a -p "$1" -d txt -Fn 2>/dev/null | sed -n 's/^n//p' | head -1
 }
 
+# The in-use refusal: one line naming each blocking process, then the way out.
+# Naming the PID is what makes the refusal actionable — the arena path says
+# which folder is stuck, never which running thing to go quit.
+#
+# When the app itself is the blocker, its AppleScript quit is the one to reach
+# for: it save-suspends running guests before exiting, where a signal drops
+# them unsaved and ⌘Q closes the windows but leaves the app resident, so the
+# arena stays busy and the next run refuses again for the same reason.
+# Callers check arena_in_use first; with no blocker this prints the tail line
+# alone, which is the harmless read on a process that exited in between.
+arena_blocked_lines() {
+    local pid exe is_app=0
+    while IFS= read -r pid; do
+        [ -z "$pid" ] && continue
+        exe=$(exe_of_pid "$pid")
+        printf 'still running from inside: PID %s%s\n' "$pid" "${exe:+ (${exe##*/})}"
+        case "$exe" in */Kernova.app/Contents/MacOS/Kernova) is_app=1 ;; esac
+    done < <(arena_pids "$1")
+    if [ "$is_app" = 1 ]; then
+        printf 'quit it, then re-run: %s (save-suspends running VMs)\n' \
+            "osascript -e 'quit app \"Kernova\"'"
+    else
+        printf 'quit it (or reboot), then re-run\n'
+    fi
+}
+
 # Unregister every bundle inside the arena, then delete the folder outright.
 # Unregister first, so no dead registration lingers until the next sweep.
 # `rm -rf`, not `trash` (the exception to the trash-first file-operations
@@ -188,8 +214,10 @@ evict_dd_arena() {
 # failed sweep can never fail the checkout that triggered it, skips anything
 # a process is still running from, and skips the fix path's re-dump
 # verification — `make ghosts` still reports anything left behind. Unlike
-# --fix it never terminates a process blocking an arena: the sweep runs
-# unattended from a git hook, and the next worktree creation sweeps again.
+# --fix it terminates nothing: --fix kills processes whose own binary is
+# already deleted, while an arena's live blocker is the user's to quit under
+# either flag. The sweep runs unattended from a git hook, and the next
+# worktree creation sweeps again.
 if [ "$SWEEP" = 1 ]; then
     while IFS= read -r path; do
         [ -z "$path" ] && continue
@@ -238,8 +266,10 @@ if [ "$EVICT" = 1 ]; then
     # Clear the in-use guard before announcing anything, so a refusal never
     # follows a "Removing…" line that turned out to be false.
     if arena_in_use "$EVICT_DIR"; then
-        printf 'ghosts.sh: a running process is still executing from inside %s — quit it, then re-run\n' \
-            "$(labeled_path "$EVICT_DIR")" >&2
+        printf 'ghosts.sh: cannot remove %s\n' "$(labeled_path "$EVICT_DIR")" >&2
+        while IFS= read -r blocked; do
+            printf 'ghosts.sh: %s\n' "$blocked" >&2
+        done < <(arena_blocked_lines "$EVICT_DIR")
         exit 1
     fi
     # Size on the way out: on a default-location machine this is the arena the
@@ -375,7 +405,9 @@ else
         dir_label=$(labeled_path "$dir")
         ghost "Orphaned arena: $dir_label — $(du -sh "$dir" 2>/dev/null | cut -f1)"
         if arena_in_use "$dir"; then
-            detail 'a running process is still executing from inside — quit it (or reboot), then re-run'
+            while IFS= read -r blocked; do
+                detail "$blocked"
+            done < <(arena_blocked_lines "$dir")
             continue
         fi
         if [ "$FIX" = 1 ]; then


### PR DESCRIPTION
## Summary

`make clean-ghosts` hit an orphaned arena that a running process was holding, refused it, and exited 1 with:

```
    a running process is still executing from inside — quit it (or reboot), then re-run
```

Repair mode had nothing else to offer: it terminates processes whose own binary is already deleted, and a live holder of an intact arena is deliberately not its call to kill. So the run ends by handing the job back, without naming what to quit — the arena path says which folder is stuck, never which running thing is holding it. Recovering meant grepping `ps` for the arena path by hand.

Now:

```
  ✗ Orphaned arena: ~/Library/…/Kernova-crazx… (worktree: declarative-seeking-conway, removed) — 835M
    running from inside: PID 28442 (Kernova)
    quit it (or reboot), then re-run
    Kernova quits cleanly with: osascript -e 'quit app "Kernova"' (save-suspends running VMs)
```

Naming the remedy matters as much as naming the PID. The AppleScript quit is the only exit that both frees the arena and preserves guest state: a signal drops running VMs unsaved, and ⌘Q closes the windows while leaving the app resident — so the arena stays busy and the next run refuses again for the same reason.

## Route taken

The refusal is rendered by one helper, `arena_blocked_lines`, shared by the `--fix`/report arena section and by `--evict` (the path behind `make clean`), which had its own separately worded copy of the same message. Two wordings for one condition is what let the `--evict` variant stay vague unnoticed.

**Holders are labelled by what they actually are.** `arena_pids` matches argv *text*, not execution origin, so `xcodebuild -derivedDataPath <arena>` and a `tail` on a build log under it match alongside the binaries that genuinely live inside. Both are reasons not to `rm -rf` the arena, but they are not the same claim, and the wrong label sends the reader after the wrong process. A holder whose executable resolves inside the arena prints as `running from inside`; everything else prints as `holding it open`.

**The list is bounded.** `make clean` evicts the arena Xcode builds into, so a build in flight puts every `swift-frontend` and `ld` output path through this. Uncapped, the refusal is a screenful and each line costs an `lsof` spawn. Five are listed, with `and N more` carrying the rest — the count is reported rather than the tail being silently dropped.

**The app's quit is additive, never a substitute.** With a mixed holder set, printing only the `osascript` line means the user quits the app, the arena stays held, and the next run refuses identically. The general advice always prints; the app line joins it. It comes from `arena_holds_app` — a single grep rather than a per-PID resolve — so the display cap cannot swallow the one line a reader most needs.

Also corrected the `--sweep` comment, which contrasted itself against a `--fix` behavior that does not exist ("Unlike `--fix` it never terminates a process blocking an arena"). `--fix` has never terminated an arena holder; the distinction is that it kills deleted-path processes and the sweep kills nothing. That sentence is what made the gap read as a detection bug on first inspection.

## Rejected alternatives

- **Have `--fix` kill the holder.** It is the obvious way to make `clean-ghosts` exit 0, and it is wrong: SIGKILL on Kernova takes running guests down without save-suspending them, to reclaim regenerable build products. The refusal is the correct behavior; only its wording was at fault.
- **Filter the list down to processes executing from inside the arena.** The executable test is used to *label* holders, not to drop them: argv-only holders still block the eviction, so filtering them out could print an empty list while still refusing — leaving the reader worse off than the vague message did.
- **Tighten `arena_pids` itself to match execution origin.** That would change what the refusal is gated on, not just how it reads, and the loose match is the safe direction — a false match only skips an eviction.

## Test plan

- [x] Single in-arena app holder: `running from inside`, singular advice, osascript line
- [x] Seven argv-only holders plus the app started last: five listed as `holding it open`, `and 3 more`, plural advice, osascript line still printed from beyond the cap
- [x] Non-app holder alone: named with the generic advice and no osascript line
- [x] Unblocked arena still evicts, exit 0
- [x] Quoted prefix strip verified under bash 3.2 (the system floor), including a path containing glob characters
- [x] `make ghosts` reports clean; `shellcheck` and `make lint` (swift-format, shellcheck, docs) pass

Verified against synthetic arenas holding a purpose-built Mach-O blocker, since the real orphaned arena was reclaimed in the course of the original cleanup.
