### PR TITLE
docs: Record what VZ supports for multiple displays

### DIFF
--- a/docs/research/2026-08-07-vz-multiple-displays.md
+++ b/docs/research/2026-08-07-vz-multiple-displays.md
@@ -1,0 +1,66 @@
+# VZ multiple displays: one for a macOS guest, several for a Linux guest — but no view can show the extras
+
+**Date:** 2026-08-07 · **Host:** M1 Max, 32 GB, macOS 27.0, Xcode 27.0 SDK
+
+## Summary
+
+Both graphics device types carry at most one display each, stated in their
+headers and enforced by `VZVirtualMachineConfiguration.validate()`. The guest
+families diverge on how many graphics *devices* one configuration may hold:
+
+- **macOS: exactly one device with exactly one display.** Two displays on a
+  `VZMacGraphicsDeviceConfiguration` fail with "Number of displays is greater
+  than the configured display port count"; two such devices fail with "Number
+  of graphics devices is greater than the maximum number supported" — both
+  `VZErrorDomain` code 2. That "display port count" is settable by no public
+  property: `maximumPortCount` exists only on
+  `VZVirtioConsolePortConfigurationArray`, for console ports.
+- **Linux/EFI: one scanout per device, but many devices.** Two scanouts on one
+  `VZVirtioGraphicsDeviceConfiguration` fail with "More than one scanout is
+  configured", while multiple single-scanout devices validate, start, and are
+  visible at runtime. Counts 1 through 64 all validated — 64 is where the probe
+  stopped asking, not a measured ceiling — and a 4-device VM started with
+  `VZVirtualMachine.graphicsDevices` reporting four `VZVirtioGraphicsDevice`s of
+  one display each.
+
+**Presentation, not configuration, is the binding constraint.**
+`VZVirtualMachineView` binds to a virtual machine — `virtualMachine`, or macOS
+27's Sendable `VZVirtualMachineViewAdaptor(virtualMachine:)`, which wraps a VM
+and nothing else — and offers no way to aim a view at a chosen
+`VZGraphicsDevice` or `VZGraphicsDisplay`. Per-display targeting does exist
+inside the framework: `automaticallyReconfiguresDisplay` is documented as
+settable "on a single VZVirtualMachineView targeting a particular
+VZGraphicsDisplay at a time" (`VZVirtualMachineView.h`). Choosing that target is
+not public API.
+
+Whether a second `VZVirtualMachineView` on one VM renders a second virtio device
+is untested — the probe ran headless.
+
+Consequences for Kernova: `ConfigurationBuilder`'s single-element `displays` and
+`scanouts` arrays sit at the framework maximum on both counts for macOS, and at
+the maximum per device but below the per-configuration allowance for Linux. A
+Linux multi-display feature is reachable in the VZ configuration and blocked at
+the view layer.
+
+## Method
+
+A standalone Objective-C probe compiled with `clang -fobjc-arc -framework
+Virtualization` and ad-hoc signed with `com.apple.security.virtualization`:
+
+1. **Validation:** `validateWithError:` over configurations varying one axis at a
+   time — displays per device, devices per configuration — for both device
+   types. The virtio cases used a diskless `VZGenericPlatformConfiguration` with
+   a `VZEFIBootLoader` and a freshly created `VZEFIVariableStore` (validate
+   rejects a nil variable store first, masking the graphics result). The mac
+   cases used a `VZMacPlatformConfiguration` built from
+   `VZMacOSRestoreImage.fetchLatestSupported`'s hardware model, with fresh
+   auxiliary storage and machine identifier.
+2. **Device-count sweep:** validation repeated for 1…64 virtio graphics devices,
+   each with one 1920×1200 scanout; all accepted.
+3. **Start:** the 4-device virtio configuration on a `VZVirtualMachine` with a
+   private serial queue, `startWithCompletionHandler:` — completes without error
+   (firmware idles with no disk), then `graphicsDevices` and each device's
+   `displays` read back on that queue before stopping.
+4. **View surface:** read `VZVirtualMachineView.h`, `VZGraphicsDevice.h`, and the
+   `Virtualization.swiftinterface` entry for `VZVirtualMachineViewAdaptor`;
+   grepped the framework headers for a display-port-count property.


### PR DESCRIPTION
## Summary

Closes #297, whose remaining open question was whether to expose multiple displays. Measured against the macOS 27.0 / Xcode 27.0 SDK rather than reasoned from the headers alone, because the headers state the per-device cap but say nothing about how many graphics *devices* a configuration may hold — which turns out to be where the two guest families diverge.

- **macOS guests are capped at one display** by two independent `validate()` limits: two displays on one `VZMacGraphicsDeviceConfiguration` ("Number of displays is greater than the configured display port count") and two such devices ("Number of graphics devices is greater than the maximum number supported"). No public property sets that port count.
- **Linux/EFI guests can carry several displays** as multiple single-scanout virtio devices. Counts 1–64 all validated, and a 4-device VM started with `VZVirtualMachine.graphicsDevices` reporting four devices of one display each — so this is real, not a validation quirk.
- **The blocker is the view layer.** `VZVirtualMachineView` binds to a virtual machine and offers no way to target a chosen `VZGraphicsDevice` or `VZGraphicsDisplay`; macOS 27's `VZVirtualMachineViewAdaptor` is only a Sendable VM wrapper. The framework targets displays internally — `automaticallyReconfiguresDisplay` is documented as settable "on a single VZVirtualMachineView targeting a particular VZGraphicsDisplay at a time" — but selecting that target is not public API.

A Linux multi-display feature is therefore config-layer trivial and view-layer unsupported.

## Why a research note rather than code

Nothing here changes what Kernova should build today: `ConfigurationBuilder`'s single-element `displays`/`scanouts` arrays are already at the framework maximum for macOS, and the Linux headroom is unreachable through the view. The durable value is the measurement and its method, which is what `docs/research/` exists for.

The rest of #297's scope was already settled elsewhere — resolution/size/HiDPI shipped in #690, the dimension ceilings were measured under #691. Its competitive analysis of UTM/Parallels/VMware/Tart was never produced and no longer gates anything, which is stated in the issue comment rather than carried forward as a stub issue.

## Stated limitation

The note records one untested case: whether a second `VZVirtualMachineView` on the same VM happens to render the second virtio device. The probe ran headless, so the view-layer conclusion rests on the absence of a public selector, not on an observed failure. That is the first experiment to run if Linux multi-display is ever picked up, and the one that could overturn the verdict.

## Test plan

- [x] `Tools/check-docs.sh` green
- [x] Docs-only change; no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YSkeWDiFTi2yoL61oLk6H