### PR TITLE
feat: Add an app-wide preference to turn the guest-agent install prompt off

### DIFF
--- a/Kernova/Utilities/AppPreferences.swift
+++ b/Kernova/Utilities/AppPreferences.swift
@@ -30,6 +30,7 @@ struct AppPreferences {
         // property's RATIONALE.
         static let quitTerminatesApp = "quitTerminatesApp"
         static let menuBarQuitReminderDismissed = "menuBarQuitReminderDismissed"
+        static let agentInstallPromptDisabled = "agentInstallPromptDisabled"
         static let mainToolbarNewVMCollapseIndex = "KernovaMainToolbarNewVMCollapseIndex"
         // Also inverted — see `keepInMenuBarOnQuit`'s RATIONALE.
         static let allowDuplicateMachineIDBoot = "allowDuplicateMachineIDBoot"
@@ -106,6 +107,18 @@ struct AppPreferences {
         nonmutating set { defaults.set(newValue, forKey: Keys.menuBarQuitReminderDismissed) }
     }
 
+    /// Whether the sidebar's guest-agent install nudge is turned off for every
+    /// VM, defaulting to `false`.
+    ///
+    /// Suppresses only the gentle `.waiting` prompt, matching the scope of the
+    /// per-VM `VMConfiguration.agentInstallNudgeDismissed` flag it overrides.
+    /// Read and written through `VMLibraryViewModel.agentInstallPromptDisabled`,
+    /// whose `@Observable` mirror is what wakes the panes that render it.
+    var agentInstallPromptDisabled: Bool {
+        get { defaults.bool(forKey: Keys.agentInstallPromptDisabled) }
+        nonmutating set { defaults.set(newValue, forKey: Keys.agentInstallPromptDisabled) }
+    }
+
     /// The main toolbar index New VM was removed from while the sidebar is
     /// collapsed, or `nil` when it sits in the toolbar.
     ///
@@ -158,9 +171,9 @@ struct AppPreferences {
     /// Re-arms every host-side reminder by clearing its dismissed flag, so each
     /// nag shows again the next time its condition is met.
     ///
-    /// Covers only the reminders whose dismissed state lives in *this* defaults
-    /// domain — the per-VM agent-install nudges in each VM's bundle configuration
-    /// are left untouched.
+    /// Covers only the menu-bar quit reminder. The guest-agent install nudge —
+    /// app-wide here, per-VM in each bundle configuration — is re-armed as one
+    /// by `VMLibraryViewModel.resetAllAgentInstallNudges()`.
     func resetHostReminders() {
         menuBarQuitReminderDismissed = false
     }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -28,6 +28,23 @@ final class VMLibraryViewModel {
         }
     }
 
+    /// Whether the sidebar's guest-agent install nudge is turned off for every
+    /// VM, overriding each VM's own `agentInstallNudgeDismissed` flag without
+    /// touching it.
+    ///
+    /// The single write path for `AppPreferences.agentInstallPromptDisabled`,
+    /// mirrored here because the sidebar and the VM Settings pane refresh from
+    /// `withObservationTracking`, which a bare `UserDefaults` read never wakes.
+    var agentInstallPromptDisabled: Bool {
+        didSet {
+            guard agentInstallPromptDisabled != oldValue else { return }
+            Self.logger.notice(
+                "Setting app-wide agent install prompt disabled=\(self.agentInstallPromptDisabled, privacy: .public)"
+            )
+            preferences.agentInstallPromptDisabled = agentInstallPromptDisabled
+        }
+    }
+
     /// Presentation delegate for alerts, sheets, and the creation wizard.
     ///
     /// Errors raised before a presenter is attached (e.g. the initial `loadVMs()`
@@ -114,6 +131,7 @@ final class VMLibraryViewModel {
         self.diskImageService = diskImageService
         self.fileSystem = fileSystem
         self.preferences = preferences
+        self.agentInstallPromptDisabled = preferences.agentInstallPromptDisabled
         self.lifecycle = VMLifecycleCoordinator(
             virtualizationService: virtualizationService,
             installService: installService,
@@ -1575,12 +1593,14 @@ final class VMLibraryViewModel {
         updateConfiguration(of: instance) { $0.agentInstallNudgeDismissed = dismissed }
     }
 
-    /// Re-arms the agent-install nudge for every VM by clearing its dismissed
-    /// flag, so each VM's `.waiting` nudge can surface again.
+    /// Re-arms the agent-install nudge everywhere: clears the app-wide
+    /// suppression *and* every VM's dismissed flag, so each VM's `.waiting`
+    /// nudge can surface again.
     ///
     /// Each VM's flag lives in its own bundle configuration and is persisted
     /// individually; VMs already armed no-op.
     func resetAllAgentInstallNudges() {
+        agentInstallPromptDisabled = false
         for instance in instances {
             setAgentInstallNudgeDismissed(false, for: instance)
         }

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -166,6 +166,12 @@ final class VMSettingsViewController: NSViewController {
     // Guest Agent
     private var logForwardingSwitch = NSSwitch()
     private var installReminderSwitch = NSSwitch()
+    /// The install-reminder row's title label, retained so `refreshGuestAgent`
+    /// can gray it in step with the switch.
+    private var installReminderLabel = NSTextField()
+    /// Explains the disabled install-reminder row while the prompt is off
+    /// app-wide; hidden otherwise.
+    private var installReminderOverrideCaption = NSView()
 
     // Clipboard
     private var clipboardSwitch = NSSwitch()
@@ -314,6 +320,7 @@ final class VMSettingsViewController: NSViewController {
                 _ = self.instance.configuration
                 _ = self.instance.status
                 _ = self.viewModel.activeRename
+                _ = self.viewModel.agentInstallPromptDisabled
             },
             apply: { [weak self] in self?.apply() }
         )
@@ -936,6 +943,11 @@ extension VMSettingsViewController {
     static let agentDependencyCaption =
         "Clipboard sharing and log forwarding require the Kernova guest agent. Kernova offers to install or update it from the clipboard window."
 
+    /// Shown under the Guest Agent card while the app-wide preference turns the
+    /// install prompt off, so the greyed row reads as controlled elsewhere.
+    static let installPromptDisabledCaption =
+        "The install reminder is turned off for all virtual machines in Settings → Reminders."
+
     /// Info-popover copy for the "Automatic Clipboard Passthrough" toggle, shared
     /// by the macOS and Linux clipboard sections.
     static let passthroughInfoParagraphs: [InfoPopoverParagraph] = [
@@ -981,10 +993,15 @@ extension VMSettingsViewController {
                     .body(
                         "Surfaces the install icon in the sidebar when the guest agent has not yet connected. Turn off to suppress the nudge for this VM. The more urgent indicators (update available, didn't reconnect, unresponsive) are not affected."
                     )
-                ]),
+                ],
+                titleLabel: { [weak self] in self?.installReminderLabel = $0 }),
         ])
+        let overrideCaption = makeGroupedFormCaption(Self.installPromptDisabledCaption)
+        overrideCaption.isHidden = true
+        installReminderOverrideCaption = overrideCaption
         return makeSection([
             makeHeader("Guest Agent"), card, makeGroupedFormCaption(Self.agentDependencyCaption),
+            overrideCaption,
         ])
     }
 
