### PR TITLE
fix: Attach the guest agent's feature channels as soon as the handshake lands

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -831,7 +831,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.56.0;
+				MARKETING_VERSION = 0.57.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
@@ -869,7 +869,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.56.0;
+				MARKETING_VERSION = 0.57.0;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -705,9 +705,17 @@ final class VMInstance {
     /// `clipboard.stream.v1`.
     ///
     /// Evaluated at accept time so it tracks reconnects.
-    func admitsFeatureChannel(requiringClipboardStreaming: Bool) -> Bool {
-        guard let control = vsockControlService, control.isConnected else { return false }
-        return !requiringClipboardStreaming || control.guestSupportsClipboardStreaming
+    func featureChannelAdmission(requiringClipboardStreaming: Bool) -> VsockAdmission {
+        guard let control = vsockControlService, control.isConnected else {
+            return .notReady(reason: "no control channel has completed its handshake")
+        }
+        guard !requiringClipboardStreaming || control.guestSupportsClipboardStreaming else {
+            return .denied(
+                reason:
+                    "the connected guest agent does not advertise \(KernovaCapability.clipboardStreamV1)"
+            )
+        }
+        return .admit
     }
 
     // MARK: - Agent Policy
@@ -794,7 +802,8 @@ final class VMInstance {
         VsockListenerHost(
             port: KernovaVsockPort.log,
             shouldAdmit: { [weak self] in
-                self?.admitsFeatureChannel(requiringClipboardStreaming: false) ?? false
+                self?.featureChannelAdmission(requiringClipboardStreaming: false)
+                    ?? .notReady(reason: "the VM instance is gone")
             }
         ) { [weak self] channel in
             guard let self else {
@@ -814,7 +823,8 @@ final class VMInstance {
         VsockListenerHost(
             port: KernovaVsockPort.clipboard,
             shouldAdmit: { [weak self] in
-                self?.admitsFeatureChannel(requiringClipboardStreaming: true) ?? false
+                self?.featureChannelAdmission(requiringClipboardStreaming: true)
+                    ?? .notReady(reason: "the VM instance is gone")
             }
         ) { [weak self] channel in
             guard let self else {
@@ -1016,25 +1026,35 @@ final class VMInstance {
             oldConfig.clipboardSharingEnabled != newConfig.clipboardSharingEnabled
         guard logChanged || clipboardChanged else { return }
 
-        // Push the policy snapshot to the guest BEFORE manipulating host
-        // listeners. On a disable transition this lets the guest pause its
-        // reconnect loop first; tearing the listener down first would make it
-        // see EOF and pound the host with reconnects until the policy frame
-        // arrives. The control service is nil in the window between accepting a
+        let logEnabled = newConfig.agentLogForwardingEnabled
+        let clipboardEnabled = newConfig.clipboardSharingEnabled
+        let clipboardApplies = clipboardChanged && newConfig.guestOS == .macOS
+
+        // A listener the guest is about to be told about goes up first: the
+        // policy frame wakes the guest's parked reconnect loop at once
+        // (`VsockGuestClient.resume()`), and a redial that beats the listener is
+        // refused and costs the guest a full retry interval.
+        if logChanged && logEnabled {
+            applyLiveLogPolicy(enabled: true, on: socketDevice)
+        }
+        if clipboardApplies && clipboardEnabled {
+            applyLiveClipboardPolicy(enabled: true, on: socketDevice)
+        }
+
+        // The control service is nil in the window between accepting a
         // connection and the guest's Hello — the next Hello-driven send catches
         // that up.
         vsockControlService?.sendPolicyUpdate(agentPolicySnapshot(for: newConfig))
 
-        if logChanged {
-            applyLiveLogPolicy(enabled: newConfig.agentLogForwardingEnabled, on: socketDevice)
+        // A listener being withdrawn comes down after, so the frame pauses the
+        // guest's loop first: tearing it down while the guest still thinks the
+        // feature is on makes the guest see EOF and pound the host with
+        // reconnects until the policy arrives.
+        if logChanged && !logEnabled {
+            applyLiveLogPolicy(enabled: false, on: socketDevice)
         }
-
-        let isMacOSGuest = newConfig.guestOS == .macOS
-        if clipboardChanged && isMacOSGuest {
-            applyLiveClipboardPolicy(
-                enabled: newConfig.clipboardSharingEnabled,
-                on: socketDevice
-            )
+        if clipboardApplies && !clipboardEnabled {
+            applyLiveClipboardPolicy(enabled: false, on: socketDevice)
         }
 
         Self.logger.notice(

--- a/Kernova/Services/VsockListenerHost.swift
+++ b/Kernova/Services/VsockListenerHost.swift
@@ -3,6 +3,20 @@ import KernovaKit
 import os
 import Virtualization
 
+/// A listener owner's verdict on one accepted connection.
+///
+/// The two refusals differ only in what they say about the peer, which is what
+/// picks the log level: a channel that arrived before the handshake gating it
+/// is the guest agent's own reconnect racing that handshake, while one refused
+/// after it is a peer that should not have connected.
+enum VsockAdmission: Equatable, Sendable {
+    case admit
+    /// The handshake this port is gated on has not completed yet.
+    case notReady(reason: String)
+    /// The handshake completed and it does not entitle this peer to this port.
+    case denied(reason: String)
+}
+
 /// Hosts a single `VZVirtioSocketListener` on a given vsock port and hands
 /// each accepted connection to a callback as a `VsockChannel`.
 ///
@@ -14,9 +28,9 @@ final class VsockListenerHost: NSObject, VZVirtioSocketListenerDelegate {
 
     /// Owner-supplied admission predicate, evaluated per accepted connection.
     ///
-    /// Returning `false` refuses the connection at the VZ level — no channel is
-    /// built and `onConnect` never fires. `nil` admits every connection.
-    typealias ShouldAdmit = @MainActor () -> Bool
+    /// Anything but `.admit` refuses the connection at the VZ level — no channel
+    /// is built and `onConnect` never fires. `nil` admits every connection.
+    typealias ShouldAdmit = @MainActor () -> VsockAdmission
 
     private static let logger = Logger(subsystem: "app.kernova", category: "VsockListenerHost")
 
@@ -77,10 +91,20 @@ final class VsockListenerHost: NSObject, VZVirtioSocketListenerDelegate {
 
         // Refusing here — before any channel exists — means the peer sees the
         // connection reset; a conformant guest agent's reconnect loop retries,
-        // by which time the control handshake has normally landed.
-        if let shouldAdmit, !shouldAdmit() {
+        // and the policy update that follows the handshake wakes it to do so at
+        // once (`VsockGuestClient.resume()`).
+        switch shouldAdmit?() ?? .admit {
+        case .admit:
+            break
+        case .notReady(let reason):
+            Self.logger.info(
+                "Refusing vsock connection on port \(self.port, privacy: .public) — \(reason, privacy: .public)"
+            )
+            close(fd)
+            return false
+        case .denied(let reason):
             Self.logger.warning(
-                "Refusing vsock connection on port \(self.port, privacy: .public) — admission check failed"
+                "Refusing vsock connection on port \(self.port, privacy: .public) — \(reason, privacy: .public)"
             )
             close(fd)
             return false

--- a/KernovaMacOSAgent/VsockGuestClient.swift
+++ b/KernovaMacOSAgent/VsockGuestClient.swift
@@ -191,6 +191,17 @@ final class VsockGuestClient: @unchecked Sendable {
     /// `resume()`; reversible, unlike `stopped`.
     private var paused = false
 
+    /// A `resume()` the loop has not acted on yet.
+    ///
+    /// Latched rather than edge-triggered: `resume()` routinely lands while the
+    /// loop is mid-attempt rather than parked, and the wake must survive to the
+    /// next park.
+    private var wakeRequested = false
+
+    /// The task holding the current between-attempts sleep; cancelling it is
+    /// what wakes the loop early.
+    private var retryWaiter: Task<Void, Never>?
+
     // MARK: - Init
 
     init(
@@ -238,10 +249,22 @@ final class VsockGuestClient: @unchecked Sendable {
         ch?.close()
     }
 
-    /// Resumes the reconnect loop after `pause()`, reconnecting within
-    /// `retryInterval`.
+    /// Resumes the reconnect loop after `pause()` and has it connect now rather
+    /// than at the end of the interval it is sleeping through.
+    ///
+    /// Idempotent, and meaningful on a client that was never paused: there it
+    /// means "reconnect at the next opportunity". The agent calls it for every
+    /// host policy update that says enabled, including one that changes
+    /// nothing, because that update is also the host's word that its control
+    /// handshake has landed — the thing the host's feature-channel admission
+    /// gate refuses connections ahead of.
     func resume() {
-        lock.withLock { paused = false }
+        let waiter: Task<Void, Never>? = lock.withLock {
+            paused = false
+            wakeRequested = true
+            return retryWaiter
+        }
+        waiter?.cancel()
     }
 
     /// Stops the loop and tears down any active channel; later `start` calls are
@@ -269,7 +292,14 @@ final class VsockGuestClient: @unchecked Sendable {
 
     private func runReconnectLoop(serve: @Sendable @escaping (VsockChannel) async -> Void) async {
         while !Task.isCancelled {
-            let isPaused = lock.withLock { paused }
+            let isPaused: Bool = lock.withLock {
+                // A wake latched before this attempt is satisfied by the attempt
+                // itself, so it must not also skip the park that follows. A
+                // `resume()` arriving mid-attempt is a fresh signal instead, and
+                // the next `waitBeforeRetry()` consumes it.
+                if !paused { wakeRequested = false }
+                return paused
+            }
             if !isPaused {
                 let outcome = await connectAndServe(serve: serve)
                 switch outcome {
@@ -281,8 +311,39 @@ final class VsockGuestClient: @unchecked Sendable {
                 }
             }
             guard !Task.isCancelled else { break }
+            await waitBeforeRetry()
+        }
+    }
+
+    /// Suspends between connect attempts until `retryInterval` elapses,
+    /// `resume()` wakes the loop, or the loop task is cancelled.
+    ///
+    /// The sleep runs in its own task so `resume()` can cancel it without
+    /// cancelling the loop, and one lock hold both consumes a pending wake and
+    /// publishes the sleeper, so a `resume()` racing this call either finds the
+    /// sleeper to cancel or leaves the flag that skips the park.
+    private func waitBeforeRetry() async {
+        let waiter = Task<Void, Never> { [clock, retryInterval] in
             try? await clock.sleep(for: retryInterval)
         }
+        let parked: Bool = lock.withLock {
+            if wakeRequested {
+                wakeRequested = false
+                return false
+            }
+            retryWaiter = waiter
+            return true
+        }
+        guard parked else {
+            waiter.cancel()
+            return
+        }
+        await withTaskCancellationHandler {
+            await waiter.value
+        } onCancel: {
+            waiter.cancel()
+        }
+        lock.withLock { retryWaiter = nil }
     }
 
     private func connectAndServe(

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -312,10 +312,12 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     }
 
     private func applyEnabledOnMain(_ enabled: Bool) {
+        // Ahead of the no-change guard, so an update that only restates
+        // "enabled" still reaches `resume()` — see its doc comment.
+        if enabled { client.resume() }
         guard self.enabled != enabled else { return }
         self.enabled = enabled
         if enabled {
-            client.resume()
             startPolling()
             clipboardActivityStorage = .enabled
             Self.logger.notice("Clipboard sharing enabled by host policy")

--- a/KernovaMacOSAgent/VsockHostConnection.swift
+++ b/KernovaMacOSAgent/VsockHostConnection.swift
@@ -39,8 +39,14 @@ final class VsockHostConnection: @unchecked Sendable {
         lock.withLock { policy == .enabled }
     }
 
-    init() {
-        self.client = VsockGuestClient(port: KernovaVsockPort.log, label: "log")
+    /// Production init — forwards on `KernovaVsockPort.log`.
+    convenience init() {
+        self.init(client: VsockGuestClient(port: KernovaVsockPort.log, label: "log"))
+    }
+
+    /// Designated init; tests inject a socketpair-backed client.
+    init(client: VsockGuestClient) {
+        self.client = client
         // Default-disabled: no connect attempts until the host's first
         // `PolicyUpdate(logForwardingEnabled: true)`.
         self.client.pause()
@@ -63,8 +69,10 @@ final class VsockHostConnection: @unchecked Sendable {
     /// Applies a host policy update for log forwarding.
     ///
     /// Enabling resumes the loop, flushing whatever was buffered while the policy
-    /// was undecided. Disabling closes the channel and discards the buffer — an
-    /// explicit "off" ships nothing retroactively. Idempotent.
+    /// was undecided; an update that only restates "enabled" still reaches
+    /// `VsockGuestClient.resume()`. Disabling closes the channel and discards the
+    /// buffer — an explicit "off" ships nothing retroactively, and repeating it
+    /// does nothing.
     func setEnabled(_ enabled: Bool) {
         let target: ForwardingPolicy = enabled ? .enabled : .disabled
         let needsTransition: Bool = lock.withLock {
@@ -72,9 +80,10 @@ final class VsockHostConnection: @unchecked Sendable {
             policy = target
             return was != target
         }
+        // Ahead of the no-change guard — see `VsockGuestClient.resume()`.
+        if enabled { client.resume() }
         guard needsTransition else { return }
         if enabled {
-            client.resume()
             Self.logger.notice("Log forwarding enabled by host policy")
         } else {
             client.pause()

--- a/KernovaMacOSAgentTests/VsockGuestClientTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClientTests.swift
@@ -483,6 +483,81 @@ struct ClassifySocketErrnoTests {
         _ = try await awaitFirst(servedStream)
         #expect(calls.value >= 1)
     }
+
+    /// The interval is far past `testWaitBackstop`, so the connect can only
+    /// arrive because `resume()` cut the sleep short — a loop that waits its
+    /// interval out fails the test rather than passing slowly.
+    @Test(
+        "resume() cuts short the sleep a parked loop is in",
+        arguments: EngineClockKind.allCases)
+    func resumeWakesAParkedLoop(kind: EngineClockKind) async throws {
+        let (localFd, remoteFd) = try makeRawSocketPair()
+        let remote = VsockChannel(fileDescriptor: remoteFd)
+        remote.start()
+        defer { remote.close() }
+
+        let client = makeTestClient(
+            kind: kind, port: 12345, label: "test", retryInterval: 600
+        ) { _, _ in .success(localFd) }
+        defer { client.stop() }
+
+        let (servedStream, continuation) = AsyncStream<Void>.makeStream()
+        client.pause()
+        client.start { channel in
+            continuation.yield(())
+            do { for try await _ in channel.incoming {} } catch {}
+        }
+
+        client.resume()
+        _ = try await awaitFirst(servedStream)
+    }
+
+    /// A wake dropped on the floor here costs a whole retry interval.
+    ///
+    /// The ordering a VM resume produces: the host refuses the feature channel
+    /// while its control handshake is still in flight, and the policy update
+    /// that clears the refusal lands before the loop reaches its next sleep.
+    @Test("A resume() landing mid-attempt is what the next park consumes")
+    func resumeMidAttemptSkipsTheNextPark() async throws {
+        let (localFd, remoteFd) = try makeRawSocketPair()
+        let remote = VsockChannel(fileDescriptor: remoteFd)
+        remote.start()
+        defer { remote.close() }
+
+        let attempts = AtomicInt()
+        let firstAttemptEntered = DispatchSemaphore(value: 0)
+        let firstAttemptRelease = DispatchSemaphore(value: 0)
+
+        let client = makeTestClient(
+            kind: .monotonic, port: 12345, label: "test", retryInterval: 600
+        ) { _, _ in
+            // The provider runs synchronously on the loop's own task, so the
+            // loop is provably mid-attempt — not parked — while it blocks here.
+            guard attempts.increment() == 1 else { return .success(localFd) }
+            firstAttemptEntered.signal()
+            firstAttemptRelease.wait()
+            return .failure(.transient("test: first attempt refused"))
+        }
+        defer { client.stop() }
+
+        let (servedStream, continuation) = AsyncStream<Void>.makeStream()
+        client.start { channel in
+            continuation.yield(())
+            do { for try await _ in channel.incoming {} } catch {}
+        }
+
+        // Blocking waits go to GCD so the cooperative pool keeps its threads
+        // (docs/TESTING.md, "Blocking bridge calls").
+        let entered = await offCooperativePool {
+            firstAttemptEntered.wait(timeout: .now() + testWaitBackstop) == .success
+        }
+        try #require(entered)
+        client.resume()
+        firstAttemptRelease.signal()
+
+        _ = try await awaitFirst(servedStream)
+        #expect(attempts.value == 2)
+    }
 }
 
 @Suite("Bounded blocking connect: socket ownership and the one-per-label gate")

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -2731,6 +2731,61 @@ struct VsockGuestClipboardAgentTests {
         #expect(offer2.generation > offer1.generation)
     }
 
+    /// A no-change guard that swallows the restated enable costs a full retry
+    /// interval.
+    ///
+    /// The resume-from-saved-state ordering: the clipboard channel redials while
+    /// the host's control handshake is still in flight, the host refuses it, and
+    /// the policy update that follows the handshake restates a value the agent
+    /// already holds — the only wake the parked loop gets.
+    @Test("a policy update restating 'enabled' reconnects a refused clipboard channel")
+    func restatedEnablePolicyReconnects() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd0, remoteFd0) = try makeRawSocketPair()
+        let (agentFd1, remoteFd1) = try makeRawSocketPair()
+        let host0 = VsockChannel(fileDescriptor: remoteFd0)
+        let host1 = VsockChannel(fileDescriptor: remoteFd1)
+        host0.start()
+        host1.start()
+        defer { host0.close(); host1.close() }
+
+        let fdBox = FdBox(fds: [agentFd0, agentFd1])
+        let provideCount = AtomicInt()
+        // A retry interval far past `testWaitBackstop`, so the second connect can
+        // only land inside the test because the policy update woke the loop.
+        let client = VsockGuestClient(
+            port: 49152,
+            label: "clipboard-restated-policy-test",
+            clock: MonotonicEngineClock(),
+            retryInterval: 600
+        ) { _, _ in
+            let n = provideCount.increment()
+            guard let fd = fdBox.fd(at: n - 1) else {
+                return .failure(.transient("test: no fd at index \(n - 1)"))
+            }
+            return .success(fd)
+        }
+
+        let agent = VsockGuestClipboardAgent(pasteboard: pasteboard, client: client)
+        defer { agent.stop() }
+
+        agent.start()
+        agent.applyPolicy(enabled: true, maxPasteBytes: ClipboardPasteLimit.defaultBytes)
+        // RATIONALE: sanctioned no-signal polls (docs/TESTING.md "Async waits in
+        // tests") — `liveChannelForTesting` is SUT-internal state, as in
+        // `startAgentAndWaitForLiveChannel`.
+        try await waitUntil { agent.liveChannelForTesting != nil }
+
+        // The host hangs up, as a refused feature channel does.
+        host0.close()
+        try await waitUntil { agent.liveChannelForTesting == nil }
+
+        // Same policy, second delivery — the enable the guest already applied.
+        agent.applyPolicy(enabled: true, maxPasteBytes: ClipboardPasteLimit.defaultBytes)
+        try await waitUntil { agent.liveChannelForTesting != nil }
+        #expect(provideCount.value == 2)
+    }
+
     // MARK: - Teardown identity (Guard #1)
 
     // The serve() teardown re-checks `liveChannel === channel` before tearing the

--- a/KernovaMacOSAgentTests/VsockHostConnectionTests.swift
+++ b/KernovaMacOSAgentTests/VsockHostConnectionTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 import Darwin
 import KernovaKit
+import KernovaTestSupport
 
 /// Tests that seed the ring directly call `bufferFrameUnlessDisabled` on a
 /// fresh connection, whose policy is `.undecided` — the state that buffers, so
@@ -386,7 +387,7 @@ struct VsockHostConnectionTests {
         #expect(conn.isLogForwardingEnabled == false)
     }
 
-    @Test("setEnabled is idempotent — repeat calls with same value are no-ops")
+    @Test("A repeated setEnabled leaves the policy and the buffer alone")
     func setEnabledIsIdempotent() {
         let conn = VsockHostConnection()
 
@@ -398,8 +399,73 @@ struct VsockHostConnectionTests {
         conn.setEnabled(true)
         #expect(conn.isLogForwardingEnabled == true)
 
-        // Buffering still works after a no-op repeat enable.
+        // Buffering still works after a repeat enable.
         conn.forwardLog(level: .info, subsystem: "t", category: "t", message: "x")
         #expect(pendingLogCount(conn) == 1)
+    }
+
+    // MARK: - Reconnect
+
+    /// The restated enable is the only wake the parked loop gets.
+    ///
+    /// The resume-from-saved-state ordering: the log channel redials while the
+    /// host's control handshake is still in flight, the host refuses it, and the
+    /// policy update that follows the handshake restates the enable the agent
+    /// already applied.
+    @Test("A policy update restating 'enabled' reconnects and flushes what was buffered")
+    func restatedEnablePolicyReconnects() async throws {
+        let (agentFd0, remoteFd0) = try makeRawSocketPair()
+        let (agentFd1, remoteFd1) = try makeRawSocketPair()
+        let host0 = VsockChannel(fileDescriptor: remoteFd0)
+        let host1 = VsockChannel(fileDescriptor: remoteFd1)
+        host0.start()
+        host1.start()
+        defer { host0.close(); host1.close() }
+
+        let fds = [agentFd0, agentFd1]
+        let provideCount = AtomicInt()
+        // A retry interval far past `testWaitBackstop`, so the second connect can
+        // only land inside the test because the policy update woke the loop.
+        let client = VsockGuestClient(
+            port: 49153,
+            label: "log-restated-policy-test",
+            clock: MonotonicEngineClock(),
+            retryInterval: 600
+        ) { _, _ in
+            let n = provideCount.increment()
+            guard n <= fds.count else { return .failure(.transient("test: no fd for attempt \(n)")) }
+            return .success(fds[n - 1])
+        }
+        let conn = VsockHostConnection(client: client)
+        defer { conn.stop() }
+
+        conn.start()
+        conn.setEnabled(true)
+        // The record's arrival is the signal that the first channel is up.
+        conn.forwardLog(level: .info, subsystem: "t", category: "t", message: "first")
+        #expect(try await message(from: host0) == "first")
+
+        // The host hangs up, as a refused feature channel does; the record
+        // written while the loop is parked has nowhere to go but the buffer.
+        host0.close()
+        // RATIONALE: sanctioned no-signal poll (docs/TESTING.md "Async waits in
+        // tests") — `liveChannel` is lock-protected client state with no signal
+        // to await.
+        try await waitUntil { client.liveChannel == nil }
+        conn.forwardLog(level: .info, subsystem: "t", category: "t", message: "buffered")
+
+        // Same policy, second delivery — the enable the agent already applied.
+        conn.setEnabled(true)
+        #expect(try await message(from: host1) == "buffered")
+        #expect(provideCount.value == 2)
+    }
+
+    /// The message of the next `LogRecord` frame on `channel`.
+    private func message(from channel: VsockChannel) async throws -> String {
+        let frame = try await nextFrame(from: channel)
+        guard case .logRecord(let record) = frame.payload else {
+            throw TestFailure("Expected a LogRecord frame, got \(String(describing: frame.payload))")
+        }
+        return record.message
     }
 }

--- a/KernovaTests/VMInstanceVsockAdmissionTests.swift
+++ b/KernovaTests/VMInstanceVsockAdmissionTests.swift
@@ -39,13 +39,34 @@ struct VMInstanceVsockAdmissionTests {
         return frame
     }
 
+    /// The verdict as the listener acts on it, for the assertions that only care
+    /// whether the channel gets in.
+    private func admits(_ instance: VMInstance, clipboard: Bool) -> Bool {
+        instance.featureChannelAdmission(requiringClipboardStreaming: clipboard) == .admit
+    }
+
+    /// Whether the refusal is the routine "handshake hasn't landed" one, which
+    /// the listener logs below `.warning`.
+    ///
+    /// The reason text is not a contract.
+    private func isNotReady(_ verdict: VsockAdmission) -> Bool {
+        if case .notReady = verdict { return true }
+        return false
+    }
+
+    /// Whether the refusal is the one that names the peer.
+    private func isDenied(_ verdict: VsockAdmission) -> Bool {
+        if case .denied = verdict { return true }
+        return false
+    }
+
     // MARK: - Tests
 
-    @Test("Nothing is admitted without a control service")
-    func refusedWithoutControlService() {
+    @Test("Nothing is admitted without a control service", arguments: [false, true])
+    func refusedWithoutControlService(clipboard: Bool) {
         let instance = makeInstance()
-        #expect(!instance.admitsFeatureChannel(requiringClipboardStreaming: false))
-        #expect(!instance.admitsFeatureChannel(requiringClipboardStreaming: true))
+        #expect(
+            isNotReady(instance.featureChannelAdmission(requiringClipboardStreaming: clipboard)))
     }
 
     @Test("Admission follows the control Hello handshake and its capabilities")
@@ -63,22 +84,20 @@ struct VMInstanceVsockAdmissionTests {
         control.start()
         defer { control.stop() }
 
-        // Channel accepted but no guest Hello yet — still refused.
-        #expect(!instance.admitsFeatureChannel(requiringClipboardStreaming: false))
+        // Channel accepted but no guest Hello yet — still refused, and as the
+        // routine "too early" verdict rather than a peer that overstepped.
+        #expect(isNotReady(instance.featureChannelAdmission(requiringClipboardStreaming: false)))
 
-        // A Hello without the streaming capability admits the log channel but
-        // not the clipboard channel.
+        // A Hello without the streaming capability admits the log channel; the
+        // clipboard channel is refused against a *completed* handshake, so that
+        // refusal names the peer.
         try guest.send(makeGuestHello(streamingCapable: false))
-        try await waitForChange {
-            instance.admitsFeatureChannel(requiringClipboardStreaming: false)
-        }
-        #expect(!instance.admitsFeatureChannel(requiringClipboardStreaming: true))
+        try await waitForChange { admits(instance, clipboard: false) }
+        #expect(isDenied(instance.featureChannelAdmission(requiringClipboardStreaming: true)))
 
         // A Hello advertising streaming flips clipboard admission too.
         try guest.send(makeGuestHello(streamingCapable: true))
-        try await waitForChange {
-            instance.admitsFeatureChannel(requiringClipboardStreaming: true)
-        }
+        try await waitForChange { admits(instance, clipboard: true) }
     }
 
     @Test("Stopping the control service withdraws admission")
@@ -96,15 +115,13 @@ struct VMInstanceVsockAdmissionTests {
         control.start()
 
         try guest.send(makeGuestHello(streamingCapable: true))
-        try await waitForChange {
-            instance.admitsFeatureChannel(requiringClipboardStreaming: true)
-        }
+        try await waitForChange { admits(instance, clipboard: true) }
 
         // stop() resets the handshake state — admission drops with it, so a
         // feature connection racing a control teardown is refused.
         control.stop()
-        #expect(!instance.admitsFeatureChannel(requiringClipboardStreaming: false))
-        #expect(!instance.admitsFeatureChannel(requiringClipboardStreaming: true))
+        #expect(!admits(instance, clipboard: false))
+        #expect(!admits(instance, clipboard: true))
     }
 
     @Test("A dead control channel withdraws admission, and a reconnect restores it")
@@ -122,18 +139,14 @@ struct VMInstanceVsockAdmissionTests {
         first.start()
 
         try firstGuest.send(makeGuestHello(streamingCapable: true))
-        try await waitForChange {
-            instance.admitsFeatureChannel(requiringClipboardStreaming: true)
-        }
+        try await waitForChange { admits(instance, clipboard: true) }
 
         // Nobody calls stop() when a guest agent simply disappears — the
         // service settles itself, and admission drops with it rather than
         // keeping log and clipboard channels admitted onto a dead channel.
         firstGuest.close()
-        try await waitForChange {
-            !instance.admitsFeatureChannel(requiringClipboardStreaming: false)
-        }
-        #expect(!instance.admitsFeatureChannel(requiringClipboardStreaming: true))
+        try await waitForChange { !admits(instance, clipboard: false) }
+        #expect(!admits(instance, clipboard: true))
 
         // The accept path, as `startVsockServices()` runs it: stop whatever is
         // installed (a no-op on an already-settled service) and install a fresh
@@ -152,9 +165,7 @@ struct VMInstanceVsockAdmissionTests {
         defer { second.stop() }
 
         try secondGuest.send(makeGuestHello(streamingCapable: true))
-        try await waitForChange {
-            instance.admitsFeatureChannel(requiringClipboardStreaming: true)
-        }
+        try await waitForChange { admits(instance, clipboard: true) }
         #expect(instance.vsockControlService !== first)
     }
 }

--- a/KernovaTests/VsockListenerHostTests.swift
+++ b/KernovaTests/VsockListenerHostTests.swift
@@ -36,13 +36,18 @@ struct VsockListenerHostTests {
 
     // MARK: - Admission (#145)
 
-    @Test("A failing admission check refuses the connection and closes the fd")
-    func admissionRefusalClosesFd() throws {
+    @Test(
+        "Either refusal verdict refuses the connection and closes the fd",
+        arguments: [
+            VsockAdmission.notReady(reason: "test: handshake pending"),
+            .denied(reason: "test: peer not entitled"),
+        ])
+    func admissionRefusalClosesFd(verdict: VsockAdmission) throws {
         let (a, b) = try makeRawSocketPair()
         defer { close(b) }  // `a` is owned — and must be closed — by the listener.
 
         var connected = false
-        let host = VsockListenerHost(port: 49_153, shouldAdmit: { false }) { _ in
+        let host = VsockListenerHost(port: 49_153, shouldAdmit: { verdict }) { _ in
             connected = true
         }
 
@@ -65,7 +70,7 @@ struct VsockListenerHostTests {
         defer { close(b) }
 
         var received: VsockChannel?
-        let host = VsockListenerHost(port: 49_153, shouldAdmit: { true }) { channel in
+        let host = VsockListenerHost(port: 49_153, shouldAdmit: { .admit }) { channel in
             received = channel
         }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,7 +134,7 @@ The vsock stack (macOS guests only):
   mirrors the same assignments guest-side.
 - `VsockListenerHost` — one `VZVirtioSocketListener` per port, bridging an accepted connection to a
   `VsockChannel`. Its `shouldAdmit` predicate refuses a connection before any channel is built;
-  `VMInstance` wires the log and clipboard listeners to `admitsFeatureChannel`, so no feature
+  `VMInstance` wires the log and clipboard listeners to `featureChannelAdmission`, so no feature
   channel is accepted before the control handshake completes. Socket-buffer sizing and its
   measurements: [research/2026-07-13-vsock-transport-throughput.md](research/2026-07-13-vsock-transport-throughput.md).
 - `VsockControlService` — `@MainActor` `@Observable` owner of the always-on control channel:


### PR DESCRIPTION
Closes #716

## The delay

`VsockGuestClient`'s reconnect loop slept a fixed `retryInterval` between
attempts with nothing able to interrupt it. Every signal that should make the
guest dial *now* — a policy enable, a host refusal that has since cleared —
landed while the loop was parked, so it took effect at the loop's next scheduled
wake instead. On a resume from saved state the cost doubled: all three channels
redial together, the host refuses the two feature ports until the per-VM control
`Hello` lands (the #145 gate), and the refusal parks them for another interval.

The issue's unverified guess about that ordering is now confirmed from a live
trace — a log-channel dial was refused 1 ms *before* the control accept:

```
15:07:42.818  I  Refusing … port 49153 — no control channel has completed its handshake
15:07:42.819     Accepted vsock connection on port 49154
15:07:42.825     Sent policy update …
15:07:42.828     Accepted vsock connection on port 49153      ← 3 ms after the policy update
```

## The route

`resume()` cancels the sleep rather than the loop. The sleep moved into its own
child task so cancelling it is separable from cancelling the loop, and one lock
hold both consumes a pending wake and publishes the sleeper — so a `resume()`
racing the park either finds the sleeper to cancel or leaves a flag that skips
the park. The flag is **latched, not edge-triggered**: `resume()` routinely lands
while the loop is mid-attempt, and that wake has to survive to the next park.
Getting that backwards is the one bug this change went through: clearing the flag
*after* the park let a wake latched before a successful connect survive the
connection and shorten the park after the *next* drop. It is cleared when an
attempt begins instead, and `resumeMidAttemptSkipsTheNextPark` pins the
distinction.

Both policy call sites call `resume()` **ahead of their no-change guard**. This
is the part that looks wrong and isn't: on a resume the policy value doesn't
change, so an update that restates "enabled" is a no-op by value — and it is also
the *only* signal the two refused channels ever get. The guards swallowed it.

Because the guest now redials the instant a policy frame lands, `applyLivePolicy`
no longer sends that frame before touching host listeners unconditionally. Each
direction is ordered by what it needs: an enable installs its listener first (a
redial that beats the listener is refused and costs the guest a full interval), a
disable still sends first (so the guest pauses before the listener goes away and
doesn't see EOF and pound the host). This one is belt-and-braces — the window was
a handful of main-actor statements against a cross-VM round trip — but it removes
the timing dependence rather than relying on the host winning.

## Refusal log level

The issue asked whether an admission refusal caused by the agent's own reconnect
should log below `.warning`. It should, so the `Bool` predicate became a
three-case `VsockAdmission` verdict carrying its reason:

- `.notReady` — no control handshake yet. The agent's own channels racing their
  own handshake, i.e. a routine resume. `.info`.
- `.denied` — refused against a *completed* handshake, so the peer is something
  that shouldn't have connected. Stays `.warning`, which is what the #145 gate
  exists to catch.

Keeping both at `.warning` was the alternative, and it is what made a normal
resume look like an intrusion in the log.

## Verification

Unit: `resume()` cuts short a parked sleep on both production clocks; a
mid-attempt `resume()` is consumed by the next park (the provider blocks on a
semaphore so the loop is *provably* mid-attempt, not parked); a restated
"enabled" policy reconnects the clipboard and the log channel. All three use a
600 s `retryInterval`, so a build without the wake times out rather than passing
slowly.

Live, agent 0.57.0 in a macOS 26.6.1 guest and a macOS 12.7.6 guest — control
accept → feature accept, against the 5.007–5.093 s deltas filed in the issue:

| Guest | Scenario | log (49153) | clipboard (49152) |
|---|---|---|---|
| 26.6.1 | agent start | +10 ms | +14 ms |
| 26.6.1 | cold boot | +12 ms | +283 ms |
| 26.6.1 | resume | +9 ms | +9 ms |
| 12.7.6 | agent start | +7 ms | +10 ms |
| 12.7.6 | cold boot | +15 ms | +19 ms |
| 12.7.6 | resume | +5 ms | +4 ms |

Monterey behaves identically, so neither `MonotonicEngineClock`'s sliced sleep
nor the pre-26 blocking-connect path resists cancellation. The 283 ms outlier is
not a timer: the guest logged "Clipboard sharing enabled by host policy" 272 ms
after the frame landed and the host accepted in that same millisecond — time
spent on the guest's main queue during login, inside `applyPolicy`'s hop.

## Review triage

Three reviews ran (medium, Codex native, Codex adversarial). The latter two found
nothing. Of the first's four low findings, two are fixed above (`applyLivePolicy`
ordering; a loop comment that contradicted its own test), and two are dismissed:

- **`.notReady` at `.info` doesn't persist, so a permanently-wedged agent leaves
  no trail in a sysdiagnose.** It leaves the trail that matters: the `.notice`
  accept and "Guest agent connected" lines are *absent* while the VM-start
  notices are present. Escalating on a repeat count would add state to the
  listener for a diagnosis the absences already support.
- **`resumeWakesAParkedLoop` passes in both orderings, so it only sometimes
  exercises the cancel-the-sleeper path.** True. Both orderings are valid
  behavior and assert the same outcome, and a regression in the cancel path
  surfaces as a 600 s hang. Forcing the ordering means holding the client's lock
  across the sleeper task's creation purely for test observability.

## Test plan

- [x] `make test` — full suite green
- [x] `make lint`
- [x] Live verification on both guests, per the table above
