### PR TITLE
fix: Gate the guest-agent disk on macOS guests and bound the Hello version fields

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -1434,9 +1434,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         case #selector(showClipboard(_:)):
             return activeInstance?.canShowClipboard ?? false
         case #selector(toggleGuestAgentDisk(_:)):
-            // Hard gates (not status-derived): a live VM for USB hot-plug and a
-            // bundled DMG to attach.
-            guard let instance = activeInstance, instance.canAttachUSBDevices else { return false }
+            // Hard gates (not status-derived): a macOS guest with a live VM for
+            // USB hot-plug, and a bundled DMG to attach.
+            guard let instance = activeInstance, instance.canManageGuestAgentDisk else { return false }
             guard Self.guestAgentDiskPath != nil else { return false }
             let model = GuestAgentDiskMenuItem.model(
                 status: instance.agentStatus,

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -1435,9 +1435,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             return activeInstance?.canShowClipboard ?? false
         case #selector(toggleGuestAgentDisk(_:)):
             // Hard gates (not status-derived): a macOS guest with a live VM for
-            // USB hot-plug, and a bundled DMG to attach.
-            guard let instance = activeInstance, instance.canManageGuestAgentDisk else { return false }
-            guard Self.guestAgentDiskPath != nil else { return false }
+            // USB hot-plug, and a bundled DMG to attach. Retitling on the way
+            // out matters as much as enabling — see `unavailableTitle`.
+            guard let instance = activeInstance, instance.canManageGuestAgentDisk,
+                Self.guestAgentDiskPath != nil
+            else {
+                menuItem.title = GuestAgentDiskMenuItem.unavailableTitle
+                return false
+            }
             let model = GuestAgentDiskMenuItem.model(
                 status: instance.agentStatus,
                 isInstallerMounted: viewModel.isGuestAgentInstallerMounted(on: instance))
@@ -1656,7 +1661,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // and attach state on every menu open.
         vmMenu.addItem(
             NSMenuItem(
-                title: "Install Guest Agent…",
+                title: GuestAgentDiskMenuItem.unavailableTitle,
                 action: #selector(toggleGuestAgentDisk(_:)),
                 keyEquivalent: ""
             ))

--- a/Kernova/App/GuestAgentDiskMenuItem.swift
+++ b/Kernova/App/GuestAgentDiskMenuItem.swift
@@ -24,6 +24,15 @@ enum GuestAgentDiskMenuItem {
         let action: Action
     }
 
+    /// The title the item carries whenever a hard gate withholds the command,
+    /// and the placeholder it is built with.
+    ///
+    /// A rejected item keeps whatever title the last accepted validation left
+    /// on it, so the reject path has to retitle too: switching from a macOS
+    /// guest with the disk attached to a Linux guest would otherwise strand
+    /// "Eject Guest Agent Media" on a VM that can never have it.
+    static let unavailableTitle = "Install Guest Agent…"
+
     /// Resolves the menu item for the given state.
     ///
     /// `isInstallerMounted` takes precedence (eject mode) over `status`: once the

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -335,6 +335,15 @@ final class VMInstance {
         (status == .running || status == .paused) && hasLiveVirtualMachine
     }
 
+    /// `true` when the bundled guest-agent installer disk can be attached to or
+    /// ejected from this VM.
+    ///
+    /// macOS guests only: the disk carries a `.app` and an `install.command`
+    /// that stages a user LaunchAgent, neither of which a Linux guest can run.
+    var canManageGuestAgentDisk: Bool {
+        canAttachUSBDevices && configuration.guestOS == .macOS
+    }
+
     /// `true` when the VM is paused-to-disk but has no live `VZVirtualMachine` in memory.
     var isColdPaused: Bool {
         status == .paused && !hasLiveVirtualMachine

--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -12,14 +12,44 @@ struct AgentPolicySnapshot: Equatable, Sendable {
     var clipboardMaxPasteBytes: Int
 }
 
-/// Guest-reported identity from one `Hello.agent_info`, with an empty
-/// `os_version` normalized to `nil`.
+/// Guest-reported identity from one `Hello.agent_info`, with each version field
+/// bounded and an empty one normalized to `nil`.
 ///
 /// No default on `osVersion`: a `nil` overwrites the persisted value, so every
 /// construction site must say it means "clear", not omit it and mean "keep".
 struct ObservedAgentInfo: Equatable, Sendable {
     var agentVersion: String
     var osVersion: String?
+
+    /// Ceiling, in UTF-8 bytes, on either version field.
+    ///
+    /// `Hello.agent_info` is peer-supplied and bounded on the wire only by
+    /// `VsockFrame.maxPayloadSize`, while the host persists both fields to
+    /// `config.json`, interpolates them into its log, and scans `os_version`
+    /// with an `NSRegularExpression` on the main actor. A dotted-decimal
+    /// version — with room for a build suffix — needs nothing like this much.
+    static let maxFieldBytes = 64
+
+    /// `reported` clipped to ``maxFieldBytes``, or `nil` when it is empty.
+    ///
+    /// The single intake normalization for both fields, so every downstream
+    /// consumer inherits the bound instead of defending itself. Cutting by
+    /// UTF-8 length rather than by `Character` is what makes the bound hold: a
+    /// single grapheme cluster can carry unboundedly many combining scalars.
+    static func boundedField(_ reported: String) -> String? {
+        guard !reported.isEmpty else { return nil }
+        guard reported.utf8.count > maxFieldBytes else { return reported }
+        var bounded = String.UnicodeScalarView()
+        var byteCount = 0
+        // Whole scalars only — a cut landing mid-scalar would have to be
+        // repaired with U+FFFD, which is wider than the bytes it replaces.
+        for scalar in reported.unicodeScalars {
+            byteCount += UTF8.width(scalar)
+            guard byteCount <= maxFieldBytes else { break }
+            bounded.append(scalar)
+        }
+        return String(bounded)
+    }
 }
 
 /// Drives the always-on control channel between the host and the macOS guest
@@ -462,9 +492,12 @@ final class VsockControlService {
         case .hello(let hello):
             isConnected = true
             isUnresponsive = false
-            let reportedVersion = hello.agentInfo.agentVersion
-            agentVersion = reportedVersion.isEmpty ? nil : reportedVersion
-            let reportedOSVersion = hello.agentInfo.osVersion
+            // Both version fields are peer-supplied: bound them here so the
+            // log line below, `config.json` and the version parser inherit one
+            // ceiling.
+            let reportedVersion = ObservedAgentInfo.boundedField(hello.agentInfo.agentVersion)
+            agentVersion = reportedVersion
+            let reportedOSVersion = ObservedAgentInfo.boundedField(hello.agentInfo.osVersion)
             guestSupportsClipboardStreamingStorage = hello.capabilities.contains(
                 KernovaCapability.clipboardStreamV1)
             guestSupportsPasteLimitStorage = hello.capabilities.contains(
@@ -472,15 +505,14 @@ final class VsockControlService {
             // `logDescription` bounds the peer-supplied capability strings so a
             // malicious peer can't write arbitrary content into the host log.
             Self.logger.notice(
-                "Guest agent connected for '\(self.label, privacy: .public)' (service=\(hello.serviceVersion, privacy: .public), agent=\(reportedVersion, privacy: .public), caps=\(KernovaCapability.logDescription(of: hello.capabilities), privacy: .public))"
+                "Guest agent connected for '\(self.label, privacy: .public)' (service=\(hello.serviceVersion, privacy: .public), agent=\(reportedVersion ?? "?", privacy: .public), caps=\(KernovaCapability.logDescription(of: hello.capabilities), privacy: .public))"
             )
             // An empty agent version means the agent didn't populate the field
             // — skip those so the host doesn't persist a meaningless value.
-            if !reportedVersion.isEmpty {
+            if let reportedVersion {
                 onAgentInfoObserved?(
                     ObservedAgentInfo(
-                        agentVersion: reportedVersion,
-                        osVersion: reportedOSVersion.isEmpty ? nil : reportedOSVersion))
+                        agentVersion: reportedVersion, osVersion: reportedOSVersion))
             }
             // Push the current policy to the freshly connected guest so it
             // doesn't run on assumed defaults.

--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -25,30 +25,39 @@ struct ObservedAgentInfo: Equatable, Sendable {
     ///
     /// `Hello.agent_info` is peer-supplied and bounded on the wire only by
     /// `VsockFrame.maxPayloadSize`, while the host persists both fields to
-    /// `config.json`, interpolates them into its log, and scans `os_version`
-    /// with an `NSRegularExpression` on the main actor. A dotted-decimal
-    /// version — with room for a build suffix — needs nothing like this much.
+    /// `config.json`, renders them in its UI, interpolates them into its log,
+    /// and scans `os_version` with an `NSRegularExpression` on the main actor.
+    /// A dotted-decimal version — with room for a build suffix — needs nothing
+    /// like this much.
     static let maxFieldBytes = 64
 
-    /// `reported` clipped to ``maxFieldBytes``, or `nil` when it is empty.
+    /// `reported` stripped of control and format characters and clipped to
+    /// ``maxFieldBytes``, or `nil` when nothing printable survives.
     ///
     /// The single intake normalization for both fields, so every downstream
-    /// consumer inherits the bound instead of defending itself. Cutting by
-    /// UTF-8 length rather than by `Character` is what makes the bound hold: a
-    /// single grapheme cluster can carry unboundedly many combining scalars.
+    /// consumer inherits it instead of defending itself. Both halves earn their
+    /// place: cutting by UTF-8 length rather than by `Character` is what makes
+    /// the bound hold, since one grapheme cluster can carry unboundedly many
+    /// combining scalars; and length alone leaves the host logging, persisting
+    /// and rendering 64 arbitrary bytes, where a newline forges a log line and
+    /// a bidi override rewrites the label the string appears in. A version
+    /// string has legitimate use for neither.
     static func boundedField(_ reported: String) -> String? {
-        guard !reported.isEmpty else { return nil }
-        guard reported.utf8.count > maxFieldBytes else { return reported }
         var bounded = String.UnicodeScalarView()
         var byteCount = 0
-        // Whole scalars only — a cut landing mid-scalar would have to be
-        // repaired with U+FFFD, which is wider than the bytes it replaces.
-        for scalar in reported.unicodeScalars {
+        // Bounded scan: nothing past `maxFieldBytes` scalars can widen the
+        // result, and this runs on the main actor against a payload the peer
+        // sizes. `controlCharacters` covers Unicode Cc and Cf both — the
+        // newlines and the bidi overrides.
+        for scalar in reported.unicodeScalars.prefix(maxFieldBytes)
+        where !CharacterSet.controlCharacters.contains(scalar) {
             byteCount += UTF8.width(scalar)
+            // Whole scalars only — a cut landing mid-scalar would have to be
+            // repaired with U+FFFD, which is wider than the bytes it replaces.
             guard byteCount <= maxFieldBytes else { break }
             bounded.append(scalar)
         }
-        return String(bounded)
+        return bounded.isEmpty ? nil : String(bounded)
     }
 }
 
@@ -492,9 +501,8 @@ final class VsockControlService {
         case .hello(let hello):
             isConnected = true
             isUnresponsive = false
-            // Both version fields are peer-supplied: bound them here so the
-            // log line below, `config.json` and the version parser inherit one
-            // ceiling.
+            // Both version fields are peer-supplied — `boundedField` is the one
+            // intake every downstream consumer inherits.
             let reportedVersion = ObservedAgentInfo.boundedField(hello.agentInfo.agentVersion)
             agentVersion = reportedVersion
             let reportedOSVersion = ObservedAgentInfo.boundedField(hello.agentInfo.osVersion)
@@ -502,8 +510,10 @@ final class VsockControlService {
                 KernovaCapability.clipboardStreamV1)
             guestSupportsPasteLimitStorage = hello.capabilities.contains(
                 KernovaCapability.clipboardPasteLimitV1)
-            // `logDescription` bounds the peer-supplied capability strings so a
-            // malicious peer can't write arbitrary content into the host log.
+            // Every peer-supplied piece of this line is filtered first — the
+            // version by `boundedField`, the capability tags by
+            // `logDescription` — so none of them can write arbitrary content
+            // into the host log.
             Self.logger.notice(
                 "Guest agent connected for '\(self.label, privacy: .public)' (service=\(hello.serviceVersion, privacy: .public), agent=\(reportedVersion ?? "?", privacy: .public), caps=\(KernovaCapability.logDescription(of: hello.capabilities), privacy: .public))"
             )

--- a/KernovaTests/GuestAgentDiskMenuTests.swift
+++ b/KernovaTests/GuestAgentDiskMenuTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import Kernova
@@ -68,5 +69,43 @@ struct GuestAgentDiskMenuTests {
             GuestAgentDiskMenuItem.model(
                 status: .connecting(expected: "0.9.2"), isInstallerMounted: false)
                 == .init(title: "Install Guest Agent…", isEnabled: false, action: .mount(.install)))
+    }
+}
+
+/// Unit tests for `VMInstance.canManageGuestAgentDisk` — the hard gate
+/// `AppDelegate.validateMenuItem` applies before consulting the model above.
+@Suite("VMInstance.canManageGuestAgentDisk")
+@MainActor
+struct GuestAgentDiskEligibilityTests {
+    private func makeInstance(guestOS: VMGuestOS, status: VMStatus, isLive: Bool) -> VMInstance {
+        let config = VMConfiguration(
+            name: "Test VM", guestOS: guestOS, bootMode: guestOS == .macOS ? .macOS : .efi)
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(config.id.uuidString, isDirectory: true)
+        let instance = VMInstance(configuration: config, bundleURL: bundleURL, status: status)
+        instance.hasLiveVirtualMachineOverrideForTesting = isLive
+        return instance
+    }
+
+    @Test("A live macOS guest can manage the disk", arguments: [VMStatus.running, .paused])
+    func liveMacOSIsEligible(status: VMStatus) {
+        #expect(makeInstance(guestOS: .macOS, status: status, isLive: true).canManageGuestAgentDisk)
+    }
+
+    @Test(
+        "A live Linux guest cannot — the disk installs a macOS agent",
+        arguments: [VMStatus.running, .paused])
+    func liveLinuxIsNotEligible(status: VMStatus) {
+        #expect(!makeInstance(guestOS: .linux, status: status, isLive: true).canManageGuestAgentDisk)
+    }
+
+    @Test("A macOS guest with no live VM cannot — USB hot-plug needs one")
+    func macOSWithoutLiveVMIsNotEligible() {
+        #expect(!makeInstance(guestOS: .macOS, status: .running, isLive: false).canManageGuestAgentDisk)
+    }
+
+    @Test("A stopped macOS guest cannot", arguments: [VMStatus.stopped, .starting, .error])
+    func stoppedMacOSIsNotEligible(status: VMStatus) {
+        #expect(!makeInstance(guestOS: .macOS, status: status, isLive: true).canManageGuestAgentDisk)
     }
 }

--- a/KernovaTests/GuestAgentDiskMenuTests.swift
+++ b/KernovaTests/GuestAgentDiskMenuTests.swift
@@ -70,6 +70,16 @@ struct GuestAgentDiskMenuTests {
                 status: .connecting(expected: "0.9.2"), isInstallerMounted: false)
                 == .init(title: "Install Guest Agent…", isEnabled: false, action: .mount(.install)))
     }
+
+    @Test("The withheld title matches the nothing-installed-yet title")
+    func unavailableTitleMatchesWaiting() {
+        // The item is built with this title and falls back to it whenever a
+        // hard gate rejects it, so it has to read as a neutral resting state
+        // rather than as a claim about the selected VM.
+        #expect(
+            GuestAgentDiskMenuItem.unavailableTitle
+                == GuestAgentDiskMenuItem.model(status: .waiting, isInstallerMounted: false).title)
+    }
 }
 
 /// Unit tests for `VMInstance.canManageGuestAgentDisk` — the hard gate

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -1067,6 +1067,32 @@ struct VsockControlServiceTests {
         #expect(observed.values == [ObservedAgentInfo(agentVersion: "0.9.2", osVersion: nil)])
     }
 
