### PR TITLE
feat: Record the image a VM was installed from, independent of the guest agent

### DIFF
--- a/Kernova/Models/InstalledImage.swift
+++ b/Kernova/Models/InstalledImage.swift
@@ -16,8 +16,9 @@ enum InstalledImage: Sendable, Equatable {
     /// and version the catalog names.
     ///
     /// Attaching an ISO is not a completed install — the distribution's own
-    /// installer runs inside the guest, and the user can have it write
-    /// something else — so this names what the VM was installed *from*.
+    /// installer runs inside the guest, and can write another distribution or
+    /// nothing at all — so this names the media the VM was set up with, and
+    /// the settings row it feeds is labelled for the media too.
     case linuxCatalogImage(distribution: String, version: String)
 
     /// The record a pending Linux download supports: a catalog entry publishes

--- a/Kernova/Models/InstalledImage.swift
+++ b/Kernova/Models/InstalledImage.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// The installer image a VM was set up from, as the install that used it named
+/// the image.
+///
+/// Written once by that install and never revised, so it stays what the VM
+/// started life as however far the guest is upgraded afterwards. The live
+/// counterpart is ``VMConfiguration/lastSeenGuestOSVersion``, which only a
+/// running guest agent can answer for.
+enum InstalledImage: Sendable, Equatable {
+    /// A macOS restore image, by the marketing version and Apple build the
+    /// image itself carries.
+    case macOSRestoreImage(version: String, build: String)
+
+    /// A Linux installer image from the bundled catalog, by the distribution
+    /// and version the catalog names.
+    ///
+    /// Attaching an ISO is not a completed install — the distribution's own
+    /// installer runs inside the guest, and the user can have it write
+    /// something else — so this names what the VM was installed *from*.
+    case linuxCatalogImage(distribution: String, version: String)
+
+    /// The record a pending Linux download supports: a catalog entry publishes
+    /// a distribution and version to record, a user-supplied URL publishes
+    /// neither.
+    init?(linuxSource: LinuxInstallContext.Source) {
+        switch linuxSource {
+        case .catalogEntry(let entry):
+            self = .linuxCatalogImage(distribution: entry.distribution, version: entry.version)
+        case .customURL:
+            return nil
+        }
+    }
+
+    /// What the settings card shows for the record.
+    var displayName: String {
+        switch self {
+        case .macOSRestoreImage(let version, let build): "macOS \(version) (\(build))"
+        case .linuxCatalogImage(let distribution, let version): "\(distribution) \(version)"
+        }
+    }
+}
+
+// MARK: - Codable
+
+extension InstalledImage: Codable {
+    /// Which case a persisted record carries, so the payload keys sit flat
+    /// beside it rather than nested under a synthesized case name.
+    private enum Kind: String, Codable {
+        case macOSRestoreImage
+        case linuxCatalogImage
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case version
+        case build
+        case distribution
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .macOSRestoreImage(let version, let build):
+            try c.encode(Kind.macOSRestoreImage, forKey: .kind)
+            try c.encode(version, forKey: .version)
+            try c.encode(build, forKey: .build)
+        case .linuxCatalogImage(let distribution, let version):
+            try c.encode(Kind.linuxCatalogImage, forKey: .kind)
+            try c.encode(distribution, forKey: .distribution)
+            try c.encode(version, forKey: .version)
+        }
+    }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        switch try c.decode(Kind.self, forKey: .kind) {
+        case .macOSRestoreImage:
+            self = .macOSRestoreImage(
+                version: try c.decode(String.self, forKey: .version),
+                build: try c.decode(String.self, forKey: .build))
+        case .linuxCatalogImage:
+            self = .linuxCatalogImage(
+                distribution: try c.decode(String.self, forKey: .distribution),
+                version: try c.decode(String.self, forKey: .version))
+        }
+    }
+}

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -196,6 +196,11 @@ struct VMConfiguration: Codable, Sendable, Equatable {
 
     var createdAt: Date
 
+    /// The installer image this VM was set up from, or `nil` when Kernova has
+    /// no record of one — a VM it did not install, or a Linux image the user
+    /// supplied by URL.
+    var installedImage: InstalledImage?
+
     // MARK: - Initializer
 
     init(
@@ -238,7 +243,8 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         sharedDirectories: [SharedDirectory]? = nil,
         installContext: MacOSInstallContext? = nil,
         linuxInstallContext: LinuxInstallContext? = nil,
-        createdAt: Date = Date()
+        createdAt: Date = Date(),
+        installedImage: InstalledImage? = nil
     ) {
         self.id = id
         self.name = name
@@ -280,6 +286,7 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         self.installContext = installContext
         self.linuxInstallContext = linuxInstallContext
         self.createdAt = createdAt
+        self.installedImage = installedImage
     }
 
     // MARK: - Codable
@@ -334,6 +341,7 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         self.linuxInstallContext = try c.decodeIfPresent(
             LinuxInstallContext.self, forKey: .linuxInstallContext)
         self.createdAt = try c.decode(Date.self, forKey: .createdAt)
+        self.installedImage = try c.decodeIfPresent(InstalledImage.self, forKey: .installedImage)
     }
 
     // MARK: - Persistence Coding

--- a/Kernova/Services/MacOSInstallService.swift
+++ b/Kernova/Services/MacOSInstallService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KernovaKit
 import Virtualization
 import os
 
