### PR TITLE
fix: Read a Linux checksum manifest only from the distribution's own host

### DIFF
--- a/Kernova/Models/ChecksumManifest.swift
+++ b/Kernova/Models/ChecksumManifest.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// The `(filename, SHA-256)` pairs a mirror publishes beside its images.
+/// The `(filename, SHA-256)` pairs a distribution publishes beside its images.
 ///
-/// Three grammars appear across the mirrors the Linux catalog names, and a
+/// Three grammars appear across the distributions the Linux catalog names, and a
 /// manifest is read in all three:
 ///
 ///     <hash>  <file>            GNU text mode (Debian, Kali)
@@ -11,14 +11,13 @@ import Foundation
 ///
 /// A line in none of them is skipped rather than refused. Fedora's manifest is
 /// a clearsigned document, so armor delimiters, the `Hash:` header, comments
-/// and the base64 signature are all lines that are not checksums, and a mirror
-/// that lists SHA-512 alongside SHA-256 lists both in the one file. Only the
-/// SHA-256 pairs come back.
+/// and the base64 signature are all lines that are not checksums, and a
+/// distribution that lists SHA-512 alongside SHA-256 lists both in the one file.
+/// Only the SHA-256 pairs come back.
 ///
-/// The signature is read past, never checked, and the manifest and the ISO are
-/// two independent requests, each following its own redirect. So a digest from
-/// here binds the ISO to whatever the manifest said — enough to catch a
-/// corrupted or wrong file, not a hostile manifest naming a hostile ISO.
+/// The clearsign signature is read past rather than checked. What a digest from
+/// here binds the ISO to is therefore the host that served the manifest, which
+/// ``LinuxImageResolveService`` holds to the one the catalog names.
 enum ChecksumManifest {
     /// One `(filename, digest)` pair a manifest states.
     struct Row: Sendable, Equatable {

--- a/Kernova/Models/LinuxImageCatalogEntry.swift
+++ b/Kernova/Models/LinuxImageCatalogEntry.swift
@@ -13,14 +13,25 @@ struct LinuxImageCatalogEntry: Codable, Sendable, Identifiable, Equatable {
     var distribution: String
     /// Version as shown to the user (`"26.04 LTS"`), not necessarily numeric.
     var version: String
-    /// Directory holding both the ISO and ``checksumManifest``, written with a
-    /// trailing slash.
+    /// Directory the ISO is fetched from, written with a trailing slash.
+    ///
+    /// Pointed at whichever address the distribution publishes for downloads,
+    /// redirector included: the digest ``checksumManifest`` states is what binds
+    /// the bytes, so the ISO can come off any mirror in the network.
     var directoryURL: URL
     /// Glob matching the ISO's filename inside ``directoryURL``, anchored at
     /// both ends, where each `*` matches a run of characters within the one
     /// filename (`"ubuntu-26.04*-desktop-arm64.iso"`).
     var isoPattern: String
-    /// Filename of the checksum manifest inside ``directoryURL``.
+    /// Directory the checksum manifest is fetched from, present only where the
+    /// distribution serves it somewhere other than ``directoryURL``.
+    ///
+    /// Nothing binds the manifest the way the manifest binds the ISO, so
+    /// whichever host answers for it is the trust anchor. This names a host the
+    /// distribution runs itself, and ``LinuxImageResolveService`` refuses a
+    /// redirect that would leave it.
+    var manifestDirectoryURL: URL?
+    /// Filename of the checksum manifest inside ``manifestDirectory``.
     var checksumManifest: String
     /// Size of the ISO the catalog was generated against, for the picker's size
     /// column.
@@ -28,6 +39,9 @@ struct LinuxImageCatalogEntry: Codable, Sendable, Identifiable, Equatable {
     /// The file resolved at download time is a near neighbour of it, never the
     /// same byte count twice.
     var approxSizeBytes: UInt64
+
+    /// Directory ``checksumManifest`` is read from.
+    var manifestDirectory: URL { manifestDirectoryURL ?? directoryURL }
 
     /// The order distributions are offered in, which is neither alphabetical
     /// nor derivable from the entries.

--- a/Kernova/Resources/LinuxImageCatalog.json
+++ b/Kernova/Resources/LinuxImageCatalog.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt" : "2026-08-06",
+  "generatedAt" : "2026-08-07",
   "images" : [
     {
       "approxSizeBytes" : 4161089536,
@@ -62,6 +62,7 @@
       "distribution" : "Fedora Workstation",
       "id" : "fedora-workstation-44",
       "isoPattern" : "Fedora-Workstation-Live-44-*.aarch64.iso",
+      "manifestDirectoryURL" : "https://dl.fedoraproject.org/pub/fedora/linux/releases/44/Workstation/aarch64/iso/",
       "version" : "44"
     },
     {
@@ -71,6 +72,7 @@
       "distribution" : "Fedora Workstation",
       "id" : "fedora-workstation-43",
       "isoPattern" : "Fedora-Workstation-Live-43-*.aarch64.iso",
+      "manifestDirectoryURL" : "https://dl.fedoraproject.org/pub/fedora/linux/releases/43/Workstation/aarch64/iso/",
       "version" : "43"
     },
     {
@@ -80,6 +82,7 @@
       "distribution" : "Kali Linux",
       "id" : "kali-current",
       "isoPattern" : "kali-linux-2026.2*-installer-arm64.iso",
+      "manifestDirectoryURL" : "https://kali.download/base-images/kali-2026.2/",
       "version" : "2026.2"
     }
   ]

--- a/Kernova/Services/LinuxImageCatalogService.swift
+++ b/Kernova/Services/LinuxImageCatalogService.swift
@@ -62,7 +62,7 @@ struct LinuxImageCatalogService: LinuxImageCatalogProviding {
             case .undecodableEntry(let index):
                 "entry at index \(index) did not decode"
             case .insecureURL(let id, let url):
-                "\(id) has a non-HTTPS directory URL (\(url))"
+                "\(id) has a non-HTTPS URL (\(url))"
             case .invalidPattern(let id, let pattern):
                 "\(id) has an ISO pattern that is not a wildcard .iso filename ('\(pattern)')"
             case .invalidManifestName(let id, let manifest):

--- a/Kernova/Services/LinuxImageCatalogService.swift
+++ b/Kernova/Services/LinuxImageCatalogService.swift
@@ -87,11 +87,11 @@ struct LinuxImageCatalogService: LinuxImageCatalogProviding {
     /// *shipped* resource is a build-time mistake.
     ///
     /// There is no host allowlist to check the way the macOS catalog checks for
-    /// Apple: these images come from each distribution's own mirrors, and a
-    /// list of them written here would go stale without anything noticing.
-    /// HTTPS authenticates whichever mirror a redirect landed on, and
-    /// ``ChecksumManifest`` covers what the SHA-256 on top of that does and
-    /// does not establish.
+    /// Apple: an ISO is fetched from whatever address a distribution publishes
+    /// for downloads, mirror network included, and a list of those written here
+    /// would go stale without anything noticing. What the entry pins instead is
+    /// the host its *manifest* is read from — see
+    /// ``LinuxImageCatalogEntry/manifestDirectoryURL``.
     static func parse(_ data: Data) -> ParseResult {
         guard let document = try? JSONDecoder().decode(LenientCatalog.self, from: data) else {
             return ParseResult(catalog: nil, rejections: [.undecodableDocument])
@@ -106,6 +106,10 @@ struct LinuxImageCatalogService: LinuxImageCatalogProviding {
         for entry in document.decodedImages {
             guard entry.directoryURL.scheme?.lowercased() == "https" else {
                 rejections.append(.insecureURL(id: entry.id, url: entry.directoryURL))
+                continue
+            }
+            guard entry.manifestDirectory.scheme?.lowercased() == "https" else {
+                rejections.append(.insecureURL(id: entry.id, url: entry.manifestDirectory))
                 continue
             }
             guard isFilenameGlob(entry.isoPattern) else {

--- a/Kernova/Services/LinuxImageResolveService.swift
+++ b/Kernova/Services/LinuxImageResolveService.swift
@@ -8,9 +8,9 @@ import os
 /// For a catalog entry the manifest is the index: it is fetched, parsed,
 /// matched against the entry's glob, and the newest match is the image — no
 /// directory listing is scraped and no filename is guessed. What comes back
-/// carries the mirror's own SHA-256, which is what the download is verified
-/// against. A pasted URL names its file outright and carries only the digest
-/// the user typed, so all that is read is the file's length.
+/// carries the distribution's own SHA-256, which is what the download is
+/// verified against. A pasted URL names its file outright and carries only the
+/// digest the user typed, so all that is read is the file's length.
 ///
 /// A class rather than a struct so `deinit` can invalidate the `URLSession`, the
 /// same reason `DownloadService` is one.
@@ -48,6 +48,9 @@ final class LinuxImageResolveService: LinuxImageResolving {
         guard entry.directoryURL.scheme?.lowercased() == "https" else {
             throw LinuxImageResolveError.insecureDirectory(url: entry.directoryURL)
         }
+        guard entry.manifestDirectory.scheme?.lowercased() == "https" else {
+            throw LinuxImageResolveError.insecureDirectory(url: entry.manifestDirectory)
+        }
         guard LinuxImageCatalogService.isFilenameGlob(entry.isoPattern) else {
             throw LinuxImageResolveError.invalidISOPattern(pattern: entry.isoPattern)
         }
@@ -55,7 +58,7 @@ final class LinuxImageResolveService: LinuxImageResolving {
             throw LinuxImageResolveError.invalidManifestName(manifest: entry.checksumManifest)
         }
 
-        let manifestURL = entry.directoryURL.appendingPathComponent(entry.checksumManifest)
+        let manifestURL = entry.manifestDirectory.appendingPathComponent(entry.checksumManifest)
         let text = try await manifestText(at: manifestURL, named: entry.checksumManifest)
         let rows = ChecksumManifest.parse(text)
         guard !rows.isEmpty else {
@@ -123,24 +126,37 @@ final class LinuxImageResolveService: LinuxImageResolving {
 
     // MARK: - HTTP
 
-    /// The checksum manifest at `url`, read up to ``maximumManifestBytes``.
+    /// The checksum manifest at `url`, read from that host and no other.
     ///
-    /// Redirects are followed, which is how the fetch lands anywhere useful:
-    /// Debian, Fedora and Kali answer even a manifest request with a redirect to
-    /// a geographically close mirror, and Ubuntu serves it directly. The body is
-    /// streamed rather than buffered whole so a mirror answering with something
-    /// enormous is stopped at the cap instead of being read into memory.
+    /// The digest a manifest states is what binds the ISO, and nothing binds the
+    /// manifest in turn, so whichever host answers here is the trust anchor. The
+    /// catalog points that at the distribution rather than at a mirror network,
+    /// and a redirect leaving the host is refused rather than followed. The body
+    /// is streamed rather than buffered whole, up to ``maximumManifestBytes``,
+    /// so a host answering with something enormous is stopped at the cap instead
+    /// of being read into memory.
     private func manifestText(at url: URL, named manifest: String) async throws -> String {
+        let origin = ManifestOriginPolicy(url: url)
         let stream: URLSession.AsyncBytes
         let response: URLResponse
         do {
-            (stream, response) = try await session.bytes(from: url)
+            (stream, response) = try await session.bytes(from: url, delegate: origin)
         } catch {
             try Task.checkCancellation()
+            if let refused = origin.refusedRedirect {
+                throw Self.redirectRefusal(of: manifest, to: refused)
+            }
             Self.logger.error(
                 "Checksum manifest at '\(DownloadService.loggableURL(url), privacy: .public)' is unreachable: \(error.localizedDescription, privacy: .public)"
             )
             throw LinuxImageResolveError.manifestUnreachable(manifest: manifest, statusCode: nil)
+        }
+        // A refused redirect completes the task with the redirect's own response,
+        // so this is checked ahead of the status: "302" states nothing about why
+        // the manifest went unread.
+        if let refused = origin.refusedRedirect {
+            stream.task.cancel()
+            throw Self.redirectRefusal(of: manifest, to: refused)
         }
         guard let http = response as? HTTPURLResponse else {
             stream.task.cancel()
@@ -174,5 +190,63 @@ final class LinuxImageResolveService: LinuxImageResolving {
             throw LinuxImageResolveError.manifestTooLarge(manifest: manifest)
         }
         return String(decoding: body, as: UTF8.self)
+    }
+
+    /// States a redirect the manifest fetch would not follow.
+    private static func redirectRefusal(of manifest: String, to url: URL)
+        -> LinuxImageResolveError
+    {
+        let host = url.host() ?? url.absoluteString
+        logger.error(
+            "Checksum manifest \(manifest, privacy: .public) redirected to '\(host, privacy: .public)' — not following it off the host the catalog names"
+        )
+        return .manifestRedirected(manifest: manifest, host: host)
+    }
+}
+
+/// Holds one checksum-manifest fetch to the host it was aimed at.
+///
+/// `URLSession` follows a redirect on its own, and following one here would move
+/// the digest's trust anchor onto whatever answered. A hop staying on the host
+/// over HTTPS — a path normalisation — is followed; any other is refused, and
+/// ``refusedRedirect`` is what the fetch reports in place of a status code.
+private final class ManifestOriginPolicy: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    /// The host the fetch may stay on, lowercased. `nil` for a URL naming none,
+    /// which no redirect target can then match.
+    private let host: String?
+    private let lock = NSLock()
+    private var refused: URL?
+
+    /// Where a redirect tried to move the fetch, once one was refused.
+    ///
+    /// Read from the awaiting task rather than from the session's delegate
+    /// queue, which is what the lock is for.
+    var refusedRedirect: URL? { lock.withLock { refused } }
+
+    init(url: URL) {
+        self.host = url.host()?.lowercased()
+        super.init()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard let target = request.url, let host,
+            target.scheme?.lowercased() == "https", target.host()?.lowercased() == host
+        else {
+            lock.withLock { refused = request.url ?? response.url }
+            // Declining leaves the task holding the redirect's own response — a
+            // body nobody here reads, and one that can sit unfinished until the
+            // request times out. Cancelling ends the fetch at the refusal;
+            // ``refusedRedirect`` is what the caller reads either way.
+            completionHandler(nil)
+            task.cancel()
+            return
+        }
+        completionHandler(request)
     }
 }

--- a/Kernova/Services/Protocols/LinuxImageResolving.swift
+++ b/Kernova/Services/Protocols/LinuxImageResolving.swift
@@ -11,6 +11,9 @@ enum LinuxImageResolveError: LocalizedError, Equatable {
     /// The checksum manifest was not served. `statusCode` is `nil` when nothing
     /// HTTP came back at all.
     case manifestUnreachable(manifest: String, statusCode: Int?)
+    /// The manifest's host answered with a redirect to `host`, which the fetch
+    /// refused rather than followed.
+    case manifestRedirected(manifest: String, host: String)
     /// The manifest's body ran past the size a manifest can honestly be.
     case manifestTooLarge(manifest: String)
     /// The manifest was served but stated no checksum at all.
@@ -31,13 +34,15 @@ enum LinuxImageResolveError: LocalizedError, Equatable {
         case .invalidManifestName(let manifest):
             "The saved image source doesn't name a checksum list to read ('\(manifest)')."
         case .manifestUnreachable(let manifest, let statusCode?):
-            "The mirror didn't serve this distribution's checksum list, \(manifest) (HTTP \(statusCode))."
+            "This distribution's site didn't serve its checksum list, \(manifest) (HTTP \(statusCode))."
         case .manifestUnreachable(let manifest, nil):
             "Couldn't reach this distribution's checksum list, \(manifest). Check your connection and try again."
+        case .manifestRedirected(let manifest, let host):
+            "This distribution's checksum list, \(manifest), was redirected to \(host) instead of served, so this image can't be verified."
         case .manifestTooLarge(let manifest):
-            "The mirror answered with far more than a checksum list can hold, so \(manifest) wasn't read."
+            "The answer for \(manifest) held far more than a checksum list can, so it wasn't read."
         case .manifestUnparseable(let manifest):
-            "The mirror's \(manifest) listed no checksums, so this image can't be verified."
+            "\(manifest) listed no checksums, so this image can't be verified."
         case .noMatchingImage(let pattern):
             "The mirror no longer lists an image named like '\(pattern)'."
         case .unusableFilename(let filename):

--- a/KernovaTests/LinuxImageCatalogTests.swift
+++ b/KernovaTests/LinuxImageCatalogTests.swift
@@ -150,6 +150,45 @@ struct LinuxImageCatalogServiceTests {
         }
     }
 
+    @Test("A manifest directory decodes when stated and falls back to the ISO directory when not")
+    func decodesManifestDirectory() throws {
+        let plain = try #require(LinuxImageCatalogService.parse(json(images: goodEntry)).catalog)
+        #expect(plain.images.first?.manifestDirectoryURL == nil)
+        #expect(
+            plain.images.first?.manifestDirectory
+                == URL(string: "https://cdimage.debian.org/debian-cd/current/arm64/iso-cd/"))
+
+        let pinned = goodEntry.replacingOccurrences(
+            of: "\"checksumManifest\"",
+            with:
+                "\"manifestDirectoryURL\": \"https://kali.download/base-images/kali-2026.2/\", \"checksumManifest\""
+        )
+        let result = LinuxImageCatalogService.parse(json(images: pinned))
+        let catalog = try #require(result.catalog)
+        #expect(result.rejections.isEmpty)
+        #expect(
+            catalog.images.first?.manifestDirectory
+                == URL(string: "https://kali.download/base-images/kali-2026.2/"))
+    }
+
+    @Test("A non-HTTPS manifest directory is rejected")
+    func rejectsInsecureManifestDirectory() throws {
+        let insecure = goodEntry.replacingOccurrences(
+            of: "\"checksumManifest\"",
+            with:
+                "\"manifestDirectoryURL\": \"http://kali.download/base-images/kali-2026.2/\", \"checksumManifest\""
+        )
+        let result = LinuxImageCatalogService.parse(json(images: insecure))
+        let catalog = try #require(result.catalog)
+        #expect(catalog.images.isEmpty)
+        #expect(
+            result.rejections == [
+                .insecureURL(
+                    id: "debian-13",
+                    url: URL(string: "http://kali.download/base-images/kali-2026.2/")!)
+            ])
+    }
+
     @Test("An ISO pattern with no wildcard, no .iso, or a path separator is rejected")
     func rejectsBadPattern() throws {
         let patterns = [
@@ -221,6 +260,8 @@ struct LinuxImageCatalogServiceTests {
             // Written with a trailing slash throughout, which is what the
             // picker shows; the resolver appends to it either way.
             #expect(entry.directoryURL.absoluteString.hasSuffix("/"))
+            #expect(entry.manifestDirectory.scheme == "https")
+            #expect(entry.manifestDirectory.absoluteString.hasSuffix("/"))
             #expect(LinuxImageCatalogService.isFilenameGlob(entry.isoPattern))
             #expect(LinuxImageCatalogService.isFilename(entry.checksumManifest))
             #expect(entry.approxSizeBytes > 0)

--- a/KernovaTests/LinuxImageResolveTests.swift
+++ b/KernovaTests/LinuxImageResolveTests.swift
@@ -320,6 +320,15 @@ final class ResolveStubURLProtocol: URLProtocol, @unchecked Sendable {
         else {
             preconditionFailure("ResolveStubURLProtocol: could not build a response")
         }
+        // A 3xx carrying a `Location` goes back as a redirect rather than as a
+        // body, which is what puts the session's redirect policy in the loop.
+        if (300..<400).contains(reply.statusCode), let location = headers["Location"],
+            let target = URL(string: location, relativeTo: url)?.absoluteURL
+        {
+            client?.urlProtocol(
+                self, wasRedirectedTo: URLRequest(url: target), redirectResponse: response)
+            return
+        }
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         if !reply.body.isEmpty { client?.urlProtocol(self, didLoad: reply.body) }
         client?.urlProtocolDidFinishLoading(self)
@@ -355,6 +364,8 @@ struct LinuxImageResolveServiceTests {
             directoryURLString:
                 "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Workstation/aarch64/iso/",
             isoPattern: "Fedora-Workstation-Live-44-*.aarch64.iso",
+            manifestDirectoryURLString:
+                "https://dl.fedoraproject.org/pub/fedora/linux/releases/44/Workstation/aarch64/iso/",
             checksumManifest: "Fedora-Workstation-44-1.7-aarch64-CHECKSUM"
         )
     }
@@ -378,12 +389,14 @@ struct LinuxImageResolveServiceTests {
     private func editedEntry(
         directoryURLString: String = "https://cdimage.ubuntu.com/ubuntu/releases/noble/release/",
         isoPattern: String = "ubuntu-24.04*-desktop-arm64.iso",
+        manifestDirectoryURLString: String? = nil,
         checksumManifest: String = "SHA256SUMS"
     ) -> LinuxImageCatalogEntry {
         makeLinuxCatalogEntry(
             id: "ubuntu-desktop-24.04",
             directoryURLString: directoryURLString,
             isoPattern: isoPattern,
+            manifestDirectoryURLString: manifestDirectoryURLString,
             checksumManifest: checksumManifest
         )
     }
@@ -410,6 +423,21 @@ struct LinuxImageResolveServiceTests {
             throws: LinuxImageResolveError.invalidISOPattern(pattern: "../*.iso")
         ) {
             _ = try await makeService().resolve(editedEntry(isoPattern: "../*.iso"))
+        }
+        #expect(ResolveStubURLProtocol.requestedURLs.isEmpty)
+    }
+
+    @Test("A manifest directory that is not HTTPS is refused before anything is requested")
+    func refusesInsecureManifestDirectory() async throws {
+        serve(manifest: ubuntuManifest)
+        defer { ResolveStubURLProtocol.reset() }
+        let entry = editedEntry(
+            manifestDirectoryURLString: "http://dl.fedoraproject.org/pub/fedora/")
+
+        await #expect(
+            throws: LinuxImageResolveError.insecureDirectory(url: entry.manifestDirectory)
+        ) {
+            _ = try await makeService().resolve(entry)
         }
         #expect(ResolveStubURLProtocol.requestedURLs.isEmpty)
     }
@@ -465,6 +493,73 @@ struct LinuxImageResolveServiceTests {
         #expect(
             image.sha256 == "66c07e7355db5e92faef680599a1789184a31c4dbaa5e02a19d050cc4e9279d2")
         #expect(image.sizeBytes == 2_689_781_760)
+    }
+
+    @Test("The manifest is read from the entry's manifest host, the ISO from its download host")
+    func readsManifestFromItsPinnedHost() async throws {
+        serve(manifest: fedoraManifest, isoSize: 2_689_781_760)
+        defer { ResolveStubURLProtocol.reset() }
+
+        let image = try await makeService().resolve(fedoraEntry)
+
+        #expect(
+            ResolveStubURLProtocol.requestedURLs.first?.absoluteString
+                == "https://dl.fedoraproject.org/pub/fedora/linux/releases/44/Workstation/aarch64/iso/Fedora-Workstation-44-1.7-aarch64-CHECKSUM"
+        )
+        #expect(image.isoURL.host() == "download.fedoraproject.org")
+    }
+
+    @Test("A redirect off the manifest's host is refused, and its target never requested")
+    func refusesOffHostManifestRedirect() async {
+        ResolveStubURLProtocol.reset()
+        ResolveStubURLProtocol.handler = { request in
+            guard request.url?.host() == "cdimage.ubuntu.com" else {
+                return ResolveStubURLProtocol.Reply(
+                    statusCode: 200, body: Data(ubuntuManifest.utf8))
+            }
+            return ResolveStubURLProtocol.Reply(
+                statusCode: 302, body: Data(),
+                headers: ["Location": "https://mirror.example/noble/SHA256SUMS"])
+        }
+        defer { ResolveStubURLProtocol.reset() }
+
+        await #expect(
+            throws: LinuxImageResolveError.manifestRedirected(
+                manifest: "SHA256SUMS", host: "mirror.example")
+        ) {
+            _ = try await makeService().resolve(ubuntuEntry)
+        }
+        // The digest would have come from whatever answered, so the mirror is
+        // not asked at all rather than asked and disbelieved.
+        #expect(
+            ResolveStubURLProtocol.requestedURLs.allSatisfy { $0.host() == "cdimage.ubuntu.com" })
+    }
+
+    @Test("A redirect staying on the manifest's host is followed")
+    func followsSameHostManifestRedirect() async throws {
+        let moved = "https://cdimage.ubuntu.com/ubuntu/releases/noble/release/SHA256SUMS.txt"
+        ResolveStubURLProtocol.reset()
+        ResolveStubURLProtocol.handler = { request in
+            guard let url = request.url else {
+                return ResolveStubURLProtocol.Reply(statusCode: 500, body: Data())
+            }
+            guard !url.lastPathComponent.hasSuffix(".iso") else {
+                return ResolveStubURLProtocol.Reply(
+                    statusCode: 200, body: Data(), headers: ["Content-Length": "3540299776"])
+            }
+            guard url.lastPathComponent == "SHA256SUMS" else {
+                return ResolveStubURLProtocol.Reply(
+                    statusCode: 200, body: Data(ubuntuManifest.utf8))
+            }
+            return ResolveStubURLProtocol.Reply(
+                statusCode: 302, body: Data(), headers: ["Location": moved])
+        }
+        defer { ResolveStubURLProtocol.reset() }
+
+        let image = try await makeService().resolve(ubuntuEntry)
+
+        #expect(image.filename == "ubuntu-24.04.4-desktop-arm64.iso")
+        #expect(ResolveStubURLProtocol.requestedURLs.map(\.absoluteString).contains(moved))
     }
 
     @Test("A manifest the mirror does not serve is reported with its status")

--- a/KernovaTests/Mocks/LinuxImageCatalogFixtures.swift
+++ b/KernovaTests/Mocks/LinuxImageCatalogFixtures.swift
@@ -34,6 +34,7 @@ func makeLinuxCatalogEntry(
     version: String = "13",
     directoryURLString: String = "https://cdimage.debian.org/debian-cd/current/arm64/iso-cd/",
     isoPattern: String = "debian-13.*-arm64-netinst.iso",
+    manifestDirectoryURLString: String? = nil,
     checksumManifest: String = "SHA256SUMS",
     approxSizeBytes: UInt64 = 735_358_976
 ) -> LinuxImageCatalogEntry {
@@ -43,6 +44,9 @@ func makeLinuxCatalogEntry(
         version: version,
         directoryURL: URL(string: directoryURLString) ?? URL(fileURLWithPath: "/"),
         isoPattern: isoPattern,
+        manifestDirectoryURL: manifestDirectoryURLString.map {
+            URL(string: $0) ?? URL(fileURLWithPath: "/")
+        },
         checksumManifest: checksumManifest,
         approxSizeBytes: approxSizeBytes
     )

--- a/Tools/regen-linux-image-catalog.swift
+++ b/Tools/regen-linux-image-catalog.swift
@@ -20,10 +20,10 @@
 //
 // ## How an entry resolves
 //
-// Each entry names a directory, a checksum manifest inside it, and a glob for
-// the ISO filename. The manifest is the index — no directory listing is
-// parsed, and no filename is guessed. Three grammars appear across these
-// mirrors, and all three are read here:
+// Each entry names a directory, a checksum manifest, and a glob for the ISO
+// filename. The manifest is the index — no directory listing is parsed, and no
+// filename is guessed. Three grammars appear across these mirrors, and all
+// three are read here:
 //
 //   <hash>  <file>            GNU text mode (Debian, Kali)
 //   <hash> *<file>            GNU binary mode (Ubuntu)
@@ -32,9 +32,19 @@
 // Among the filenames the glob matches, the highest version wins — Ubuntu
 // keeps several point releases of one series side by side.
 //
+// ## Where a manifest is read from
+//
+// An entry's ISO comes off whichever mirror the distribution's redirector
+// picks, because the manifest's digest binds it. Nothing binds the manifest in
+// turn, so it is read from a host the distribution runs — `manifestDirectoryURL`
+// where that differs from `directoryURL` — and a redirect leaving that host
+// fails the entry here, the same refusal the app makes at download time.
+//
 // A run that cannot resolve every entry writes nothing and exits non-zero. A
 // mirror reorganising its layout is the failure this catches, and a shipped
-// catalog naming a file nobody serves is worse than a stale one.
+// catalog naming a file nobody serves is worse than a stale one. A manifest
+// host that has started redirecting is the same kind of signal: the pin has
+// gone stale and wants a new host, by hand.
 
 import Foundation
 
@@ -70,8 +80,12 @@ struct CatalogEntry: Codable {
     var version: String
     var directoryURL: String
     var isoPattern: String
+    var manifestDirectoryURL: String?
     var checksumManifest: String
     var approxSizeBytes: UInt64
+
+    /// Directory `checksumManifest` is read from.
+    var manifestDirectory: String { manifestDirectoryURL ?? directoryURL }
 }
 
 struct Catalog: Codable {
@@ -109,13 +123,75 @@ let session: URLSession = {
     return URLSession(configuration: configuration)
 }()
 
-/// Fetches a URL, following the geo-redirects Debian, Fedora and Kali answer
-/// with (`URLSession` follows them by default; Ubuntu serves directly).
+/// Fetches a URL, following the geo-redirects a distribution's download
+/// redirector answers with (`URLSession` follows them by default).
 func get(_ url: URL) async -> Data? {
     guard let (data, response) = try? await session.data(from: url),
         let http = response as? HTTPURLResponse, http.statusCode == 200
     else { return nil }
     return data
+}
+
+/// Refuses a redirect that would take a fetch off the host it was aimed at,
+/// mirroring the app's `ManifestOriginPolicy`.
+final class OriginPolicy: NSObject, URLSessionTaskDelegate {
+    private let host: String?
+    private let lock = NSLock()
+    private var refusedStorage: URL?
+
+    /// Where a redirect tried to move the fetch, once one was refused.
+    var refused: URL? { lock.withLock { refusedStorage } }
+
+    init(url: URL) {
+        self.host = url.host()?.lowercased()
+        super.init()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard let target = request.url, let host,
+            target.scheme?.lowercased() == "https", target.host()?.lowercased() == host
+        else {
+            lock.withLock { refusedStorage = request.url ?? response.url }
+            completionHandler(nil)
+            task.cancel()
+            return
+        }
+        completionHandler(request)
+    }
+}
+
+/// What a fetch held to its own host came back with.
+enum OriginFetch {
+    case fetched(Data)
+    case refused(reason: String)
+}
+
+/// Fetches a URL that must be served by the host it names, stating why instead
+/// of the body when it is not.
+func getFromOrigin(_ url: URL) async -> OriginFetch {
+    let policy = OriginPolicy(url: url)
+    let answer = try? await session.data(from: url, delegate: policy)
+    if let refused = policy.refused {
+        return .refused(
+            reason: "\(url.absoluteString) redirected to "
+                + "\(refused.host() ?? refused.absoluteString) rather than serving the manifest "
+                + "— the manifest host has to be one the distribution runs, so repoint "
+                + "manifestDirectoryURL by hand")
+    }
+    guard let (data, response) = answer, let http = response as? HTTPURLResponse,
+        http.statusCode == 200
+    else {
+        return .refused(
+            reason: "no checksum manifest at \(url.absoluteString) — a respin renames the "
+                + "manifest, so check the directory and update checksumManifest")
+    }
+    return .fetched(data)
 }
 
 /// The byte size a mirror reports for a file.
@@ -371,6 +447,15 @@ func newerPinnedEntry(for entry: CatalogEntry) async -> (entry: CatalogEntry, no
         bumped[keyPath: field] = rolled
         notes.append("\(name) '\(stated)' → '\(rolled)'")
     }
+    // The pinned manifest directory names the same release the ISO directory
+    // does, so it rolls with it rather than being left on the old one.
+    if let stated = bumped.manifestDirectoryURL {
+        let rolled = stated.replacingOccurrences(of: pinned.version, with: newest)
+        if rolled != stated {
+            bumped.manifestDirectoryURL = rolled
+            notes.append("manifestDirectoryURL '\(stated)' → '\(rolled)'")
+        }
+    }
     return (bumped, notes)
 }
 
@@ -403,14 +488,19 @@ for original in catalog.images {
         failures.append((entry.id, notes, "'\(entry.directoryURL)' is not an HTTPS URL"))
         continue
     }
-    let manifestURL = directory.appendingPathComponent(entry.checksumManifest)
-    guard let manifestData = await get(manifestURL) else {
-        failures.append(
-            (
-                entry.id, notes,
-                "no checksum manifest at \(manifestURL.absoluteString) — a respin renames the "
-                    + "manifest, so check the directory and update checksumManifest"
-            ))
+    guard let manifestDirectory = URL(string: entry.manifestDirectory),
+        manifestDirectory.scheme == "https"
+    else {
+        failures.append((entry.id, notes, "'\(entry.manifestDirectory)' is not an HTTPS URL"))
+        continue
+    }
+    let manifestURL = manifestDirectory.appendingPathComponent(entry.checksumManifest)
+    let manifestData: Data
+    switch await getFromOrigin(manifestURL) {
+    case .fetched(let data):
+        manifestData = data
+    case .refused(let reason):
+        failures.append((entry.id, notes, reason))
         continue
     }
 
@@ -484,7 +574,7 @@ let stamp = ISO8601DateFormatter().string(from: Date()).prefix(10)
 let payload: [String: Any] = [
     "generatedAt": String(stamp),
     "images": resolutions.map { resolution -> [String: Any] in
-        [
+        var image: [String: Any] = [
             "id": resolution.entry.id,
             "distribution": resolution.entry.distribution,
             "version": resolution.entry.version,
@@ -493,6 +583,12 @@ let payload: [String: Any] = [
             "checksumManifest": resolution.entry.checksumManifest,
             "approxSizeBytes": resolution.entry.approxSizeBytes,
         ]
+        // Absent where the distribution serves the manifest from the directory
+        // the ISO is in, which is the shape the app defaults to.
+        if let manifestDirectory = resolution.entry.manifestDirectoryURL {
+            image["manifestDirectoryURL"] = manifestDirectory
+        }
+        return image
     },
 ]
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,9 +112,10 @@ substitute mocks. Services split by concurrency: those that touch
   and a checksum manifest rather than a fixed URL.
 - `LinuxImageResolveService` (a `final class`, for `URLSession` lifetime) — turns a Linux image
   source into the file to fetch, returning its URL, SHA-256, and size. A catalog entry resolves
-  against its mirror's manifest; a user-supplied URL names its own file and carries only the
-  digest the user typed, so all that is read is its length. The wizard's "Image URL…" check and
-  the install pipeline both go through it, so one set of admission rules governs both.
+  against the manifest its distribution serves; a user-supplied URL names its own file and
+  carries only the digest the user typed, so all that is read is its length. The wizard's
+  "Image URL…" check and the install pipeline both go through it, so one set of admission rules
+  governs both.
 
 `ConfigurationBuilder` translates a `VMConfiguration` into a `VZVirtualMachineConfiguration` — the
 single VZ-facing translation point, covering boot loader, CPU, memory, storage, network, display,


### PR DESCRIPTION
Closes #726.

## The hole, narrower than the issue title

The Linux image pipeline fetched the checksum manifest and the ISO as two
independent requests, each following its own redirect. The SHA-256 therefore
bound the ISO to *whatever host answered the manifest request*, which caught
corruption and wrong-file cases but not a hostile answer naming a hostile ISO.

Measured against the shipped catalog, the reachable part is narrower than
"nothing is signed":

| Entry | Manifest request | Answers |
|---|---|---|
| Ubuntu | `cdimage.ubuntu.com` | directly |
| Debian | `cdimage.debian.org` | directly |
| Fedora | `download.fedoraproject.org` | 302 → volunteer geo mirror |
| Kali | `cdimage.kali.org` | 302 → volunteer geo mirror |

So for Fedora and Kali the trust anchor was "whichever community mirror the
redirect landed on". HTTPS authenticated the mirror, not the distribution.

## Why not GPG verification

The issue proposed verifying the distro signatures — Fedora clearsigns its
`CHECKSUM`; Ubuntu, Debian and Kali publish detached `SHA256SUMS.gpg`. Declined:

- **No third-party dependencies** (AGENTS.md), and no Apple framework does
  OpenPGP. Verification means hand-writing an RFC 4880 packet parser plus
  clearsign canonicalisation over attacker-supplied input — a fresh
  security-critical attack surface introduced to close a security hole.
- **Key pinning is a standing burden.** Fedora signs each release with a new
  key, so every catalog addition would ship a key-management decision, and an
  unnoticed rotation becomes broken downloads for users.

## What this does instead

The asymmetry worth exploiting: the **ISO** can come from any mirror, because
its SHA-256 is bound by the manifest. Only the **manifest** needs a
trustworthy origin.

1. `LinuxImageCatalogEntry` gains an optional `manifestDirectoryURL`, defaulting
   to `directoryURL` through a `manifestDirectory` accessor. The ISO still
   resolves against `directoryURL`, so the mirror network keeps carrying the
   multi-gigabyte transfer.
2. The manifest fetch runs under a `ManifestOriginPolicy` task delegate that
   declines — and cancels — any redirect changing host or leaving HTTPS,
   surfaced as a new `manifestRedirected` error rather than as a bare 302.
   The `DownloadService` path for the ISO is untouched.
3. Each manifest host was verified live before pinning: Fedora →
   `dl.fedoraproject.org`, Kali → `kali.download`, Fedora-run and Kali-run
   respectively, both serving the byte-identical manifest with no redirect.
   Ubuntu and Debian already serve directly and gain no field.
4. `Tools/regen-linux-image-catalog.swift` reads manifests under the same
   policy and refuses to write when a manifest host starts redirecting — that
   is the signal a pin went stale, caught at refresh time rather than in a
   user's download.

The pin is deliberately implicit for Ubuntu and Debian: the redirect policy
keys on the manifest URL's own host, so an entry without the field is pinned to
`directoryURL` and protected identically. Adding a field equal to `directoryURL`
would be data with no behavioural effect. The accepted cost is that a host which
starts redirecting fails every install of that distribution closed, recoverable
only by shipping a new catalog — which is the correct direction to fail, and the
regen tool surfaces it at refresh time rather than in a user's download.

The trust-model prose on `ChecksumManifest`, `LinuxImageCatalogService.parse`
and `LinuxImageResolveService.manifestText` accurately described the weaker
model and is rewritten to describe this one.

The issue's parser note — scoping `ChecksumManifest.parse` to the signed region
of a clearsigned document — only matters under signature verification, so it
dies with the decline. No change.

## Test plan

- [x] `make test` — 2305 cases, 0 failures. New coverage: a redirect off the
      manifest host is refused and its target never requested; a same-host
      redirect is followed; the manifest is read from the manifest host while
      the ISO resolves against the download host; a non-HTTPS manifest
      directory is refused by both the parser and the resolver; entries decode
      with and without the field.
- [x] `make lint`
- [x] `swift Tools/regen-linux-image-catalog.swift` resolves all nine entries
      against the live hosts and reproduces the committed catalog.
- [x] Same tool with Fedora 44 repointed at `download.fedoraproject.org` fails
      that entry, names the mirror it was bounced to, and writes nothing.

## Review note: pending installs persisted before this change

`LinuxInstallContext.Source.catalogEntry` embeds the whole entry in the VM's
`config.json` and re-resolves it on every Start, so a Fedora or Kali VM whose
ISO download was still pending when this lands would resolve with
`manifestDirectoryURL` absent, fall back to the redirecting host, and fail.

Not addressed, deliberately. The catalog feature merged two days ago and the
repository has no tags and no releases, so no such data has shipped — and
AGENTS.md's Persisted Data rule ("no migration code … given only for old-shape
data confirmed to exist") is what governs. The fix a reviewer suggested — prefer
the bundled entry by `id` — would also reverse the decision documented on that
case: the entry is embedded *because* the catalog is rewritten whenever the
mirrors move, and a pending download must keep fetching the release the user
chose, not whatever the id points at after a regen.

If a pending Fedora or Kali VM exists on a dev machine, delete and recreate it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147MHianER1jVdm3SND3LsW