+    @Test("Over-long version fields are clipped before they reach the callback")
+    func oversizedAgentInfoFieldsAreBounded() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let observed = ObservedRecorder()
+        let service = makeService(
+            channel: host,
+            onAgentInfoObserved: { observed.append($0) }
+        )
+        service.start()
+        defer { service.stop() }
+
+        _ = try await nextFrame(from: guest)  // host hello
+        let flood = String(repeating: "9", count: 4096)
+        try guest.send(makeGuestHello(agentVersion: flood, osVersion: flood))
+        try await waitForChange { service.isConnected }
+
+        let bound = ObservedAgentInfo.maxFieldBytes
+        let expected = String(repeating: "9", count: bound)
+        #expect(service.agentVersion == expected)
+        #expect(observed.values == [ObservedAgentInfo(agentVersion: expected, osVersion: expected)])
+    }
+
     @Test("sendPolicyUpdate emits a PolicyUpdate frame with the supplied snapshot")
     func sendPolicyUpdateEmitsFrame() async throws {
         let (guest, host) = try makePair()
@@ -1239,6 +1265,47 @@ struct VsockControlServiceTests {
         #expect(result.pushedBytes == UInt64(ClipboardPasteLimit.defaultBytes))
         #expect(result.guestSupportsPasteLimit == false)
         #expect(result.guestWillEnforce == ClipboardPasteLimit.defaultBytes)
+    }
+
+    // MARK: - ObservedAgentInfo.boundedField
+
+    @Test("An empty field normalizes to nil")
+    func boundedFieldEmptyIsNil() {
+        #expect(ObservedAgentInfo.boundedField("") == nil)
+    }
+
+    @Test("A field within the bound passes through verbatim")
+    func boundedFieldWithinBoundIsVerbatim() {
+        #expect(ObservedAgentInfo.boundedField("26.0.1") == "26.0.1")
+        let atLimit = String(repeating: "a", count: ObservedAgentInfo.maxFieldBytes)
+        #expect(ObservedAgentInfo.boundedField(atLimit) == atLimit)
+    }
+
+    @Test("An over-long field is clipped to the bound")
+    func boundedFieldOverBoundIsClipped() {
+        let bound = ObservedAgentInfo.maxFieldBytes
+        let bounded = ObservedAgentInfo.boundedField(String(repeating: "a", count: bound + 1))
+        #expect(bounded == String(repeating: "a", count: bound))
+    }
+
+    @Test("A single grapheme cluster of many scalars is still bounded")
+    func boundedFieldBoundsOneLongCharacter() throws {
+        // A `Character`-based prefix would let this through whole — it is one
+        // Character however many combining marks it carries.
+        let combining = "e" + String(repeating: "\u{0301}", count: 100_000)
+        let bounded = try #require(ObservedAgentInfo.boundedField(combining))
+        #expect(bounded.utf8.count <= ObservedAgentInfo.maxFieldBytes)
+    }
+
+    @Test("The cut lands on a scalar boundary, never mid-scalar")
+    func boundedFieldCutsWholeScalars() throws {
+        // 3 bytes each: 21 fit in the bound and the 22nd does not, so the
+        // result stops one byte short rather than splitting a scalar — which
+        // would need a 3-byte U+FFFD to repair and overshoot the bound.
+        let euros = String(repeating: "€", count: 100)
+        let bounded = try #require(ObservedAgentInfo.boundedField(euros))
+        #expect(bounded == String(repeating: "€", count: 21))
+        #expect(!bounded.unicodeScalars.contains("\u{FFFD}"))
     }
 }
 

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -1297,6 +1297,28 @@ struct VsockControlServiceTests {
         #expect(bounded.utf8.count <= ObservedAgentInfo.maxFieldBytes)
     }
 