@@ -1470,7 +1487,16 @@ extension VMSettingsViewController {
     private func refreshGuestAgent() {
         guard isGuestAgentSectionVisible(guestOS: instance.configuration.guestOS) else { return }
         logForwardingSwitch.state = instance.configuration.agentLogForwardingEnabled ? .on : .off
+        // The per-VM flag keeps its value while the app-wide preference overrides
+        // it, so the switch still shows what this VM reverts to when the
+        // preference is turned back on — it just can't be changed from here.
         installReminderSwitch.state = instance.configuration.agentInstallNudgeDismissed ? .off : .on
+        let overridden = viewModel.agentInstallPromptDisabled
+        installReminderSwitch.isEnabled = !overridden
+        // AppKit fades the disabled switch but not its label, which leaves the
+        // row half-lit; gray the text in step so the row reads as inert.
+        installReminderLabel.textColor = overridden ? .disabledControlTextColor : .labelColor
+        installReminderOverrideCaption.isHidden = !overridden
     }
 
     private func refreshClipboard() {

--- a/Kernova/Views/Settings/RemindersSettingsViewController.swift
+++ b/Kernova/Views/Settings/RemindersSettingsViewController.swift
@@ -9,8 +9,10 @@ import os
 /// VM Settings pane's "Show install reminder" toggle.
 ///
 /// The app-wide *Menu Bar Quit Reminder* is backed by `AppPreferences`; the
-/// per-VM *guest-agent install nudge* rows are backed by each VM's bundle
-/// configuration and written through
+/// app-wide *Guest Agent Install Reminder* by
+/// `VMLibraryViewModel.agentInstallPromptDisabled`, which overrides every
+/// per-VM row below it; the per-VM *guest-agent install nudge* rows are backed
+/// by each VM's bundle configuration and written through
 /// `VMLibraryViewModel.setAgentInstallNudgeDismissed(_:for:)`.
 ///
 /// `viewWillAppear()` rebuilds the per-VM rows from `viewModel.instances` and
@@ -31,12 +33,18 @@ final class RemindersSettingsViewController: NSViewController {
     private let viewModel: VMLibraryViewModel
 
     private let menuBarQuitSwitch = NSSwitch()
+    private let agentInstallSwitch = NSSwitch()
 
     /// The persistent container in the content stack that holds either the
     /// per-VM card or the empty-state caption, rebuilt on every appear.
     private let vmSection = NSStackView()
-    /// The live per-VM switches, paired with their VM, rebuilt on every appear.
-    private var vmSwitches: [(instance: VMInstance, control: NSSwitch)] = []
+    /// The live per-VM switches, paired with their VM and row label, rebuilt on
+    /// every appear.
+    ///
+    /// The label is grayed in step with a disabled switch.
+    private var vmSwitches: [(instance: VMInstance, control: NSSwitch, label: NSTextField)] = []
+    /// Explains the disabled per-VM rows while the app-wide switch is off.
+    private var vmOverrideCaption = NSTextField()
     /// Keeps the per-VM rows in sync with the library while the pane is visible.
     private var vmObservation: ObservationLoop?
 
@@ -56,14 +64,20 @@ final class RemindersSettingsViewController: NSViewController {
         menuBarQuitSwitch.controlSize = .small
         menuBarQuitSwitch.target = self
         menuBarQuitSwitch.action = #selector(menuBarQuitToggled)
+        agentInstallSwitch.controlSize = .small
+        agentInstallSwitch.target = self
+        agentInstallSwitch.action = #selector(agentInstallToggled)
 
-        // App-wide reminders: one card, one row.
+        // App-wide reminders.
         let appCard = makeGroupedFormCard(rows: [
-            makeGroupedFormCardRow("Menu Bar Quit Reminder", control: menuBarQuitSwitch)
+            makeGroupedFormCardRow("Menu Bar Quit Reminder", control: menuBarQuitSwitch),
+            makeGroupedFormCardRow("Guest Agent Install Reminder", control: agentInstallSwitch),
         ])
         let appMenuCaption = makeGroupedFormCaption(
             "The Menu Bar Quit Reminder appears when you quit (⌘Q) and Kernova keeps running in the "
-                + "menu bar, reminding you it — and your virtual machines — are still going.")
+                + "menu bar, reminding you it — and your virtual machines — are still going. The "
+                + "Guest Agent Install Reminder is the sidebar prompt to install the Kernova guest "
+                + "agent; turning it off silences it for every virtual machine.")
 
         // Per-VM reminders: rebuilt on every appear (VMs may be added or removed).
         vmSection.orientation = .vertical
@@ -72,6 +86,10 @@ final class RemindersSettingsViewController: NSViewController {
         let vmCaption = makeGroupedFormCaption(
             "Turn a virtual machine off to stop its sidebar reminder to install the Kernova guest "
                 + "agent. This has no effect once the agent is installed.")
+        vmOverrideCaption = makeGroupedFormCaption(
+            "The Guest Agent Install Reminder above is off, so these have no effect. Turn it back "
+                + "on to choose per virtual machine.")
+        vmOverrideCaption.isHidden = true
 
         let resetButton = NSButton(
             title: "Reset All Reminders", target: self, action: #selector(resetAllReminders))
@@ -88,6 +106,7 @@ final class RemindersSettingsViewController: NSViewController {
             makeGroupedFormSectionHeader("Virtual Machine Reminders"),
             vmSection,
             vmCaption,
+            vmOverrideCaption,
             resetButton,
             resetCaption,
         ])
@@ -95,13 +114,15 @@ final class RemindersSettingsViewController: NSViewController {
         content.alignment = .leading
         content.spacing = Spacing.small
         // Separate each logical group so they read as distinct blocks, matching
-        // the General pane's rhythm.
+        // the General pane's rhythm. The override caption sits between the two,
+        // so the spacing follows whichever of the pair is visible.
         content.setCustomSpacing(Spacing.section, after: appMenuCaption)
         content.setCustomSpacing(Spacing.section, after: vmCaption)
+        content.setCustomSpacing(Spacing.section, after: vmOverrideCaption)
 
         // Full-width members (cards and wrapping captions). The reset button is
         // intentionally excluded so it hugs its intrinsic width at the leading edge.
-        for member in [appCard, appMenuCaption, vmSection, vmCaption, resetCaption] {
+        for member in [appCard, appMenuCaption, vmSection, vmCaption, vmOverrideCaption, resetCaption] {
             member.widthAnchor.constraint(equalTo: content.widthAnchor).isActive = true
         }
 
@@ -156,14 +177,16 @@ final class RemindersSettingsViewController: NSViewController {
     /// Re-arms the observation that keeps the per-VM rows current while the pane
     /// is on screen.
     ///
-    /// Tracks the VM list's identity *and* each VM's nudge flag, so a VM created
-    /// or deleted in the main window, or a nudge dismissed from the sidebar
-    /// popover or VM Settings, is reflected here without a tab round-trip.
+    /// Tracks the VM list's identity, each VM's nudge flag, *and* the app-wide
+    /// suppression, so a VM created or deleted in the main window, or a nudge
+    /// dismissed from the sidebar popover or VM Settings, is reflected here
+    /// without a tab round-trip.
     private func startVMObservation() {
         vmObservation?.cancel()
         vmObservation = observeRecurring(
             track: { [weak self] in
                 guard let self else { return }
+                _ = viewModel.agentInstallPromptDisabled
                 for instance in viewModel.instances {
                     _ = instance.id
                     _ = instance.name
@@ -204,8 +227,11 @@ final class RemindersSettingsViewController: NSViewController {
             toggle.controlSize = .small
             toggle.target = self
             toggle.action = #selector(vmReminderToggled(_:))
-            vmSwitches.append((instance, toggle))
-            rows.append(makeGroupedFormCardRow(instance.name, control: toggle))
+            var rowLabel = NSTextField()
+            let row = makeGroupedFormCardRow(
+                instance.name, control: toggle, titleLabel: { rowLabel = $0 })
+            vmSwitches.append((instance, toggle, rowLabel))
+            rows.append(row)
         }
 
         let card = makeGroupedFormCard(rows: rows)
@@ -215,15 +241,30 @@ final class RemindersSettingsViewController: NSViewController {
 
     /// Mirrors every switch to current state — ON when the reminder is shown
     /// (its dismissed flag is `false`).
+    ///
+    /// A per-VM row keeps showing what its VM reverts to while the app-wide
+    /// install reminder is off; it just can't be changed until that goes back on.
     private func refreshSwitches() {
         menuBarQuitSwitch.state = preferences.menuBarQuitReminderDismissed ? .off : .on
-        for (instance, toggle) in vmSwitches {
+        let overridden = viewModel.agentInstallPromptDisabled
+        agentInstallSwitch.state = overridden ? .off : .on
+        vmOverrideCaption.isHidden = !overridden
+        for (instance, toggle, label) in vmSwitches {
             toggle.state = instance.configuration.agentInstallNudgeDismissed ? .off : .on
+            toggle.isEnabled = !overridden
+            // AppKit fades the disabled switch but not its label, which leaves
+            // the row half-lit; gray the text in step so the row reads as inert.
+            label.textColor = overridden ? .disabledControlTextColor : .labelColor
         }
     }
 
     @objc private func menuBarQuitToggled() {
         preferences.menuBarQuitReminderDismissed = (menuBarQuitSwitch.state == .off)
+    }
+
+    @objc private func agentInstallToggled() {
+        viewModel.agentInstallPromptDisabled = (agentInstallSwitch.state == .off)
+        refreshSwitches()
     }
 
     @objc private func vmReminderToggled(_ sender: NSSwitch) {

--- a/Kernova/Views/Settings/RemindersSettingsViewController.swift
+++ b/Kernova/Views/Settings/RemindersSettingsViewController.swift
@@ -44,6 +44,7 @@ final class RemindersSettingsViewController: NSViewController, SettingsPaneScrol
     /// The label is grayed in step with a disabled switch.
     private var vmSwitches: [(instance: VMInstance, control: NSSwitch, label: NSTextField)] = []
     /// Explains the disabled per-VM rows while the app-wide switch is off.
+    private var vmCaption = NSTextField()
     private var vmOverrideCaption = NSTextField()
     /// Flashes the pane's scroller when its content overflows the viewport,
     /// signaling there's more below.
@@ -99,7 +100,7 @@ final class RemindersSettingsViewController: NSViewController, SettingsPaneScrol
         vmSection.orientation = .vertical
         vmSection.alignment = .leading
         vmSection.spacing = Spacing.none
-        let vmCaption = makeGroupedFormCaption(
+        vmCaption = makeGroupedFormCaption(
             "Turn a virtual machine off to stop its own reminder. This has no effect once the "
                 + "agent is installed.")
         vmOverrideCaption = makeGroupedFormCaption(
@@ -325,8 +326,14 @@ final class RemindersSettingsViewController: NSViewController, SettingsPaneScrol
         let overridden = viewModel.agentInstallPromptDisabled
         agentInstallSwitch.state = overridden ? .off : .on
 
+        // Both captions talk about the per-VM switches. With no VMs the section
+        // is a lone "No virtual machines yet." row, so they would be describing
+        // controls that aren't on screen.
+        let hasVMs = !vmSwitches.isEmpty
+        vmCaption.isHidden = !hasVMs
+        let showOverrideCaption = overridden && hasVMs
         let wasShowingOverrideCaption = !vmOverrideCaption.isHidden
-        vmOverrideCaption.isHidden = !overridden
+        vmOverrideCaption.isHidden = !showOverrideCaption
 
         for (instance, toggle, label) in vmSwitches {
             toggle.state = instance.configuration.agentInstallNudgeDismissed ? .off : .on
@@ -336,7 +343,7 @@ final class RemindersSettingsViewController: NSViewController, SettingsPaneScrol
             label.textColor = overridden ? .disabledControlTextColor : .labelColor
         }
 
-        if wasShowingOverrideCaption != overridden { rearmScrollFlash() }
+        if wasShowingOverrideCaption != showOverrideCaption { rearmScrollFlash() }
     }
 
     @objc private func menuBarQuitToggled() {

--- a/Kernova/Views/Settings/RemindersSettingsViewController.swift
+++ b/Kernova/Views/Settings/RemindersSettingsViewController.swift
@@ -77,8 +77,8 @@ final class RemindersSettingsViewController: NSViewController {
         agentInstallSwitch.target = self
         agentInstallSwitch.action = #selector(agentInstallToggled)
 
-        // App-wide reminders: one card per reminder, each with its own caption,
-        // so neither description has to name which switch it belongs to.
+        // One card per reminder, each with its own caption, so no description has
+        // to name the switch it belongs to.
         let menuBarCard = makeGroupedFormCard(rows: [
             makeGroupedFormCardRow("Menu Bar Quit Reminder", control: menuBarQuitSwitch)
         ])
@@ -86,24 +86,50 @@ final class RemindersSettingsViewController: NSViewController {
             "Appears when you quit (⌘Q) and Kernova keeps running in the menu bar, reminding you "
                 + "it — and your virtual machines — are still going.")
 
+        // The governing control of the Virtual Machine Reminders section, so it
+        // heads that section rather than sitting with the app reminder above.
         let agentInstallCard = makeGroupedFormCard(rows: [
             makeGroupedFormCardRow("Guest Agent Install Reminder", control: agentInstallSwitch)
         ])
         let agentInstallCaption = makeGroupedFormCaption(
             "The sidebar prompt to install the Kernova guest agent on a running macOS virtual "
-                + "machine. Turning it off silences it for every virtual machine.")
+                + "machine.")
 
         // Per-VM reminders: rebuilt on every appear (VMs may be added or removed).
         vmSection.orientation = .vertical
         vmSection.alignment = .leading
         vmSection.spacing = Spacing.none
         let vmCaption = makeGroupedFormCaption(
-            "Turn a virtual machine off to stop its sidebar reminder to install the Kernova guest "
-                + "agent. This has no effect once the agent is installed.")
+            "Turn a virtual machine off to stop its own reminder. This has no effect once the "
+                + "agent is installed.")
         vmOverrideCaption = makeGroupedFormCaption(
-            "The Guest Agent Install Reminder above is off, so these have no effect. Turn it back "
-                + "on to choose per virtual machine.")
+            "The reminder above is off, so these have no effect. Turn it back on to choose per "
+                + "virtual machine.")
         vmOverrideCaption.isHidden = true
+
+        // Indented beneath the switch that governs them, the alignment Apple's
+        // guidance uses to show a control's subordinates.
+        let vmSubordinates = NSStackView(views: [vmSection, vmCaption, vmOverrideCaption])
+        vmSubordinates.orientation = .vertical
+        vmSubordinates.alignment = .leading
+        vmSubordinates.spacing = Spacing.small
+        vmSubordinates.translatesAutoresizingMaskIntoConstraints = false
+        // A plain container, not an arranged subview of `content` directly: the
+        // content stack pins its members' leading edges to its own, which an
+        // inset applied out there would fight. Holding the inset inside keeps
+        // the container full-width and the stack's alignment satisfied.
+        let vmGroup = NSView()
+        vmGroup.addSubview(vmSubordinates)
+        NSLayoutConstraint.activate([
+            vmSubordinates.topAnchor.constraint(equalTo: vmGroup.topAnchor),
+            vmSubordinates.bottomAnchor.constraint(equalTo: vmGroup.bottomAnchor),
+            vmSubordinates.leadingAnchor.constraint(
+                equalTo: vmGroup.leadingAnchor, constant: groupedFormSubOptionIndent),
+            vmSubordinates.trailingAnchor.constraint(equalTo: vmGroup.trailingAnchor),
+        ])
+        for member in [vmSection, vmCaption, vmOverrideCaption] {
+            member.widthAnchor.constraint(equalTo: vmSubordinates.widthAnchor).isActive = true
+        }
 
         let resetButton = NSButton(
             title: "Reset All Reminders", target: self, action: #selector(resetAllReminders))
@@ -117,12 +143,10 @@ final class RemindersSettingsViewController: NSViewController {
             makeGroupedFormSectionHeader("App Reminders"),
             menuBarCard,
             menuBarCaption,
+            makeGroupedFormSectionHeader("Virtual Machine Reminders"),
             agentInstallCard,
             agentInstallCaption,
-            makeGroupedFormSectionHeader("Virtual Machine Reminders"),
-            vmSection,
-            vmCaption,
-            vmOverrideCaption,
+            vmGroup,
             resetButton,
             resetCaption,
         ])
@@ -130,20 +154,17 @@ final class RemindersSettingsViewController: NSViewController {
         content.alignment = .leading
         content.spacing = Spacing.small
         // A caption closes its group, so the gap after one is what separates
-        // blocks: the wider `section` step where a section ends, a `large` step
-        // between the two cards within App Reminders. `vmOverrideCaption` follows
-        // `vmCaption` directly, so both carry the section step and whichever ends
-        // up last-visible supplies the gap above the reset button.
-        content.setCustomSpacing(Spacing.large, after: menuBarCaption)
-        content.setCustomSpacing(Spacing.section, after: agentInstallCaption)
-        content.setCustomSpacing(Spacing.section, after: vmCaption)
-        content.setCustomSpacing(Spacing.section, after: vmOverrideCaption)
+        // blocks. The governing switch's caption keeps the tighter step, so its
+        // subordinates read as continuing the same group rather than opening a
+        // new one.
+        content.setCustomSpacing(Spacing.section, after: menuBarCaption)
+        content.setCustomSpacing(Spacing.section, after: vmGroup)
 
         // Full-width members (cards and wrapping captions). The reset button is
         // intentionally excluded so it hugs its intrinsic width at the leading edge.
         for member in [
             menuBarCard, menuBarCaption, agentInstallCard, agentInstallCaption,
-            vmSection, vmCaption, vmOverrideCaption, resetCaption,
+            vmGroup, resetCaption,
         ] {
             member.widthAnchor.constraint(equalTo: content.widthAnchor).isActive = true
         }

--- a/Kernova/Views/Settings/RemindersSettingsViewController.swift
+++ b/Kernova/Views/Settings/RemindersSettingsViewController.swift
@@ -22,7 +22,7 @@ import os
 /// VMs can be created or deleted — and the same nudge dismissed from the sidebar
 /// popover or VM Settings — while this pane is visible.
 @MainActor
-final class RemindersSettingsViewController: NSViewController {
+final class RemindersSettingsViewController: NSViewController, SettingsPaneScrollCueing {
     private static let logger = Logger(subsystem: "app.kernova", category: "RemindersSettingsViewController")
 
     /// Height at which the pane stops growing and starts scrolling — keeps a
@@ -255,6 +255,12 @@ final class RemindersSettingsViewController: NSViewController {
         rebuildVMRows()
         refreshSwitches()
         if previousRowCount != vmSwitches.count { rearmScrollFlash() }
+    }
+
+    /// Re-arms the flash for a fresh appearance, so arriving at an overflowing
+    /// pane cues every visit rather than only the first.
+    func rearmScrollMoreCue() {
+        rearmScrollFlash()
     }
 
     /// Re-arms the "more below" scroller flash after the pane's content height

--- a/Kernova/Views/Settings/RemindersSettingsViewController.swift
+++ b/Kernova/Views/Settings/RemindersSettingsViewController.swift
@@ -45,6 +45,15 @@ final class RemindersSettingsViewController: NSViewController {
     private var vmSwitches: [(instance: VMInstance, control: NSSwitch, label: NSTextField)] = []
     /// Explains the disabled per-VM rows while the app-wide switch is off.
     private var vmOverrideCaption = NSTextField()
+    /// Flashes the pane's scroller when its content overflows the viewport,
+    /// signaling there's more below.
+    private var scrollMoreIndicator: ScrollMoreIndicator?
+
+    #if DEBUG
+    /// The more-below indicator, so a test can assert the flash re-arms when
+    /// the pane's content grows and stays latched when it doesn't.
+    var scrollMoreIndicatorForTesting: ScrollMoreIndicator? { scrollMoreIndicator }
+    #endif
     /// Keeps the per-VM rows in sync with the library while the pane is visible.
     private var vmObservation: ObservationLoop?
 
@@ -68,16 +77,21 @@ final class RemindersSettingsViewController: NSViewController {
         agentInstallSwitch.target = self
         agentInstallSwitch.action = #selector(agentInstallToggled)
 
-        // App-wide reminders.
-        let appCard = makeGroupedFormCard(rows: [
-            makeGroupedFormCardRow("Menu Bar Quit Reminder", control: menuBarQuitSwitch),
-            makeGroupedFormCardRow("Guest Agent Install Reminder", control: agentInstallSwitch),
+        // App-wide reminders: one card per reminder, each with its own caption,
+        // so neither description has to name which switch it belongs to.
+        let menuBarCard = makeGroupedFormCard(rows: [
+            makeGroupedFormCardRow("Menu Bar Quit Reminder", control: menuBarQuitSwitch)
         ])
-        let appMenuCaption = makeGroupedFormCaption(
-            "The Menu Bar Quit Reminder appears when you quit (⌘Q) and Kernova keeps running in the "
-                + "menu bar, reminding you it — and your virtual machines — are still going. The "
-                + "Guest Agent Install Reminder is the sidebar prompt to install the Kernova guest "
-                + "agent; turning it off silences it for every virtual machine.")
+        let menuBarCaption = makeGroupedFormCaption(
+            "Appears when you quit (⌘Q) and Kernova keeps running in the menu bar, reminding you "
+                + "it — and your virtual machines — are still going.")
+
+        let agentInstallCard = makeGroupedFormCard(rows: [
+            makeGroupedFormCardRow("Guest Agent Install Reminder", control: agentInstallSwitch)
+        ])
+        let agentInstallCaption = makeGroupedFormCaption(
+            "The sidebar prompt to install the Kernova guest agent on a running macOS virtual "
+                + "machine. Turning it off silences it for every virtual machine.")
 
         // Per-VM reminders: rebuilt on every appear (VMs may be added or removed).
         vmSection.orientation = .vertical
@@ -101,8 +115,10 @@ final class RemindersSettingsViewController: NSViewController {
 
         let content = NSStackView(views: [
             makeGroupedFormSectionHeader("App Reminders"),
-            appCard,
-            appMenuCaption,
+            menuBarCard,
+            menuBarCaption,
+            agentInstallCard,
+            agentInstallCaption,
             makeGroupedFormSectionHeader("Virtual Machine Reminders"),
             vmSection,
             vmCaption,
@@ -113,16 +129,22 @@ final class RemindersSettingsViewController: NSViewController {
         content.orientation = .vertical
         content.alignment = .leading
         content.spacing = Spacing.small
-        // Separate each logical group so they read as distinct blocks, matching
-        // the General pane's rhythm. The override caption sits between the two,
-        // so the spacing follows whichever of the pair is visible.
-        content.setCustomSpacing(Spacing.section, after: appMenuCaption)
+        // A caption closes its group, so the gap after one is what separates
+        // blocks: the wider `section` step where a section ends, a `large` step
+        // between the two cards within App Reminders. `vmOverrideCaption` follows
+        // `vmCaption` directly, so both carry the section step and whichever ends
+        // up last-visible supplies the gap above the reset button.
+        content.setCustomSpacing(Spacing.large, after: menuBarCaption)
+        content.setCustomSpacing(Spacing.section, after: agentInstallCaption)
         content.setCustomSpacing(Spacing.section, after: vmCaption)
         content.setCustomSpacing(Spacing.section, after: vmOverrideCaption)
 
         // Full-width members (cards and wrapping captions). The reset button is
         // intentionally excluded so it hugs its intrinsic width at the leading edge.
-        for member in [appCard, appMenuCaption, vmSection, vmCaption, vmOverrideCaption, resetCaption] {
+        for member in [
+            menuBarCard, menuBarCaption, agentInstallCard, agentInstallCaption,
+            vmSection, vmCaption, vmOverrideCaption, resetCaption,
+        ] {
             member.widthAnchor.constraint(equalTo: content.widthAnchor).isActive = true
         }
 
@@ -132,6 +154,13 @@ final class RemindersSettingsViewController: NSViewController {
         // Let the pane's size flow from its content (see the General/Advanced
         // panes for why the root must not use autoresizing-mask constraints).
         scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        // Flash-only (no chevron/fade overlays): this scroll view *is* the pane's
+        // root, so it has no superview of its own to host them until the tab view
+        // adopts it. The window is sized once per tab selection, so content that
+        // grows while the pane is on screen — a VM added or removed, the override
+        // caption appearing — overflows in place; the flash is what says so.
+        scrollMoreIndicator = ScrollMoreIndicator(scrollView: scrollView, cues: .flash)
 
         // The hug must stay weaker than every subview's compression resistance:
         // once the tab controller fixes the window height at the cap, a
@@ -201,8 +230,28 @@ final class RemindersSettingsViewController: NSViewController {
 
     /// Rebuilds the per-VM rows and mirrors every switch to current state.
     private func refreshVMRows() {
+        let previousRowCount = vmSwitches.count
         rebuildVMRows()
         refreshSwitches()
+        if previousRowCount != vmSwitches.count { rearmScrollFlash() }
+    }
+
+    /// Re-arms the "more below" scroller flash after the pane's content height
+    /// changes while it is on screen.
+    ///
+    /// The window is sized once per tab selection, so content that grows
+    /// afterwards overflows in place with nothing to say so. Layout has to
+    /// settle first: overflow is measured against the document's real height,
+    /// and an un-laid-out subtree still reports the old one.
+    ///
+    /// Skipped before the pane has a height, which is where the first row build
+    /// runs: every content height beats a zero-height viewport, so re-arming
+    /// there would latch the flash against geometry the user never sees and
+    /// spend the cue the pane's actual appearance needs.
+    private func rearmScrollFlash() {
+        guard view.frame.height > 0 else { return }
+        view.layoutSubtreeIfNeeded()
+        scrollMoreIndicator?.rearmFlash()
     }
 
     /// Rebuilds the per-VM section from `viewModel.instances`: one switch row per
@@ -248,7 +297,10 @@ final class RemindersSettingsViewController: NSViewController {
         menuBarQuitSwitch.state = preferences.menuBarQuitReminderDismissed ? .off : .on
         let overridden = viewModel.agentInstallPromptDisabled
         agentInstallSwitch.state = overridden ? .off : .on
+
+        let wasShowingOverrideCaption = !vmOverrideCaption.isHidden
         vmOverrideCaption.isHidden = !overridden
+
         for (instance, toggle, label) in vmSwitches {
             toggle.state = instance.configuration.agentInstallNudgeDismissed ? .off : .on
             toggle.isEnabled = !overridden
@@ -256,6 +308,8 @@ final class RemindersSettingsViewController: NSViewController {
             // the row half-lit; gray the text in step so the row reads as inert.
             label.textColor = overridden ? .disabledControlTextColor : .labelColor
         }
+
+        if wasShowingOverrideCaption != overridden { rearmScrollFlash() }
     }
 
     @objc private func menuBarQuitToggled() {

--- a/Kernova/Views/Settings/SettingsTabViewController.swift
+++ b/Kernova/Views/Settings/SettingsTabViewController.swift
@@ -1,6 +1,18 @@
 import AppKit
 import os
 
+/// A Settings pane that can outgrow the window and shows a scroller flash to
+/// say there is more below.
+///
+/// The flash latches after firing once, so a pane that lives as long as the
+/// Settings window would cue only its first visit. The tab container re-arms
+/// every pane it selects, which is what makes the cue greet each arrival.
+@MainActor
+protocol SettingsPaneScrollCueing: AnyObject {
+    /// Re-arms the pane's "more below" flash for a fresh appearance.
+    func rearmScrollMoreCue()
+}
+
 /// Layout tokens shared by every pane of the Settings window.
 ///
 /// Surface-specific, so they live here (next to the tab container that owns the
@@ -28,9 +40,11 @@ final class SettingsTabViewController: NSTabViewController {
     private static let logger = Logger(subsystem: "app.kernova", category: "SettingsTabViewController")
 
     private let viewModel: VMLibraryViewModel
+    private let preferences: AppPreferences
 
-    init(viewModel: VMLibraryViewModel) {
+    init(viewModel: VMLibraryViewModel, preferences: AppPreferences = .shared) {
         self.viewModel = viewModel
+        self.preferences = preferences
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -43,24 +57,28 @@ final class SettingsTabViewController: NSTabViewController {
         super.viewDidLoad()
         tabStyle = .toolbar
 
-        let general = NSTabViewItem(viewController: GeneralSettingsViewController())
+        let general = NSTabViewItem(
+            viewController: GeneralSettingsViewController(preferences: preferences))
         general.label = "General"
         general.image = Self.symbol("gearshape")
         addTabViewItem(general)
 
         let reminders = NSTabViewItem(
-            viewController: RemindersSettingsViewController(viewModel: viewModel))
+            viewController: RemindersSettingsViewController(
+                preferences: preferences, viewModel: viewModel))
         reminders.label = "Reminders"
         reminders.image = Self.symbol("bell")
         addTabViewItem(reminders)
 
         let clipboard = NSTabViewItem(
-            viewController: ClipboardSettingsViewController(viewModel: viewModel))
+            viewController: ClipboardSettingsViewController(
+                preferences: preferences, viewModel: viewModel))
         clipboard.label = "Clipboard"
         clipboard.image = Self.symbol("clipboard")
         addTabViewItem(clipboard)
 
-        let advanced = NSTabViewItem(viewController: AdvancedSettingsViewController())
+        let advanced = NSTabViewItem(
+            viewController: AdvancedSettingsViewController(preferences: preferences))
         advanced.label = "Advanced"
         advanced.image = Self.symbol("gearshape.2")
         addTabViewItem(advanced)
@@ -77,6 +95,10 @@ final class SettingsTabViewController: NSTabViewController {
     override func tabView(_ tabView: NSTabView, didSelect tabViewItem: NSTabViewItem?) {
         super.tabView(tabView, didSelect: tabViewItem)
         resizeWindow(toFit: tabViewItem?.viewController, animate: true)
+        // After the resize, never before: the cue is a statement about the pane
+        // overflowing the window it just got, and re-arming against the outgoing
+        // tab's height would answer for the wrong geometry.
+        rearmScrollMoreCue(on: tabViewItem?.viewController)
     }
 
     /// Sizes the window to the pane that is about to become visible.
@@ -91,6 +113,14 @@ final class SettingsTabViewController: NSTabViewController {
     override func viewWillAppear() {
         super.viewWillAppear()
         resizeWindow(toFit: tabView.selectedTabViewItem?.viewController, animate: false)
+        // Reopening the window re-shows the pane the last session left selected
+        // without a tab switch, so this is the only hook that cues it.
+        rearmScrollMoreCue(on: tabView.selectedTabViewItem?.viewController)
+    }
+
+    /// Re-arms `pane`'s "more below" flash, for panes that publish one.
+    private func rearmScrollMoreCue(on pane: NSViewController?) {
+        (pane as? any SettingsPaneScrollCueing)?.rearmScrollMoreCue()
     }
 
     /// Resizes the window so its content area matches the content size of `pane`.

--- a/Kernova/Views/Settings/SettingsTabViewController.swift
+++ b/Kernova/Views/Settings/SettingsTabViewController.swift
@@ -113,8 +113,18 @@ final class SettingsTabViewController: NSTabViewController {
     override func viewWillAppear() {
         super.viewWillAppear()
         resizeWindow(toFit: tabView.selectedTabViewItem?.viewController, animate: false)
-        // Reopening the window re-shows the pane the last session left selected
-        // without a tab switch, so this is the only hook that cues it.
+    }
+
+    /// Cues the pane the window opened on, once that window is on screen.
+    ///
+    /// Reopening the window re-shows the pane the last session left selected
+    /// without a tab switch, so this is the only hook that cues it. It has to be
+    /// `viewDidAppear`, not `viewWillAppear`: the scroller flash animates a
+    /// fade-in, and one started before the window is ordered on screen is
+    /// already spent by the time anyone can look — leaving the pane's first
+    /// visit showing a scroller that only fades out, unlike every later visit.
+    override func viewDidAppear() {
+        super.viewDidAppear()
         rearmScrollMoreCue(on: tabView.selectedTabViewItem?.viewController)
     }
 

--- a/Kernova/Views/Shared/GroupedFormStyle.swift
+++ b/Kernova/Views/Shared/GroupedFormStyle.swift
@@ -91,19 +91,23 @@ func makeGroupedFormHairline() -> NSView {
 ///
 /// By default the control is pushed to the trailing edge (for steppers, switches,
 /// popups, and read-only values). Pass `fillsControl: true` for an input that
-/// should stretch to fill the row (a text field).
+/// should stretch to fill the row (a text field). `titleLabel` hands the
+/// freshly-built label back to the caller, for rows whose text has to be
+/// restyled later.
 @MainActor
 func makeGroupedFormCardRow(
     _ labelText: String,
     control: NSView,
     alignment: NSLayoutConstraint.Attribute = .centerY,
-    fillsControl: Bool = false
+    fillsControl: Bool = false,
+    titleLabel: ((NSTextField) -> Void)? = nil
 ) -> NSView {
     let label = NSTextField(labelWithString: labelText)
     label.font = Typography.body
     label.isSelectable = false
     label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     label.setContentCompressionResistancePriority(.required, for: .horizontal)
+    titleLabel?(label)
 
     let views: [NSView]
     if fillsControl {

--- a/Kernova/Views/Shared/ScrollMoreIndicator.swift
+++ b/Kernova/Views/Shared/ScrollMoreIndicator.swift
@@ -143,19 +143,29 @@ final class ScrollMoreIndicator {
             setOverlaysVisible(moreBelow, animated: true)
         }
 
-        // Flash the scroller once when overflowing content first appears. Deferred to
-        // the next main-actor hop because `flashScrollers()` is a no-op before the
-        // scroll view has drawn.
-        if cues.contains(.flash), overflows, !didFlash {
+        // Flash the scroller once when overflowing content first appears, and only
+        // with a window to animate against — see `canFlash`. Deferred to the next
+        // main-actor hop because `flashScrollers()` is a no-op before the scroll
+        // view has drawn.
+        if cues.contains(.flash), overflows, !didFlash, canFlash {
             didFlash = true
             #if DEBUG
             flashCountForTesting += 1
             #endif
-            Self.logger.debug(
-                "Flashing scroller (window present: \(scrollView.window != nil, privacy: .public))")
+            Self.logger.debug("Flashing scroller")
             Task { @MainActor [weak self] in self?.scrollView?.flashScrollers() }
         }
     }
+
+    /// Whether the scroller has an on-screen window to animate against.
+    ///
+    /// `flashScrollers()` fades the scroller in, holds it, then fades it out.
+    /// Run before the window is ordered on screen, the fade-in plays where
+    /// nobody can see it and the user meets the scroller already at full alpha
+    /// with only the fade-out left — so a surface's first visit looks unlike
+    /// every later one. Staying armed until there is a visible window means the
+    /// next geometry change or ``rearmFlash()`` shows the whole animation.
+    private var canFlash: Bool { scrollView?.window?.isVisible == true }
 
     /// Adds the overlays to the scroll view's superview, pinned over its bottom
     /// edge, the first time both exist.

--- a/Kernova/Views/Shared/ScrollMoreIndicator.swift
+++ b/Kernova/Views/Shared/ScrollMoreIndicator.swift
@@ -54,6 +54,13 @@ final class ScrollMoreIndicator {
 
     /// Whether the one-time scroller flash has latched.
     var hasFlashedForTesting: Bool { didFlash }
+
+    /// How many times the flash has fired.
+    ///
+    /// A re-arm over still-overflowing content re-latches immediately, so
+    /// ``hasFlashedForTesting`` reads `true` both before and after — only the
+    /// count separates a fresh flash from the one that already happened.
+    private(set) var flashCountForTesting = 0
     #endif
 
     /// Creates an indicator for `scrollView`, showing the cues named by `cues`.
@@ -141,6 +148,9 @@ final class ScrollMoreIndicator {
         // scroll view has drawn.
         if cues.contains(.flash), overflows, !didFlash {
             didFlash = true
+            #if DEBUG
+            flashCountForTesting += 1
+            #endif
             Self.logger.debug(
                 "Flashing scroller (window present: \(scrollView.window != nil, privacy: .public))")
             Task { @MainActor [weak self] in self?.scrollView?.flashScrollers() }

--- a/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
+++ b/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
@@ -22,6 +22,12 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
     private static let iconSlotWidth: CGFloat = 20
 
     private weak var instance: VMInstance?
+    /// The app-wide install-prompt suppression as of the last `configure`.
+    ///
+    /// Snapshotted rather than read live: it lives in `AppPreferences`, so the
+    /// cell's own observation loop can't see it change — the controller reloads
+    /// the rows off its `@Observable` mirror instead.
+    private var installPromptDisabled = false
     private var rowObservation: ObservationLoop?
     /// Commits the edited name; the `Bool` is `true` when editing ended by Return,
     /// which decides whether the controller restores sidebar focus.
@@ -144,6 +150,7 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
     func configure(
         instance: VMInstance,
         isRenaming: Bool,
+        installPromptDisabled: Bool,
         onCommitRename: @escaping (String, Bool) -> Void,
         onCancelRename: @escaping () -> Void,
         onMountAgent: @escaping () -> Void,
@@ -151,6 +158,7 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
     ) {
         let isRebindToDifferentVM = self.instance !== instance
         self.instance = instance
+        self.installPromptDisabled = installPromptDisabled
         self.onCommitRename = onCommitRename
         self.onCancelRename = onCancelRename
 
@@ -206,7 +214,9 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
             iconView.toolTip = instance.statusToolTip
         }
 
-        if let agentStatus = Self.visibleAgentStatus(for: instance) {
+        if let agentStatus = Self.visibleAgentStatus(
+            for: instance, installPromptDisabled: installPromptDisabled)
+        {
             agentButton.isHidden = false
             let dismissible = agentStatus == .waiting
             agentButton.configure(
@@ -435,12 +445,15 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
     /// The agent status to surface as a sidebar indicator, or `nil` to hide.
     ///
     /// Hidden for Linux guests, during macOS install, when `.current`, when
-    /// `.waiting` was dismissed, and — the outermost gate — whenever the VM has
+    /// `.waiting` was dismissed for this VM or turned off app-wide by
+    /// `installPromptDisabled`, and — the outermost gate — whenever the VM has
     /// no live session: every state the badge renders is a statement about *this*
     /// session's control channel. On a stopped or cold-paused VM `agentStatus`
     /// degrades to `.waiting`, and the badge would report "guest agent not
     /// installed" for a VM whose agent state is unknown.
-    static func visibleAgentStatus(for instance: VMInstance) -> AgentStatus? {
+    static func visibleAgentStatus(
+        for instance: VMInstance, installPromptDisabled: Bool
+    ) -> AgentStatus? {
         guard instance.configuration.guestOS == .macOS else { return nil }
         guard instance.setupState == nil else { return nil }
         // Live-paused counts: the VM is still in memory and resumable, so the
@@ -449,7 +462,9 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
         guard instance.status == .running || instance.isLivePaused else { return nil }
         let status = instance.agentStatus
         if case .current = status { return nil }
-        if case .waiting = status, instance.configuration.agentInstallNudgeDismissed {
+        if case .waiting = status,
+            installPromptDisabled || instance.configuration.agentInstallNudgeDismissed
+        {
             return nil
         }
         return status

--- a/Kernova/Views/Sidebar/SidebarViewController.swift
+++ b/Kernova/Views/Sidebar/SidebarViewController.swift
@@ -142,6 +142,10 @@ final class SidebarViewController: NSViewController {
                     // later without any id-list change; tracking this too routes
                     // that settle through `reloadInstances()`.
                     _ = self.viewModel.instances.map(\.isPreparing)
+                    // The install-prompt preference is snapshotted into each cell
+                    // at configure time, so a Settings-window toggle only reaches
+                    // the badges through a reload.
+                    _ = self.viewModel.agentInstallPromptDisabled
                 },
                 apply: { [weak self] in self?.reloadInstances() }
             )
@@ -378,7 +382,9 @@ final class SidebarViewController: NSViewController {
             instances.map { instance in
                 SidebarVMRowCellView.contentWidth(
                     forName: instance.name,
-                    showsAgentAccessory: SidebarVMRowCellView.visibleAgentStatus(for: instance) != nil
+                    showsAgentAccessory: SidebarVMRowCellView.visibleAgentStatus(
+                        for: instance,
+                        installPromptDisabled: viewModel.agentInstallPromptDisabled) != nil
                 )
             }.max() ?? 0
 
@@ -555,6 +561,7 @@ extension SidebarViewController: NSOutlineViewDelegate {
         cell.configure(
             instance: instance,
             isRenaming: viewModel.activeRename == .sidebar(instance.id),
+            installPromptDisabled: viewModel.agentInstallPromptDisabled,
             // Capture `instance` weakly: the cell stores these closures, so a
             // strong capture would keep a deleted VM alive until the cell is
             // recycled.

--- a/Kernova/Views/Sidebar/SidebarViewController.swift
+++ b/Kernova/Views/Sidebar/SidebarViewController.swift
@@ -119,8 +119,15 @@ final class SidebarViewController: NSViewController {
     override func viewDidAppear() {
         super.viewDidAppear()
         startObservations()
-        applySelectionFromModel()
-        applyRenameState()
+        // Everything the observations watch can change while they are torn down,
+        // and re-arming them fires nothing — a `withObservationTracking`
+        // registration only reports changes made *after* it. Rows are stale on
+        // arrival, most visibly for the app-wide install-prompt preference each
+        // cell snapshots at configure time: toggled in the Settings window while
+        // the sidebar is collapsed, its badges would otherwise keep the old
+        // answer until some unrelated change reloaded them. `reloadInstances()`
+        // ends with the selection and rename passes, so it subsumes both.
+        reloadInstances()
     }
 
     override func viewWillDisappear() {

--- a/KernovaTests/RemindersSettingsViewControllerTests.swift
+++ b/KernovaTests/RemindersSettingsViewControllerTests.swift
@@ -64,6 +64,32 @@ struct RemindersSettingsViewControllerTests {
         return (controller, viewModel)
     }
 
+    /// A laid-out pane hosted in an on-screen window, for the flash assertions.
+    ///
+    /// The window has to be up before the geometry settles: the cue only fires
+    /// against a visible window, so measuring it off screen would count flashes
+    /// the app never shows.
+    private func makeShownPane(vmCount: Int) -> (
+        controller: RemindersSettingsViewController, window: NSWindow
+    ) {
+        let viewModel = makeViewModel()
+        for index in 1...vmCount {
+            viewModel.instances.append(makeInstance(name: "VM \(index)"))
+        }
+        let controller = RemindersSettingsViewController(
+            preferences: preferences, viewModel: viewModel)
+        // Measure while detached, exactly as the pane does before the tab
+        // controller sizes the window, then hand the window that measurement.
+        controller.viewWillAppear()
+        let window = showInTestWindow(controller.view, size: controller.preferredContentSize)
+        controller.view.layoutSubtreeIfNeeded()
+        // Stands in for the tab container's `viewDidAppear`. Ordering a window on
+        // screen changes no geometry, so nothing re-runs the cue on its own — the
+        // arrival hook is what spends the flash once there is something to see.
+        controller.rearmScrollMoreCue()
+        return (controller, window)
+    }
+
     /// Every switch in the pane wired to `action`, in row order.
     private func switches(action name: String, in controller: RemindersSettingsViewController)
         -> [NSSwitch]
@@ -220,8 +246,11 @@ struct RemindersSettingsViewControllerTests {
     /// flash again.
     @Test("Revealing the override caption flashes the scroller again")
     func revealingOverrideCaptionRearmsFlash() throws {
-        let controller = makeLaidOutPane(vmCount: 9).controller
-        defer { controller.viewDidDisappear() }
+        let (controller, window) = makeShownPane(vmCount: 9)
+        defer {
+            controller.viewDidDisappear()
+            window.orderOut(nil)
+        }
         let indicator = try #require(controller.scrollMoreIndicatorForTesting)
 
         // A 9-VM pane overflows the height cap, so appearing flashes — exactly
@@ -238,6 +267,30 @@ struct RemindersSettingsViewControllerTests {
         // re-arm, or an unrelated toggle would flash the scroller for nothing.
         try setAppWideInstallReminder(on: false, in: controller)
         #expect(indicator.flashCountForTesting == 2)
+    }
+
+    /// Both captions describe the per-VM switches, so with none on screen they
+    /// point at nothing — "these have no effect" directly under "No virtual
+    /// machines yet." reads as a bug.
+    @Test("Neither per-VM caption shows when there are no virtual machines")
+    func perVMCaptionsHideWithoutVMs() throws {
+        let controller = RemindersSettingsViewController(
+            preferences: preferences, viewModel: makeViewModel())
+        _ = controller.view
+        controller.viewWillAppear()
+        defer { controller.viewDidDisappear() }
+        controller.view.setFrameSize(controller.preferredContentSize)
+        controller.view.layoutSubtreeIfNeeded()
+
+        // Turning the app-wide reminder off is what would reveal the override
+        // caption; the empty state has to suppress it anyway.
+        try setAppWideInstallReminder(on: false, in: controller)
+
+        let visible = allSubviews(NSTextField.self, in: controller.view) { !$0.isHidden }
+            .map(\.stringValue)
+        #expect(visible.contains { $0.hasPrefix("No virtual machines yet") })
+        #expect(!visible.contains { $0.contains("have no effect") })
+        #expect(!visible.contains { $0.contains("Turn a virtual machine off") })
     }
 
     /// The disabled rows keep showing each VM's own setting, so turning the

--- a/KernovaTests/RemindersSettingsViewControllerTests.swift
+++ b/KernovaTests/RemindersSettingsViewControllerTests.swift
@@ -78,11 +78,17 @@ struct RemindersSettingsViewControllerTests {
     }
 
     /// The grouped-form card `control` sits in — the nearest ancestor carrying
-    /// the card's `NSBox` background.
+    /// the card's rounded `NSBox` background.
+    ///
+    /// Keyed on the corner radius, not on `NSBox` alone: a multi-row card's
+    /// inter-row hairlines are `NSBox`es too, so the looser test stops at the
+    /// card's inner stack and reports an edge inset by the card's padding.
     private func card(containing control: NSView) -> NSView? {
         var candidate = control.superview
         while let view = candidate {
-            if view.subviews.contains(where: { $0 is NSBox }) { return view }
+            if view.subviews.contains(where: { ($0 as? NSBox)?.cornerRadius ?? 0 > 0 }) {
+                return view
+            }
             candidate = view.superview
         }
         return nil
@@ -112,7 +118,7 @@ struct RemindersSettingsViewControllerTests {
         for fragment in [
             "Appears when you quit",
             "sidebar prompt to install",
-            "stop its sidebar reminder",
+            "stop its own reminder",
             "Turns every reminder above back on",
         ] {
             let caption = findLabel(containing: fragment, in: root)
@@ -139,8 +145,10 @@ struct RemindersSettingsViewControllerTests {
         #expect(documentView.frame.height > scrollView.frame.height)
     }
 
-    @Test("Each app-wide reminder is its own single-row card")
-    func appRemindersAreSeparateCards() throws {
+    /// Each governing switch owns a card, so its caption sits directly under it
+    /// and needs no "The <name> reminder…" prefix to say what it describes.
+    @Test("Each reminder switch is its own single-row card")
+    func remindersAreSeparateCards() throws {
         let controller = makeLaidOutController(vmCount: 2)
         defer { controller.viewDidDisappear() }
 
@@ -149,8 +157,6 @@ struct RemindersSettingsViewControllerTests {
         // Two app-wide switches plus one per VM.
         #expect(allSubviews(NSSwitch.self, in: controller.view).count == 4)
 
-        // Each app-wide switch sits in a card of its own, so its caption needs
-        // no "The <name> reminder…" prefix to say which switch it describes.
         let menuBarToggle = try #require(
             switches(action: "menuBarQuitToggled", in: controller).first)
         let agentToggle = try #require(
@@ -160,6 +166,28 @@ struct RemindersSettingsViewControllerTests {
         #expect(menuBarCard !== agentCard)
         #expect(allSubviews(NSSwitch.self, in: menuBarCard).count == 1)
         #expect(allSubviews(NSSwitch.self, in: agentCard).count == 1)
+    }
+
+    /// Apple's guidance for showing that one control governs others is to indent
+    /// the subordinates beneath it.
+    ///
+    /// The greying only speaks while the governing switch is off; the indent
+    /// states the relationship at all times.
+    @Test("The per-VM rows are indented beneath the switch that governs them")
+    func perVMRowsIndentUnderGoverningSwitch() throws {
+        let controller = makeLaidOutController(vmCount: 2)
+        defer { controller.viewDidDisappear() }
+
+        let agentToggle = try #require(
+            switches(action: "agentInstallToggled", in: controller).first)
+        let governingCard = try #require(card(containing: agentToggle))
+        let vmToggle = try #require(vmSwitches(in: controller).first)
+        let vmCard = try #require(card(containing: vmToggle))
+
+        let root = controller.view
+        let governingLeading = governingCard.convert(governingCard.bounds, to: root).minX
+        let subordinateLeading = vmCard.convert(vmCard.bounds, to: root).minX
+        #expect(subordinateLeading - governingLeading == groupedFormSubOptionIndent)
     }
 
     @Test("Turning the app-wide install reminder off disables and explains the per-VM rows")

--- a/KernovaTests/RemindersSettingsViewControllerTests.swift
+++ b/KernovaTests/RemindersSettingsViewControllerTests.swift
@@ -77,6 +77,17 @@ struct RemindersSettingsViewControllerTests {
         switches(action: "vmReminderToggled:", in: controller)
     }
 
+    /// The grouped-form card `control` sits in — the nearest ancestor carrying
+    /// the card's `NSBox` background.
+    private func card(containing control: NSView) -> NSView? {
+        var candidate = control.superview
+        while let view = candidate {
+            if view.subviews.contains(where: { $0 is NSBox }) { return view }
+            candidate = view.superview
+        }
+        return nil
+    }
+
     /// Flips the app-wide install-reminder switch the way a click does, so the
     /// pane's own action wiring is what drives the change.
     private func setAppWideInstallReminder(
@@ -99,7 +110,8 @@ struct RemindersSettingsViewControllerTests {
             }
         }
         for fragment in [
-            "Menu Bar Quit Reminder appears",
+            "Appears when you quit",
+            "sidebar prompt to install",
             "stop its sidebar reminder",
             "Turns every reminder above back on",
         ] {
@@ -127,16 +139,27 @@ struct RemindersSettingsViewControllerTests {
         #expect(documentView.frame.height > scrollView.frame.height)
     }
 
-    @Test("The app card carries the Menu Bar Quit and Guest Agent Install rows")
-    func appCardHasBothRows() throws {
+    @Test("Each app-wide reminder is its own single-row card")
+    func appRemindersAreSeparateCards() throws {
         let controller = makeLaidOutController(vmCount: 2)
         defer { controller.viewDidDisappear() }
 
         #expect(findLabel(withText: "Menu Bar Quit Reminder", in: controller.view) != nil)
         #expect(findLabel(withText: "Guest Agent Install Reminder", in: controller.view) != nil)
-        // Two app-wide switches plus one per VM: an extra would mean a third row
-        // crept into the app card.
+        // Two app-wide switches plus one per VM.
         #expect(allSubviews(NSSwitch.self, in: controller.view).count == 4)
+
+        // Each app-wide switch sits in a card of its own, so its caption needs
+        // no "The <name> reminder…" prefix to say which switch it describes.
+        let menuBarToggle = try #require(
+            switches(action: "menuBarQuitToggled", in: controller).first)
+        let agentToggle = try #require(
+            switches(action: "agentInstallToggled", in: controller).first)
+        let menuBarCard = try #require(card(containing: menuBarToggle))
+        let agentCard = try #require(card(containing: agentToggle))
+        #expect(menuBarCard !== agentCard)
+        #expect(allSubviews(NSSwitch.self, in: menuBarCard).count == 1)
+        #expect(allSubviews(NSSwitch.self, in: agentCard).count == 1)
     }
 
     @Test("Turning the app-wide install reminder off disables and explains the per-VM rows")
@@ -160,6 +183,33 @@ struct RemindersSettingsViewControllerTests {
         #expect(viewModel.agentInstallPromptDisabled == false)
         #expect(vmSwitches(in: controller).allSatisfy { $0.isEnabled })
         #expect(explanation.isHidden)
+    }
+
+    /// The window is sized once per tab selection.
+    ///
+    /// So the caption appearing grows the content in place with nothing to say
+    /// the pane now overflows; re-arming the indicator is what lets the scroller
+    /// flash again.
+    @Test("Revealing the override caption flashes the scroller again")
+    func revealingOverrideCaptionRearmsFlash() throws {
+        let controller = makeLaidOutPane(vmCount: 9).controller
+        defer { controller.viewDidDisappear() }
+        let indicator = try #require(controller.scrollMoreIndicatorForTesting)
+
+        // A 9-VM pane overflows the height cap, so appearing flashes — exactly
+        // once, against the pane's settled geometry rather than the zero-height
+        // frame the first row build runs under.
+        #expect(indicator.flashCountForTesting == 1)
+
+        // The latch is one-shot, so without a re-arm the caption could grow the
+        // content with no cue at all.
+        try setAppWideInstallReminder(on: false, in: controller)
+        #expect(indicator.flashCountForTesting == 2)
+
+        // A refresh that moves neither the row count nor the caption must not
+        // re-arm, or an unrelated toggle would flash the scroller for nothing.
+        try setAppWideInstallReminder(on: false, in: controller)
+        #expect(indicator.flashCountForTesting == 2)
     }
 
     /// The disabled rows keep showing each VM's own setting, so turning the

--- a/KernovaTests/RemindersSettingsViewControllerTests.swift
+++ b/KernovaTests/RemindersSettingsViewControllerTests.swift
@@ -43,6 +43,14 @@ struct RemindersSettingsViewControllerTests {
     /// way NSTabViewController does: it reads `preferredContentSize` at switch
     /// time and sizes the pane's view to exactly that.
     private func makeLaidOutController(vmCount: Int) -> RemindersSettingsViewController {
+        makeLaidOutPane(vmCount: vmCount).controller
+    }
+
+    /// As ``makeLaidOutController(vmCount:)``, also handing back the view model
+    /// so a test can drive the app-wide install-prompt preference.
+    private func makeLaidOutPane(vmCount: Int) -> (
+        controller: RemindersSettingsViewController, viewModel: VMLibraryViewModel
+    ) {
         let viewModel = makeViewModel()
         for index in 1...vmCount {
             viewModel.instances.append(makeInstance(name: "VM \(index)"))
@@ -53,7 +61,33 @@ struct RemindersSettingsViewControllerTests {
         controller.viewWillAppear()
         controller.view.setFrameSize(controller.preferredContentSize)
         controller.view.layoutSubtreeIfNeeded()
-        return controller
+        return (controller, viewModel)
+    }
+
+    /// Every switch in the pane wired to `action`, in row order.
+    private func switches(action name: String, in controller: RemindersSettingsViewController)
+        -> [NSSwitch]
+    {
+        allSubviews(NSSwitch.self, in: controller.view) {
+            $0.action.map(NSStringFromSelector) == name
+        }
+    }
+
+    private func vmSwitches(in controller: RemindersSettingsViewController) -> [NSSwitch] {
+        switches(action: "vmReminderToggled:", in: controller)
+    }
+
+    /// Flips the app-wide install-reminder switch the way a click does, so the
+    /// pane's own action wiring is what drives the change.
+    private func setAppWideInstallReminder(
+        on: Bool, in controller: RemindersSettingsViewController
+    ) throws {
+        let toggle = try #require(
+            switches(action: "agentInstallToggled", in: controller).first)
+        let action = try #require(toggle.action)
+        toggle.state = on ? .on : .off
+        let delivered = NSApp.sendAction(action, to: toggle.target, from: toggle)
+        #expect(delivered)
     }
 
     private func expectHeadersAndCaptionsVisible(in root: NSView) {
@@ -93,15 +127,55 @@ struct RemindersSettingsViewControllerTests {
         #expect(documentView.frame.height > scrollView.frame.height)
     }
 
-    @Test("The app card carries the lone Menu Bar Quit row")
-    func appCardHasOneRow() throws {
+    @Test("The app card carries the Menu Bar Quit and Guest Agent Install rows")
+    func appCardHasBothRows() throws {
         let controller = makeLaidOutController(vmCount: 2)
         defer { controller.viewDidDisappear() }
 
         #expect(findLabel(withText: "Menu Bar Quit Reminder", in: controller.view) != nil)
-        // One app-wide switch plus one per VM: an extra would mean a second row
-        // crept back into the app card.
-        #expect(allSubviews(NSSwitch.self, in: controller.view).count == 3)
+        #expect(findLabel(withText: "Guest Agent Install Reminder", in: controller.view) != nil)
+        // Two app-wide switches plus one per VM: an extra would mean a third row
+        // crept into the app card.
+        #expect(allSubviews(NSSwitch.self, in: controller.view).count == 4)
+    }
+
+    @Test("Turning the app-wide install reminder off disables and explains the per-VM rows")
+    func appWideDisableGreysPerVMRows() throws {
+        let (controller, viewModel) = makeLaidOutPane(vmCount: 2)
+        defer { controller.viewDidDisappear() }
+
+        #expect(vmSwitches(in: controller).allSatisfy { $0.isEnabled })
+        let explanation = try #require(
+            findLabel(containing: "so these have no effect", in: controller.view))
+        #expect(explanation.isHidden)
+
+        try setAppWideInstallReminder(on: false, in: controller)
+
+        #expect(viewModel.agentInstallPromptDisabled == true)
+        #expect(vmSwitches(in: controller).allSatisfy { !$0.isEnabled })
+        #expect(!explanation.isHidden)
+
+        try setAppWideInstallReminder(on: true, in: controller)
+
+        #expect(viewModel.agentInstallPromptDisabled == false)
+        #expect(vmSwitches(in: controller).allSatisfy { $0.isEnabled })
+        #expect(explanation.isHidden)
+    }
+
+    /// The disabled rows keep showing each VM's own setting, so turning the
+    /// app-wide reminder back on restores what the user had chosen.
+    @Test("A disabled per-VM row still reflects its VM's dismissed flag")
+    func disabledPerVMRowKeepsItsState() throws {
+        let (controller, viewModel) = makeLaidOutPane(vmCount: 2)
+        defer { controller.viewDidDisappear() }
+        viewModel.instances[0].configuration.agentInstallNudgeDismissed = true
+        viewModel.agentInstallPromptDisabled = true
+        controller.viewWillAppear()
+
+        let switches = vmSwitches(in: controller)
+        #expect(switches.count == 2)
+        #expect(switches[0].state == .off)
+        #expect(switches[1].state == .on)
     }
 
     @Test("A short VM list hugs the content with the text laid out")

--- a/KernovaTests/ScrollMoreIndicatorTests.swift
+++ b/KernovaTests/ScrollMoreIndicatorTests.swift
@@ -113,13 +113,43 @@ struct ScrollMoreIndicatorTests {
         #expect(hiddenOverlays.allSatisfy { $0.alphaValue == 0 })
     }
 
+    /// A scroll view already hosted in an on-screen window.
+    ///
+    /// The flash only fires against a visible window, so every flash assertion
+    /// builds its scroll view through this rather than ``makeScrollView(documentHeight:)``.
+    private func makeShownScrollView(documentHeight: CGFloat) -> (NSScrollView, NSWindow) {
+        let scrollView = makeScrollView(documentHeight: documentHeight)
+        return (scrollView, showInTestWindow(scrollView))
+    }
+
     @Test("Latches the one-time scroller flash on overflow, not when content fits")
     func flashLatch() {
-        let fits = ScrollMoreIndicator(scrollView: makeScrollView(documentHeight: 50))
+        let (fitting, fittingWindow) = makeShownScrollView(documentHeight: 50)
+        defer { fittingWindow.orderOut(nil) }
+        let fits = ScrollMoreIndicator(scrollView: fitting)
         #expect(fits.hasFlashedForTesting == false)
 
-        let overflows = ScrollMoreIndicator(scrollView: makeScrollView(documentHeight: 1000))
+        let (overflowing, overflowingWindow) = makeShownScrollView(documentHeight: 1000)
+        defer { overflowingWindow.orderOut(nil) }
+        let overflows = ScrollMoreIndicator(scrollView: overflowing)
         #expect(overflows.hasFlashedForTesting == true)
+    }
+
+    /// The latch has to survive until there is a visible window to spend it on.
+    ///
+    /// The cue is an animated fade-in, so one fired before the window is ordered
+    /// on screen is spent where nobody can see it — the pane's first visit then
+    /// shows a scroller that only fades out, unlike every later visit.
+    @Test("Holds the flash until the scroller has a visible window")
+    func flashWaitsForAVisibleWindow() {
+        let scrollView = makeScrollView(documentHeight: 1000)
+        let indicator = ScrollMoreIndicator(scrollView: scrollView, cues: .flash)
+        #expect(indicator.hasFlashedForTesting == false)
+
+        let window = showInTestWindow(scrollView)
+        defer { window.orderOut(nil) }
+        indicator.rearmFlash()
+        #expect(indicator.hasFlashedForTesting == true)
     }
 
     @Test("Flash-only cue flashes the scroller but inserts no overlays, even once mounted")
@@ -127,14 +157,13 @@ struct ScrollMoreIndicatorTests {
         // The settings pane opts into `.flash` alone: it should still latch the
         // one-time scroller flash on overflow, but never build or host the
         // chevron/fade overlays (its root is an NSStackView).
-        let scrollView = makeScrollView(documentHeight: 1000)
+        let (scrollView, window) = makeShownScrollView(documentHeight: 1000)
+        defer { window.orderOut(nil) }
         let indicator = ScrollMoreIndicator(scrollView: scrollView, cues: .flash)
         #expect(indicator.hasFlashedForTesting == true)
 
-        // Mount + a geometry notification would normally lazily insert overlays;
-        // with `.flash` only they must stay absent.
-        let host = NSView(frame: NSRect(x: 0, y: 0, width: Self.width, height: Self.viewportHeight))
-        host.addSubview(scrollView)
+        // Mounted (the window's content view) + a geometry notification would
+        // normally lazily insert overlays; with `.flash` only they must stay absent.
         scrollView.contentView.scroll(to: NSPoint(x: 0, y: 1))
         scrollView.reflectScrolledClipView(scrollView.contentView)
         #expect(indicator.overlaysForTesting.isEmpty)
@@ -156,7 +185,8 @@ struct ScrollMoreIndicatorTests {
     @Test("rearmFlash re-arms the one-time flash for a reused indicator")
     func rearmFlashReevaluates() {
         // Mirrors the settings pane reusing one indicator across VM switches.
-        let scrollView = makeScrollView(documentHeight: 1000)
+        let (scrollView, window) = makeShownScrollView(documentHeight: 1000)
+        defer { window.orderOut(nil) }
         let indicator = ScrollMoreIndicator(scrollView: scrollView, cues: .flash)
         #expect(indicator.hasFlashedForTesting == true)  // flashed on first overflow
 

--- a/KernovaTests/SettingsTabViewControllerTests.swift
+++ b/KernovaTests/SettingsTabViewControllerTests.swift
@@ -40,19 +40,28 @@ struct SettingsTabViewControllerTests {
     /// Builds the container plus a laid-out Reminders pane tall enough to
     /// overflow, standing in for the window the tab controller would size.
     private func makeOverflowingPane() throws -> (
-        SettingsTabViewController, RemindersSettingsViewController
+        SettingsTabViewController, RemindersSettingsViewController, NSWindow
     ) {
         let tabController = SettingsTabViewController(
             viewModel: makeViewModel(vmCount: 9), preferences: preferences)
         tabController.loadViewIfNeeded()
-        let pane = try #require(
-            tabController.tabViewItems.compactMap { $0.viewController }
-                .compactMap { $0 as? RemindersSettingsViewController }.first)
+        let item = try remindersItem(in: tabController)
+        // Select before hosting: selecting moves the pane's view into the tab
+        // view, which has no window here, and the cue only fires against a
+        // visible one. Doing it first lets `showInTestWindow` take the view back
+        // while the item stays selected, so `viewDidAppear` still targets it.
+        tabController.tabView.selectTabViewItem(item)
+        let pane = try #require(item.viewController as? RemindersSettingsViewController)
         pane.loadViewIfNeeded()
+        // Measure detached first, then give the window that size, standing in for
+        // the container's own `resizeWindow(toFit:)`.
         pane.viewWillAppear()
-        pane.view.setFrameSize(pane.preferredContentSize)
+        let window = showInTestWindow(pane.view, size: pane.preferredContentSize)
         pane.view.layoutSubtreeIfNeeded()
-        return (tabController, pane)
+        // The arrival cue: ordering a window on screen changes no geometry, so
+        // nothing re-runs the flash on its own.
+        pane.rearmScrollMoreCue()
+        return (tabController, pane, window)
     }
 
     private func remindersItem(in tabController: SettingsTabViewController) throws -> NSTabViewItem {
@@ -62,8 +71,11 @@ struct SettingsTabViewControllerTests {
 
     @Test("Every selection of an overflowing pane re-arms its scroller flash")
     func selectingOverflowingPaneFlashesEachTime() throws {
-        let (tabController, pane) = try makeOverflowingPane()
-        defer { pane.viewDidDisappear() }
+        let (tabController, pane, window) = try makeOverflowingPane()
+        defer {
+            pane.viewDidDisappear()
+            window.orderOut(nil)
+        }
         let indicator = try #require(pane.scrollMoreIndicatorForTesting)
         let item = try remindersItem(in: tabController)
 
@@ -83,23 +95,47 @@ struct SettingsTabViewControllerTests {
     /// tab switch, so the container's own appearance is the only cue hook.
     @Test("The container's appearance re-arms the selected pane")
     func containerAppearanceRearmsSelectedPane() throws {
-        let (tabController, pane) = try makeOverflowingPane()
-        defer { pane.viewDidDisappear() }
+        let (tabController, pane, window) = try makeOverflowingPane()
+        defer {
+            pane.viewDidDisappear()
+            window.orderOut(nil)
+        }
         let indicator = try #require(pane.scrollMoreIndicatorForTesting)
-        tabController.tabView.selectTabViewItem(try remindersItem(in: tabController))
+        let before = indicator.flashCountForTesting
+
+        tabController.viewDidAppear()
+
+        #expect(indicator.flashCountForTesting == before + 1)
+    }
+
+    /// The cue must be spent *after* the window is ordered on screen: the flash
+    /// animates a fade-in, so one started on the way in is already over by the
+    /// time the window appears, and the pane's first visit shows a scroller that
+    /// only fades out — unlike every visit after it.
+    @Test("The pre-appearance hook does not spend the flash")
+    func viewWillAppearDoesNotFlash() throws {
+        let (tabController, pane, window) = try makeOverflowingPane()
+        defer {
+            pane.viewDidDisappear()
+            window.orderOut(nil)
+        }
+        let indicator = try #require(pane.scrollMoreIndicatorForTesting)
         let before = indicator.flashCountForTesting
 
         tabController.viewWillAppear()
 
-        #expect(indicator.flashCountForTesting == before + 1)
+        #expect(indicator.flashCountForTesting == before)
     }
 
     /// A pane that never overflows publishes no cue, so selecting it must not
     /// reach for one — the container asks only panes that opt in.
     @Test("Selecting a pane without a cue is inert")
     func selectingNonCueingPaneIsInert() throws {
-        let (tabController, pane) = try makeOverflowingPane()
-        defer { pane.viewDidDisappear() }
+        let (tabController, pane, window) = try makeOverflowingPane()
+        defer {
+            pane.viewDidDisappear()
+            window.orderOut(nil)
+        }
         let indicator = try #require(pane.scrollMoreIndicatorForTesting)
         let general = try #require(
             tabController.tabViewItems.first {

--- a/KernovaTests/SettingsTabViewControllerTests.swift
+++ b/KernovaTests/SettingsTabViewControllerTests.swift
@@ -1,0 +1,114 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import Kernova
+
+/// Tests for the Settings window's tab container.
+///
+/// The container owns what happens *between* panes: sizing the window to the
+/// one being selected, and re-arming its "more below" cue so an overflowing
+/// pane says so on every arrival rather than only its first.
+@Suite("Settings Tab Tests", .serialized)
+@MainActor
+struct SettingsTabViewControllerTests {
+    private let preferences: AppPreferences
+
+    init() {
+        self.preferences = makeEphemeralPreferences(suiteName: "test.kernova.settings-tab")
+    }
+
+    private func makeViewModel(vmCount: Int) -> VMLibraryViewModel {
+        let viewModel = VMLibraryViewModel(
+            storageService: MockVMStorageService(),
+            diskImageService: MockDiskImageService(),
+            virtualizationService: MockVirtualizationService(),
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService(),
+            usbDeviceService: MockUSBDeviceService(),
+            preferences: preferences
+        )
+        for index in 1...vmCount {
+            let config = VMConfiguration(name: "VM \(index)", guestOS: .macOS, bootMode: .efi)
+            let bundleURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(config.id.uuidString, isDirectory: true)
+            viewModel.instances.append(VMInstance(configuration: config, bundleURL: bundleURL))
+        }
+        return viewModel
+    }
+
+    /// Builds the container plus a laid-out Reminders pane tall enough to
+    /// overflow, standing in for the window the tab controller would size.
+    private func makeOverflowingPane() throws -> (
+        SettingsTabViewController, RemindersSettingsViewController
+    ) {
+        let tabController = SettingsTabViewController(
+            viewModel: makeViewModel(vmCount: 9), preferences: preferences)
+        tabController.loadViewIfNeeded()
+        let pane = try #require(
+            tabController.tabViewItems.compactMap { $0.viewController }
+                .compactMap { $0 as? RemindersSettingsViewController }.first)
+        pane.loadViewIfNeeded()
+        pane.viewWillAppear()
+        pane.view.setFrameSize(pane.preferredContentSize)
+        pane.view.layoutSubtreeIfNeeded()
+        return (tabController, pane)
+    }
+
+    private func remindersItem(in tabController: SettingsTabViewController) throws -> NSTabViewItem {
+        try #require(
+            tabController.tabViewItems.first { $0.viewController is RemindersSettingsViewController })
+    }
+
+    @Test("Every selection of an overflowing pane re-arms its scroller flash")
+    func selectingOverflowingPaneFlashesEachTime() throws {
+        let (tabController, pane) = try makeOverflowingPane()
+        defer { pane.viewDidDisappear() }
+        let indicator = try #require(pane.scrollMoreIndicatorForTesting)
+        let item = try remindersItem(in: tabController)
+
+        // Appearing already flashed once; each later arrival must flash again,
+        // which the one-shot latch prevents without the container's re-arm.
+        let afterFirstAppearance = indicator.flashCountForTesting
+        #expect(afterFirstAppearance == 1)
+
+        tabController.tabView(tabController.tabView, didSelect: item)
+        #expect(indicator.flashCountForTesting == afterFirstAppearance + 1)
+
+        tabController.tabView(tabController.tabView, didSelect: item)
+        #expect(indicator.flashCountForTesting == afterFirstAppearance + 2)
+    }
+
+    /// Reopening the window re-shows whichever pane was last selected without a
+    /// tab switch, so the container's own appearance is the only cue hook.
+    @Test("The container's appearance re-arms the selected pane")
+    func containerAppearanceRearmsSelectedPane() throws {
+        let (tabController, pane) = try makeOverflowingPane()
+        defer { pane.viewDidDisappear() }
+        let indicator = try #require(pane.scrollMoreIndicatorForTesting)
+        tabController.tabView.selectTabViewItem(try remindersItem(in: tabController))
+        let before = indicator.flashCountForTesting
+
+        tabController.viewWillAppear()
+
+        #expect(indicator.flashCountForTesting == before + 1)
+    }
+
+    /// A pane that never overflows publishes no cue, so selecting it must not
+    /// reach for one — the container asks only panes that opt in.
+    @Test("Selecting a pane without a cue is inert")
+    func selectingNonCueingPaneIsInert() throws {
+        let (tabController, pane) = try makeOverflowingPane()
+        defer { pane.viewDidDisappear() }
+        let indicator = try #require(pane.scrollMoreIndicatorForTesting)
+        let general = try #require(
+            tabController.tabViewItems.first {
+                $0.viewController is GeneralSettingsViewController
+            })
+        let before = indicator.flashCountForTesting
+
+        tabController.tabView(tabController.tabView, didSelect: general)
+
+        #expect(indicator.flashCountForTesting == before)
+    }
+}

--- a/KernovaTests/SidebarViewControllerTests.swift
+++ b/KernovaTests/SidebarViewControllerTests.swift
@@ -54,6 +54,12 @@ struct SidebarViewControllerTests {
         return instance
     }
 
+    /// The sidebar badge gate with the app-wide install prompt left on, which is
+    /// every case but the ones exercising that preference.
+    private func visibleAgentStatus(for instance: VMInstance) -> AgentStatus? {
+        SidebarVMRowCellView.visibleAgentStatus(for: instance, installPromptDisabled: false)
+    }
+
     private func titles(of menu: NSMenu) -> [String] {
         menu.items.map(\.title)
     }
@@ -97,20 +103,20 @@ struct SidebarViewControllerTests {
     @Test("Agent indicator hidden for Linux guests")
     func agentHiddenForLinux() {
         let instance = makeInstance(guestOS: .linux, status: .running)
-        #expect(SidebarVMRowCellView.visibleAgentStatus(for: instance) == nil)
+        #expect(visibleAgentStatus(for: instance) == nil)
     }
 
     @Test("Agent indicator shows .waiting for a running macOS VM without an agent")
     func agentWaitingVisibleForRunningMac() {
         let instance = makeInstance(guestOS: .macOS, status: .running)
-        #expect(SidebarVMRowCellView.visibleAgentStatus(for: instance) == .waiting)
+        #expect(visibleAgentStatus(for: instance) == .waiting)
     }
 
     @Test("Agent indicator suppressed once the install nudge is dismissed")
     func agentSuppressedWhenDismissed() {
         let instance = makeInstance(guestOS: .macOS, status: .running)
         instance.configuration.agentInstallNudgeDismissed = true
-        #expect(SidebarVMRowCellView.visibleAgentStatus(for: instance) == nil)
+        #expect(visibleAgentStatus(for: instance) == nil)
     }
 
     @Test("Agent indicator suppressed for a stopped macOS VM")
@@ -118,11 +124,11 @@ struct SidebarViewControllerTests {
         // Neither a VM that has never had an agent nor one that has: with no
         // live control channel, `.waiting` means "unknown", not "not installed".
         let fresh = makeInstance(guestOS: .macOS, status: .stopped)
-        #expect(SidebarVMRowCellView.visibleAgentStatus(for: fresh) == nil)
+        #expect(visibleAgentStatus(for: fresh) == nil)
 
         let seen = makeInstance(guestOS: .macOS, status: .stopped)
         seen.configuration.lastSeenAgentVersion = "1.2.3"
-        #expect(SidebarVMRowCellView.visibleAgentStatus(for: seen) == nil)
+        #expect(visibleAgentStatus(for: seen) == nil)
     }
 
     @Test(
@@ -131,14 +137,14 @@ struct SidebarViewControllerTests {
     )
     func agentSuppressedWhenNotInLiveSession(status: VMStatus) {
         let instance = makeInstance(guestOS: .macOS, status: status)
-        #expect(SidebarVMRowCellView.visibleAgentStatus(for: instance) == nil)
+        #expect(visibleAgentStatus(for: instance) == nil)
     }
 
     @Test("Agent indicator suppressed for a cold-paused VM")
     func agentSuppressedWhenColdPaused() {
         let instance = makeInstance(guestOS: .macOS, status: .paused)  // no live VM
         #expect(instance.isColdPaused)
-        #expect(SidebarVMRowCellView.visibleAgentStatus(for: instance) == nil)
+        #expect(visibleAgentStatus(for: instance) == nil)
     }
 
     /// The live-session gate must not swallow the *louder* agent states — only
@@ -150,7 +156,7 @@ struct SidebarViewControllerTests {
         instance.configuration.lastSeenAgentVersion = "1.2.3"
         instance.agentExpectedButMissing = true
         #expect(
-            SidebarVMRowCellView.visibleAgentStatus(for: instance)
+            visibleAgentStatus(for: instance)
                 == .expectedMissing(expected: "1.2.3")
         )
 
@@ -158,9 +164,36 @@ struct SidebarViewControllerTests {
         // gate is scoped to `.waiting`.
         instance.configuration.agentInstallNudgeDismissed = true
         #expect(
-            SidebarVMRowCellView.visibleAgentStatus(for: instance)
+            visibleAgentStatus(for: instance)
                 == .expectedMissing(expected: "1.2.3")
         )
+    }
+
+    @Test("The app-wide preference suppresses .waiting without touching the per-VM flag")
+    func agentSuppressedWhenPromptDisabledAppWide() {
+        let instance = makeInstance(guestOS: .macOS, status: .running)
+        #expect(
+            SidebarVMRowCellView.visibleAgentStatus(for: instance, installPromptDisabled: true)
+                == nil)
+        // The per-VM flag is overridden, never written: turning the preference
+        // back on must restore what this VM was set to.
+        #expect(instance.configuration.agentInstallNudgeDismissed == false)
+        #expect(visibleAgentStatus(for: instance) == .waiting)
+    }
+
+    /// The app-wide preference carries the same scope as the per-VM switch —
+    /// only the gentle install nudge.
+    ///
+    /// A gate that over-reached would silence the "didn't reconnect" and
+    /// "update available" affordances app-wide.
+    @Test("The app-wide preference leaves the louder agent states alone")
+    func agentLouderStatesSurviveAppWideDisable() {
+        let missing = makeInstance(guestOS: .macOS, status: .running)
+        missing.configuration.lastSeenAgentVersion = "1.2.3"
+        missing.agentExpectedButMissing = true
+        #expect(
+            SidebarVMRowCellView.visibleAgentStatus(for: missing, installPromptDisabled: true)
+                == .expectedMissing(expected: "1.2.3"))
     }
 
     // MARK: - Reorder index math

--- a/KernovaTests/SidebarViewControllerTests.swift
+++ b/KernovaTests/SidebarViewControllerTests.swift
@@ -196,6 +196,31 @@ struct SidebarViewControllerTests {
                 == .expectedMissing(expected: "1.2.3"))
     }
 
+    /// Re-arming an observation reports only changes made *after* it registers.
+    ///
+    /// So anything that moved while the sidebar was off screen — a collapsed
+    /// split item, a closed main window — arrives unobserved. The install-prompt
+    /// preference is the sharpest case: each cell snapshots it at configure
+    /// time, so without a reload on appear the badges keep answering from the
+    /// value the preference held before the user changed it in Settings.
+    @Test("Appearing reloads rows so state changed while off screen isn't stale")
+    func appearingReloadsAfterOffScreenChange() {
+        let viewModel = makeViewModel()
+        viewModel.instances.append(makeInstance(guestOS: .macOS, status: .running))
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
+        controller.loadViewIfNeeded()
+        controller.viewDidAppear()
+
+        controller.viewWillDisappear()
+        let reloadsWhileOffScreen = controller.reloadInstancesCallCountForTesting
+        viewModel.agentInstallPromptDisabled = true
+        #expect(controller.reloadInstancesCallCountForTesting == reloadsWhileOffScreen)
+
+        controller.viewDidAppear()
+
+        #expect(controller.reloadInstancesCallCountForTesting > reloadsWhileOffScreen)
+    }
+
     // MARK: - Reorder index math
 
     @Test("reorderTarget maps drops and skips no-ops")

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -307,3 +307,26 @@ func makeTestWindow(styleMask: NSWindow.StyleMask) -> NSWindow {
     window.isReleasedWhenClosed = false
     return window
 }
+
+/// Hosts `view` as an on-screen window's content view, for behavior that only
+/// runs against one.
+///
+/// `ScrollMoreIndicator` holds its scroller flash until there is a visible
+/// window to animate the fade-in against, so a flash assertion made off screen
+/// asserts the opposite of what the app does.
+///
+/// `view` becomes the content view rather than a bare subview: a pane root with
+/// `translatesAutoresizingMaskIntoConstraints` off and no pinning constraints
+/// hands its frame to the layout engine, which resolves it to something the test
+/// never asked for. `size` defaults to the frame `view` already carries; pass a
+/// measured `preferredContentSize` for a pane that sizes its own window.
+///
+/// Keep the returned window alive for the length of the test.
+@MainActor
+func showInTestWindow(_ view: NSView, size: NSSize? = nil) -> NSWindow {
+    let window = makeTestWindow(styleMask: [.titled, .closable])
+    window.setContentSize(size ?? view.frame.size)
+    window.contentView = view
+    window.orderFront(nil)
+    return window
+}

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2841,7 +2841,7 @@ struct VMLibraryViewModelTests {
         #expect(storage.saveConfigurationCallCount == 1)
     }
 
-    @Test("resetAllAgentInstallNudges re-arms every VM")
+    @Test("resetAllAgentInstallNudges re-arms every VM and the app-wide preference")
     func resetAllAgentInstallNudgesReArmsEveryVM() {
         let (viewModel, _, _, _, _) = makeViewModel()
         let first = makeInstance(name: "First")
@@ -2851,12 +2851,54 @@ struct VMLibraryViewModelTests {
         second.configuration.agentInstallNudgeDismissed = true
         // `third` stays armed to confirm the reset no-ops on already-armed VMs.
         viewModel.instances = [first, second, third]
+        viewModel.agentInstallPromptDisabled = true
 
         viewModel.resetAllAgentInstallNudges()
 
         #expect(first.configuration.agentInstallNudgeDismissed == false)
         #expect(second.configuration.agentInstallNudgeDismissed == false)
         #expect(third.configuration.agentInstallNudgeDismissed == false)
+        #expect(viewModel.agentInstallPromptDisabled == false)
+        #expect(preferences.agentInstallPromptDisabled == false)
+    }
+
+    @Test("agentInstallPromptDisabled defaults off and persists in both directions")
+    func agentInstallPromptDisabledPersistsBothDirections() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        #expect(viewModel.agentInstallPromptDisabled == false)
+
+        viewModel.agentInstallPromptDisabled = true
+        #expect(preferences.agentInstallPromptDisabled == true)
+
+        viewModel.agentInstallPromptDisabled = false
+        #expect(preferences.agentInstallPromptDisabled == false)
+    }
+
+    @Test("agentInstallPromptDisabled is seeded from the stored preference")
+    func agentInstallPromptDisabledSeededFromPreferences() {
+        preferences.agentInstallPromptDisabled = true
+
+        let (viewModel, _, _, _, _) = makeViewModel()
+
+        #expect(viewModel.agentInstallPromptDisabled == true)
+    }
+
+    /// The app-wide preference overrides the per-VM flag rather than rewriting
+    /// it, so each VM reverts to its own choice when the preference goes off.
+    @Test("Toggling agentInstallPromptDisabled leaves every per-VM flag alone")
+    func agentInstallPromptDisabledLeavesPerVMFlagsAlone() {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        let dismissed = makeInstance(name: "Dismissed")
+        let armed = makeInstance(name: "Armed")
+        dismissed.configuration.agentInstallNudgeDismissed = true
+        viewModel.instances = [dismissed, armed]
+
+        viewModel.agentInstallPromptDisabled = true
+        viewModel.agentInstallPromptDisabled = false
+
+        #expect(dismissed.configuration.agentInstallNudgeDismissed == true)
+        #expect(armed.configuration.agentInstallNudgeDismissed == false)
+        #expect(storage.saveConfigurationCallCount == 0)
     }
 
     // MARK: - Rename

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Kernova
 
-@Suite("VMSettingsViewController Tests")
+@Suite("VMSettingsViewController Tests", .serialized)
 @MainActor
 struct VMSettingsViewControllerTests {
     // MARK: - Fixtures

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -467,6 +467,46 @@ struct VMSettingsViewControllerTests {
         #expect(cancelled && !confirmed)
     }
 
+    // MARK: - Guest agent install reminder
+
+    @Test("The install-reminder switch is live while the prompt is on app-wide")
+    func installReminderEnabledByDefault() throws {
+        let (vc, instance, _) = makeController(guestOS: .macOS, isReadOnly: false)
+
+        let toggle = try #require(firstSwitch(action: "installReminderToggled", in: vc.view))
+        #expect(toggle.isEnabled)
+        #expect(!visibleLabel(VMSettingsViewController.installPromptDisabledCaption, in: vc.view))
+
+        toggle.state = .off
+        toggle.sendAction(toggle.action, to: toggle.target)
+        #expect(instance.configuration.agentInstallNudgeDismissed == true)
+    }
+
+    /// The app-wide preference is not overridable per VM, so the switch goes
+    /// inert — and says where the preference that made it inert lives, or the
+    /// disabled state reads as broken.
+    @Test("The app-wide preference disables the install-reminder switch and says why")
+    func installReminderDisabledByAppWidePreference() throws {
+        let (vc, instance, viewModel) = makeController(guestOS: .macOS, isReadOnly: false)
+
+        viewModel.agentInstallPromptDisabled = true
+        // Stands in for the observation pass a Settings-window toggle triggers.
+        vc.viewDidAppear()
+
+        let toggle = try #require(firstSwitch(action: "installReminderToggled", in: vc.view))
+        #expect(!toggle.isEnabled)
+        #expect(visibleLabel(VMSettingsViewController.installPromptDisabledCaption, in: vc.view))
+        // Overridden, not rewritten: the row still shows this VM's own choice.
+        #expect(instance.configuration.agentInstallNudgeDismissed == false)
+        #expect(toggle.state == .on)
+
+        viewModel.agentInstallPromptDisabled = false
+        vc.viewDidAppear()
+
+        #expect(toggle.isEnabled)
+        #expect(!visibleLabel(VMSettingsViewController.installPromptDisabledCaption, in: vc.view))
+    }
+
     // MARK: - Display section
 
     /// Builds a controller over a config with explicit display settings.


### PR DESCRIPTION
Closes #330

## Summary

Silences the sidebar "install guest agent" nudge for every VM at once. Suppression was per-VM only — dismissing from the sidebar popover, or the install-reminder switch in VM Settings, both writing that one VM's `agentInstallNudgeDismissed` — and `VMInstance`'s post-start watchdog deliberately re-arms that flag when an expected agent never reconnects, so a user who doesn't intend to install the agent could dismiss the same nudge more than once per VM.

Scoped to the gentle `.waiting` prompt, matching the per-VM switch: `.outdated`, `.expectedMissing`, and `.unresponsive` still surface. The `GuestAgentDiskMenuItem` "Install Guest Agent…" command and the clipboard window's install button are commands rather than prompts and are untouched.

## Where it lives

Settings → Reminders. **Guest Agent Install Reminder** heads the *Virtual Machine Reminders* section, with the per-VM card and its captions indented 20pt beneath it. *Reset All Reminders* re-arms it along with every per-VM flag.

Apple's guidance for a control that governs others is to indent the subordinates below it:

> In a group of checkboxes, each checkbox should be independent of all the others, unless interdependency is clearly indicated (for example, by displaying a subordinate checkbox indented below a superior checkbox).

The indent states the relationship at all times; the greying below only speaks while the switch is off. The same 20pt `groupedFormSubOptionIndent` already carries Clipboard Sharing → Automatic Clipboard Passthrough.

**Not followed:** the same guidance recommends checkboxes rather than switches for a hierarchy of settings. Kernova's Settings panes use switches throughout, so converting only this pane would trade a small deviation for a larger inconsistency.

Each reminder gets a single-row card of its own, so no caption has to name the switch it describes. Both per-VM captions hide when the library is empty — they describe the per-VM switches, and beneath a lone "No virtual machines yet." row "…so these have no effect" points at controls that aren't there.

## The per-VM switch goes inert, and says why

While the preference is on, VM Settings → Guest Agent → "Show install reminder" is disabled with its label greyed, and a caption appears under the card: *"The install reminder is turned off for all virtual machines in Settings → Reminders."* Without it the disabled switch reads as broken rather than as controlled elsewhere. The Reminders pane's own per-VM rows get the same treatment.

The per-VM `agentInstallNudgeDismissed` value is never written by any of this — each VM reverts to its own choice when the preference goes back off, which the tests assert directly.

## Route taken

**Propagation.** The preference stores in `AppPreferences`, alongside every other app-wide setting. But the sidebar badge and both panes refresh through `withObservationTracking`, which a `UserDefaults` read never wakes — and the Settings window is separate from the main one, so a toggle has to repaint the sidebar behind it. `VMLibraryViewModel.agentInstallPromptDisabled` is therefore an `@Observable` mirror and the single write path for the stored value.

*Rejected:* `UserDefaults` KVO via an `@objc dynamic` shim, and `UserDefaults.didChangeNotification`. The first duplicates the key string into a second declaration that must match it exactly and bridges a KVO callback onto the main actor; the second wakes on every unrelated defaults write (sidebar sections, VM order, last selection). The mirror needs no new machinery and uses the reactivity mechanism the rest of the app already runs on.

**Sidebar staleness.** Each row cell snapshots the preference at configure time, and `SidebarViewController` tears its observations down on disappear. Re-arming a `withObservationTracking` registration reports only changes made *after* it, so toggling the preference with the sidebar collapsed left every cell holding its old answer. `viewDidAppear` now calls `reloadInstances()`, which subsumes the selection and rename passes it replaces. The gap pre-dated this branch for `instances`/`isPreparing`; the new snapshot is what made it reachable.

One behavior change comes with it, surfaced in review and accepted: `reloadInstances()` opens by committing any in-flight rename, because a reload tears the field editor down underneath the user. So hiding the sidebar mid-rename (⌘H, or the window ordered out) now commits the partial name instead of resuming the edit. It commits rather than discards, matches the commit-on-focus-loss model VM Settings already uses on `viewWillDisappear`, and is undone by renaming again — while the alternative is to keep the stale badges the reload exists to clear.

**Pane growth.** Revealing the override caption grows the pane after the window has been sized — `SettingsTabViewController` sizes once per tab selection — so the content overflows in place. The cue is a scroller flash rather than a window resize: resizing would mean teaching the container to react to a child's `preferredContentSize`, which affects every pane. The flash latches after firing once and a pane lives as long as the window, so `SettingsPaneScrollCueing` lets the container re-arm the pane it selects, and the cue greets every arrival rather than only the first. Re-armed *after* `resizeWindow(toFit:)`: the cue answers whether the pane overflows the window it just got.

Reminders is the only pane that scrolls today — the other three size the window to their full content. The contract sits on the container so a future pane with a height cap is cued by adopting it.

**Cue timing.** `flashScrollers()` animates a fade-in, hold, then fade-out. Armed from `viewWillAppear` — before the window is ordered on screen — the fade-in plays behind an unshown window, so the pane's first visit met a scroller already at full alpha that only faded out, while every later visit showed the whole animation. The arrival cue therefore runs from `viewDidAppear`, and `ScrollMoreIndicator.canFlash` keeps the one-shot latch armed until there is a visible window, so an early call defers instead of spending the cue. `resizeWindow(toFit:)` stays in `viewWillAppear` — the window is still sized before it is shown.

Ordering a window on screen changes no geometry, so no bounds or frame notification fires and nothing re-runs the cue by itself. The arrival hook is what spends it. That also drives the test harness: the window owns the pane's view, sized from its measured `preferredContentSize`, and the harness makes the same arrival call the container does.

## Incidental

- `makeGroupedFormCardRow` gains an optional `titleLabel:` callback, mirroring `makeToggleRowWithInfo`'s existing one, so a card row's label can be greyed in step with its disabled control.
- `SettingsTabViewController` gains an injectable `AppPreferences`, threaded to all four panes. Each pane already accepted one; only the container didn't, which forced its panes onto the real `.shared` domain — including in tests.
- `ScrollMoreIndicator` gains a DEBUG `flashCountForTesting`. A re-arm over still-overflowing content re-latches immediately, so `hasFlashedForTesting` reads `true` on both sides and only a count separates a fresh flash from the previous one.
- `VMSettingsViewControllerTests` gains `.serialized`, matching its three sibling suites. It writes a shared `UserDefaults` suite that `makeEphemeralDefaults` clears per test instance, and this branch made one test read state another writes.

## Test plan

- [x] `make test` — full suite green. 21 new tests across six suites: the badge gate with the preference on and off and the louder agent states surviving it; the view model's persistence, seeding, reset, and hands-off treatment of per-VM flags; both panes' disabled state, caption visibility, and preserved switch positions; the 20pt indent measured between card edges; the flash re-arm on content growth and on every pane selection; the latch surviving a flash attempted with no visible window, `viewWillAppear` not spending the cue, and both per-VM captions hidden with zero VMs.
- [x] `make lint` — clean.
- [x] Guard tests confirmed failing without their fix: the sidebar reload on appear, and the container's re-arm on selection.
- [x] Three independent reviews: Codex native, Codex adversarial, and a recall-biased in-house pass. The first two found nothing actionable. The third raised two low findings — the rename commit above (accepted, documented here) and the empty-state caption (fixed).
- [x] Visual pass — done by the maintainer. It caught the cue-timing bug above: the scroller appeared fully drawn and only faded out on the pane's first showing, then faded in and out on every later one.

## Notes

- No `RATIONALE:` comments added.
- No ARCHITECTURE.md change: no component boundary moved. `SettingsPaneScrollCueing` is a cue contract between the Settings container and its own panes, not a new service or a changed data flow between components.
- One test helper subtlety worth knowing: a grouped-form card's inter-row hairlines are `NSBox`es too, so finding a card by matching `NSBox` alone stops at a multi-row card's inner stack and reports an edge inset by the card's padding. The helper keys on the corner radius instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013X6t2Kk6VkxD3YN9YZ7uA8
