### PR TITLE
docs: Record that macOS 13/14 accept the vsock socket timeouts on the blocking path

### DIFF
--- a/docs/research/2026-08-08-macos13-14-vsock-blocking-socket-timeouts.md
+++ b/docs/research/2026-08-08-macos13-14-vsock-blocking-socket-timeouts.md
@@ -1,0 +1,38 @@
+# macOS 13 and 14 accept the vsock socket timeouts on the blocking connect path
+
+**Date:** 2026-08-08 · **Host:** M1 Max, 32 GB, macOS 27.0 · **Guests:** macOS
+13.7.8 and 14.8.9, clean Kernova library VMs, 4 vCPU / 8 GB
+
+## Summary
+
+`setsockopt(SO_RCVTIMEO)` and `setsockopt(SO_SNDTIMEO)` both succeed on an
+`AF_VSOCK` fd that reached the connected state through a blocking `connect(2)`
+— the path `VsockGuestClient.openVsockToHost` takes below macOS 26. The
+`EINVAL` these options return on 13 and 14 in
+`2026-08-06-macos13-vsock-nonblocking-state-blind.md` and
+`2026-08-06-macos14-vsock-state-blind.md` is a property of the non-blocking
+connect idiom, one more face of the state-blind fd those OSes hand back
+alongside `POLLHUP`-with-`SO_ERROR`-0 and the kqueue reader's phantom EOF.
+
+So `VsockChannel.writeFramed`'s blocking `FileHandle.write` carries the
+`socketTimeoutSeconds` bound on every macOS guest Kernova supports, on all
+three channels.
+
+Both guests also hold a full agent session over that path — control, log, and
+clipboard connected, clipboard streaming in both directions.
+
+## Method
+
+The 0.57.0 agent installed into each clean guest from the mounted installer
+disk, both VMs running concurrently for 15+ min:
+
+1. In each guest, after all three channels had connected,
+   `log show --last <n>m | grep -ci setsockopt` printed `0`.
+   `applySocketTimeouts` logs a warning per rejected option on every connect,
+   so zero is six consecutive acceptances per guest.
+2. Host: six `Accepted vsock connection` lines total — one per channel per VM,
+   no retries — and one `Guest agent connected` line each. 270 heartbeats from
+   13.7.8 and 183 from 14.8.9, on control sessions that never reconnected.
+3. Clipboard both ways on both guests: `Paste from Mac` streamed a 27-byte
+   snapshot host→guest, and ⌘C in the guest streamed three representations
+   (659 bytes on 13.7.8, 667 on 14.8.9) guest→host, each on the first attempt.


### PR DESCRIPTION
Closes #754

## Summary

#754 asked whether `setsockopt(SO_RCVTIMEO)`/`SO_SNDTIMEO` still return `EINVAL`
on macOS 13/14 guests now that `VsockGuestClient.openVsockToHost` routes every
guest below macOS 26 through a blocking `connect(2)`. Both prior observations
(`docs/research/2026-08-06-macos13-…`, `…-macos14-…`) were taken on the
non-blocking path, which those OSes no longer take, so the premise behind the
proposed write-side watchdog was unverified.

Measured on real guests: **both options are accepted on the blocking path**, on
all three channels, on both OSes. The `EINVAL` is a property of the non-blocking
connect idiom — one more face of the state-blind fd, alongside
`POLLHUP`-with-`SO_ERROR`-0 and the kqueue reader's phantom EOF — not of
`AF_VSOCK` on those releases.

That makes `VsockChannel.writeFramed`'s blocking `FileHandle.write` bounded by
`socketTimeoutSeconds` everywhere, so the clipboard and log channels do not need
the watchdog the issue proposed, and no code changes here.

## Changes

- `docs/research/2026-08-08-macos13-14-vsock-blocking-socket-timeouts.md` — the
  finding and its method. The two 2026-08-06 notes are immutable and stay as
  they are; this one supersedes their timeout-option claim.

## Test plan

- [x] 0.57.0 agent installed into clean `macOS 13.7.8` and `macOS 14.8.9` VMs,
      run concurrently for 15+ min.
- [x] In each guest, after control, log and clipboard had all connected,
      `log show --last <n>m | grep -ci setsockopt` → `0` (six acceptances/guest).
- [x] Host log: six `Accepted vsock connection` lines — one per channel per VM,
      no retries; 270 heartbeats from 13.7.8 and 183 from 14.8.9 on control
      sessions that never reconnected.
- [x] Clipboard both directions on both guests (27 B host→guest; three reps,
      659 B / 667 B guest→host), each on the first attempt.
- [x] `make lint`

## Notes

Acceptance is what was measured — the criterion #754 itself set. Whether the
kernel *enforces* the deadline on a genuinely parked write was not separately
measured; that would need a host that accepts and then stops reading, which
`VsockListenerHost` never does. With the `EINVAL` that motivated the concern
disproven, an accepted-but-ignored option is hypothetical and falls under
AGENTS.md's Dismiss bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C29NGmosaaocZU1LhZekvq