### PR TITLE
fix: Fade the Reminders pane's scroller in on its first visit too

### DIFF
--- a/Kernova/Views/Settings/RemindersSettingsViewController.swift
+++ b/Kernova/Views/Settings/RemindersSettingsViewController.swift
@@ -182,7 +182,12 @@ final class RemindersSettingsViewController: NSViewController, SettingsPaneScrol
         // adopts it. The window is sized once per tab selection, so content that
         // grows while the pane is on screen — a VM added or removed, the override
         // caption appearing — overflows in place; the flash is what says so.
-        scrollMoreIndicator = ScrollMoreIndicator(scrollView: scrollView, cues: .flash)
+        // Not armed at birth: the tab container cues every arrival explicitly,
+        // and a born-armed flash fires from `viewWillAppear`'s layout churn — in
+        // the already-visible window, behind the tab transition — so the first
+        // visit would meet a scroller already at full alpha.
+        scrollMoreIndicator = ScrollMoreIndicator(
+            scrollView: scrollView, cues: .flash, flashOnFirstOverflow: false)
 
         // The hug must stay weaker than every subview's compression resistance:
         // once the tab controller fixes the window height at the cap, a

--- a/Kernova/Views/Shared/ScrollMoreIndicator.swift
+++ b/Kernova/Views/Shared/ScrollMoreIndicator.swift
@@ -36,6 +36,10 @@ final class ScrollMoreIndicator {
     /// Height of the bottom fade strip.
     private static let fadeHeight: CGFloat = 36
 
+    /// How long the veiled scroller takes to fade in, matching the system
+    /// scroller reveal it stands in for.
+    private static let unveilDuration: TimeInterval = 0.3
+
     private weak var scrollView: NSScrollView?
     private let cues: ScrollMoreCues
     private let fade = ScrollMoreFadeView()
@@ -64,9 +68,33 @@ final class ScrollMoreIndicator {
     #endif
 
     /// Creates an indicator for `scrollView`, showing the cues named by `cues`.
-    init(scrollView: NSScrollView, cues: ScrollMoreCues = .all) {
+    ///
+    /// `flashOnFirstOverflow` arms the one-time flash at birth, which suits a
+    /// surface built fresh per appearance (a wizard step, a sheet) where the
+    /// first overflow against a visible window *is* the arrival. Pass `false`
+    /// for a surface whose arrivals are cued by an explicit ``rearmFlash()``:
+    /// the flash then waits for that cue, and an overlay scroller is held at
+    /// zero alpha until the first one executes.
+    init(
+        scrollView: NSScrollView, cues: ScrollMoreCues = .all, flashOnFirstOverflow: Bool = true
+    ) {
         self.scrollView = scrollView
         self.cues = cues
+        self.didFlash = !flashOnFirstOverflow
+
+        // AppKit reveals an overlay scroller when content first fills it, and a
+        // reveal applied to a layer that has never been presented takes effect
+        // instantly rather than animating. A surface reaching the screen for the
+        // first time therefore draws its scroller already solid, and the arriving
+        // flash has only its fade-out left to play. Hold the scroller at zero
+        // alpha from here so that first frame carries no scroller at all; the
+        // first flash to execute animates it in (see `recompute`).
+        //
+        // Overlay scrollers only: a legacy scroller is a persistent control, and
+        // veiling it would hide a scrollbar meant to stay on screen.
+        if !flashOnFirstOverflow, scrollView.scrollerStyle == .overlay {
+            scrollView.verticalScroller?.alphaValue = 0
+        }
 
         assert(
             scrollView.contentView.isFlipped,
@@ -120,6 +148,19 @@ final class ScrollMoreIndicator {
         recompute()
     }
 
+    /// Animates off the zero-alpha veil the initializer may have put on the
+    /// scroller, so the flash that follows reads as a fade-in.
+    ///
+    /// A no-op once the veil is gone, which is every flash after the first: from
+    /// then on the scroller rests hidden and AppKit's own reveal animates it.
+    private func unveilScroller() {
+        guard let scroller = scrollView?.verticalScroller, scroller.alphaValue < 1 else { return }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = Self.unveilDuration
+            scroller.animator().alphaValue = 1
+        }
+    }
+
     @objc private func geometryChanged() {
         recompute()
     }
@@ -153,7 +194,11 @@ final class ScrollMoreIndicator {
             flashCountForTesting += 1
             #endif
             Self.logger.debug("Flashing scroller")
-            Task { @MainActor [weak self] in self?.scrollView?.flashScrollers() }
+            Task { @MainActor [weak self] in
+                guard let scrollView = self?.scrollView else { return }
+                self?.unveilScroller()
+                scrollView.flashScrollers()
+            }
         }
     }
 

--- a/Kernova/Views/Shared/ScrollMoreIndicator.swift
+++ b/Kernova/Views/Shared/ScrollMoreIndicator.swift
@@ -56,14 +56,11 @@ final class ScrollMoreIndicator {
     /// else empty.
     var overlaysForTesting: [NSView] { didInsertOverlays ? [fade, chevron] : [] }
 
-    /// Whether the one-time scroller flash has latched.
-    var hasFlashedForTesting: Bool { didFlash }
-
     /// How many times the flash has fired.
     ///
-    /// A re-arm over still-overflowing content re-latches immediately, so
-    /// ``hasFlashedForTesting`` reads `true` both before and after — only the
-    /// count separates a fresh flash from the one that already happened.
+    /// The only signal that separates a flash from a spent latch: `didFlash` also
+    /// reads spent for one held at birth by `flashOnFirstOverflow: false`, and a
+    /// re-arm over still-overflowing content re-latches before a test can look.
     private(set) var flashCountForTesting = 0
     #endif
 
@@ -90,9 +87,11 @@ final class ScrollMoreIndicator {
         // alpha from here so that first frame carries no scroller at all; the
         // first flash to execute animates it in (see `recompute`).
         //
-        // Overlay scrollers only: a legacy scroller is a persistent control, and
-        // veiling it would hide a scrollbar meant to stay on screen.
-        if !flashOnFirstOverflow, scrollView.scrollerStyle == .overlay {
+        // A flash is the only thing that lifts the veil, so an indicator without
+        // that cue applies none. Overlay scrollers only: a legacy scroller is a
+        // persistent control, and veiling it would hide a scrollbar meant to stay
+        // on screen.
+        if !flashOnFirstOverflow, cues.contains(.flash), scrollView.scrollerStyle == .overlay {
             scrollView.verticalScroller?.alphaValue = 0
         }
 

--- a/KernovaTests/RemindersSettingsViewControllerTests.swift
+++ b/KernovaTests/RemindersSettingsViewControllerTests.swift
@@ -269,6 +269,49 @@ struct RemindersSettingsViewControllerTests {
         #expect(indicator.flashCountForTesting == 2)
     }
 
+    /// A tab switch adopts the pane into the already-visible Settings window
+    /// before its appearance pass runs.
+    ///
+    /// The appearance pass's layout churn therefore recomputes overflow against
+    /// a window the flash may fire in — while the tab transition still hides the
+    /// pane. The first visit must hold the cue for the container's arrival hook:
+    /// one spent here plays its fade-in where nobody can see, and the arrival
+    /// re-arm then meets a scroller already at full alpha — solid, then a bare
+    /// fade-out, unlike every later visit.
+    @Test("The first visit holds the flash for the arrival cue")
+    func firstVisitHoldsFlashForArrivalCue() throws {
+        let viewModel = makeViewModel()
+        for index in 1...9 {
+            viewModel.instances.append(makeInstance(name: "VM \(index)"))
+        }
+        let controller = RemindersSettingsViewController(
+            preferences: preferences, viewModel: viewModel)
+        _ = controller.view
+
+        // Host the pane in an on-screen window first, as the tab view does — and
+        // sized, because the tab view pins the adopted view to its own bounds
+        // (the outgoing pane's height) before any appearance callback runs. The
+        // pre-appearance row build and measurement layout therefore both run
+        // against real, overflowing geometry in a visible window.
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 520, height: 400))
+        let window = showInTestWindow(host)
+        defer {
+            controller.viewDidDisappear()
+            window.orderOut(nil)
+        }
+        controller.view.setFrameSize(NSSize(width: 520, height: 400))
+        host.addSubview(controller.view)
+        controller.viewWillAppear()
+        controller.view.layoutSubtreeIfNeeded()
+
+        let indicator = try #require(controller.scrollMoreIndicatorForTesting)
+        #expect(indicator.flashCountForTesting == 0)
+
+        // The container's arrival hook spends it — the first flash anyone sees.
+        controller.rearmScrollMoreCue()
+        #expect(indicator.flashCountForTesting == 1)
+    }
+
     /// Both captions describe the per-VM switches, so with none on screen they
     /// point at nothing — "these have no effect" directly under "No virtual
     /// machines yet." reads as a bug.

--- a/KernovaTests/ScrollMoreIndicatorTests.swift
+++ b/KernovaTests/ScrollMoreIndicatorTests.swift
@@ -127,12 +127,12 @@ struct ScrollMoreIndicatorTests {
         let (fitting, fittingWindow) = makeShownScrollView(documentHeight: 50)
         defer { fittingWindow.orderOut(nil) }
         let fits = ScrollMoreIndicator(scrollView: fitting)
-        #expect(fits.hasFlashedForTesting == false)
+        #expect(fits.flashCountForTesting == 0)
 
         let (overflowing, overflowingWindow) = makeShownScrollView(documentHeight: 1000)
         defer { overflowingWindow.orderOut(nil) }
         let overflows = ScrollMoreIndicator(scrollView: overflowing)
-        #expect(overflows.hasFlashedForTesting == true)
+        #expect(overflows.flashCountForTesting == 1)
     }
 
     /// The latch has to survive until there is a visible window to spend it on.
@@ -144,12 +144,12 @@ struct ScrollMoreIndicatorTests {
     func flashWaitsForAVisibleWindow() {
         let scrollView = makeScrollView(documentHeight: 1000)
         let indicator = ScrollMoreIndicator(scrollView: scrollView, cues: .flash)
-        #expect(indicator.hasFlashedForTesting == false)
+        #expect(indicator.flashCountForTesting == 0)
 
         let window = showInTestWindow(scrollView)
         defer { window.orderOut(nil) }
         indicator.rearmFlash()
-        #expect(indicator.hasFlashedForTesting == true)
+        #expect(indicator.flashCountForTesting == 1)
     }
 
     @Test("Flash-only cue flashes the scroller but inserts no overlays, even once mounted")
@@ -160,7 +160,7 @@ struct ScrollMoreIndicatorTests {
         let (scrollView, window) = makeShownScrollView(documentHeight: 1000)
         defer { window.orderOut(nil) }
         let indicator = ScrollMoreIndicator(scrollView: scrollView, cues: .flash)
-        #expect(indicator.hasFlashedForTesting == true)
+        #expect(indicator.flashCountForTesting == 1)
 
         // Mounted (the window's content view) + a geometry notification would
         // normally lazily insert overlays; with `.flash` only they must stay absent.
@@ -173,7 +173,7 @@ struct ScrollMoreIndicatorTests {
     func overlaysOnlyCueSkipsFlash() {
         let scrollView = makeScrollView(documentHeight: 1000)
         let indicator = ScrollMoreIndicator(scrollView: scrollView, cues: .overlays)
-        #expect(indicator.hasFlashedForTesting == false)
+        #expect(indicator.flashCountForTesting == 0)
 
         let host = NSView(frame: NSRect(x: 0, y: 0, width: Self.width, height: Self.viewportHeight))
         host.addSubview(scrollView)
@@ -249,24 +249,38 @@ struct ScrollMoreIndicatorTests {
         #expect(scroller.alphaValue == 1)
     }
 
+    /// A flash is the only thing that lifts the veil, so a flash-less indicator
+    /// applies none.
+    ///
+    /// Veiled with nothing to unveil it, the scroller would stay invisible for the
+    /// scroll view's whole life.
+    @Test("An indicator without the flash cue never veils the scroller")
+    func flashlessIndicatorIsNotVeiled() throws {
+        let scrollView = makeScrollView(documentHeight: 1000, scrollerStyle: .overlay)
+        let scroller = try #require(scrollView.verticalScroller)
+        _ = ScrollMoreIndicator(
+            scrollView: scrollView, cues: .overlays, flashOnFirstOverflow: false)
+        #expect(scroller.alphaValue == 1)
+    }
+
     @Test("rearmFlash re-arms the one-time flash for a reused indicator")
     func rearmFlashReevaluates() {
         // Mirrors the settings pane reusing one indicator across VM switches.
         let (scrollView, window) = makeShownScrollView(documentHeight: 1000)
         defer { window.orderOut(nil) }
         let indicator = ScrollMoreIndicator(scrollView: scrollView, cues: .flash)
-        #expect(indicator.hasFlashedForTesting == true)  // flashed on first overflow
+        #expect(indicator.flashCountForTesting == 1)  // flashed on first overflow
 
         // Switching to a shorter form that fits, then re-arming, clears the latch
-        // and — since nothing overflows now — leaves it un-flashed.
+        // with nothing to spend it on — so the count holds.
         scrollView.documentView?.setFrameSize(NSSize(width: Self.width, height: 50))
         indicator.rearmFlash()
-        #expect(indicator.hasFlashedForTesting == false)
+        #expect(indicator.flashCountForTesting == 1)
 
         // A subsequent overflow re-flashes, proving the latch was genuinely cleared
-        // (a never-reset latch would have stayed `true` throughout).
+        // (a never-reset latch would have left the count at 1).
         scrollView.documentView?.setFrameSize(NSSize(width: Self.width, height: 1000))
-        #expect(indicator.hasFlashedForTesting == true)
+        #expect(indicator.flashCountForTesting == 2)
     }
 
     @Test("Re-evaluates when content grows in place")

--- a/KernovaTests/ScrollMoreIndicatorTests.swift
+++ b/KernovaTests/ScrollMoreIndicatorTests.swift
@@ -182,6 +182,73 @@ struct ScrollMoreIndicatorTests {
         #expect(indicator.overlaysForTesting.count == 2)
     }
 
+    /// A surface whose arrivals are cued by an explicit `rearmFlash()` opts out
+    /// of the born-armed flash: fired from pre-appearance layout churn, it would
+    /// spend the fade-in off screen and leave the arrival cue a scroller already
+    /// at full alpha.
+    @Test("An indicator born spent holds the flash for an explicit rearm")
+    func bornSpentFlashWaitsForRearm() {
+        let (scrollView, window) = makeShownScrollView(documentHeight: 1000)
+        defer { window.orderOut(nil) }
+        let indicator = ScrollMoreIndicator(
+            scrollView: scrollView, cues: .flash, flashOnFirstOverflow: false)
+        // Overflowing content against a visible window — the born-armed
+        // configuration flashes here; born spent must not.
+        #expect(indicator.flashCountForTesting == 0)
+
+        // Nor from later geometry churn (a pane laying out before it is shown).
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 1))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        #expect(indicator.flashCountForTesting == 0)
+
+        // The arrival cue is the first flash anyone gets.
+        indicator.rearmFlash()
+        #expect(indicator.flashCountForTesting == 1)
+    }
+
+    /// A scroll view with an explicit scroller style, so the veil assertions do
+    /// not depend on the host's "Show scroll bars" setting.
+    private func makeScrollView(documentHeight: CGFloat, scrollerStyle: NSScroller.Style)
+        -> NSScrollView
+    {
+        let scrollView = makeScrollView(documentHeight: documentHeight)
+        scrollView.hasVerticalScroller = true
+        scrollView.scrollerStyle = scrollerStyle
+        return scrollView
+    }
+
+    /// AppKit presents a virgin overlay scroller already shown, so an
+    /// arrival-cued surface would meet a solid scroller on its first-ever frame.
+    ///
+    /// The reveal can't animate on a never-presented layer. The indicator veils
+    /// the scroller behind zero view alpha at init; the first executed flash
+    /// animates it off.
+    @Test("Born-spent init veils an overlay scroller; born-armed leaves it alone")
+    func bornSpentVeilsOverlayScroller() throws {
+        let veiled = makeScrollView(documentHeight: 1000, scrollerStyle: .overlay)
+        let veiledScroller = try #require(veiled.verticalScroller)
+        _ = ScrollMoreIndicator(scrollView: veiled, cues: .flash, flashOnFirstOverflow: false)
+        #expect(veiledScroller.alphaValue == 0)
+
+        // The born-armed default serves surfaces whose first presentation is a
+        // brand-new window, where the system reveal reads fine — no veil.
+        let stock = makeScrollView(documentHeight: 1000, scrollerStyle: .overlay)
+        let stockScroller = try #require(stock.verticalScroller)
+        _ = ScrollMoreIndicator(scrollView: stock, cues: .flash)
+        #expect(stockScroller.alphaValue == 1)
+    }
+
+    /// A legacy scroller is a persistent control rather than a transient
+    /// overlay, so veiling one would hide a scrollbar meant to stay on screen —
+    /// what a reader with "Show scroll bars: Always" would see.
+    @Test("A legacy scroller is never veiled")
+    func legacyScrollerIsNotVeiled() throws {
+        let scrollView = makeScrollView(documentHeight: 1000, scrollerStyle: .legacy)
+        let scroller = try #require(scrollView.verticalScroller)
+        _ = ScrollMoreIndicator(scrollView: scrollView, cues: .flash, flashOnFirstOverflow: false)
+        #expect(scroller.alphaValue == 1)
+    }
+
     @Test("rearmFlash re-arms the one-time flash for a reused indicator")
     func rearmFlashReevaluates() {
         // Mirrors the settings pane reusing one indicator across VM switches.


### PR DESCRIPTION
## Summary

The Settings → Reminders pane met its first visitor after each launch with a scroller already at full alpha that only faded out; every later visit faded in and out normally. Both paths now play the whole animation.

## The two causes

**The cue was spent early.** The pane's indicator was armed at birth *and* re-armed by the tab container on every arrival. A tab switch adopts the pane into the already-visible Settings window before its appearance pass runs, so `viewWillAppear`'s measurement layout could fire the flash behind the tab transition — the arrival cue then met a scroller already solid.

**AppKit hands over a virgin overlay scroller already revealed.** It reveals an overlay scroller when content first fills it, and a reveal applied to a layer that has never been presented takes effect instantly rather than animating. The pane's first-ever frame therefore carried a solid scroller, which no amount of flash re-scheduling could soften — deferring the flash behind one and then two CoreAnimation commits was measured and changed nothing. This is also why only the first visit after a full app launch shows it: from then on the scroller has completed a hide cycle and rests hidden.

## The fix

`ScrollMoreIndicator` gains a `flashOnFirstOverflow` parameter, defaulting to today's behavior. The default suits a surface built fresh per appearance — a wizard step, a sheet — where the first overflow against a visible window *is* the arrival. Passing `false` suits a surface whose arrivals are cued explicitly: the flash waits for `rearmFlash()`, and the overlay scroller is held at zero alpha so the first frame carries no scroller at all. The first flash to execute animates that veil off, which is the fade-in AppKit could not deliver; every flash after runs on the stock reveal.

A legacy scroller is never veiled. With "Show scroll bars: Always" the scroller is a persistent control, not a transient overlay, and veiling it would cost a scrollbar meant to stay on screen.

The Reminders pane opts out of the born-armed flash, leaving the tab container's arrival cue as its only trigger.

## Verification

Logs can show a flash firing but not whether its fade-in renders, so this was measured off the screen: the scroller region was recorded during pristine first visits and per-frame brightness extracted. A broken first visit steps to full brightness in a single frame; the fixed build shows clean content, a fade-in ramp, a hold, then a fade-out — matching a later visit.

## Rejected alternatives

- **Deferring the flash** (a main-actor hop, one CoreAnimation completion, then two) — measured, no effect. The scroller is not shown by the flash, so rescheduling the flash cannot fix it.
- **Pre-warming the scroller** by pre-loading every pane and running a flash cycle in `loadView` — measured, no effect off screen.

## Test plan

- [x] `make test` — full suite green, including the held flash, the overlay veil, the legacy exemption, and the pane's real first-visit adoption order
- [x] `make lint`
- [x] Frame-brightness traces of a first visit after launch and a later visit in the running app