### PR TITLE
fix: Let a Suspended VM be deleted without discarding its saved state

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -1425,7 +1425,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             return instance.status.canEditSettings && !viewModel.hasPreparing
         case #selector(deleteVM(_:)), #selector(deleteImmediatelyVM(_:)):
             // Same gate for both the primary and its ⌥-alternate.
-            return activeInstance?.status.canEditSettings ?? false
+            return activeInstance?.canDelete ?? false
         case #selector(showVMInFinder(_:)):
             return activeInstance != nil
         // AppKit bypasses NSMenuItemValidation for windowsMenu items, so

--- a/Kernova/App/MainWindowController.swift
+++ b/Kernova/App/MainWindowController.swift
@@ -436,7 +436,7 @@ extension MainWindowController: NSToolbarItemValidation {
             guard let instance else { return false }
             return instance.status.canEditSettings && !viewModel.hasPreparing
         case Self.toolbarMoveToTrash:
-            return instance?.status.canEditSettings ?? false
+            return instance?.canDelete ?? false
         default:
             guard let instance, !instance.isPreparing else { return false }
 

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -367,6 +367,20 @@ final class VMInstance {
         status.canForceStop && !isColdPaused
     }
 
+    /// `true` when the VM can be deleted — nothing live in memory, no
+    /// transitional status, and no import or clone writing into the bundle.
+    ///
+    /// Cold-paused VMs are included: the saved state is a file inside the
+    /// bundle and is removed along with it, so no discard step is needed first.
+    ///
+    /// Enablement only. A cold resume holds `.paused` with no live VM while it
+    /// builds its configuration, so this stays `true` after one starts;
+    /// ``VMLibraryViewModel/deleteConfirmed(_:deletingExternalIDs:permanently:)``
+    /// revalidates against the lifecycle lock at confirm time.
+    var canDelete: Bool {
+        !isPreparing && (status.canEditSettings || isColdPaused)
+    }
+
     /// `true` when the VM can be cold-booted into macOS Recovery.
     ///
     /// Stopped macOS guests only — Virtualization.framework has no recovery

--- a/Kernova/Utilities/DetailAlertsPresenter.swift
+++ b/Kernova/Utilities/DetailAlertsPresenter.swift
@@ -233,6 +233,7 @@ final class DetailAlertsPresenter: NSObject {
             vmName: request.instance.name,
             bundledDisks: viewModel.bundledDisks(for: request.instance),
             externals: resolved.externals,
+            hasSavedState: request.instance.hasSaveFile,
             mode: request.permanently ? .immediate : .trash
         )
         content.delegate = self

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -733,6 +733,18 @@ final class VMLibraryViewModel {
             )
             return []
         }
+        // The sheet is window-modal but leaves the menu key equivalents live, so
+        // a Start or Resume can land between opening it and confirming — and a
+        // cold resume holds `.paused` with no live VM while it builds its
+        // configuration, which `canDelete` alone still reads as deletable.
+        // Trashing the bundle then pulls the disk image out from under a guest
+        // that is running or about to.
+        guard instance.canDelete, !lifecycle.hasActiveOperation(for: instance.id) else {
+            Self.logger.notice(
+                "Refusing delete of '\(instance.name, privacy: .public)': no longer deletable (status '\(instance.status.displayName, privacy: .public)')"
+            )
+            return []
+        }
         instance.tearDownSession()
         let toDelete =
             deletingExternalIDs.isEmpty

