### PR TITLE
feat: Deliver the guest agent disk over virtio to macOS guests below 12.3

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -1434,9 +1434,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         case #selector(showClipboard(_:)):
             return activeInstance?.canShowClipboard ?? false
         case #selector(toggleGuestAgentDisk(_:)):
-            // Hard gates (not status-derived): a macOS guest with a live VM for
-            // USB hot-plug, and a bundled DMG to attach. Retitling on the way
-            // out matters as much as enabling — see `unavailableTitle`.
+            // Hard gates (not status-derived): a macOS guest with a live session
+            // to look inside, and a bundled DMG for it to hold. Retitling on the
+            // way out matters as much as enabling — see `unavailableTitle`.
             guard let instance = activeInstance, instance.canManageGuestAgentDisk,
                 Self.guestAgentDiskPath != nil
             else {

--- a/Kernova/App/DetailContainerViewController.swift
+++ b/Kernova/App/DetailContainerViewController.swift
@@ -355,8 +355,10 @@ extension DetailContainerViewController: VMLibraryPresenting {
         alertsPresenter.presentCancelPreparing(for: instance)
     }
 
-    func presentInstallerMounted(vmName: String, purpose: GuestAgentInstallerPurpose) {
-        alertsPresenter.presentInstallerMounted(vmName: vmName, purpose: purpose)
+    func presentInstallerMounted(
+        vmName: String, purpose: GuestAgentInstallerPurpose, delivery: GuestAgentDiskDelivery
+    ) {
+        alertsPresenter.presentInstallerMounted(vmName: vmName, purpose: purpose, delivery: delivery)
     }
 
     func focusGuestDisplay(for instance: VMInstance) {

--- a/Kernova/Models/GuestAgentDiskDelivery.swift
+++ b/Kernova/Models/GuestAgentDiskDelivery.swift
@@ -1,0 +1,59 @@
+import Foundation
+import KernovaKit
+
+/// How the bundled guest-agent installer image reaches a macOS guest.
+///
+/// A guest below ``usbMassStorageFloor`` enumerates a
+/// `VZUSBMassStorageDeviceConfiguration` but binds no driver to it, so the disk
+/// never appears in the guest and the USB path delivers nothing.
+enum GuestAgentDiskDelivery: Equatable, Sendable {
+    /// Hot-plugged onto the XHCI controller on demand, and ejectable while the
+    /// VM runs.
+    case usb
+    /// Attached on `storageDevices` at every boot, for the whole session.
+    case virtio
+
+    /// The macOS release where `IOUSBMassStorageDriver.kext` entered the boot
+    /// kernel collection, and so the first one whose kernel holds the
+    /// personalities that match a VZ USB mass storage device.
+    ///
+    /// On an earlier guest the kext is present in `/System/Library/Extensions`
+    /// but absent from the collection `kmutil inspect` reports, the device stops
+    /// at `IOUSBHostInterface`, and `kernelmanagerd` logs no load request
+    /// (`docs/research/2026-08-07-macos12-usb-mass-storage.md`). This is a
+    /// property of the *guest*, never of the host.
+    static let usbMassStorageFloor = MacOSVersion(major: 12, minor: 3)
+
+    /// The bus the guest described by `config` takes the installer image on.
+    ///
+    /// A guest whose version neither signal answers for gets ``usb``, the
+    /// behavior every VM had before this policy existed.
+    static func mode(for config: VMConfiguration) -> GuestAgentDiskDelivery {
+        // `guestOS`, not `bootMode`: a Linux guest has no Kernova agent at all,
+        // and both enums carry a `.macOS` case.
+        guard config.guestOS == .macOS else { return .usb }
+        guard let version = effectiveGuestVersion(for: config) else { return .usb }
+        return version.isAtLeast(usbMassStorageFloor) ? .usb : .virtio
+    }
+
+    /// The best available reading of what macOS the guest is running.
+    ///
+    /// ``VMConfiguration/lastSeenGuestOSVersion`` wins: the agent rewrites it
+    /// whenever the guest reports something new, so it survives an in-guest
+    /// upgrade that leaves ``VMConfiguration/installedImage`` describing a
+    /// release no longer installed. It is peer-supplied free text, though, so a
+    /// report that parses to nothing falls through to the install record rather
+    /// than erasing its vote.
+    static func effectiveGuestVersion(for config: VMConfiguration) -> MacOSVersion? {
+        if let reported = config.lastSeenGuestOSVersion,
+            let numeric = KernovaOSVersion.numericVersion(in: reported),
+            let version = MacOSVersion(numeric)
+        {
+            return version
+        }
+        if case .macOSRestoreImage(let version, _) = config.installedImage {
+            return MacOSVersion(version)
+        }
+        return nil
+    }
+}

--- a/Kernova/Models/RestoreImageFilename.swift
+++ b/Kernova/Models/RestoreImageFilename.swift
@@ -57,6 +57,21 @@ struct MacOSVersion: Sendable, Equatable {
         self.components = Array(components.prefix(3))
     }
 
+    /// A version fixed at compile time, for thresholds no string has to parse
+    /// into.
+    init(major: Int, minor: Int, patch: Int = 0) {
+        components = [major, minor, patch]
+    }
+
+    /// Whether this version is `other` or newer, compared component by component
+    /// as numbers — so 12.10 outranks 12.3, which comparing the text does not.
+    func isAtLeast(_ other: MacOSVersion) -> Bool {
+        for (mine, theirs) in zip(components, other.components) where mine != theirs {
+            return mine > theirs
+        }
+        return true
+    }
+
     /// Whether a guest at this version can run on the given host.
     ///
     /// Virtualization refuses a guest newer than the host, and the framework's

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -24,6 +24,10 @@ struct ConfigurationBuilder: Sendable {
 
     private static let logger = Logger(subsystem: "app.kernova", category: "ConfigurationBuilder")
 
+    /// The guest-agent installer image to attach to a guest that takes it over
+    /// virtio, `nil` when this build carries none.
+    var guestAgentDiskURL: URL? = KernovaMacOSAgentInfo.installerDiskImageURL
+
     /// Builds a validated `VZVirtualMachineConfiguration` from the given VM configuration and bundle URL.
     func build(from config: VMConfiguration, bundleURL: URL) throws -> BuildResult {
         try assemble(from: config, bundleURL: bundleURL, validate: true)
@@ -60,6 +64,7 @@ struct ConfigurationBuilder: Sendable {
         // XHCI controller exists for items to attach to.
         configureUSBControllers(vzConfig)
         try configureStorageDisks(vzConfig, config: config, bundleURL: bundleURL)
+        let guestAgentDiskAttached = configureGuestAgentDisk(vzConfig, config: config, bundleURL: bundleURL)
         let coldRemovableMedia = try configureRemovableMedia(vzConfig, config: config)
         configureNetwork(vzConfig, config: config)
         configureEntropy(vzConfig)
@@ -77,7 +82,8 @@ struct ConfigurationBuilder: Sendable {
         }
 
         if validate {
-            try vzConfig.validate()
+            try validateConfiguration(
+                vzConfig, guestAgentDiskAttached: guestAgentDiskAttached, config: config)
         }
 
         Self.logger.info(
@@ -373,6 +379,73 @@ struct ConfigurationBuilder: Sendable {
         vzConfig.storageDevices = built
     }
 
+    /// Appends the guest-agent installer image for a guest that takes it over
+    /// virtio, and reports whether it did.
+    ///
+    /// Never throws: a guest that boots without the agent disk is a degraded
+    /// session, while a guest that refuses to boot is a broken VM. The disk goes
+    /// last so every configured disk keeps its index — guests name block devices
+    /// by attachment order, and a VM the user never touched must not see its own
+    /// disks renamed.
+    private func configureGuestAgentDisk(
+        _ vzConfig: VZVirtualMachineConfiguration,
+        config: VMConfiguration,
+        bundleURL: URL
+    ) -> Bool {
+        guard GuestAgentDiskDelivery.mode(for: config) == .virtio else { return false }
+        guard let installerURL = guestAgentDiskURL else {
+            Self.logger.warning(
+                "No guest agent installer image to attach to '\(config.name, privacy: .public)'")
+            return false
+        }
+
+        let disk = Self.guestAgentDisk(
+            installerPath: installerURL.path(percentEncoded: false), bundleURL: bundleURL)
+        do {
+            let resolved = try Self.resolveFile(
+                at: disk.path, context: "Guest agent disk",
+                notFound: .storageDiskNotFound(disk.path, disk.label),
+                isDirectory: .storageDiskPathIsDirectory(disk.path, disk.label))
+            let attachment = try VZDiskImageStorageDeviceAttachment(
+                url: resolved.url, readOnly: disk.readOnly)
+            let blockDevice = VZVirtioBlockDeviceConfiguration(attachment: attachment)
+            blockDevice.blockDeviceIdentifier = disk.blockDeviceIdentifier
+            vzConfig.storageDevices.append(blockDevice)
+        } catch {
+            Self.logger.warning(
+                "Couldn't attach the guest agent disk to '\(config.name, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+            return false
+        }
+
+        Self.logger.info(
+            "Attached the guest agent disk to '\(config.name, privacy: .public)' as a virtio block device"
+        )
+        return true
+    }
+
+    /// Runs `vzConfig.validate()`, retrying once without the guest-agent disk.
+    ///
+    /// The retry keeps this feature from turning a VM that used to boot into one
+    /// that doesn't — whatever ceiling or collision the extra device crossed,
+    /// the configuration the user had before it existed still validates.
+    private func validateConfiguration(
+        _ vzConfig: VZVirtualMachineConfiguration,
+        guestAgentDiskAttached: Bool,
+        config: VMConfiguration
+    ) throws {
+        do {
+            try vzConfig.validate()
+        } catch {
+            guard guestAgentDiskAttached else { throw error }
+            Self.logger.warning(
+                "Dropping the guest agent disk from '\(config.name, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+            vzConfig.storageDevices.removeLast()
+            try vzConfig.validate()
+        }
+    }
+
     /// Attaches every `removableMedia` item to the XHCI controller's
     /// `usbDevices` list and returns the matching `USBDeviceInfo`s for
     /// runtime tracking in `instance.liveRemovableMedia`.
@@ -437,13 +510,46 @@ struct ConfigurationBuilder: Sendable {
         )
     }
 
+    /// Synthesizes the guest-agent installer's disk entry.
+    ///
+    /// The entry is built per boot and never written to `config.storageDisks`:
+    /// persisting it would put the app's own bundled resource into the Settings
+    /// disk list, the boot-order sheet, and the delete sheet's offer to trash
+    /// external files.
+    static func guestAgentDisk(installerPath: String, bundleURL: URL) -> StorageDisk {
+        StorageDisk(
+            id: stableGuestAgentDiskID(forBundleAt: bundleURL),
+            path: installerPath,
+            readOnly: true,
+            label: KernovaMacOSAgentInfo.diskLabel,
+            // The path is absolute and outside the bundle, and `.dmg` would
+            // otherwise default to the USB bus this delivery exists to avoid.
+            isInternal: false,
+            kind: .virtio
+        )
+    }
+
     /// Deterministic UUID for the synthesized main disk, derived from the bundle path.
     ///
     /// Without stable identity, `removeStorageDisk`'s lookup-by-id would miss the
     /// row the user just clicked — silently no-op'ing the entry removal while
     /// still trashing the underlying file.
     private static func stableMainDiskID(forBundleAt bundleURL: URL) -> UUID {
-        let digest = SHA256.hash(data: Data(bundleURL.path.utf8))
+        stableDiskID(seed: bundleURL.path)
+    }
+
+    /// Deterministic UUID for the guest-agent disk, salted so it can never
+    /// collide with the main disk's on the same bundle.
+    ///
+    /// It reaches the guest as `blockDeviceIdentifier`, so a fresh UUID per
+    /// launch would vary the disk's guest-side name from one boot to the next.
+    private static func stableGuestAgentDiskID(forBundleAt bundleURL: URL) -> UUID {
+        stableDiskID(seed: bundleURL.path + "\u{0}guest-agent")
+    }
+
+    /// A UUID fixed by `seed`.
+    private static func stableDiskID(seed: String) -> UUID {
+        let digest = SHA256.hash(data: Data(seed.utf8))
         let bytes = Array(digest.prefix(16))
         return UUID(
             uuid: (

--- a/Kernova/Services/KernovaMacOSAgentInfo.swift
+++ b/Kernova/Services/KernovaMacOSAgentInfo.swift
@@ -14,6 +14,12 @@ enum KernovaMacOSAgentInfo {
     private static let dmgResourceName = "KernovaMacOSAgent"
     private static let dmgResourceExtension = "dmg"
 
+    /// Label every attachment of the installer image carries, matching the
+    /// volume name the "Package Guest Agent DMG" build phase gives it — so the
+    /// name Kernova shows for the attachment is the name the guest shows for
+    /// the mounted volume.
+    static let diskLabel = "Kernova Guest Agent"
+
     /// The version of the guest agent embedded in this build of the host.
     ///
     /// Read from `KernovaMacOSAgentVersion.txt`, written by the "Package Guest

--- a/Kernova/Utilities/DetailAlertsPresenter.swift
+++ b/Kernova/Utilities/DetailAlertsPresenter.swift
@@ -187,8 +187,10 @@ final class DetailAlertsPresenter: NSObject {
         enqueue { $0.present($0.cancelPreparingConfig(instance)) }
     }
 
-    func presentInstallerMounted(vmName: String, purpose: GuestAgentInstallerPurpose) {
-        enqueue { $0.present($0.installerMountedConfig(vmName, purpose: purpose)) }
+    func presentInstallerMounted(
+        vmName: String, purpose: GuestAgentInstallerPurpose, delivery: GuestAgentDiskDelivery
+    ) {
+        enqueue { $0.present($0.installerMountedConfig(vmName, purpose: purpose, delivery: delivery)) }
     }
 
     // MARK: - Serialization queue
@@ -354,23 +356,34 @@ final class DetailAlertsPresenter: NSObject {
     }
 
     private func installerMountedConfig(
-        _ vmName: String, purpose: GuestAgentInstallerPurpose
+        _ vmName: String, purpose: GuestAgentInstallerPurpose, delivery: GuestAgentDiskDelivery
     ) -> AlertConfiguration {
-        let title: String
         let nextStep: String
         switch purpose {
         case .install:
-            title = "Installer Mounted"
             nextStep = "run install.command to complete setup."
         case .manage:
-            title = "Guest Agent Disk Attached"
             nextStep =
                 "run install.command to reinstall, or uninstall.command to remove the agent."
         }
+
+        let title: String
+        let lead: String
+        switch delivery {
+        case .usb:
+            title = purpose == .install ? "Installer Mounted" : "Guest Agent Disk Attached"
+            lead = "The Kernova guest agent disk has been attached to \(vmName) as a USB disk."
+        case .virtio:
+            // Nothing was attached just now — the disk is there for the whole
+            // session, so the alert describes where it already is.
+            title = "Guest Agent Disk Attached"
+            lead = "The Kernova guest agent disk stays attached to \(vmName) whenever it runs."
+        }
+
         return AlertConfiguration(
             title: title,
             message:
-                "The Kernova guest agent disk has been attached to \(vmName) as a USB disk. Inside the VM, open the “Kernova Guest Agent” disk in Finder and \(nextStep)",
+                "\(lead) Inside the VM, open the “\(KernovaMacOSAgentInfo.diskLabel)” disk in Finder and \(nextStep)",
             buttons: [AlertButton("OK", role: .cancel)])
     }
 }

--- a/Kernova/ViewModels/VMLibraryPresenting.swift
+++ b/Kernova/ViewModels/VMLibraryPresenting.swift
@@ -54,8 +54,10 @@ protocol VMLibraryPresenting: AnyObject {
     /// Show the cancel-preparing (clone/import) confirmation.
     func presentCancelPreparing(for instance: VMInstance)
     /// Show the "guest agent disk attached, here are the next steps" alert,
-    /// worded for `purpose` (install vs. install-or-uninstall).
-    func presentInstallerMounted(vmName: String, purpose: GuestAgentInstallerPurpose)
+    /// worded for `purpose` (install vs. install-or-uninstall) and for how
+    /// `delivery` put the disk in front of the guest.
+    func presentInstallerMounted(
+        vmName: String, purpose: GuestAgentInstallerPurpose, delivery: GuestAgentDiskDelivery)
     /// Present the VM creation wizard sheet.
     func presentCreationWizard()
     /// Move keyboard focus into `instance`'s inline guest display, called at

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -1556,6 +1556,9 @@ final class VMLibraryViewModel {
     /// On mount — and when the disk is already mounted — asks the presenter to show
     /// the next-step alert, so every entry point gives the user feedback. The mount
     /// itself is a no-op when the DMG is already in this VM's `removableMedia` list.
+    ///
+    /// A guest taking the disk over virtio already has it, attached for the whole
+    /// session, so there the alert is the entire action.
     func mountGuestAgentInstaller(
         on instance: VMInstance, purpose: GuestAgentInstallerPurpose = .install
     ) {
@@ -1564,9 +1567,16 @@ final class VMLibraryViewModel {
             assertionFailure("KernovaMacOSAgent.dmg missing — check 'Package Guest Agent DMG' build phase outputs")
             return
         }
+        let delivery = GuestAgentDiskDelivery.mode(for: instance.configuration)
+        guard delivery == .usb else {
+            Self.logger.debug(
+                "Guest agent disk reaches '\(instance.name, privacy: .public)' over virtio; showing next steps only")
+            presenter?.presentInstallerMounted(vmName: instance.name, purpose: purpose, delivery: delivery)
+            return
+        }
         if isGuestAgentInstallerMounted(on: instance) {
             Self.logger.debug("Guest agent installer already mounted on '\(instance.name, privacy: .public)'")
-            presenter?.presentInstallerMounted(vmName: instance.name, purpose: purpose)
+            presenter?.presentInstallerMounted(vmName: instance.name, purpose: purpose, delivery: delivery)
             return
         }
         let path = url.path(percentEncoded: false)
@@ -1577,11 +1587,11 @@ final class VMLibraryViewModel {
                     RemovableMediaItem(
                         path: path,
                         readOnly: true,
-                        label: "Kernova Guest Agent"
+                        label: KernovaMacOSAgentInfo.diskLabel
                     )
                 ]
         }
-        presenter?.presentInstallerMounted(vmName: instance.name, purpose: purpose)
+        presenter?.presentInstallerMounted(vmName: instance.name, purpose: purpose, delivery: delivery)
     }
 
     /// Marks this VM's `.waiting` install nudge as dismissed and persists the choice.

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -544,13 +544,14 @@ extension VMSettingsViewController {
 
     /// What the install-record row is called for `guestOS`.
     ///
-    /// A macOS install ran to completion under Kernova, so its row names what
-    /// the VM was installed from. A Linux ISO is only attached for the
+    /// A macOS install ran to completion under Kernova, so its row names the
+    /// version the VM started life at, sitting beside the "OS Version" row that
+    /// names what the guest reports today. A Linux ISO is only attached for the
     /// distribution's own installer to use — which can install something else,
     /// or nothing — so that row names the media and claims nothing about the
     /// outcome.
     static func installedImageRowLabel(guestOS: VMGuestOS) -> String {
-        guestOS == .macOS ? "Installed From" : "Installer Image"
+        guestOS == .macOS ? "Installed Version" : "Installer Image"
     }
 
     private func buildGeneralSection() -> NSView {

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -1250,4 +1250,147 @@ struct ConfigurationBuilderTests {
             attachedPath == realCanonical,
             "Attachment URL should be the symlink target. Got: \(attachedPath), expected: \(realCanonical)")
     }
+
+    // MARK: - Guest Agent Disk
+
+    /// A macOS-guest config carrying `installedVersion` as its install record.
+    ///
+    /// `bootMode: .efi` rather than `.macOS`: the delivery decision reads
+    /// `guestOS`, while the Mac boot path needs hardware-model data that only a
+    /// real restore image can produce.
+    private func makeAgentDiskConfig(installedVersion: String?) -> VMConfiguration {
+        var config = VMConfiguration(name: "Test macOS", guestOS: .macOS, bootMode: .efi)
+        if let installedVersion {
+            config.installedImage = .macOSRestoreImage(version: installedVersion, build: "21A559")
+        }
+        return config
+    }
+
+    /// Writes a stand-in for the bundled installer image.
+    ///
+    /// `Bundle.main` in a test run is the test host, not the app, so the real
+    /// resource is never found — every guest-agent-disk test injects its own.
+    ///
+    /// Caller must `defer` removal of the returned URL.
+    private func makeAgentDiskImage() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).dmg")
+        try Data(count: 1_048_576).write(to: url)
+        return url
+    }
+
+    @Test("A guest below the USB floor gets the agent disk on virtio, attached last")
+    func subFloorGuestGetsVirtioAgentDisk() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+        let agentURL = try makeAgentDiskImage()
+        defer { try? FileManager.default.removeItem(at: agentURL) }
+
+        let builder = ConfigurationBuilder(guestAgentDiskURL: agentURL)
+        let result = try builder.assemble(
+            from: makeAgentDiskConfig(installedVersion: "12.0.1"), bundleURL: bundleURL,
+            validate: false)
+        let vz = result.configuration
+
+        #expect(vz.storageDevices.count == 2)
+        let agentDevice = try #require(vz.storageDevices.last as? VZVirtioBlockDeviceConfiguration)
+        let attachment = try #require(agentDevice.attachment as? VZDiskImageStorageDeviceAttachment)
+        #expect(attachment.isReadOnly)
+        #expect(
+            attachment.url.standardizedFileURL.path(percentEncoded: false)
+                == agentURL.standardizedFileURL.path(percentEncoded: false))
+        // The whole point of the virtio path: nothing lands on the USB bus.
+        #expect(vz.usbControllers.first?.usbDevices.isEmpty == true)
+    }
+
+    @Test(
+        "A guest at or above the USB floor gets no agent disk",
+        arguments: ["12.3", "12.3.1", "13.0", "26.0"])
+    func atFloorGuestGetsNoAgentDisk(installedVersion: String) throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+        let agentURL = try makeAgentDiskImage()
+        defer { try? FileManager.default.removeItem(at: agentURL) }
+
+        let builder = ConfigurationBuilder(guestAgentDiskURL: agentURL)
+        let result = try builder.assemble(
+            from: makeAgentDiskConfig(installedVersion: installedVersion), bundleURL: bundleURL,
+            validate: false)
+        #expect(result.configuration.storageDevices.count == 1)
+    }
+
+    @Test("A guest of unknown version gets no agent disk")
+    func unknownVersionGuestGetsNoAgentDisk() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+        let agentURL = try makeAgentDiskImage()
+        defer { try? FileManager.default.removeItem(at: agentURL) }
+
+        let builder = ConfigurationBuilder(guestAgentDiskURL: agentURL)
+        let result = try builder.assemble(
+            from: makeAgentDiskConfig(installedVersion: nil), bundleURL: bundleURL, validate: false)
+        #expect(result.configuration.storageDevices.count == 1)
+    }
+
+    @Test("A Linux guest gets no agent disk")
+    func linuxGuestGetsNoAgentDisk() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+        let agentURL = try makeAgentDiskImage()
+        defer { try? FileManager.default.removeItem(at: agentURL) }
+
+        var config = makeLinuxConfig()
+        config.installedImage = .macOSRestoreImage(version: "12.0.1", build: "21A559")
+        let builder = ConfigurationBuilder(guestAgentDiskURL: agentURL)
+        let result = try builder.assemble(from: config, bundleURL: bundleURL, validate: false)
+        #expect(result.configuration.storageDevices.count == 1)
+    }
+
+    @Test("A missing installer image leaves the VM bootable")
+    func missingAgentDiskStillBuilds() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).dmg")
+        let builder = ConfigurationBuilder(guestAgentDiskURL: missing)
+        let result = try builder.assemble(
+            from: makeAgentDiskConfig(installedVersion: "12.0.1"), bundleURL: bundleURL,
+            validate: false)
+        #expect(result.configuration.storageDevices.count == 1)
+    }
+
+    @Test("A build carrying no installer image leaves the VM bootable")
+    func absentAgentDiskStillBuilds() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        let builder = ConfigurationBuilder(guestAgentDiskURL: nil)
+        let result = try builder.assemble(
+            from: makeAgentDiskConfig(installedVersion: "12.0.1"), bundleURL: bundleURL,
+            validate: false)
+        #expect(result.configuration.storageDevices.count == 1)
+    }
+
+    @Test("The agent disk's identity is fixed by the bundle and distinct from the main disk's")
+    func agentDiskIDIsStableAndDistinct() throws {
+        let bundleURL = try makeTempBundle()
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+        let otherBundleURL = try makeTempBundle()
+        defer { try? FileManager.default.removeItem(at: otherBundleURL) }
+
+        let disk = ConfigurationBuilder.guestAgentDisk(installerPath: "/tmp/a.dmg", bundleURL: bundleURL)
+        let again = ConfigurationBuilder.guestAgentDisk(installerPath: "/tmp/a.dmg", bundleURL: bundleURL)
+        let other = ConfigurationBuilder.guestAgentDisk(
+            installerPath: "/tmp/a.dmg", bundleURL: otherBundleURL)
+        let mainDisk = ConfigurationBuilder.defaultMainDisk(layout: VMBundleLayout(bundleURL: bundleURL))
+
+        #expect(disk.id == again.id)
+        #expect(disk.id != other.id)
+        #expect(disk.id != mainDisk.id)
+        // `.dmg` would otherwise default to the USB bus this delivery avoids.
+        #expect(disk.kind == .virtio)
+        #expect(disk.readOnly)
+        #expect(!disk.isInternal)
+    }
 }

--- a/KernovaTests/GuestAgentDiskDeliveryTests.swift
+++ b/KernovaTests/GuestAgentDiskDeliveryTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("GuestAgentDiskDelivery Tests")
+struct GuestAgentDiskDeliveryTests {
+    // MARK: - Helpers
+
+    /// One row of the decision table.
+    struct Case: Sendable, CustomStringConvertible {
+        let lastSeen: String?
+        let installedVersion: String?
+        let expected: GuestAgentDiskDelivery
+
+        init(_ lastSeen: String?, _ installedVersion: String?, _ expected: GuestAgentDiskDelivery) {
+            self.lastSeen = lastSeen
+            self.installedVersion = installedVersion
+            self.expected = expected
+        }
+
+        var description: String {
+            "reported \(lastSeen ?? "nil"), installed \(installedVersion ?? "nil") → \(expected)"
+        }
+    }
+
+    private static func makeConfig(
+        guestOS: VMGuestOS = .macOS,
+        lastSeen: String? = nil,
+        installedVersion: String? = nil
+    ) -> VMConfiguration {
+        var config = VMConfiguration(
+            name: "Test", guestOS: guestOS, bootMode: guestOS == .macOS ? .macOS : .efi)
+        config.lastSeenGuestOSVersion = lastSeen
+        if let installedVersion {
+            config.installedImage = .macOSRestoreImage(version: installedVersion, build: "21A559")
+        }
+        return config
+    }
+
+    // MARK: - Decision table
+
+    @Test(
+        "Delivery follows the guest's version",
+        arguments: [
+            // No signal at all keeps the behavior every VM had before the
+            // virtio path existed.
+            Case(nil, nil, .usb),
+            // Install record alone, on both sides of the floor.
+            Case(nil, "12.0.1", .virtio),
+            Case(nil, "12.2.1", .virtio),
+            Case(nil, "12.3", .usb),
+            Case(nil, "12.3.1", .usb),
+            Case(nil, "13.0", .usb),
+            // Compared as numbers, not as text: "12.10" sorts below "12.3".
+            Case(nil, "12.10", .usb),
+            // The agent's report outranks the install record, both directions.
+            Case("12.7.6", "12.0.1", .usb),
+            Case("12.0.1", "12.7.6", .virtio),
+            // Localized free-form reports still read as a version.
+            Case("Versión 12.2.1 (Compilación 21D62)", nil, .virtio),
+            Case("Version 12.3 (Build 21E230)", nil, .usb),
+            // A report that parses to nothing falls through rather than
+            // erasing the install record's vote.
+            Case("macOS", "12.0.1", .virtio),
+            Case("", "12.0.1", .virtio),
+            Case("macOS", nil, .usb),
+        ])
+    func deliveryFollowsGuestVersion(testCase: Case) {
+        let config = Self.makeConfig(
+            lastSeen: testCase.lastSeen, installedVersion: testCase.installedVersion)
+        #expect(GuestAgentDiskDelivery.mode(for: config) == testCase.expected)
+    }
+
+    @Test("A Linux guest never takes the virtio path", arguments: [nil, "12.1"] as [String?])
+    func linuxGuestAlwaysUSB(lastSeen: String?) {
+        let config = Self.makeConfig(
+            guestOS: .linux, lastSeen: lastSeen, installedVersion: "12.0.1")
+        #expect(GuestAgentDiskDelivery.mode(for: config) == .usb)
+    }
+
+    // MARK: - Hostile reports
+
+    @Test("A report carrying a command still reads as its leading version")
+    func reportWithTrailingJunk() {
+        #expect(GuestAgentDiskDelivery.mode(for: Self.makeConfig(lastSeen: "12.3; rm -rf /")) == .usb)
+    }
+
+    @Test("A negative report reads as its digits, below the floor")
+    func negativeReport() {
+        #expect(GuestAgentDiskDelivery.mode(for: Self.makeConfig(lastSeen: "-1")) == .virtio)
+    }
+
+    @Test("A report too large to be a version falls through to the install record")
+    func unparsablyLargeReport() {
+        let huge = String(repeating: "9", count: 10_000)
+        #expect(GuestAgentDiskDelivery.mode(for: Self.makeConfig(lastSeen: huge)) == .usb)
+        #expect(
+            GuestAgentDiskDelivery.mode(
+                for: Self.makeConfig(lastSeen: huge, installedVersion: "12.0.1")) == .virtio)
+    }
+
+    @Test("An unparsable install record leaves the version unknown")
+    func unparsableInstallRecord() {
+        var config = Self.makeConfig()
+        config.installedImage = .macOSRestoreImage(version: "not a version", build: "21A559")
+        #expect(GuestAgentDiskDelivery.effectiveGuestVersion(for: config) == nil)
+        #expect(GuestAgentDiskDelivery.mode(for: config) == .usb)
+    }
+
+    @Test("A Linux install record never answers for a macOS guest's version")
+    func linuxInstallRecordIsNotAVersion() {
+        var config = Self.makeConfig()
+        config.installedImage = .linuxCatalogImage(distribution: "Ubuntu", version: "12.0.1")
+        #expect(GuestAgentDiskDelivery.effectiveGuestVersion(for: config) == nil)
+        #expect(GuestAgentDiskDelivery.mode(for: config) == .usb)
+    }
+
+    // MARK: - Version comparison
+
+    @Test(
+        "isAtLeast compares components as numbers",
+        arguments: [
+            ("12.3", true),
+            ("12.3.0", true),
+            ("12.3.1", true),
+            ("12.10", true),
+            ("13.0", true),
+            ("26.0", true),
+            ("12.2.1", false),
+            ("12.2", false),
+            ("12.0.1", false),
+            ("11.7.10", false),
+        ])
+    func isAtLeastComparesNumerically(version: String, expected: Bool) throws {
+        let parsed = try #require(MacOSVersion(version))
+        #expect(parsed.isAtLeast(GuestAgentDiskDelivery.usbMassStorageFloor) == expected)
+    }
+
+    @Test("A compile-time version equals the same version parsed from text")
+    func compileTimeVersionMatchesParsed() {
+        #expect(MacOSVersion(major: 12, minor: 3) == MacOSVersion("12.3"))
+        #expect(MacOSVersion(major: 12, minor: 3) == MacOSVersion("12.3.0"))
+        #expect(MacOSVersion(major: 12, minor: 3, patch: 1) == MacOSVersion("12.3.1"))
+    }
+}

--- a/KernovaTests/Mocks/MockVMLibraryPresenting.swift
+++ b/KernovaTests/Mocks/MockVMLibraryPresenting.swift
@@ -25,6 +25,9 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
     private(set) var cancelPreparingInstances: [VMInstance] = []
     private(set) var installerMountedNames: [String] = []
     private(set) var installerMountedPurposes: [GuestAgentInstallerPurpose] = []
+    /// Parallel to `installerMountedNames`: how each request said the disk
+    /// reaches the guest.
+    private(set) var installerMountedDeliveries: [GuestAgentDiskDelivery] = []
     private(set) var creationWizardCount = 0
     private(set) var focusGuestDisplayInstances: [VMInstance] = []
 
@@ -44,9 +47,12 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
     func presentRecoveryBoot(for instance: VMInstance) { recoveryBootInstances.append(instance) }
     func presentStopPaused(for instance: VMInstance) { stopPausedInstances.append(instance) }
     func presentCancelPreparing(for instance: VMInstance) { cancelPreparingInstances.append(instance) }
-    func presentInstallerMounted(vmName: String, purpose: GuestAgentInstallerPurpose) {
+    func presentInstallerMounted(
+        vmName: String, purpose: GuestAgentInstallerPurpose, delivery: GuestAgentDiskDelivery
+    ) {
         installerMountedNames.append(vmName)
         installerMountedPurposes.append(purpose)
+        installerMountedDeliveries.append(delivery)
     }
     func presentCreationWizard() { creationWizardCount += 1 }
     func focusGuestDisplay(for instance: VMInstance) {
@@ -73,6 +79,7 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
     var showInstallerMountedAlert: Bool { !installerMountedNames.isEmpty }
     var installerMountedVMName: String? { installerMountedNames.last }
     var installerMountedPurpose: GuestAgentInstallerPurpose? { installerMountedPurposes.last }
+    var installerMountedDelivery: GuestAgentDiskDelivery? { installerMountedDeliveries.last }
     var showCreationWizard: Bool { creationWizardCount > 0 }
 
     /// Clears all recorded requests (mirrors resetting the former flags).
@@ -89,6 +96,7 @@ final class MockVMLibraryPresenting: VMLibraryPresenting {
         cancelPreparingInstances.removeAll()
         installerMountedNames.removeAll()
         installerMountedPurposes.removeAll()
+        installerMountedDeliveries.removeAll()
         creationWizardCount = 0
         focusGuestDisplayInstances.removeAll()
     }

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -4281,6 +4281,54 @@ struct VMLibraryViewModelTests {
         viewModel.mountGuestAgentInstaller(on: instance, purpose: .manage)
 
         #expect(presenter.installerMountedPurpose == .manage)
+        #expect(presenter.installerMountedDelivery == .usb)
+    }
+
+    @Test("mountGuestAgentInstaller attaches nothing for a guest that takes the disk on virtio")
+    func mountGuestAgentInstallerVirtioAttachesNothing() async throws {
+        _ = try #require(KernovaMacOSAgentInfo.installerDiskImageURL)
+        let mock = MockUSBDeviceService()
+        let (viewModel, _, _, _, _) = makeViewModel(usbDeviceService: mock)
+        let instance = makeInstance(guestOS: .macOS)
+        instance.configuration.installedImage = .macOSRestoreImage(version: "12.0.1", build: "21A559")
+        instance.status = .running
+        viewModel.instances.append(instance)
+
+        viewModel.mountGuestAgentInstaller(on: instance)
+        await Task.yield()
+
+        #expect(presenter.showInstallerMountedAlert == true)
+        #expect(presenter.installerMountedDelivery == .virtio)
+        // The disk rides in on `storageDevices` at boot, so neither the
+        // removable-media list nor the persisted disk list may grow.
+        #expect(instance.configuration.removableMedia == nil)
+        #expect(instance.configuration.storageDisks == nil)
+        #expect(mock.attachCallCount == 0)
+        #expect(!viewModel.isGuestAgentInstallerMounted(on: instance))
+    }
+
+    @Test("A virtio-delivery guest still ejects a USB disk left over from an earlier session")
+    func virtioGuestStillEjectsStaleUSBDisk() async throws {
+        let installerURL = try #require(KernovaMacOSAgentInfo.installerDiskImageURL)
+        let mock = MockUSBDeviceService()
+        let (viewModel, _, _, _, _) = makeViewModel(usbDeviceService: mock)
+        let instance = makeInstance(guestOS: .macOS)
+        instance.configuration.installedImage = .macOSRestoreImage(version: "12.0.1", build: "21A559")
+        instance.status = .running
+        let installerItem = RemovableMediaItem(
+            path: installerURL.path(percentEncoded: false), readOnly: true)
+        instance.configuration.removableMedia = [installerItem]
+        instance.liveRemovableMedia = [
+            USBDeviceInfo(id: installerItem.id, path: installerItem.path, readOnly: installerItem.readOnly)
+        ]
+        viewModel.instances.append(instance)
+
+        viewModel.unmountGuestAgentInstaller(from: instance)
+
+        while !instance.liveRemovableMedia.isEmpty { await Task.yield() }
+
+        #expect(mock.detachCallCount == 1)
+        #expect(instance.configuration.removableMedia == nil)
     }
 
     @Test("isGuestAgentInstallerMounted reflects whether the bundled DMG is attached")

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -161,7 +161,7 @@ struct VMSettingsViewControllerTests {
             installedImage: .macOSRestoreImage(version: "26.5.2", build: "25F84"),
             lastSeenGuestOSVersion: "Version 26.6 (Build 25G12)")
 
-        #expect(visibleLabel("Installed From", in: vc.view))
+        #expect(visibleLabel("Installed Version", in: vc.view))
         #expect(visibleLabel("macOS 26.5.2 (25F84)", in: vc.view))
         #expect(visibleLabel("OS Version", in: vc.view))
         #expect(visibleLabel("26.6", in: vc.view))
@@ -173,7 +173,7 @@ struct VMSettingsViewControllerTests {
             guestOS: .macOS,
             installedImage: .macOSRestoreImage(version: "26.5.2", build: "25F84"))
 
-        #expect(visibleLabel("Installed From", in: vc.view))
+        #expect(visibleLabel("Installed Version", in: vc.view))
         #expect(!visibleLabel("OS Version", in: vc.view))
     }
 
@@ -182,7 +182,7 @@ struct VMSettingsViewControllerTests {
         let (vc, _, _) = makeOSRowsController(
             guestOS: .macOS, lastSeenGuestOSVersion: "26.6")
 
-        #expect(!visibleLabel("Installed From", in: vc.view))
+        #expect(!visibleLabel("Installed Version", in: vc.view))
         #expect(visibleLabel("OS Version", in: vc.view))
     }
 
@@ -190,7 +190,7 @@ struct VMSettingsViewControllerTests {
     func osRowsNeitherKnown() {
         let (vc, _, _) = makeOSRowsController(guestOS: .macOS)
 
-        #expect(!visibleLabel("Installed From", in: vc.view))
+        #expect(!visibleLabel("Installed Version", in: vc.view))
         #expect(!visibleLabel("OS Version", in: vc.view))
     }
 
@@ -206,7 +206,7 @@ struct VMSettingsViewControllerTests {
         // Booting that ISO is not installing from it — the guest's own
         // installer can write another distribution, or nothing at all — so the
         // row must never claim the install happened.
-        #expect(!containsLabel("Installed From", in: vc.view))
+        #expect(!containsLabel("Installed Version", in: vc.view))
         // Linux guests have no Kernova agent, so the row is never even built.
         #expect(!containsLabel("OS Version", in: vc.view))
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,7 +65,8 @@ band.
 matches `VZUSBDeviceConfiguration.uuid` against the saved-state file's recorded device list, so
 `RemovableMediaItem.id` is written to `config.json` and reused as the device UUID, and the
 synthesized main disk derives its own from the bundle path
-(`ConfigurationBuilder.stableMainDiskID(forBundleAt:)`). Fresh UUIDs break restore.
+(`ConfigurationBuilder.stableMainDiskID(forBundleAt:)`), as does the guest-agent disk from a
+salted variant of it. Fresh UUIDs break restore.
 `clonedForNewInstance` regenerates them so two bundles never share device identity.
 
 ### Services
@@ -362,10 +363,13 @@ kernel resources until relaunch — hence one owner (`RuntimeFileAccess`) and on
   signature when the DMG is baked — export-time re-signing cannot reach inside a DMG resource
   ([RELEASING.md](RELEASING.md)); version bumps are in [BUILD.md](BUILD.md).
 
-  The host's `toggleGuestAgentDisk` menu item attaches that DMG to a running VM as USB mass storage;
-  the guest user runs its `install.command`, which stages the bundle into `~/Applications` and
-  registers a user LaunchAgent; the host auto-ejects once the agent handshakes a current version
-  (`VMInstance.onAgentBecameCurrent`). The agent runs `NSApplication.run()`, **not** `dispatchMain()`
+  That DMG reaches a guest on one of two buses, and `GuestAgentDiskDelivery` owns the choice:
+  the host's `toggleGuestAgentDisk` menu item hot-plugs it as USB mass storage, while a guest too
+  old to bind a driver to one ([VERSION-FLOORS.md](VERSION-FLOORS.md)) instead gets it on
+  `vzConfig.storageDevices` at every boot, appended by `ConfigurationBuilder` and never persisted
+  into `config.storageDisks`. Either way the guest user runs its `install.command`, which stages
+  the bundle into `~/Applications` and registers a user LaunchAgent; the host auto-ejects the USB
+  attachment once the agent handshakes a current version (`VMInstance.onAgentBecameCurrent`). The agent runs `NSApplication.run()`, **not** `dispatchMain()`
   — pasteboard promise callbacks (`provideDataForType`) are delivered by CFRunLoop and never fire
   under a GCD-only main queue. Its executable and Swift module stay `KernovaMacOSAgent` while the
   product is `Kernova Guest Agent`, because the LaunchAgent's `ProgramArguments` path and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,8 +65,7 @@ band.
 matches `VZUSBDeviceConfiguration.uuid` against the saved-state file's recorded device list, so
 `RemovableMediaItem.id` is written to `config.json` and reused as the device UUID, and the
 synthesized main disk derives its own from the bundle path
-(`ConfigurationBuilder.stableMainDiskID(forBundleAt:)`), as does the guest-agent disk from a
-salted variant of it. Fresh UUIDs break restore.
+(`ConfigurationBuilder.stableMainDiskID(forBundleAt:)`). Fresh UUIDs break restore.
 `clonedForNewInstance` regenerates them so two bundles never share device identity.
 
 ### Services

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Deep-dive documentation, read on demand. The always-relevant operating guide —
 | [TOOLBAR.md](TOOLBAR.md) | Adding or changing a toolbar item — the macOS 26 glass-platter model (capsule clustering, the 36×36 metric), the constraints on view-backed items, and the sidebar section's collapse rules |
 | [BUILD.md](BUILD.md) | Touching build machinery — git hooks and worktree setup, the signing identity, test-target topology, DerivedData and build arenas, build-number derivation, guest-agent versioning, LaunchServices ghost cleanup |
 | [SANDBOX.md](SANDBOX.md) | Touching entitlements, or auditing what a build is permitted to do — the Mac App Store readiness story and launch model behind the sandbox rules in AGENTS.md |
+| [VERSION-FLOORS.md](VERSION-FLOORS.md) | Choosing how to deliver something to a guest, or explaining why a feature works on one guest and not another — the guest-side capability floors and what Virtualization allows a live VM |
 | [TESTING.md](TESTING.md) | Writing any test that waits on async state or needs private production state — the async-wait seams, the injected-timeout rule, and test-only exposure patterns |
 | [REVIEW.md](REVIEW.md) | Filing review-debt issues or annotating findings — the full severity bar, issue format and labels, issue hygiene, `RATIONALE:` and `periphery:ignore` formats |
 | [RELEASING.md](RELEASING.md) | Cutting a release — the notarized Developer ID release flow, one-time signing prerequisites, and verification checklist |

--- a/docs/VERSION-FLOORS.md
+++ b/docs/VERSION-FLOORS.md
@@ -1,0 +1,25 @@
+# Version floors
+
+Read this when choosing how to deliver something to a guest, or when a feature works on one guest and not another. Its reader is deciding an approach, not writing an `@available` — the compiler owns those, and Kernova's deployment target is in the project file.
+
+Two different questions live here and are easy to conflate. **Guest-side** floors are what the guest's own kernel and userspace can do; the host API exists at every one of them, so a call that succeeds on the host tells you nothing. **Host-side** limits are what Virtualization.framework offers this build of Kernova at all.
+
+## Guest-side floors — macOS guests
+
+| Capability | Floor | Evidence |
+|---|---|---|
+| A USB mass storage device binds a driver and mounts | macOS **12.3** | [2026-08-07 note](research/2026-08-07-macos12-usb-mass-storage.md) — below it the device enumerates and nothing claims it, because `IOUSBMassStorageDriver.kext` is not in the guest's boot kernel collection |
+| A virtio block device mounts | none within what Virtualization can install | Same note, probe 6 — a raw GPT/APFS image mounts on 12.0.1 |
+| Guest-initiated virtio-vsock connects to a host listener | none within what Virtualization can install | [2026-07-31 note](research/2026-07-31-macos12-guest-vsock.md) — 12.0.1 and 12.7.6 both complete the handshake |
+| `VZMacTrackpadConfiguration` is used instead of the USB pointing device | macOS **13.0** | `VZMacTrackpadConfiguration.h` discussion; pairing both devices is what makes an older guest work, and `ConfigurationBuilder.configureMacOSDevices` does exactly that |
+| SPICE clipboard | never, at any version | macOS ships no `spice-vdagent` counterpart; macOS guests reach the clipboard over vsock instead (`ConfigurationBuilder.configureClipboardSharing`) |
+
+A guest's version is not a thing Kernova can look up on demand — see `GuestAgentDiskDelivery.effectiveGuestVersion`, which reads the agent's last report and falls back to the image the VM was installed from.
+
+## Host-side limits
+
+**A running VM's device set is fixed at boot, except over USB.** `VZUSBController.attach(device:)` / `detach(device:)` are the only APIs that add or remove a device from a live VM. A live `VZVirtioFileSystemDevice` can be pointed at a different share, but that changes a device rather than adding one.
+
+Anything else — a storage device, a network device, a socket device — costs a restart. That is why a guest taking the agent disk over virtio carries it at every boot rather than on demand.
+
+**`VZUSBPassthroughDeviceConfiguration` is macOS 27.0**, above Kernova's deployment target, so it needs an availability guard. Every other Virtualization API Kernova uses is available unconditionally.

--- a/docs/research/2026-08-07-macos12-usb-mass-storage.md
+++ b/docs/research/2026-08-07-macos12-usb-mass-storage.md
@@ -1,0 +1,57 @@
+# macOS guests bind a driver to a VZ USB mass storage device only from 12.3
+
+**Date:** 2026-08-07 · **Host:** M1 Max, 32 GB, macOS 27.0 · **Guests:** macOS 12.0.1 and 12.7.6, Kernova library VMs, 4 vCPU / 8 GB
+
+## Summary
+
+A `VZUSBMassStorageDeviceConfiguration` reaches a macOS 12.0.1 guest intact —
+the device enumerates, configures, and publishes an `IOUSBHostInterface` node
+with correct Bulk-Only Transport descriptors — and then nothing claims it. The
+matching stops there because `IOUSBMassStorageDriver.kext` is absent from that
+guest's boot kernel collection: since Big Sur only a KC-resident kext has
+personalities in the kernel's matching catalogue, and the kext's presence in
+`/System/Library/Extensions` buys nothing. On 12.7.6 the same device grows the
+full `IOUSBMassStorageInterfaceNub → IOUSBMassStorageDriver → SCSI → IOMedia`
+stack and mounts.
+
+The maintainer placed the boundary by hand: 12.2.1 fails, 12.3 works. Every
+macOS guest below 12.3 therefore needs its media on another bus, and a virtio
+block device carrying the same image mounts on 12.0.1.
+
+This is not a Kernova-side descriptor problem, and no host-side change can fix
+it — the guest kernel simply holds no personality that matches class 8.
+
+## Method
+
+Both guests ran the same Kernova build, with the same
+`Resources/KernovaMacOSAgent.dmg` attached through the same
+`USBDeviceService.attach` call, and were probed from their own Terminal.
+
+1. `ioreg -p IOUSB -l` — on both guests the device appears with
+   `kUSBCurrentConfiguration = 1` and an interface descriptor of
+   `bInterfaceClass = 8`, `bInterfaceSubClass = 6`, `bInterfaceProtocol = 80`
+   (0x50, Bulk-Only Transport). Enumeration and configuration are identical;
+   the difference is entirely in what matches afterwards.
+
+2. `ioreg -r -n "Virtual USB Mass Storage Device"` — 12.7.6 shows the whole
+   stack down to an `IOMedia` named for the volume. 12.0.1 stops at
+   `IOUSBHostInterface` with no child.
+
+3. On 12.0.1, `IOUSBMassStorageDriver.kext` is present in
+   `/System/Library/Extensions`, and its `Info.plist` carries the personality
+   that would match: `IOUSBMassStorageInterfaceNubSCSI`, keyed
+   `bInterfaceClass = 8` / `bInterfaceSubClass = 6` on provider class
+   `IOUSBHostInterface` — an exact match for the descriptors in probe 1.
+
+4. `kmutil inspect` — the 12.0.1 boot kernel collection does not list the
+   kext. 12.7.6's lists `IOUSBMassStorageDriver 210.120.3` and
+   `AppleUSBMassStorageInterfaceNub 533.120.2`.
+
+5. The guest's own `kernelmanagerd` log across an attach records no load
+   request for the kext — only unrelated `com.apple.fileutil` and
+   `com.apple.filesystems.autofs` loads — confirming nothing even tries.
+
+6. The same image attached as a `VZVirtioBlockDeviceConfiguration` mounts on
+   12.0.1, and the guest agent was installed from it that way. The image is a
+   raw GPT disk holding one APFS container, so the guest reads it with no USB
+   stack involved.


### PR DESCRIPTION
## Summary

A macOS guest older than 12.3 cannot use the USB path the guest-agent installer has always taken. The device enumerates and configures correctly, and then nothing claims it: `IOUSBMassStorageDriver.kext` is absent from those guests' boot kernel collection, so the kernel holds no personality matching interface class 8. Today the user gets a "Guest Agent Disk Attached" alert pointing at a disk that will never appear.

This is reachable from the built-in picker — `RestoreImageCatalog.json` offers 12.0.1, 12.1, 12.2 and 12.2.1, all below the floor.

Guests below 12.3 now take the installer image on `vzConfig.storageDevices` as a read-only virtio block device, attached at every boot, and the "Install Guest Agent…" command tells the user where the disk already is rather than attaching anything. Every other guest keeps the USB hot-plug path unchanged.

Closes #686 — its remaining open question was exactly this host-side gating, and the retarget itself landed in #747.

## Route taken

**The version signal.** `GuestAgentDiskDelivery.effectiveGuestVersion` reads `lastSeenGuestOSVersion` (agent-reported, stays fresh across an in-guest upgrade) and falls back to `installedImage` (written once at install, goes stale). It takes the first that *parses*, not the first that is non-nil: `AgentInfo.os_version` is peer-supplied free text, so a garbage report must not erase the install record's vote. **Unknown resolves to `.usb`**, preserving today's behavior for every VM predating both signals.

**Always attached, not on demand.** VZ has no runtime block-storage attach — `VZUSBController.attach` is its only live device-set mutation — so an on-demand virtio disk would cost a restart each way. Carrying it every boot also keeps `uninstall.command` reachable, which "Manage Guest Agent…" exists to reach.

**The builder never throws for this disk.** Losing the agent disk is a degraded session; failing the boot is a broken VM. A missing image or a refused attachment logs `.warning` and returns. If `vzConfig.validate()` rejects the configuration *with* the disk, the builder drops it and validates again, so this feature cannot turn a VM that used to boot into one that doesn't.

**Never persisted into `config.storageDisks`.** Writing it would put the app's own bundled resource into the Settings disk list, the boot-order sheet, `clonedForNewInstance`'s id regeneration, and — worst — the delete sheet's offer to trash external files, whose `storageDisks` loop has no agent-DMG exclusion.

**The disk is appended last** with a salted deterministic id. Guests name block devices by attachment order, so prepending would rename a user's own disks on a VM they never touched; a salted seed keeps the id from ever colliding with the synthesized main disk's on the same bundle.

## Rejected alternatives

- **A third `GuestAgentDiskMenuItem.Action` case.** It would re-decide downstream of the view model inside the one type whose job is keeping title and action from disagreeing, and it cannot be authoritative anyway — the sidebar and clipboard entry points never consult it. `mountGuestAgentInstaller` is the single funnel for all three entry points, so the branch belongs there.
- **A sibling of the menu item's hard gate.** That predicate is right on both delivery paths, for the general reason that there is a live guest session to look inside. After rebasing onto #773 it is `VMInstance.canManageGuestAgentDisk`, which also folds in the macOS-guest check; this branch only corrects its comment, which still described the gate as existing for USB hot-plug.
- **Keying on `bootMode`.** `VMInstance.agentStatus` already discriminates agent concerns on `guestOS`, and both enums carry a `.macOS` case. `guestOS` is the correct question: does this guest have a Kernova agent at all.
- **Explaining the guest's age in the alert.** Both version inputs can be stale, so an explanation could be wrong in a way the instructions are not.

## Known limitations

- **A VM created before #763 that has never run the agent is not fixed.** Both signals are nil, so it resolves to `.usb` and still fails. Inherent to the agreed rule that an unknown version must not change existing behavior — filed as #765.
- **One-time loss of suspended sessions for affected VMs.** A sub-12.3 VM saved under the current build resumes under a configuration with one extra storage device; VZ rejects the restore and `restoreOrColdBoot` deletes the save file and cold-boots.
- The effective version can change mid-run (`recordObservedAgentInfo`) while the device set cannot follow. Both directions are transient and self-correct at the next boot.

## Changes

- **New** `Kernova/Models/GuestAgentDiskDelivery.swift` — the `.usb`/`.virtio` decision and the 12.3 floor
- `MacOSVersion` gains a compile-time initializer and `isAtLeast(_:)`, comparing components as numbers so 12.10 outranks 12.3
- `ConfigurationBuilder` — `configureGuestAgentDisk`, the validate-with-fallback, the shared deterministic-id helper, and an injectable `guestAgentDiskURL`
- `VMLibraryViewModel.mountGuestAgentInstaller` — the virtio branch
- `presentInstallerMounted` gains `delivery:`; `DetailAlertsPresenter` gains the virtio copy
- `KernovaMacOSAgentInfo.diskLabel` replaces the label literal duplicated across attachment sites
- **New** `docs/VERSION-FLOORS.md` + its `docs/README.md` row, **new** `docs/research/2026-08-07-macos12-usb-mass-storage.md`, and surgical `docs/ARCHITECTURE.md` edits

Riding along in its own commit: the macOS install-record row is renamed **"Installed From" → "Installed Version"**. It reads against the neighbouring "OS Version" row as then-and-now, which matters more now that this change makes `installedImage` load-bearing rather than merely informational. The Linux label is untouched — attaching an ISO is not a completed install. Say the word if you'd rather it went out on its own.

## Test plan

- [x] `make test` — full suite green, including the new `GuestAgentDiskDeliveryTests` decision table (both sides of the floor, signal precedence in both directions, localized and hostile reports), the `ConfigurationBuilderTests` guest-agent-disk section, and the view-model virtio path
- [x] `make lint` — swift-format strict, shell, and docs checks green
- [x] macOS 12.0.1 guest, on the real host: `ConfigurationBuilder` logs `Attached the guest agent disk … as a virtio block device`, VZ validates the configuration with it, and the guest mounts it with no menu action — `/dev/disk2s1 on /Volumes/Kernova Guest Agent (apfs, local, read-only, journaled)`. "Manage Guest Agent…" shows the virtio alert and attaches nothing: Removable Media stays empty and Storage Disks still lists only the main disk, so the synthesized entry is never persisted. `install.command` runs from the mounted volume and the agent handshakes at 0.56.0, after which Settings shows OS Version 12.0.1.
- [x] macOS 12.7.6 guest: unchanged. No agent disk is attached at boot, "Install Guest Agent…" mounts over USB with the original "Installer Mounted" copy, and "Eject Guest Agent Media" removes it.

## Notes

- No `RATIONALE:` comments added.
- Follow-ups filed from this work: #765 (no override when both version signals are absent), plus #766 and #767, both since fixed and merged in #773 — this branch is rebased onto that.
- A later review added two notes to #765: the watchdog that clears `lastSeenGuestOSVersion` can demote a working virtio VM back to the broken USB attach when that is its only signal, and `mountGuestAgentInstaller` re-derives the delivery at click time rather than reading what was actually attached at boot. Both close if an unknown version resolves to virtio instead of USB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9G6569SozRdRQ1aU2kY2C