+    @Test("Newlines are stripped, so a version cannot forge a host log line")
+    func boundedFieldStripsNewlines() {
+        let forged = "1.0\nGuest agent connected for 'other-vm'"
+        #expect(
+            ObservedAgentInfo.boundedField(forged)
+                == "1.0Guest agent connected for 'other-vm'")
+    }
+
+    @Test("Format characters are stripped, so a version cannot rewrite its label")
+    func boundedFieldStripsFormatCharacters() {
+        // U+202E is Cf, not Cc: a bidi override reverses the run that follows
+        // it in every label the host renders the version into.
+        #expect(ObservedAgentInfo.boundedField("26.\u{202E}0") == "26.0")
+        #expect(ObservedAgentInfo.boundedField("2\u{200D}6.0") == "26.0")
+        #expect(ObservedAgentInfo.boundedField("26.0\u{0000}") == "26.0")
+    }
+
+    @Test("A field of nothing but control characters normalizes to nil")
+    func boundedFieldAllControlIsNil() {
+        #expect(ObservedAgentInfo.boundedField(String(repeating: "\n", count: 128)) == nil)
+    }
+
     @Test("The cut lands on a scalar boundary, never mid-scalar")
     func boundedFieldCutsWholeScalars() throws {
         // 3 bytes each: 21 fit in the bound and the 22nd does not, so the


### PR DESCRIPTION
Two pre-existing guest-agent defects, both found while auditing the `Hello` handshake and the menu path that hangs off it. Separate commits — they share a subsystem, not a mechanism.

Closes #767, closes #766

## The menu gate (#767)

`AppDelegate.validateMenuItem` gated the Guest Agent Disk item on `canAttachUSBDevices` plus the bundled DMG's presence, and `GuestAgentDiskMenuItem.model` derives its title from `agentStatus`. Nothing in that chain reads `guestOS`, so a running Linux VM offered the command and would attach a disk whose `install.command` stages a macOS `.app` and a user LaunchAgent.

The gate lands as `VMInstance.canManageGuestAgentDisk`, next to `canStartInRecovery` — the existing precedent for a `guestOS == .macOS` eligibility property — rather than inline in the `switch`. That is what makes it testable: `validateMenuItem` needs a live `NSApp`, the property does not.

The other two surfaces that can mount this disk already gate correctly (`SidebarVMRowCellView.visibleAgentStatus` and `ClipboardContentViewController`'s `canInstallKernovaAgent`), so the menu was the only hole. The item carries no key equivalent and is built into the main menu, so `validateMenuItem` is its only path to the action — no second guard in `toggleGuestAgentDisk` is needed, and adding one would just be a second place to drift.

Adding a gate to that `switch` case exposed a second defect: the title is assigned only on the accepted path, so a rejected item keeps whatever the last accepted validation left on it. Switching from a macOS guest with the disk attached to a Linux guest stranded "Eject Guest Agent Media" on a VM that can never have it. The reject path now retitles, and the withheld title and the item's build-time placeholder are one constant (`GuestAgentDiskMenuItem.unavailableTitle`) rather than two copies of the same literal.

## The intake bound (#766)

`Hello.agent_info.os_version` is peer-supplied and bounded on the wire only by `VsockFrame.maxPayloadSize`. It is persisted to `config.json` on every differing Hello and scanned by `KernovaOSVersion.numericVersion(in:)` — an `NSRegularExpression` pass over the whole string, on the main actor.

Bounded once at intake per the issue's suggestion, so consumers inherit it rather than each defending itself. Decisions worth calling out:

- **`agent_version` is bounded too.** The issue names only `os_version`, but the field beside it reaches the same `config.json` and — unlike the capability list one interpolation over, which already routes through `KernovaCapability.logDescription` for exactly this reason — was written into the connect log line verbatim. Bounding one and not the other would have left a parallel path open.
- **The cut is by UTF-8 length, on a scalar boundary.** `prefix(64)` over `Character`s does not bound anything: a single grapheme cluster can carry unboundedly many combining scalars, and 128 MiB of U+0301 is one `Character`. Cutting mid-scalar and repairing with `String(decoding:as:)` would bound it, but U+FFFD is 3 bytes replacing as few as 1, so the result can overshoot the stated ceiling — whole scalars only, and the test asserts no U+FFFD appears.
- **Length alone was not enough.** 64 *arbitrary* bytes still reach the log, `config.json` and the UI. A newline in `agent_version` forges a line in the host's own `app.kernova` subsystem — a real escalation over the guest log channel, whose records are tagged `app.kernova.guest` — and a bidi override rewrites whatever label the version renders into (`AgentStatus.outdated`'s "Update available (…)", `guestOSVersionDisplay`'s raw `?? reported` fallback). `boundedField` now drops Unicode Cc and Cf as well. Filtering by category rather than by a version-shaped allowlist removes exactly what causes the harm and cannot mangle a legitimate value such as a Linux `uname -r` string.

Persisted oversized values need no cleanup: only a guest that already exploited this could have written one, and the next `Hello` overwrites it. No migration code, per the persisted-data rule.

## Test plan

- [x] `make test` — full suite green
- [x] `make lint`
- [x] `GuestAgentDiskEligibilityTests` (macOS/Linux × live/stopped matrix) and the withheld-title invariant
- [x] `VsockControlServiceTests` covers the bound end-to-end over a socket pair and as a unit: empty, at-limit, over-limit, one long grapheme cluster, a multi-byte cut, forged newlines, U+202E / U+200D / NUL, and an all-control field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSBUXUjyDS9K1LKWd2niXc