--- a/Kernova/Views/Detail/DeleteVMSheetContentViewController.swift
+++ b/Kernova/Views/Detail/DeleteVMSheetContentViewController.swift
@@ -36,6 +36,9 @@ final class DeleteVMSheetContentViewController: NSViewController {
     private let vmName: String
     private let bundledDisks: [StorageDisk]
     private let externals: [ExternalAttachment]
+    /// Whether the bundle holds a suspended VM's saved state, listed alongside
+    /// the disks so the user sees it going with the bundle.
+    private let hasSavedState: Bool
     private let mode: Mode
 
     /// Per-row checkboxes for the *selectable* (non-shared) externals, keyed
@@ -80,11 +83,13 @@ final class DeleteVMSheetContentViewController: NSViewController {
         vmName: String,
         bundledDisks: [StorageDisk],
         externals: [ExternalAttachment],
+        hasSavedState: Bool,
         mode: Mode = .trash
     ) {
         self.vmName = vmName
         self.bundledDisks = bundledDisks
         self.externals = externals
+        self.hasSavedState = hasSavedState
         self.mode = mode
         super.init(nibName: nil, bundle: nil)
     }
@@ -165,13 +170,18 @@ final class DeleteVMSheetContentViewController: NSViewController {
                 "The VM moves to the Trash. Restore it with Finder's Put Back, or empty the Trash to delete it permanently."
         case .immediate:
             titleText = "Delete \u{201C}\(vmName)\u{201D} Immediately?"
-            // Name the external files only when at least one is selectable — a
-            // list of only locked-off rows offers no choice, so the plain
-            // VM-only wording stays accurate.
-            bodyText =
+            // This sentence enumerates what is destroyed, so it names the saved
+            // state too. External files are named only when at least one is
+            // selectable — a list of only locked-off rows offers no choice, so
+            // the plain wording stays accurate.
+            let removed =
+                hasSavedState
+                ? "This VM, its disks, and its saved state" : "This VM and its disks"
+            let externalsClause =
                 externals.contains(where: \.isSelectable)
-                ? "This VM and its disks, plus any external files you select below, will be deleted immediately. You can't undo this action."
-                : "This VM and its disks will be deleted immediately. You can't undo this action."
+                ? ", plus any external files you select below," : ""
+            bodyText =
+                "\(removed)\(externalsClause) will be deleted immediately. You can't undo this action."
         }
 
         let title = NSTextField(labelWithString: titleText)
@@ -244,10 +254,21 @@ final class DeleteVMSheetContentViewController: NSViewController {
         )
         listStack.translatesAutoresizingMaskIntoConstraints = false
 
-        // Section 1 — in-bundle disks removed along with the VM.
+        // Section 1 — in-bundle files removed along with the VM.
         listStack.addArrangedSubview(makeGroupedFormSectionHeader("Removed with the VM"))
         for disk in bundledDisks {
-            listStack.addArrangedSubview(makeBundledRow(disk))
+            listStack.addArrangedSubview(
+                makeBundledRow(
+                    symbolName: diskIconSystemName(for: disk),
+                    label: disk.label,
+                    detail: disk.displayPath))
+        }
+        if hasSavedState {
+            listStack.addArrangedSubview(
+                makeBundledRow(
+                    symbolName: "pause.circle",
+                    label: "Saved State",
+                    detail: "In-bundle machine state"))
         }
 
         // Section 2 — external files the user can individually trash.
@@ -335,11 +356,11 @@ final class DeleteVMSheetContentViewController: NSViewController {
         return height
     }
 
-    /// Read-only row for an in-bundle disk (no checkbox; it rides along with
+    /// Read-only row for an in-bundle file (no checkbox; it rides along with
     /// the bundle).
-    private func makeBundledRow(_ disk: StorageDisk) -> NSView {
+    private func makeBundledRow(symbolName: String, label labelText: String, detail: String) -> NSView {
         let icon = NSImageView(
-            image: .systemSymbol(diskIconSystemName(for: disk), accessibilityDescription: "")
+            image: .systemSymbol(symbolName, accessibilityDescription: "")
         )
         icon.contentTintColor = .secondaryLabelColor
         icon.translatesAutoresizingMaskIntoConstraints = false
@@ -348,14 +369,14 @@ final class DeleteVMSheetContentViewController: NSViewController {
         icon.setContentCompressionResistancePriority(.required, for: .horizontal)
         icon.widthAnchor.constraint(equalToConstant: Self.iconColumnWidth).isActive = true
 
-        let label = NSTextField(labelWithString: disk.label)
+        let label = NSTextField(labelWithString: labelText)
         label.font = Typography.body
         label.lineBreakMode = .byWordWrapping
         label.maximumNumberOfLines = 0
         label.isSelectable = false
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
-        let subtitle = NSTextField(labelWithString: disk.displayPath)
+        let subtitle = NSTextField(labelWithString: detail)
         subtitle.font = .preferredFont(forTextStyle: .caption1)
         subtitle.textColor = .secondaryLabelColor
         subtitle.lineBreakMode = .byTruncatingMiddle

--- a/Kernova/Views/Sidebar/SidebarViewController.swift
+++ b/Kernova/Views/Sidebar/SidebarViewController.swift
@@ -774,12 +774,12 @@ extension SidebarViewController {
         // "Move to Trash…" gathers input (which externals to delete), so the
         // ellipsis is correct here.
         let trash = item("Move to Trash…", #selector(menuMoveToTrash(_:)), instance)
-        trash.isEnabled = status.canEditSettings
+        trash.isEnabled = instance.canDelete
         menu.addItem(trash)
         // An ⌥-alternate of "Move to Trash…". This pair sits at the menu's end, so
         // collapsing the primary can't shift the menu; no anchor item is needed.
         let deleteImmediately = item("Delete Immediately…", #selector(menuDeleteImmediately(_:)), instance)
-        deleteImmediately.isEnabled = status.canEditSettings
+        deleteImmediately.isEnabled = instance.canDelete
         if !preferences.alwaysShowAdvancedOptions {
             trash.keyEquivalentModifierMask = []
             deleteImmediately.keyEquivalentModifierMask = [.option]

--- a/KernovaTests/DeleteVMSheetContentViewControllerTests.swift
+++ b/KernovaTests/DeleteVMSheetContentViewControllerTests.swift
@@ -32,6 +32,30 @@ struct DeleteVMSheetContentViewControllerTests {
         #expect(vc.checkboxes.isEmpty)
     }
 
+    @Test("a suspended VM's saved state is listed alongside the in-bundle disks")
+    func savedStateRowRendered() {
+        let vc = make(
+            vmName: "MyVM",
+            bundledDisks: [makeDisk(label: "Main Disk", path: "Disk.asif")],
+            hasSavedState: true)
+        vc.loadViewIfNeeded()
+        let labels = collectLabels(in: vc.view).map(\.stringValue)
+        #expect(labels.contains("Removed with the VM"))
+        #expect(labels.contains("Saved State"))
+        #expect(labels.contains("In-bundle machine state"))
+        // Read-only like the disk rows — the saved state can't be kept behind.
+        #expect(vc.checkboxes.isEmpty)
+    }
+
+    @Test("no saved-state row for a VM with nothing suspended")
+    func savedStateRowAbsentWithoutSavedState() {
+        let vc = make(
+            vmName: "MyVM", bundledDisks: [makeDisk(label: "Main Disk", path: "Disk.asif")])
+        vc.loadViewIfNeeded()
+        let labels = collectLabels(in: vc.view).map(\.stringValue)
+        #expect(!labels.contains("Saved State"))
+    }
+
     @Test("one row rendered per external attachment, in order")
     func rowsRendered() {
         let externals = [
@@ -359,6 +383,25 @@ struct DeleteVMSheetContentViewControllerTests {
         #expect(!labels.contains { $0.contains("external files you select") })
     }
 
+    @Test("immediate mode body names the saved state alongside the disks")
+    func immediateModeBodyNamesSavedState() {
+        let vc = make(vmName: "MyVM", hasSavedState: true, mode: .immediate)
+        vc.loadViewIfNeeded()
+        let labels = collectLabels(in: vc.view).map(\.stringValue)
+        // The sentence enumerates what is destroyed, so omitting the saved state
+        // would understate what deleting a suspended VM costs.
+        #expect(labels.contains { $0.contains("its saved state") && $0.contains("can't undo") })
+    }
+
+    @Test("immediate mode body omits the saved state when the bundle holds none")
+    func immediateModeBodyOmitsSavedState() {
+        let vc = make(vmName: "MyVM", mode: .immediate)
+        vc.loadViewIfNeeded()
+        let labels = collectLabels(in: vc.view).map(\.stringValue)
+        #expect(labels.contains { $0.contains("This VM and its disks") })
+        #expect(!labels.contains { $0.contains("saved state") })
+    }
+
     @Test("immediate mode confirm button reads Delete Immediately and is not the Return default")
     func immediateModeConfirmButton() {
         let vc = make(vmName: "MyVM", mode: .immediate)
@@ -479,10 +522,12 @@ struct DeleteVMSheetContentViewControllerTests {
         vmName: String,
         bundledDisks: [StorageDisk] = [],
         externals: [ExternalAttachment] = [],
+        hasSavedState: Bool = false,
         mode: DeleteVMSheetContentViewController.Mode = .trash
     ) -> DeleteVMSheetContentViewController {
         DeleteVMSheetContentViewController(
-            vmName: vmName, bundledDisks: bundledDisks, externals: externals, mode: mode
+            vmName: vmName, bundledDisks: bundledDisks, externals: externals,
+            hasSavedState: hasSavedState, mode: mode
         )
     }
 

--- a/KernovaTests/Mocks/SuspendingMockVirtualizationService.swift
+++ b/KernovaTests/Mocks/SuspendingMockVirtualizationService.swift
@@ -21,6 +21,13 @@ final class SuspendingMockVirtualizationService: VirtualizationProviding {
     /// Set to `false` to allow subsequent calls through immediately.
     var shouldSuspendOnPause = true
 
+    /// When `true`, `resume` will suspend *before* touching `status`, standing in
+    /// for the window a real cold resume spends building its configuration while
+    /// the VM still reads as cold-paused.
+    ///
+    /// Defaults to `false` so existing callers keep the immediate behavior.
+    var shouldSuspendOnResume = false
+
     // MARK: - Suspension Mechanism
 
     /// Continuation that, when resumed, unblocks the suspended operation.
@@ -87,6 +94,9 @@ final class SuspendingMockVirtualizationService: VirtualizationProviding {
     }
 
     func resume(_ instance: VMInstance) async throws {
+        if shouldSuspendOnResume {
+            await suspendIfNeeded()
+        }
         instance.status = .running
     }
 

--- a/KernovaTests/SidebarViewControllerTests.swift
+++ b/KernovaTests/SidebarViewControllerTests.swift
@@ -238,6 +238,38 @@ struct SidebarViewControllerTests {
         #expect(!menuTitles.contains("Suspend"))
     }
 
+    @Test("Context menu enables delete for a cold-paused VM but keeps Clone disabled")
+    func contextMenuColdPausedEnablesDelete() {
+        let viewModel = makeViewModel()
+        let instance = makeInstance(status: .paused)  // no live VM ⇒ cold-paused
+        viewModel.instances.append(instance)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
+
+        let menu = controller.buildContextMenu(for: instance)
+
+        // The saved state is a file inside the bundle, so deleting takes no
+        // Discard Saved State pass first.
+        #expect(menuItem("Move to Trash…", in: menu)?.isEnabled == true)
+        #expect(menuItem("Delete Immediately…", in: menu)?.isEnabled == true)
+        // Clone still needs a settled bundle, so it stays on `canEditSettings`.
+        #expect(menuItem("Clone", in: menu)?.isEnabled == false)
+    }
+
+    @Test("Context menu disables delete for a live-paused VM")
+    func contextMenuLivePausedDisablesDelete() {
+        let viewModel = makeViewModel()
+        let instance = makeInstance(status: .paused)
+        instance.hasLiveVirtualMachineOverrideForTesting = true
+        viewModel.instances.append(instance)
+        let controller = SidebarViewController(viewModel: viewModel, preferences: preferences)
+
+        let menu = controller.buildContextMenu(for: instance)
+
+        #expect(instance.isLivePaused)
+        #expect(menuItem("Move to Trash…", in: menu)?.isEnabled == false)
+        #expect(menuItem("Delete Immediately…", in: menu)?.isEnabled == false)
+    }
+
     @Test("Force Stop is the Option-alternate of Stop on a running VM (advanced options off)")
     func contextMenuForceStopIsOptionAlternate() {
         preferences.alwaysShowAdvancedOptions = false

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -319,6 +319,51 @@ struct VMInstanceTests {
         }
     }
 
+    // MARK: - canDelete
+
+    @Test("canDelete is true when stopped, in error, or awaiting initial boot")
+    func canDeleteInertStatuses() {
+        for status in [VMStatus.stopped, .error, .initialBoot] {
+            let instance = makeInstance(status: status)
+            #expect(instance.canDelete == true)
+        }
+    }
+
+    @Test("canDelete is true for a cold-paused VM (the saved state goes with the bundle)")
+    func canDeleteColdPaused() {
+        let instance = makeInstance(status: .paused)
+        #expect(instance.isColdPaused == true)
+        #expect(instance.canDelete == true)
+    }
+
+    @Test("canDelete is false for a live-paused VM (its VZVirtualMachine is still in memory)")
+    func canDeleteLivePaused() {
+        let instance = makeInstance(status: .paused)
+        instance.hasLiveVirtualMachineOverrideForTesting = true
+        #expect(instance.isLivePaused == true)
+        #expect(instance.canDelete == false)
+    }
+
+    @Test("canDelete is false while running or transitioning")
+    func canDeleteRunningAndTransitions() {
+        for status in [VMStatus.running, .starting, .saving, .restoring, .installing] {
+            let instance = makeInstance(status: status)
+            #expect(instance.canDelete == false)
+        }
+    }
+
+    @Test("canDelete is false while an import or clone is writing into the bundle")
+    func canDeletePreparing() {
+        // The toolbar's Move to Trash reads this predicate without a preparing
+        // guard of its own, so the check has to live here to hold on every surface.
+        let instance = makeInstance(status: .stopped)
+        let task = Task {}
+        defer { task.cancel() }
+        instance.preparingState = VMInstance.PreparingState(operation: .cloning, task: task)
+        #expect(instance.isPreparing == true)
+        #expect(instance.canDelete == false)
+    }
+
     // MARK: - Bundle Paths
 
     @Test("Bundle path URLs are correctly derived from bundleURL")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -279,6 +279,82 @@ struct VMLibraryViewModelTests {
         #expect(presenter.lastDeleteSheetPermanently == true)
     }
 
+    @Test("deleteConfirmed removes a cold-paused VM without a discard-saved-state pass")
+    func deleteConfirmedColdPaused() {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .paused  // no live VM ⇒ cold-paused ("Suspended")
+        viewModel.instances.append(instance)
+        viewModel.selectedID = instance.id
+        storage.bundles[instance.bundleURL] = instance.configuration
+
+        #expect(instance.isColdPaused)
+        #expect(instance.canDelete)
+        viewModel.deleteConfirmed(instance)
+
+        // The whole bundle goes, saved state included — no separate discard.
+        #expect(viewModel.instances.isEmpty)
+        #expect(viewModel.selectedID == nil)
+        #expect(storage.deleteVMBundleCallCount == 1)
+    }
+
+    @Test("deleteConfirmed refuses a VM that stopped being deletable while the sheet was open")
+    func deleteConfirmedRefusesWhenNoLongerDeletable() {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        instance.status = .paused  // Suspended when the sheet opened…
+        viewModel.instances.append(instance)
+        storage.bundles[instance.bundleURL] = instance.configuration
+
+        // …but a Resume landed via its still-live menu key equivalent before the
+        // user clicked Move to Trash.
+        instance.status = .running
+
+        viewModel.deleteConfirmed(instance)
+
+        #expect(viewModel.instances.count == 1)
+        #expect(storage.deleteVMBundleCallCount == 0)
+    }
+
+    @Test("deleteConfirmed refuses a cold-paused VM whose resume is still in flight")
+    func deleteConfirmedRefusesDuringInFlightResume() async throws {
+        let storage = MockVMStorageService()
+        let suspending = SuspendingMockVirtualizationService()
+        suspending.shouldSuspendOnResume = true
+        let viewModel = VMLibraryViewModel(
+            storageService: storage,
+            diskImageService: MockDiskImageService(),
+            virtualizationService: suspending,
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService(),
+            usbDeviceService: MockUSBDeviceService(),
+            fileSystem: fileSystem,
+            preferences: preferences
+        )
+        viewModel.presenter = presenter
+        let instance = makeInstance()
+        instance.status = .paused
+        viewModel.instances.append(instance)
+        storage.bundles[instance.bundleURL] = instance.configuration
+
+        let resume = Task { @MainActor in try await viewModel.lifecycle.resume(instance) }
+        await suspending.waitUntilSuspended()
+
+        // A real cold resume holds `.paused` with no live VM while it builds its
+        // configuration, so the enablement predicate still reads deletable — only
+        // the lifecycle lock can refuse here.
+        #expect(instance.isColdPaused)
+        #expect(instance.canDelete)
+
+        viewModel.deleteConfirmed(instance)
+
+        #expect(viewModel.instances.count == 1)
+        #expect(storage.deleteVMBundleCallCount == 0)
+
+        suspending.resumeSuspended()
+        try await resume.value
+    }
+
     @Test("deleteConfirmed permanently hard-deletes the bundle, bypassing the Trash")
     func deleteConfirmedPermanentlyUsesHardDelete() {
         let (viewModel, storage, _, _, _) = makeViewModel()

--- a/KernovaTests/VMStorageServiceTests.swift
+++ b/KernovaTests/VMStorageServiceTests.swift
@@ -109,6 +109,25 @@ struct VMStorageServiceTests {
         #expect(!FileManager.default.fileExists(atPath: bundleURL.path(percentEncoded: false)))
     }
 
+    @Test("Permanently deleting a suspended VM's bundle takes its saved state with it")
+    func permanentlyDeleteBundleRemovesSaveFile() throws {
+        let config = VMConfiguration(
+            name: "Suspended Delete VM",
+            guestOS: .linux,
+            bootMode: .efi
+        )
+
+        let bundleURL = try service.createVMBundle(for: config)
+        let saveFileURL = VMBundleLayout(bundleURL: bundleURL).saveFileURL
+        try Data("saved state".utf8).write(to: saveFileURL)
+        #expect(FileManager.default.fileExists(atPath: saveFileURL.path(percentEncoded: false)))
+
+        try service.permanentlyDeleteVMBundle(at: bundleURL)
+
+        #expect(!FileManager.default.fileExists(atPath: saveFileURL.path(percentEncoded: false)))
+        #expect(!FileManager.default.fileExists(atPath: bundleURL.path(percentEncoded: false)))
+    }
+
     @Test("Permanently deleting non-existent bundle throws error")
     func permanentlyDeleteNonExistentThrows() {
         let fakeURL = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Summary

A Suspended VM can now be moved to the Trash or deleted immediately straight from the menu bar, the sidebar context menu, and the toolbar — no Discard Saved State… pass first. The delete sheet names the saved state among the things going with the bundle, and delete is revalidated at confirm time so a Start or Resume landing while the sheet is open can't trash a bundle out from under a live guest.

Closes #772

## The argument

All three surfaces gated delete on `VMStatus.canEditSettings` (`.stopped`, `.error`, `.initialBoot`). `.paused` is absent, so a suspended VM needed its saved state discarded — a destructive confirmation of its own — before the delete it was headed for anyway.

The predicate had to move to `VMInstance` rather than `VMStatus`: `.paused` alone can't distinguish **Suspended** (`isColdPaused` — no live `VZVirtualMachine`) from **Paused** (`isLivePaused` — still in memory), and only the former is safe to delete. `canEditSettings` is left alone, so Clone and settings editing keep their existing gate; only delete moved off it.

`!isPreparing` is folded into `canDelete` because `MainWindowController.validateToolbarItem` handles `toolbarMoveToTrash` *before* the `default:` branch carrying the `!instance.isPreparing` guard — so the toolbar's trash button was enabled during an import or clone while the menu bar and sidebar both blocked it. Pre-existing, but it sat on the exact line this change rewrites, and one predicate is what makes the three surfaces agree.

## Confirm-time revalidation

Surfaced by review, and the reason this touches more than the UI layer.

The delete sheet is window-modal but leaves the menu key equivalents live (`DetailAlertsPresenter` says so in its own comment), and `presentDeleteSheet` resolves external attachments off-main before showing. So between opening the sheet and confirming it, a Start or Resume can land. Worse, `VirtualizationService.resume`'s cold path holds `.paused` with no live VM across `await buildConfiguration(for:)` — `openRuntimeFileAccess()` has already run — before `attachVirtualMachine` and `status = .restoring`. Inside that window `isColdPaused` is still true, so the enablement predicate alone reads deletable.

`deleteConfirmed` now revalidates `canDelete` **and** `lifecycle.hasActiveOperation(for:)`. The lifecycle lock is what closes the cold-resume window specifically: `VMLifecycleCoordinator.serialized` writes its token synchronously before the first `await`, so it is set for the whole span where status still says `.paused`.

Without the guard the confirm path calls `tearDownSession()` — which nils the `VZVirtualMachine` without stopping it — and then trashes the bundle under a running guest.

## Rejected alternatives

- **Adding `.paused` to `VMStatus.canEditSettings`.** Would hand Clone and settings editing to live-paused VMs too, and can't see VM liveness at all.
- **Setting `status = .restoring` before the cold resume's first suspension** (a reviewer's suggestion for the same race). It would fix the window at the source, but `.restoring` drives the display placeholder, the transition overlay, and toolbar state, so it changes cold-resume UX well beyond this issue. The confirm-time guard is the contained fix; the status change is worth considering separately.
- **Alerting on a refused confirm.** By the time the guard trips the VM is visibly running or restoring, so the sheet closing without deleting matches what the user can already see. Refusals log at `.notice`, which persists.

## Review

Three passes: `/code-review medium`, Codex review, Codex adversarial review. The adversarial pass approved with no material findings; the other two independently found the confirm-time race and the untrue half of the `canDelete` doc comment. Both are fixed here. No `RATIONALE:` comments added.

## Test plan

- [x] `make build`, `make test` (full suite green), `make lint`
- [x] `VMInstanceTests` — `canDelete` across inert, cold-paused, live-paused, running/transitioning, preparing
- [x] `SidebarViewControllerTests` — delete enabled for cold-paused (Clone still disabled), disabled for live-paused
- [x] `VMLibraryViewModelTests` — `deleteConfirmed` on a cold-paused instance; refused after a resume completes, and refused while one is still in flight (`SuspendingMockVirtualizationService.shouldSuspendOnResume` holds the VM inside the cold-resume window)
- [x] `VMStorageServiceTests` — permanent delete takes `SaveFile.vzvmsave` with the bundle
- [x] `DeleteVMSheetContentViewControllerTests` — saved-state row present/absent, immediate-mode copy
- [ ] Manual: suspend a VM, confirm delete is live on all three surfaces and the sheet lists the saved state

The menu-bar and toolbar validators have no test harness in this repo — `AppDelegate` menu logic is covered only through extracted pure helpers. Both are one-line delegations to the directly-tested `canDelete`, so the surfaces themselves rest on the manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQAgn9neQ3efZSBN11kdSW
