### PR TITLE
fix: Make literal-returning @objc AppKit overrides nonisolated

### DIFF
--- a/Kernova/App/ClipboardToolbarButton.swift
+++ b/Kernova/App/ClipboardToolbarButton.swift
@@ -83,7 +83,7 @@ private final class TransferBarView: NSView {
 
     /// Decoration only: hands every event through to the button underneath, so
     /// the bar can't swallow hits over the bottom of the circle.
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    nonisolated override func hitTest(_ point: NSPoint) -> NSView? { nil }
 
     override func draw(_ dirtyRect: NSRect) {
         let radius = bounds.height / 2

--- a/Kernova/Views/Clipboard/ClipboardConcealedPreviewView.swift
+++ b/Kernova/Views/Clipboard/ClipboardConcealedPreviewView.swift
@@ -68,7 +68,7 @@ final class ClipboardConcealedPreviewView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override var wantsUpdateLayer: Bool { true }
+    nonisolated override var wantsUpdateLayer: Bool { true }
 
     override func updateLayer() {
         layer?.backgroundColor = NSColor.textBackgroundColor.cgColor

--- a/Kernova/Views/Clipboard/ClipboardDropContainerView.swift
+++ b/Kernova/Views/Clipboard/ClipboardDropContainerView.swift
@@ -38,7 +38,7 @@ final class ClipboardDropContainerView: NSView {
     /// `copy(_:)` when the text editor is hidden or unfocused — AppKit inserts a
     /// view controller after its view, but only if some view in the window can
     /// take first-responder status.
-    override var acceptsFirstResponder: Bool { true }
+    nonisolated override var acceptsFirstResponder: Bool { true }
 
     // MARK: - NSDraggingDestination
 

--- a/Kernova/Views/Clipboard/ClipboardFilePreviewView.swift
+++ b/Kernova/Views/Clipboard/ClipboardFilePreviewView.swift
@@ -65,7 +65,7 @@ final class ClipboardFilePreviewView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override var wantsUpdateLayer: Bool { true }
+    nonisolated override var wantsUpdateLayer: Bool { true }
 
     override func updateLayer() {
         layer?.backgroundColor = NSColor.textBackgroundColor.cgColor

--- a/Kernova/Views/Clipboard/ClipboardFilesPreviewView.swift
+++ b/Kernova/Views/Clipboard/ClipboardFilesPreviewView.swift
@@ -12,7 +12,7 @@ final class ClipboardFilesPreviewView: NSView {
     /// to the top of the scroll area (an unflipped doc view would stick the rows
     /// to the bottom).
     private final class FlippedView: NSView {
-        override var isFlipped: Bool { true }
+        nonisolated override var isFlipped: Bool { true }
     }
 
     private let headerLabel: NSTextField
@@ -93,7 +93,7 @@ final class ClipboardFilesPreviewView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override var wantsUpdateLayer: Bool { true }
+    nonisolated override var wantsUpdateLayer: Bool { true }
 
     override func updateLayer() {
         layer?.backgroundColor = NSColor.textBackgroundColor.cgColor

--- a/Kernova/Views/Clipboard/ClipboardImagePreviewView.swift
+++ b/Kernova/Views/Clipboard/ClipboardImagePreviewView.swift
@@ -56,7 +56,7 @@ final class ClipboardImagePreviewView: NSView {
 
     /// Matches the text editor's background so switching preview modes doesn't
     /// shift the window's tone.
-    override var wantsUpdateLayer: Bool { true }
+    nonisolated override var wantsUpdateLayer: Bool { true }
 
     override func updateLayer() {
         layer?.backgroundColor = NSColor.textBackgroundColor.cgColor

--- a/Kernova/Views/Clipboard/ClipboardRichTextPreviewView.swift
+++ b/Kernova/Views/Clipboard/ClipboardRichTextPreviewView.swift
@@ -57,7 +57,7 @@ final class ClipboardRichTextPreviewView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override var wantsUpdateLayer: Bool { true }
+    nonisolated override var wantsUpdateLayer: Bool { true }
 
     override func updateLayer() {
         layer?.backgroundColor = NSColor.textBackgroundColor.cgColor

--- a/Kernova/Views/Clipboard/ClipboardSummaryView.swift
+++ b/Kernova/Views/Clipboard/ClipboardSummaryView.swift
@@ -62,7 +62,7 @@ final class ClipboardSummaryView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override var wantsUpdateLayer: Bool { true }
+    nonisolated override var wantsUpdateLayer: Bool { true }
 
     override func updateLayer() {
         layer?.backgroundColor = NSColor.textBackgroundColor.cgColor

--- a/Kernova/Views/Shared/GroupedFormStyle.swift
+++ b/Kernova/Views/Shared/GroupedFormStyle.swift
@@ -23,7 +23,7 @@ enum GroupedFormStyle {
 /// the viewport, the initial scroll position shows the bottom, clipping the top
 /// out of view.
 final class FlippedClipView: NSClipView {
-    override var isFlipped: Bool { true }
+    nonisolated override var isFlipped: Bool { true }
 }
 
 /// Wraps `content` in a borderless vertical scroll view.

--- a/Kernova/Views/Shared/ScrollMoreIndicator.swift
+++ b/Kernova/Views/Shared/ScrollMoreIndicator.swift
@@ -265,11 +265,11 @@ final class ScrollMoreIndicator {
 ///
 /// Hit-transparent, so it never blocks scrolling.
 private final class ScrollMoreFadeView: NSView {
-    override var isOpaque: Bool { false }
+    nonisolated override var isOpaque: Bool { false }
 
     // nil from hitTest drops the view from event routing so the scroll view
     // beneath still scrolls under the cursor.
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    nonisolated override func hitTest(_ point: NSPoint) -> NSView? { nil }
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
@@ -290,7 +290,7 @@ private final class ScrollMoreFadeView: NSView {
 /// A passive overlay container that lets clicks and scroll-wheel events fall
 /// through to the content beneath.
 private final class ScrollMoreHitTransparentView: NSView {
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    nonisolated override func hitTest(_ point: NSPoint) -> NSView? { nil }
 }
 
 /// Builds the chevron disc: a `chevron.down` on a small adaptive grey disc.


### PR DESCRIPTION
Closes #711

## Summary

`EXC_BAD_ACCESS (code=1, address=0x0)` on the main thread, inside the executor check the compiler injects into the `@objc` thunk of `FlippedClipView.isFlipped` — not in the property body. It surfaced during a layout pass on window teardown while stopping two VMs.

Under `SWIFT_STRICT_CONCURRENCY = complete` / Swift 6, `NSView` is `@MainActor`, so an override inherits that isolation. Because the member is `@objc`-visible, the compiler emits a dynamic executor check into the ObjC-callable thunk. A scratch reproduction confirms the mechanism and that it is **not** debug-only — diffing the emitted thunk for `override var isFlipped: Bool { true }` on an `NSClipView` subclass at `-swift-version 6 -strict-concurrency=complete -O`:

```
before:  bl _$sScMMa                        ; MainActor metadata
         bl _$sScM6sharedScMvgZ             ; MainActor.shared
         bl _$sScA15unownedExecutorScevgTj  ; .unownedExecutor
         bl _swift_task_isCurrentExecutor
         bl _swift_task_reportUnexpectedExecutor

after:   mov w0, #1
         ret
```

Those are frames 4-6 of the reported stack, and `swift_task_isCurrentExecutor` reaching `swift_getObjectType` → `objc_msgSend` on a null receiver is exactly the reported null dereference.

AppKit queries these properties constantly and deep inside geometry, layout, and event-routing machinery, so the check sits on an extremely hot, framework-driven path where it buys nothing for a body that reads no state. `nonisolated` removes the executor code from the thunk entirely, and is sound here precisely because the getter touches no state — there is nothing for a concurrent caller to race against.

**Scope of the fix — it removes the crash site, not an underlying defect.** A null receiver reaching `swift_task_isCurrentExecutor` implies the concurrency runtime's state was already corrupted before our thunk ran; the check was where that corruption became fatal, not its cause. Immediately before the crash AppKit logged an `NSInternalInconsistencyException` from `ViewBridge/NSRemoteView.m` (`SPCompletionListServiceViewController`, the out-of-process autofill completion popup, complaining about window ordering) — a plausible source, but not established from the stack alone. That corruption lives in AppKit/ViewBridge and is not actionable in-repo. This change removes the crash surface either way; it does not explain the assertion.

## Changes

Added `nonisolated` to 13 `@objc`-visible AppKit overrides across 10 files. Keyword only — no body, signature, or doc-comment changes.

| Symbol | File |
|---|---|
| `FlippedClipView.isFlipped` | `Kernova/Views/Shared/GroupedFormStyle.swift` |
| `ClipboardFilesPreviewView.FlippedView.isFlipped` | `Kernova/Views/Clipboard/ClipboardFilesPreviewView.swift` |
| `ClipboardFilesPreviewView.wantsUpdateLayer` | `Kernova/Views/Clipboard/ClipboardFilesPreviewView.swift` |
| `ScrollMoreFadeView.isOpaque` | `Kernova/Views/Shared/ScrollMoreIndicator.swift` |
| `ScrollMoreFadeView.hitTest` | `Kernova/Views/Shared/ScrollMoreIndicator.swift` |
| `ScrollMoreHitTransparentView.hitTest` | `Kernova/Views/Shared/ScrollMoreIndicator.swift` |
| `ClipboardDropContainerView.acceptsFirstResponder` | `Kernova/Views/Clipboard/ClipboardDropContainerView.swift` |
| `ClipboardFilePreviewView.wantsUpdateLayer` | `Kernova/Views/Clipboard/ClipboardFilePreviewView.swift` |
| `ClipboardConcealedPreviewView.wantsUpdateLayer` | `Kernova/Views/Clipboard/ClipboardConcealedPreviewView.swift` |
| `ClipboardRichTextPreviewView.wantsUpdateLayer` | `Kernova/Views/Clipboard/ClipboardRichTextPreviewView.swift` |
| `ClipboardSummaryView.wantsUpdateLayer` | `Kernova/Views/Clipboard/ClipboardSummaryView.swift` |
| `ClipboardImagePreviewView.wantsUpdateLayer` | `Kernova/Views/Clipboard/ClipboardImagePreviewView.swift` |
| `TransferBarView.hitTest` | `Kernova/App/ClipboardToolbarButton.swift` |

**Thirteen sites, where the issue listed ten.** The issue swept `override var` only. The three `hitTest(_:) -> NSView? { nil }` `override func` sites qualify under the issue's own criterion — identical thunk, same bare-literal body, and they sit directly on AppKit's event-routing path — so the set is closed at 13 rather than 10.

**Deliberately excluded: `SidebarTableRowView.isEmphasized`.** Its getter is `rendersUnemphasized ? false : super.isEmphasized` — a mutable stored property plus a `super` read — and it has a setter writing through to `super`, with `rendersUnemphasized` mutated from `prepareForReuse()` and `settleEmphasis()`. It is main-actor-protected state and `nonisolated` there would be a real data race. The test is applied per site — "returns a bare literal and reads no state" — never as a blanket sweep. An independent sweep of all four source trees confirms these 13 are the complete qualifying set: 11 `override var` total (the 10 literal ones plus `isEmphasized`), 3 literal-returning `override func`, zero `override class var`.

## Rejected alternatives

- **A lint rule**, floated in the issue. `swift-format` has no custom-rule mechanism, and a grep-based check in `Tools/` would have to model "reads no state", which grep cannot do — a naive rule fires on `SidebarTableRowView.isEmphasized`, the one site where the change is unsafe.
- **`RATIONALE:` comments at the 13 sites.** They fail docs/REVIEW.md condition 2 ("no better home") and would tax every future reader 13 times over.
- **No doc edits.** Per AGENTS.md's documentation routing, the argument lives here in the PR body.
- **No new tests.** These are UI views, exempt under AGENTS.md ("Test models, services, and view models — UI views need none"), and a compiler-emitted thunk has no unit-testable seam.

## Test plan

- [x] `make lint` clean
- [x] `make build` succeeds with no new warnings
- [x] `make build CONFIGURATION=Release` succeeds — confirms the change is clean in the config where the check actually ships
- [x] `make test` passes (all three targets via Kernova.xctestplan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)