@@ -17,13 +18,15 @@ final class MacOSInstallService {
     ///
     /// `progressHandler` receives installation progress in 0.0–1.0.
     ///
+    /// - Returns: The image's own version and build, read off the loaded
+    ///   `VZMacOSRestoreImage` rather than the install intent that named it.
     /// - Throws: ``MacOSInstallError`` if the restore image is missing or
     ///   incompatible with this host, or any error rethrown from `VZMacOSInstaller`.
     func install(
         into instance: VMInstance,
         restoreImageURL: URL,
         progressHandler: @MainActor @Sendable @escaping (Double) -> Void
-    ) async throws {
+    ) async throws -> InstalledImage {
         instance.status = .installing
 
         Self.logger.info("Starting macOS installation for '\(instance.name, privacy: .public)'")
@@ -124,6 +127,10 @@ final class MacOSInstallService {
         instance.setupState?.progress = .fraction(1.0)
 
         Self.logger.info("macOS installation completed for '\(instance.name, privacy: .public)'")
+
+        return .macOSRestoreImage(
+            version: KernovaOSVersion.displayString(restoreImage.operatingSystemVersion),
+            build: restoreImage.buildVersion)
     }
 
     /// Waits for `vm.state` to reach `.stopped`, the timeout to elapse, or the

--- a/Kernova/Services/Protocols/MacOSInstallProviding.swift
+++ b/Kernova/Services/Protocols/MacOSInstallProviding.swift
@@ -3,9 +3,11 @@ import Foundation
 /// Abstraction for macOS guest installation.
 @MainActor
 protocol MacOSInstallProviding: Sendable {
+    /// Installs macOS and answers with the restore image it ran from, for the
+    /// caller to record on the VM.
     func install(
         into instance: VMInstance,
         restoreImageURL: URL,
         progressHandler: @MainActor @Sendable @escaping (Double) -> Void
-    ) async throws
+    ) async throws -> InstalledImage
 }

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -365,7 +365,7 @@ final class VMLifecycleCoordinator {
                     instance.status = .installing
                 }
 
-                try await installService.install(
+                let installedImage = try await installService.install(
                     into: instance,
                     restoreImageURL: ipswURL
                 ) { @MainActor progress in
@@ -373,9 +373,13 @@ final class VMLifecycleCoordinator {
                 }
 
                 // Clear the persisted install intent so subsequent Starts take the
-                // normal boot path, and clear `setupState` so the progress UI
-                // tears down before the caller chains an auto-boot.
-                instance.performConfigurationMutation { $0.installContext = nil }
+                // normal boot path, record the image this VM now carries, and
+                // clear `setupState` so the progress UI tears down before the
+                // caller chains an auto-boot.
+                instance.performConfigurationMutation {
+                    $0.installContext = nil
+                    $0.installedImage = installedImage
+                }
                 instance.setupState = nil
             } catch is CancellationError {
                 Self.logger.info("macOS installation cancelled for '\(instance.name, privacy: .public)'")
@@ -529,7 +533,8 @@ final class VMLifecycleCoordinator {
                 }
 
                 attachInstallerImage(
-                    at: downloadDestination, named: image.filename, to: instance)
+                    at: downloadDestination, named: image.filename,
+                    from: InstalledImage(linuxSource: context.source), to: instance)
                 instance.setupState = nil
                 // The VM entered `.installing` for the pipeline and nothing
                 // else takes it out — unlike a macOS install, no VZ session ran
@@ -580,8 +585,9 @@ final class VMLifecycleCoordinator {
         downloadService.discardResumeData(at: destination, permanently: false)
     }
 
-    /// Attaches the fetched installer image ahead of the VM's main disk and
-    /// clears the pending download intent.
+    /// Attaches the fetched installer image ahead of the VM's main disk,
+    /// records `installedImage` as what the VM was set up from, and clears the
+    /// pending download intent.
     ///
     /// `filename` is the name the source gave the ISO, which is what the disk
     /// is labelled with — the file it was written to carries a discriminator
@@ -592,7 +598,8 @@ final class VMLifecycleCoordinator {
     /// consumed by an install, this attachment outlives the setup and has to
     /// track the file if the user later moves it.
     private func attachInstallerImage(
-        at destination: URL, named filename: String, to instance: VMInstance
+        at destination: URL, named filename: String, from installedImage: InstalledImage?,
+        to instance: VMInstance
     ) {
         let installer = StorageDisk(
             path: destination.path(percentEncoded: false),
@@ -608,6 +615,7 @@ final class VMLifecycleCoordinator {
                 [installer]
                 + (config.storageDisks ?? [ConfigurationBuilder.defaultMainDisk(layout: layout)])
             config.linuxInstallContext = nil
+            config.installedImage = installedImage
         }
         Self.logger.notice(
             "Attached installer image '\(destination.lastPathComponent, privacy: .public)' to '\(instance.name, privacy: .public)'"

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -74,8 +74,13 @@ final class VMSettingsViewController: NSViewController {
     // General
     private var nameButton = NSButton()
     private let nameField = NSTextField()
-    /// Value label of the OS Version row; `nil` for Linux guests, which have
-    /// no agent to report one.
+    /// The "Installed From" row and its value label, hidden while the VM
+    /// carries no record of the image it was set up from.
+    private var installedImageRow: GroupedFormCollapsibleRow?
+    private var installedImageValueLabel: NSTextField?
+    /// The OS Version row and its value label, hidden until an agent reports
+    /// one; both `nil` for Linux guests, which have no agent to report one.
+    private var guestOSVersionRow: GroupedFormCollapsibleRow?
     private var guestOSVersionValueLabel: NSTextField?
     private var nameDisplayRow = NSView()
     private var nameEditRow = NSView()
@@ -575,12 +580,30 @@ extension VMSettingsViewController {
             makeGroupedFormCardRow(
                 "Type", control: makeGroupedFormValueLabel(instance.configuration.guestOS.displayName)),
         ]
+        // Both OS rows are built whatever the VM knows today, then hidden until
+        // it knows: an install completing or a first agent Hello fills one in
+        // while this pane is on screen, and only `apply()` runs then.
+        let installedImage = instance.configuration.installedImage?.displayName
+        let installedLabel = makeGroupedFormValueLabel(installedImage ?? "")
+        installedImageValueLabel = installedLabel
+        let installedRow = GroupedFormCollapsibleRow(
+            row: makeGroupedFormCardRow("Installed From", control: installedLabel))
+        installedRow.isHidden = installedImage == nil
+        installedImageRow = installedRow
+        rows.append(installedRow)
+
         if instance.configuration.guestOS == .macOS {
-            let versionLabel = makeGroupedFormValueLabel(instance.guestOSVersionDisplay)
+            let reported = instance.guestOSVersionDisplay
+            let versionLabel = makeGroupedFormValueLabel(reported ?? "")
             guestOSVersionValueLabel = versionLabel
-            rows.append(makeGroupedFormCardRow("OS Version", control: versionLabel))
+            let versionRow = GroupedFormCollapsibleRow(
+                row: makeGroupedFormCardRow("OS Version", control: versionLabel))
+            versionRow.isHidden = reported == nil
+            guestOSVersionRow = versionRow
+            rows.append(versionRow)
         } else {
             guestOSVersionValueLabel = nil
+            guestOSVersionRow = nil
         }
         rows += [
             makeGroupedFormCardRow(
@@ -1214,7 +1237,12 @@ extension VMSettingsViewController {
     private func refreshGeneral() {
         nameButton.title = instance.name
         nameButton.isEnabled = instance.status.canRename
-        guestOSVersionValueLabel?.stringValue = instance.guestOSVersionDisplay
+        let installedImage = instance.configuration.installedImage?.displayName
+        installedImageValueLabel?.stringValue = installedImage ?? ""
+        installedImageRow?.isHidden = installedImage == nil
+        let reportedOSVersion = instance.guestOSVersionDisplay
+        guestOSVersionValueLabel?.stringValue = reportedOSVersion ?? ""
+        guestOSVersionRow?.isHidden = reportedOSVersion == nil
         let renaming = isRenaming
         if renaming != nameRowIsEditing {
             if renaming {

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -535,6 +535,17 @@ extension VMSettingsViewController {
 
     // MARK: General
 
+    /// What the install-record row is called for `guestOS`.
+    ///
+    /// A macOS install ran to completion under Kernova, so its row names what
+    /// the VM was installed from. A Linux ISO is only attached for the
+    /// distribution's own installer to use — which can install something else,
+    /// or nothing — so that row names the media and claims nothing about the
+    /// outcome.
+    static func installedImageRowLabel(guestOS: VMGuestOS) -> String {
+        guestOS == .macOS ? "Installed From" : "Installer Image"
+    }
+
     private func buildGeneralSection() -> NSView {
         nameButton = NSButton(title: instance.name, target: self, action: #selector(startRename))
         nameButton.isBordered = false
@@ -587,7 +598,9 @@ extension VMSettingsViewController {
         let installedLabel = makeGroupedFormValueLabel(installedImage ?? "")
         installedImageValueLabel = installedLabel
         let installedRow = GroupedFormCollapsibleRow(
-            row: makeGroupedFormCardRow("Installed From", control: installedLabel))
+            row: makeGroupedFormCardRow(
+                Self.installedImageRowLabel(guestOS: instance.configuration.guestOS),
+                control: installedLabel))
         installedRow.isHidden = installedImage == nil
         installedImageRow = installedRow
         rows.append(installedRow)

--- a/Kernova/Views/Shared/GroupedFormStyle.swift
+++ b/Kernova/Views/Shared/GroupedFormStyle.swift
@@ -124,6 +124,32 @@ func makeGroupedFormCardRow(
     return row
 }
 
+/// A card row that can be shown and hidden after its card is built.
+///
+/// ``makeGroupedFormCard(rows:)`` draws a hairline before every row but the
+/// first, which a row hidden on its own would leave stranded against the next
+/// separator. This carries that hairline instead, so `isHidden` takes both.
+/// Never a card's first row — the hairline would have nothing above it.
+@MainActor
+final class GroupedFormCollapsibleRow: NSStackView {
+    init(row: NSView) {
+        super.init(frame: .zero)
+        orientation = .vertical
+        alignment = .leading
+        spacing = Spacing.relaxed
+        translatesAutoresizingMaskIntoConstraints = false
+        for view in [makeGroupedFormHairline(), row] {
+            addArrangedSubview(view)
+            view.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("GroupedFormCollapsibleRow does not support NSCoder")
+    }
+}
+
 @MainActor
 func makeGroupedFormCard(rows: [NSView]) -> NSView {
     let content = NSStackView()
@@ -133,7 +159,11 @@ func makeGroupedFormCard(rows: [NSView]) -> NSView {
     content.translatesAutoresizingMaskIntoConstraints = false
 
     for (index, row) in rows.enumerated() {
-        if index > 0 { content.addArrangedSubview(makeGroupedFormHairline()) }
+        // A collapsible row carries its own hairline, so that hiding it takes
+        // the separator with it.
+        if index > 0, !(row is GroupedFormCollapsibleRow) {
+            content.addArrangedSubview(makeGroupedFormHairline())
+        }
         content.addArrangedSubview(row)
     }
 

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -26,14 +26,14 @@ extension VMInstance {
         }
     }
 
-    /// The guest-reported OS version for display, or "Unknown" when no agent
-    /// has vouched for one.
+    /// The guest-reported OS version for display, or `nil` when no agent has
+    /// vouched for one and there is nothing to show.
     ///
     /// What an agent reports is peer-supplied, so it is read through
     /// `KernovaOSVersion.numericVersion(in:)` rather than shown raw.
-    var guestOSVersionDisplay: String {
+    var guestOSVersionDisplay: String? {
         guard let reported = configuration.lastSeenGuestOSVersion, !reported.isEmpty else {
-            return "Unknown"
+            return nil
         }
         return KernovaOSVersion.numericVersion(in: reported) ?? reported
     }

--- a/KernovaTests/InstalledImageTests.swift
+++ b/KernovaTests/InstalledImageTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("InstalledImage Tests")
+struct InstalledImageTests {
+    private func roundTrip(_ image: InstalledImage) throws -> InstalledImage {
+        let data = try VMConfiguration.makeJSONEncoder().encode(image)
+        return try VMConfiguration.makeJSONDecoder().decode(InstalledImage.self, from: data)
+    }
+
+    @Test("A macOS restore image survives a round trip")
+    func macOSRoundTrip() throws {
+        let image = InstalledImage.macOSRestoreImage(version: "26.5.2", build: "25F84")
+
+        #expect(try roundTrip(image) == image)
+    }
+
+    @Test("A Linux catalog image survives a round trip")
+    func linuxRoundTrip() throws {
+        let image = InstalledImage.linuxCatalogImage(
+            distribution: "Ubuntu Desktop", version: "26.04 LTS")
+
+        #expect(try roundTrip(image) == image)
+    }
+
+    @Test("The payload keys sit flat beside the case name")
+    func encodesFlat() throws {
+        let data = try VMConfiguration.makeJSONEncoder().encode(
+            InstalledImage.macOSRestoreImage(version: "26.5.2", build: "25F84"))
+        let json = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: String])
+
+        #expect(json == ["kind": "macOSRestoreImage", "version": "26.5.2", "build": "25F84"])
+    }
+
+    @Test("A macOS record reads as the restore image's version and build")
+    func macOSDisplayName() {
+        #expect(
+            InstalledImage.macOSRestoreImage(version: "26.5.2", build: "25F84").displayName
+                == "macOS 26.5.2 (25F84)")
+    }
+
+    @Test("A Linux record reads as the distribution and version the catalog names")
+    func linuxDisplayName() {
+        #expect(
+            InstalledImage.linuxCatalogImage(distribution: "Ubuntu Desktop", version: "26.04 LTS")
+                .displayName == "Ubuntu Desktop 26.04 LTS")
+    }
+
+    @Test("A catalog source records the distribution and version it publishes")
+    func recordsCatalogSource() {
+        let source = LinuxInstallContext.Source.catalogEntry(
+            makeLinuxCatalogEntry(distribution: "Fedora Workstation", version: "44"))
+
+        #expect(
+            InstalledImage(linuxSource: source)
+                == .linuxCatalogImage(distribution: "Fedora Workstation", version: "44"))
+    }
+
+    @Test("A user-supplied URL records nothing")
+    func recordsNothingForURLSource() {
+        let source = LinuxInstallContext.Source.customURL(
+            CustomLinuxImage(
+                url: URL(string: "https://mirror.example/alpine-3.22-aarch64.iso")!,
+                sha256: String(repeating: "a", count: 64)))
+
+        #expect(InstalledImage(linuxSource: source) == nil)
+    }
+}

--- a/KernovaTests/Mocks/MockMacOSInstallService.swift
+++ b/KernovaTests/Mocks/MockMacOSInstallService.swift
@@ -6,6 +6,8 @@ import Foundation
 final class MockMacOSInstallService: MacOSInstallProviding {
     var installCallCount = 0
     var lastRestoreImageURL: URL?
+    /// What a successful install reports the VM was set up from.
+    var installedImage = InstalledImage.macOSRestoreImage(version: "26.5.2", build: "25F84")
 
     var installError: (any Error)?
 
@@ -13,7 +15,7 @@ final class MockMacOSInstallService: MacOSInstallProviding {
         into instance: VMInstance,
         restoreImageURL: URL,
         progressHandler: @MainActor @Sendable @escaping (Double) -> Void
-    ) async throws {
+    ) async throws -> InstalledImage {
         installCallCount += 1
         lastRestoreImageURL = restoreImageURL
         if let error = installError { throw error }
@@ -23,5 +25,6 @@ final class MockMacOSInstallService: MacOSInstallProviding {
         // `.stopped` so the caller's auto-boot runs the normal cold-boot
         // path with no stale refs.
         instance.resetToStopped()
+        return installedImage
     }
 }

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -1026,6 +1026,59 @@ struct VMConfigurationTests {
         #expect(config.lastSeenGuestOSVersion == nil)
     }
 
+    // MARK: - installedImage Tests
+
+    @Test("Default installedImage is nil")
+    func defaultInstalledImage() {
+        let config = VMConfiguration(
+            name: "Test VM",
+            guestOS: .macOS,
+            bootMode: .macOS
+        )
+        #expect(config.installedImage == nil)
+    }
+
+    @Test("Configuration round-trips a macOS installedImage")
+    func macOSInstalledImageRoundTrip() throws {
+        let config = VMConfiguration(
+            name: "Persisted VM",
+            guestOS: .macOS,
+            bootMode: .macOS,
+            installedImage: .macOSRestoreImage(version: "26.5.2", build: "25F84")
+        )
+
+        let decoded = try VMConfiguration.makeJSONDecoder().decode(
+            VMConfiguration.self, from: VMConfiguration.makeJSONEncoder().encode(config))
+
+        #expect(decoded.installedImage == .macOSRestoreImage(version: "26.5.2", build: "25F84"))
+    }
+
+    @Test("Configuration round-trips a Linux installedImage")
+    func linuxInstalledImageRoundTrip() throws {
+        let config = VMConfiguration(
+            name: "Persisted VM",
+            guestOS: .linux,
+            bootMode: .efi,
+            installedImage: .linuxCatalogImage(distribution: "Ubuntu Desktop", version: "26.04 LTS")
+        )
+
+        let decoded = try VMConfiguration.makeJSONDecoder().decode(
+            VMConfiguration.self, from: VMConfiguration.makeJSONEncoder().encode(config))
+
+        #expect(
+            decoded.installedImage
+                == .linuxCatalogImage(distribution: "Ubuntu Desktop", version: "26.04 LTS"))
+    }
+
+    @Test("A config omitting installedImage decodes it as nil")
+    func missingInstalledImageDecodesNil() throws {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let config = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
+
+        #expect(config.installedImage == nil)
+    }
+
     // MARK: - agentInstallNudgeDismissed Tests
 
     @Test("Default agentInstallNudgeDismissed is false")

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -1295,13 +1295,13 @@ struct VMInstanceTests {
         #expect(instance.guestOSVersionDisplay == "macOS")
     }
 
-    @Test("guestOSVersionDisplay reads Unknown for nil and empty values")
+    @Test("guestOSVersionDisplay is nil for nil and empty values, so the row hides")
     func guestOSVersionDisplayUnknown() {
-        #expect(makeMacOSInstanceWithAgentInstalled().guestOSVersionDisplay == "Unknown")
+        #expect(makeMacOSInstanceWithAgentInstalled().guestOSVersionDisplay == nil)
         // "" can only come from a hand-edited config.json (the service and
-        // recorder both normalize it to nil) but must not render as blank.
+        // recorder both normalize it to nil) but must not render as a blank row.
         #expect(
             makeMacOSInstanceWithAgentInstalled(lastSeenGuestOSVersion: "").guestOSVersionDisplay
-                == "Unknown")
+                == nil)
     }
 }

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -5184,7 +5184,7 @@ private final class CancelRaceInstallService: MacOSInstallProviding {
         into instance: VMInstance,
         restoreImageURL: URL,
         progressHandler: @MainActor @Sendable @escaping (Double) -> Void
-    ) async throws {
+    ) async throws -> InstalledImage {
         installStartedContinuation.yield(())
         installStartedContinuation.finish()
         // Park until the surrounding Task is cancelled. `try? await

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -558,6 +558,34 @@ struct VMLifecycleCoordinatorTests {
         #expect(instance.setupState == nil)
     }
 
+    @Test("installMacOS records the image the install ran from")
+    func installMacOSRecordsTheInstalledImage() async throws {
+        let (coordinator, _, installService, _, _) = makeCoordinator()
+        let instance = makeInstance()
+        instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
+        installService.installedImage = .macOSRestoreImage(version: "15.6.1", build: "24G90")
+        let context = MacOSInstallContext(source: .localFile, localIPSWPath: "/tmp/restore.ipsw")
+
+        try await coordinator.installMacOS(on: instance, context: context)
+
+        #expect(
+            instance.configuration.installedImage
+                == .macOSRestoreImage(version: "15.6.1", build: "24G90"))
+    }
+
+    @Test("A failed install records no image")
+    func installMacOSFailureRecordsNoImage() async {
+        let (coordinator, _, installService, _, _) = makeCoordinator()
+        let instance = makeInstance()
+        instance.onUpdateConfiguration = { mutate in mutate(&instance.configuration) }
+        installService.installError = MacOSInstallError.unsupportedRestoreImage
+        let context = MacOSInstallContext(source: .localFile, localIPSWPath: "/tmp/restore.ipsw")
+
+        _ = try? await coordinator.installMacOS(on: instance, context: context)
+
+        #expect(instance.configuration.installedImage == nil)
+    }
+
     @Test("installMacOS throws CancellationError on cancel and preserves installContext")
     func installMacOSCancelPreservesContext() async {
         let downloads = FileManager.default.temporaryDirectory
@@ -968,6 +996,48 @@ struct VMLifecycleCoordinatorTests {
         // The pipeline put the VM in `.installing`; it has to come to rest in a
         // status the auto-boot chained off this return can start from.
         #expect(instance.status == .stopped)
+    }
+
+    @Test("downloadLinuxImage records the catalog image the ISO came from")
+    func downloadLinuxImageRecordsTheCatalogImage() async throws {
+        let fixture = try makeLinuxFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.downloads) }
+        let context = LinuxInstallContext(
+            source: .catalogEntry(
+                makeLinuxCatalogEntry(distribution: "Ubuntu Desktop", version: "26.04 LTS")))
+        let instance = makeLinuxInstance(context: context)
+
+        try await fixture.coordinator.downloadLinuxImage(on: instance, context: context)
+
+        #expect(
+            instance.configuration.installedImage
+                == .linuxCatalogImage(distribution: "Ubuntu Desktop", version: "26.04 LTS"))
+    }
+
+    @Test("downloadLinuxImage records nothing for a user-supplied URL")
+    func downloadLinuxImageRecordsNothingForAURL() async throws {
+        let fixture = try makeLinuxFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.downloads) }
+        let context = makeCustomURLContext(fixture: fixture, verified: true)
+        let instance = makeLinuxInstance(context: context)
+
+        try await fixture.coordinator.downloadLinuxImage(on: instance, context: context)
+
+        #expect(instance.configuration.installedImage == nil)
+    }
+
+    @Test("A failed Linux download records no image")
+    func downloadLinuxImageFailureRecordsNoImage() async throws {
+        let fixture = try makeLinuxFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.downloads) }
+        fixture.downloadService.downloadError = DownloadError.downloadFailed(
+            URLError(.notConnectedToInternet))
+        let context = LinuxInstallContext(source: .catalogEntry(makeLinuxCatalogEntry()))
+        let instance = makeLinuxInstance(context: context)
+
+        _ = try? await fixture.coordinator.downloadLinuxImage(on: instance, context: context)
+
+        #expect(instance.configuration.installedImage == nil)
     }
 
     @Test("downloadLinuxImage keeps a pre-existing main disk and puts the ISO in front of it")

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -136,6 +136,149 @@ struct VMSettingsViewControllerTests {
         #expect(!containsLabel(caption, in: linuxVC.view))
     }
 
+    // MARK: - General card OS rows
+
+    private func makeOSRowsController(
+        guestOS: VMGuestOS,
+        installedImage: InstalledImage? = nil,
+        lastSeenGuestOSVersion: String? = nil
+    ) -> (VMSettingsViewController, VMInstance, VMLibraryViewModel) {
+        let viewModel = makeViewModel()
+        let instance = makeInstance(guestOS: guestOS)
+        instance.configuration.installedImage = installedImage
+        instance.configuration.lastSeenGuestOSVersion = lastSeenGuestOSVersion
+        let vc = VMSettingsViewController(
+            instance: instance, viewModel: viewModel, isReadOnly: false)
+        vc.loadViewIfNeeded()
+        vc.viewDidAppear()
+        return (vc, instance, viewModel)
+    }
+
+    @Test("A macOS VM that knows both shows the install record and the agent report side by side")
+    func osRowsBothKnown() {
+        let (vc, _, _) = makeOSRowsController(
+            guestOS: .macOS,
+            installedImage: .macOSRestoreImage(version: "26.5.2", build: "25F84"),
+            lastSeenGuestOSVersion: "Version 26.6 (Build 25G12)")
+
+        #expect(visibleLabel("Installed From", in: vc.view))
+        #expect(visibleLabel("macOS 26.5.2 (25F84)", in: vc.view))
+        #expect(visibleLabel("OS Version", in: vc.view))
+        #expect(visibleLabel("26.6", in: vc.view))
+    }
+
+    @Test("A macOS VM with no agent shows only what the install recorded")
+    func osRowsInstallRecordOnly() {
+        let (vc, _, _) = makeOSRowsController(
+            guestOS: .macOS,
+            installedImage: .macOSRestoreImage(version: "26.5.2", build: "25F84"))
+
+        #expect(visibleLabel("Installed From", in: vc.view))
+        #expect(!visibleLabel("OS Version", in: vc.view))
+    }
+
+    @Test("A macOS VM Kernova did not install shows only what the agent reports")
+    func osRowsAgentReportOnly() {
+        let (vc, _, _) = makeOSRowsController(
+            guestOS: .macOS, lastSeenGuestOSVersion: "26.6")
+
+        #expect(!visibleLabel("Installed From", in: vc.view))
+        #expect(visibleLabel("OS Version", in: vc.view))
+    }
+
+    @Test("A macOS VM that knows neither shows neither row")
+    func osRowsNeitherKnown() {
+        let (vc, _, _) = makeOSRowsController(guestOS: .macOS)
+
+        #expect(!visibleLabel("Installed From", in: vc.view))
+        #expect(!visibleLabel("OS Version", in: vc.view))
+    }
+
+    @Test("A Linux VM shows the image it was installed from and never an OS Version row")
+    func osRowsLinuxCatalogImage() {
+        let (vc, _, _) = makeOSRowsController(
+            guestOS: .linux,
+            installedImage: .linuxCatalogImage(
+                distribution: "Ubuntu Desktop", version: "26.04 LTS"))
+
+        #expect(visibleLabel("Installed From", in: vc.view))
+        #expect(visibleLabel("Ubuntu Desktop 26.04 LTS", in: vc.view))
+        // Linux guests have no Kernova agent, so the row is never even built.
+        #expect(!containsLabel("OS Version", in: vc.view))
+    }
+
+    @Test("A Linux VM installed from a URL shows no OS rows at all")
+    func osRowsLinuxWithoutRecord() {
+        let (vc, _, _) = makeOSRowsController(guestOS: .linux)
+
+        #expect(!visibleLabel("Installed From", in: vc.view))
+        #expect(!containsLabel("OS Version", in: vc.view))
+    }
+
+    /// The General card's visible run of rows and hairlines, `true` for a
+    /// hairline — collapsible rows expanded, hidden views dropped.
+    private func generalCardLayout(in view: NSView) -> [Bool] {
+        // The card's content stack is the one holding hairlines directly, which
+        // no section or form stack does.
+        guard
+            let content = firstSubview(
+                NSStackView.self, in: view,
+                where: { stack in
+                    stack.arrangedSubviews.contains { $0 is NSBox }
+                        && findLabel(withText: "Boot Mode", in: stack) != nil
+                })
+        else {
+            Issue.record("Expected a General card content stack")
+            return []
+        }
+        return content.arrangedSubviews.filter { !$0.isHidden }.flatMap { view -> [Bool] in
+            guard let collapsible = view as? GroupedFormCollapsibleRow else { return [view is NSBox] }
+            return collapsible.arrangedSubviews.filter { !$0.isHidden }.map { $0 is NSBox }
+        }
+    }
+
+    /// Whether a card's rows and hairlines strictly alternate, starting and
+    /// ending on a row — the shape a hidden row must not disturb.
+    private func separatesEveryRow(_ layout: [Bool]) -> Bool {
+        layout.first == false && layout.last == false
+            && zip(layout, layout.dropFirst()).allSatisfy { $0 != $1 }
+    }
+
+    @Test("Hidden OS rows take their separators with them")
+    func osRowsLeaveNoStrandedSeparator() {
+        // Every combination, since each leaves a different run of rows behind.
+        let noRows = makeOSRowsController(guestOS: .macOS).0
+        #expect(separatesEveryRow(generalCardLayout(in: noRows.view)))
+
+        let installOnly = makeOSRowsController(
+            guestOS: .macOS, installedImage: .macOSRestoreImage(version: "26.5.2", build: "25F84")
+        ).0
+        #expect(separatesEveryRow(generalCardLayout(in: installOnly.view)))
+
+        let agentOnly = makeOSRowsController(guestOS: .macOS, lastSeenGuestOSVersion: "26.6").0
+        #expect(separatesEveryRow(generalCardLayout(in: agentOnly.view)))
+
+        let bothRows = makeOSRowsController(
+            guestOS: .macOS, installedImage: .macOSRestoreImage(version: "26.5.2", build: "25F84"),
+            lastSeenGuestOSVersion: "26.6"
+        ).0
+        #expect(separatesEveryRow(generalCardLayout(in: bothRows.view)))
+        // Both OS rows really are in the run the check passed on.
+        #expect(generalCardLayout(in: bothRows.view).count == generalCardLayout(in: noRows.view).count + 4)
+    }
+
+    @Test("A first agent report reveals the OS Version row without rebuilding the form")
+    func osVersionRowAppearsOnFirstReport() {
+        let (vc, instance, viewModel) = makeOSRowsController(guestOS: .macOS)
+        #expect(!visibleLabel("OS Version", in: vc.view))
+
+        instance.configuration.lastSeenGuestOSVersion = "26.6"
+        vc.reconfigure(instance: instance, viewModel: viewModel, isReadOnly: false)
+
+        #expect(visibleLabel("OS Version", in: vc.view))
+        #expect(visibleLabel("26.6", in: vc.view))
+    }
+
     // MARK: - Read-only lock behavior
 
     @Test("Read-only disables lockable controls but not hot-toggleable ones")

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -194,24 +194,28 @@ struct VMSettingsViewControllerTests {
         #expect(!visibleLabel("OS Version", in: vc.view))
     }
 
-    @Test("A Linux VM shows the image it was installed from and never an OS Version row")
+    @Test("A Linux VM names the attached media and never an OS Version row")
     func osRowsLinuxCatalogImage() {
         let (vc, _, _) = makeOSRowsController(
             guestOS: .linux,
             installedImage: .linuxCatalogImage(
                 distribution: "Ubuntu Desktop", version: "26.04 LTS"))
 
-        #expect(visibleLabel("Installed From", in: vc.view))
+        #expect(visibleLabel("Installer Image", in: vc.view))
         #expect(visibleLabel("Ubuntu Desktop 26.04 LTS", in: vc.view))
+        // Booting that ISO is not installing from it — the guest's own
+        // installer can write another distribution, or nothing at all — so the
+        // row must never claim the install happened.
+        #expect(!containsLabel("Installed From", in: vc.view))
         // Linux guests have no Kernova agent, so the row is never even built.
         #expect(!containsLabel("OS Version", in: vc.view))
     }
 
-    @Test("A Linux VM installed from a URL shows no OS rows at all")
+    @Test("A Linux VM set up from a URL shows no OS rows at all")
     func osRowsLinuxWithoutRecord() {
         let (vc, _, _) = makeOSRowsController(guestOS: .linux)
 
-        #expect(!visibleLabel("Installed From", in: vc.view))
+        #expect(!visibleLabel("Installer Image", in: vc.view))
         #expect(!containsLabel("OS Version", in: vc.view))
     }
 


### PR DESCRIPTION
## Summary

A VM now persists what Kernova set it up from, so it can name its OS without depending on the guest agent being installed and running. `VMConfiguration.installedImage` is written once by the install that used the image and never revised — the divergence between it and the agent's live report is the point.

- **macOS** — the restore image's own marketing version and Apple build, read off the loaded `VZMacOSRestoreImage` rather than `MacOSInstallContext`'s copy of it (which is `nil` for a local-file pick and only a preview for "Download Latest").
- **Linux** — the catalog entry an attached installer ISO came from.
- **Nothing recorded** — a custom-URL Linux image, a VM Kernova did not install, and either setup's failure paths.

The settings General card shows the install record and the agent report as separate rows, each hidden when its own value is unknown. That replaces the permanent "Unknown" a macOS VM with no agent used to read, and gives Linux guests an OS affordance for the first time.

Closes #760

## The UI decision the issue deferred

Each row's value names an **image**, never a running version, and each row is labelled for exactly what its guest knows:

| | Install record | OS Version |
|---|---|---|
| macOS | **Installed From** — `macOS 26.5.2 (25F84)` | `26.6` |
| Linux | **Installer Image** — `Ubuntu Desktop 26.04 LTS` | — (no agent) |

The labels differ because the two records know different things. `VZMacOSInstaller` ran to completion under Kernova, so "Installed From" is exactly true. A Linux ISO is only attached for the distribution's own installer to use — the user can quit it, leave the disk blank, or install something else entirely — so that row names the media and claims nothing about the outcome. The macOS value matches what the creation wizard already showed the user for that image.

The rows never appear together, so no user sees both labels at once; per-guest truth beats a uniform phrase that overstates on one path.

## Route taken

**The record is sourced from the image, not the intent.** `MacOSInstallProviding.install` now returns the `InstalledImage` it ran from, and the coordinator records it in the same `performConfigurationMutation` that clears `installContext` — so the write is exactly as atomic as the "install completed" signal it rides on. The service already loads the restore image; nothing extra is read.

**`InstalledImage` is an enum, encoded flat.** Synthesized enum `Codable` nests the payload under the case name; `LinuxInstallContext` already rejected that shape for a hand-written `kind` discriminator, so this follows it and `config.json` stays readable.

**Hidden rows needed a layout primitive.** `makeGroupedFormCard(rows:)` interleaves hairlines between arranged rows, so hiding a row on its own leaves its separator stranded against the next one — a visible double line. `GroupedFormCollapsibleRow` carries that hairline itself and the card draws none before it, so `isHidden` takes both. A test asserts the card's visible run of rows and hairlines strictly alternates in every known/unknown combination.

**Both rows are built unconditionally and hidden, not built conditionally.** The form's structure is per-instance and only rebuilt on a VM switch, but these values change live — a first agent Hello, or an install completing with the pane on screen. Building conditionally would have left the row missing until the user navigated away and back.

### Rejected alternatives

- **One flat `installedOSVersion: String?`.** Cheaper, but it forces the display string into the persisted format and loses the macOS build as a separate field.
- **Rebuilding the General card when its row set changes**, mirroring the attachment lists' structural-vs-in-place engine. It works, but a rebuild destroys an in-progress inline rename, so it would have needed the same deferral guard the lists carry — more machinery than the hairline fix.
- **Keeping `guestOSVersionDisplay` returning "Unknown"** and hiding on the string. Making it `String?` puts the "nothing to show" decision in one place and is what the row-visibility tests assert against.

## Test plan

- [x] `make test` — full suite green
- [x] `make lint`
- [x] Config default, both round-trips, absent-key decode, and the flat encoded shape
- [x] Capture on macOS install success and on Linux catalog attach; no capture for a custom-URL source or either failure path
- [x] Row visibility for all four known/unknown combinations, both Linux cases, a first agent report revealing its row without a form rebuild, and the card separators staying strictly alternating throughout
- [x] The Linux row asserts "Installer Image" *and* asserts "Installed From" is absent, so the distinction cannot silently regress

## Review

Three reviews ran: a standard Codex review (clean), an adversarial Codex review, and a `medium` Claude review.

**Fixed** — the adversarial review caught that the Linux row claimed an install that may never have happened, since the record is written at ISO attach and the guest's installer runs afterward. The label is now "Installer Image" for Linux; the recording point is unchanged, being what #760 specifies.

**Dismissed**, per the severity bar in [docs/REVIEW.md](docs/REVIEW.md):

- *`GroupedFormCollapsibleRow`'s "never the first row" invariant is prose-only.* Unreachable — both collapsibles sit at indices 2 and 3 of the General card, and a future misuse shows a stray line that review catches.
- *`attachInstallerImage` nil-clobbers a prior record for a URL source.* Unreachable: reaching it requires `linuxInstallContext != nil`, which means the VM never completed setup and so has no record to clear.
- *"Written once and never revised" is falsified by a repeat macOS install.* The premise does not hold — `installContext` is minted only by the creation wizard (`VMLibraryViewModel.swift:220`), cleared on success, and nilled by `clonedForNewInstance`, so no flow re-runs an install on a VM that already has a record.

## Notes

- No `RATIONALE:` comments added.
- Not verified in the running app: another session held the computer-use grant. The separator layout is covered by the structural test described above instead, which is the specific thing a screenshot would have been checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167naHb48Zj3UMRdrnYieiN
