### PR TITLE
feat: Stream folder archives end to end instead of spooling them

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -831,7 +831,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.57.0;
+				MARKETING_VERSION = 0.58.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
@@ -869,7 +869,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.57.0;
+				MARKETING_VERSION = 0.58.0;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -861,6 +861,9 @@ final class VMInstance {
                 channel: channel, label: self.name,
                 maxPasteBytes: { [weak self] in
                     self?.effectiveClipboardMaxPasteBytes ?? ClipboardPasteLimit.defaultBytes
+                },
+                peerStreamsDirectories: { [weak self] in
+                    self?.vsockControlService?.guestSupportsDirectoryStreaming ?? false
                 })
             let publisher = self.hostClipboardPublisher
             service.hostPasteboardHoldsOurWrite = { publisher.pasteboardHoldsLastWrite }

--- a/Kernova/Services/ClipboardTransferIssue.swift
+++ b/Kernova/Services/ClipboardTransferIssue.swift
@@ -116,6 +116,20 @@ extension ClipboardTransferIssue {
             date: Date())
     }
 
+    /// Raised when a copied folder is left out of the offer because the guest
+    /// agent predates streamed folders.
+    ///
+    /// The copy itself is fine — nothing else about it changed — so the message
+    /// names the one thing the user can act on.
+    static func folderSkippedForOutdatedGuest() -> ClipboardTransferIssue {
+        ClipboardTransferIssue(
+            kind: .localFailure(
+                code: ClipboardErrorCode.folderPeerOutdated.rawValue,
+                message:
+                    "The guest agent needs updating before a folder can be copied to this VM."),
+            date: Date())
+    }
+
     /// Raised when a copied folder's archive arrived but could not be unpacked
     /// into a real folder for the paste to create.
     static func pasteFolderUnpackFailed() -> ClipboardTransferIssue {

--- a/Kernova/Services/ClipboardTransferIssue.swift
+++ b/Kernova/Services/ClipboardTransferIssue.swift
@@ -9,10 +9,12 @@ import KernovaKit
 /// message it has already dismissed once.
 struct ClipboardTransferIssue: Equatable, Sendable {
     enum Kind: Equatable, Sendable {
-        /// Not enough disk space on the receiving side to stage a streamed file.
-        /// `needed` is the transfer size; `available` is the staging volume's
-        /// free capacity when known.
-        case diskFull(needed: Int, available: Int?)
+        /// Not enough disk space on the receiving side to stage a streamed
+        /// payload. `needed` is the transfer size, `nil` when the payload
+        /// declared none — a streamed folder archive's compressed size is not
+        /// known until its last byte. `available` is the staging volume's free
+        /// capacity when known.
+        case diskFull(needed: Int?, available: Int?)
 
         /// The peer rejected a clipboard message (e.g. format unavailable,
         /// delivery failure on its side).
@@ -47,7 +49,7 @@ extension ClipboardTransferIssue {
     /// mid-stream, carrying whatever numbers the abort knew.
     static func diskFull(from info: ClipboardStreamAbortInfo) -> ClipboardTransferIssue {
         ClipboardTransferIssue(
-            kind: .diskFull(needed: info.neededBytes ?? 0, available: info.availableBytes),
+            kind: .diskFull(needed: info.neededBytes, available: info.availableBytes),
             date: Date())
     }
 

--- a/Kernova/Services/HostClipboardPublisher.swift
+++ b/Kernova/Services/HostClipboardPublisher.swift
@@ -315,21 +315,15 @@ final class HostClipboardPublisher {
 
     /// Returns the pasteboard `public.file-url` for a resolved file payload.
     ///
-    /// A directory payload is extracted from its streamed `.aar` into a real
-    /// folder under the launch-swept root so a Finder paste recreates the tree. An
-    /// inline-and-named payload (image file) is written to a fresh sink so its
+    /// An inline-and-named payload (image file) is written to a fresh sink so its
     /// `.fileURL` outlives the VM teardown.
     nonisolated private static func stagedFileURL(
         for representation: ClipboardContent.Representation, generation: UInt64,
         staging: ClipboardFileStaging
     ) -> URL? {
-        if representation.isDirectory {
-            return ClipboardDirectoryArchive.extractedDirectoryURL(
-                for: representation, into: staging, generation: generation)
-        }
         if let existing = representation.fileURL {
-            // Already staged to disk (a pulled file rep, or a rare spilled inline
-            // payload) — serve that path.
+            // Already on disk — a pulled file rep, a folder whose tree its
+            // transfer extracted, or a rare spilled inline payload.
             return existing
         }
         guard let data = representation.inMemoryData,

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -517,8 +517,9 @@ final class VsockClipboardService: ClipboardServicing {
             // Deliberately *not* latched into `lastGrabbedDigest`: the capability
             // is re-read from every `Hello`, and a control-channel blip alone
             // clears it, so latching would strand this buffer for the rest of the
-            // session even once the guest advertises it again. Reported once per
-            // buffer instead, since the poll re-enters here every tick.
+            // session even once the guest advertises it again. Leaving it
+            // unlatched is also what lets a later call reach this branch again,
+            // so the report is held to once per buffer.
             noteFoldersSkipped(
                 "Offering nothing to '\(label)' — every representation is a folder and the guest agent lacks \(KernovaCapability.clipboardStreamDirectoryV1) (agent needs updating)"
             )

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -76,6 +76,10 @@ final class VsockClipboardService: ClipboardServicing {
     /// check rather than captured, so a Settings change reaches a live session.
     private let maxPasteBytes: @MainActor () -> Int
 
+    /// The buffer digest whose offer was last skipped for lacking anything the
+    /// peer can take, so the skip is reported once rather than every poll tick.
+    @ObservationIgnored private var skippedOfferDigest: Data?
+
     /// Whether the connected guest can receive a folder archived straight onto
     /// the wire (`clipboard.stream.directory.v1`).
     ///
@@ -493,13 +497,23 @@ final class VsockClipboardService: ClipboardServicing {
         // Filtering can empty the list. Send nothing rather than an offer with no
         // representations: the peer would drop its promise and be left with a
         // pasteboard item nothing can serve, where leaving the previous offer
-        // standing keeps a working clipboard. The digest still advances, so this
-        // buffer isn't re-examined every poll; a reconnect builds a fresh service
-        // and re-offers under whatever the peer advertises then.
+        // standing keeps a working clipboard.
         guard !content.representations.isEmpty else {
-            lastGrabbedDigest = clipboardContent.digest
+            // Deliberately *not* latched into `lastGrabbedDigest`: the capability
+            // is re-read from every `Hello`, and a control-channel blip alone
+            // clears it, so latching would strand this buffer for the rest of the
+            // session even once the guest advertises it again. Reported once per
+            // buffer instead, since the poll re-enters here every tick.
+            if skippedOfferDigest != clipboardContent.digest {
+                skippedOfferDigest = clipboardContent.digest
+                lastTransferIssue = .folderSkippedForOutdatedGuest()
+                Self.logger.notice(
+                    "Offering nothing to '\(self.label, privacy: .public)' — every representation is a folder and the guest agent lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public) (agent needs updating)"
+                )
+            }
             return
         }
+        skippedOfferDigest = nil
 
         var offer = Frame()
         offer.protocolVersion = 1
@@ -541,9 +555,11 @@ final class VsockClipboardService: ClipboardServicing {
         guard !peerStreamsDirectories() else { return clipboardContent }
         let kept = clipboardContent.representations.filter { !$0.isDirectory }
         guard kept.count != clipboardContent.representations.count else { return clipboardContent }
-        Self.logger.notice(
-            "Dropping \(self.clipboardContent.representations.count - kept.count, privacy: .public) folder representation(s) from the clipboard offer to '\(self.label, privacy: .public)' — the guest agent lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public) (agent needs updating)"
-        )
+        if skippedOfferDigest != clipboardContent.digest {
+            Self.logger.notice(
+                "Dropping \(self.clipboardContent.representations.count - kept.count, privacy: .public) folder representation(s) from the clipboard offer to '\(self.label, privacy: .public)' — the guest agent lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public) (agent needs updating)"
+            )
+        }
         return ClipboardContent(representations: kept, isConcealed: clipboardContent.isConcealed)
     }
 
@@ -1172,8 +1188,10 @@ final class VsockClipboardService: ClipboardServicing {
                 transferID,
                 // A folder's bytes are an archive of its tree, extracted as they
                 // arrive: the stream layer learns that here, from the offer this
-                // side already read, rather than from the wire.
+                // side already read, rather than from the wire — including the
+                // size the extract is held to.
                 extractsDirectoryNamed: info.isDirectory ? info.filename : nil,
+                advertisedByteCount: Int(clamping: info.byteCount),
                 onComplete: { pull.resume($0) },
                 onAbort: { [weak self] info in
                     // A volume that fills *during* the transfer; the pre-flight
@@ -1376,8 +1394,10 @@ final class VsockClipboardService: ClipboardServicing {
             transferID,
             // A folder's bytes are an archive of its tree, extracted as they
             // arrive: the stream layer learns that here, from the offer this side
-            // already read, rather than from the wire.
+            // already read, rather than from the wire — including the size the
+            // extract is held to.
             extractsDirectoryNamed: snapshot.isDirectory ? snapshot.filename : nil,
+            advertisedByteCount: Int(clamping: snapshot.byteCount),
             onComplete: { rep in coordinator.deliver(transferID, rep) },
             onAbort: { abort in coordinator.abort(transferID, abort) },
             // Re-arm the inactivity backstop on each chunk so a large still-

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -48,22 +48,12 @@ final class VsockClipboardService: ClipboardServicing {
 
     private let staging: ClipboardFileStaging
 
-    /// Holds folder archives built to *send* to the guest, kept separate from
-    /// `staging` so an outbound archive's generation can't share (or evict) a
-    /// directory with an inbound transfer, whose generations are the guest's
-    /// own counter.
-    private let sendStaging: ClipboardFileStaging
-
-    /// Monotonic generation for outbound folder archives in `sendStaging`, so a
-    /// new request-time archive supersedes older temps instead of accumulating.
-    private var sendArchiveGeneration: UInt64 = 1
-
     /// Holds the files a window drop materializes from a file promise, one
     /// generation per drop.
     ///
-    /// Separate from `sendStaging`, whose archives this session builds and owns:
-    /// a drop's files are the *source* the buffer and the offer read from, so
-    /// they retire on their own schedule (`retireUnreferencedDropDirectories`).
+    /// Separate from `staging`, which holds what a peer streams in: a drop's
+    /// files are the *source* the buffer and the offer read from, so they retire
+    /// on their own schedule (`retireUnreferencedDropDirectories`).
     private let dropStaging: ClipboardFileStaging
 
     /// Generation for the next drop, so each drop's files can be retired without
@@ -85,6 +75,15 @@ final class VsockClipboardService: ClipboardServicing {
     /// The ceiling on a paste's file-representation total, read at each budget
     /// check rather than captured, so a Settings change reaches a live session.
     private let maxPasteBytes: @MainActor () -> Int
+
+    /// Whether the connected guest can receive a folder archived straight onto
+    /// the wire (`clipboard.stream.directory.v1`).
+    ///
+    /// Read at each offer, so an agent that reconnects after an update starts
+    /// getting folders without restarting the service. Defaults to refusing, so
+    /// a service built without capability information never offers a folder the
+    /// peer might not be able to take.
+    private let peerStreamsDirectories: @MainActor () -> Bool
 
     /// Off-main authority for this VM's clipboard progress, aggregating every
     /// transfer of one operation into the snapshot each surface renders.
@@ -234,6 +233,7 @@ final class VsockClipboardService: ClipboardServicing {
         channel: VsockChannel, label: String,
         freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
         maxPasteBytes: @escaping @MainActor () -> Int = { ClipboardPasteLimit.defaultBytes },
+        peerStreamsDirectories: @escaping @MainActor () -> Bool = { false },
         lazyPullTimeout: TimeInterval = ClipboardStreamTuning.lazyPullTimeout,
         progressRevealDelay: TimeInterval = ClipboardProgressTracker.defaultRevealDelay,
         progressIdleLinger: TimeInterval = ClipboardProgressTracker.defaultIdleLinger,
@@ -243,13 +243,11 @@ final class VsockClipboardService: ClipboardServicing {
         self.channel = channel
         self.label = label
         self.maxPasteBytes = maxPasteBytes
+        self.peerStreamsDirectories = peerStreamsDirectories
         self.lazyPullTimeout = lazyPullTimeout
         self.progressCenter = progressCenter
         self.staging = ClipboardFileStaging(
             label: "host-\(label)", tempRoot: stagingTempRoot,
-            freeSpaceProvider: freeSpaceProvider)
-        self.sendStaging = ClipboardFileStaging(
-            label: "host-send-\(label)", tempRoot: stagingTempRoot,
             freeSpaceProvider: freeSpaceProvider)
         self.dropStaging = ClipboardFileStaging(
             label: "host-drops-\(label)", tempRoot: stagingTempRoot,
@@ -271,13 +269,10 @@ final class VsockClipboardService: ClipboardServicing {
 
     func start() {
         guard consumeTask == nil else { return }
-        // Earlier sessions' staging roots: outbound-archive roots never back a
-        // host-pasteboard URL, so they are always reclaimable; receive and drop
-        // roots may still be serving the pasteboard's current write (a stopped
-        // session's materialized reps stay servable, and a dropped file's URL is
-        // copied as-is), so they are reclaimed only once the pasteboard no longer
-        // holds this VM's write.
-        sendStaging.reclaimSiblingRoots()
+        // Earlier sessions' receive and drop roots may still be serving the
+        // pasteboard's current write (a stopped session's materialized reps stay
+        // servable, and a dropped file's URL is copied as-is), so they are
+        // reclaimed only once the pasteboard no longer holds this VM's write.
         if hostPasteboardHoldsOurWrite?() != true {
             staging.reclaimSiblingRoots()
             dropStaging.reclaimSiblingRoots()
@@ -357,13 +352,11 @@ final class VsockClipboardService: ClipboardServicing {
         // Synchronously, not via the tracker's emission hop: a readout still
         // standing for a VM that has gone is the stuck indicator §13 forbids.
         publishProgress(nil)
-        // Only the outbound archives: the inbound promise and its receive staging
-        // deliberately survive stop() — the host pasteboard may still advertise
-        // this offer, and every rep already materialized stays servable from the
-        // cache and the staged files (docs/CLIPBOARD.md §3). Only supersession —
-        // a newer offer or a release — retracts the pasteboard write; the staged
-        // files then age out of the generation window or the sibling reclaim.
-        sendStaging.sweep()
+        // Nothing is swept here: the inbound promise and its receive staging
+        // deliberately survive stop(), because the host pasteboard may still
+        // advertise this offer and every materialized rep stays servable from the
+        // cache and the staged files (docs/CLIPBOARD.md §3). Only supersession
+        // retracts the write; the files then age out of the generation window.
         // Unconditional, unlike `publishProgress`'s change-guarded push: a stopped
         // VM's last snapshot would otherwise pin the status item's readout.
         progressCenter.progressChanged(from: self, nil)
@@ -490,7 +483,7 @@ final class VsockClipboardService: ClipboardServicing {
         let generation = nextLocalGeneration
         // Cap to the 16-bit rep-index limit; the buffer's own (uncapped) digest
         // stays the dedup key so an unchanged buffer isn't re-offered.
-        let capped = clipboardContent.cappedToOfferLimit()
+        let capped = offerableContent().cappedToOfferLimit()
         if let originalCount = capped.truncatedFrom {
             Self.logger.warning(
                 "Clipboard offer truncated from \(originalCount, privacy: .public) to \(ClipboardContent.maxOfferableRepresentations, privacy: .public) representations (16-bit transfer-id limit)"
@@ -525,6 +518,23 @@ final class VsockClipboardService: ClipboardServicing {
                 "Failed to send clipboard offer for '\(self.label, privacy: .public)': \(error.localizedDescription, privacy: .public)"
             )
         }
+    }
+
+    /// The buffer's content as this peer can consume it: folder representations
+    /// are dropped for a guest agent that predates
+    /// `clipboard.stream.directory.v1`, which cannot receive one.
+    ///
+    /// Filtering here rather than at the wire keeps `pendingOutbound` and the
+    /// offer built from the same list, so a `transfer_id`'s low 16 bits keep
+    /// addressing the representation the guest asked for.
+    private func offerableContent() -> ClipboardContent {
+        guard !peerStreamsDirectories() else { return clipboardContent }
+        let kept = clipboardContent.representations.filter { !$0.isDirectory }
+        guard kept.count != clipboardContent.representations.count else { return clipboardContent }
+        Self.logger.notice(
+            "Dropping \(self.clipboardContent.representations.count - kept.count, privacy: .public) folder representation(s) from the clipboard offer to '\(self.label, privacy: .public)' — the guest agent lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public) (agent needs updating)"
+        )
+        return ClipboardContent(representations: kept, isConcealed: clipboardContent.isConcealed)
     }
 
     // MARK: - Frame consumer
@@ -670,13 +680,28 @@ final class VsockClipboardService: ClipboardServicing {
             session: session, id: xid, expectedBytes: UInt64(max(0, representation.byteCount)), name: label)
         let tracker = progress
         // A directory rep is offered as a source URL plus an estimate — no
-        // archive exists yet. Archive at request time (off the main actor) and
-        // stream that.
+        // archive exists. Archive the tree straight onto the wire, so nothing
+        // larger than the credit window is ever held (docs/CLIPBOARD.md §2).
         if case .directory(let sourceURL, let estimatedByteCount) = representation.source {
-            archiveAndStream(
-                sourceURL: sourceURL, folderName: representation.filename, repIndex: repIndex,
-                estimatedByteCount: estimatedByteCount, request: request,
-                isCurrent: generation, session: session, sender: sender)
+            Self.logger.notice(
+                "Streaming clipboard folder '\(representation.filename, privacy: .public)' to '\(self.label, privacy: .public)' (gen=\(request.generation, privacy: .public), conn=\(self.connectionTag, privacy: .public), rep \(repIndex, privacy: .public), estimate \(estimatedByteCount, privacy: .public) bytes)"
+            )
+            sender.startDirectoryTransfer(
+                transferID: request.transferID,
+                generation: request.generation,
+                sourceDirectoryURL: sourceURL,
+                folderName: representation.filename,
+                uti: representation.uti,
+                maxAcceptByteCount: request.maxAcceptByteCount,
+                isCurrent: { generationValue in generation.isCurrent(generationValue) },
+                onProgress: { sent, total in
+                    tracker.unitProgressed(
+                        session: session, id: xid, bytesTransferred: UInt64(max(0, sent)),
+                        totalBytes: UInt64(max(0, total)))
+                },
+                onComplete: { success in
+                    tracker.unitEnded(session: session, id: xid, succeeded: success)
+                })
             return
         }
         sender.startTransfer(
@@ -697,68 +722,6 @@ final class VsockClipboardService: ClipboardServicing {
         Self.logger.debug(
             "Streaming clipboard rep \(repIndex, privacy: .public) to '\(self.label, privacy: .public)' (gen=\(request.generation, privacy: .public), conn=\(self.connectionTag, privacy: .public), \(representation.byteCount, privacy: .public) bytes)"
         )
-    }
-
-    /// Archives a source directory at request time and streams the `.aar` — the
-    /// serving path for every folder rep the guest pulls.
-    private func archiveAndStream(
-        sourceURL: URL, folderName: String, repIndex: Int, estimatedByteCount: Int,
-        request: Kernova_V1_ClipboardRequest,
-        isCurrent: AtomicGeneration, session: ClipboardProgressTracker.SessionToken,
-        sender: ClipboardStreamSender
-    ) {
-        let staging = self.sendStaging
-        let archiveGeneration = sendArchiveGeneration
-        sendArchiveGeneration += 1
-        let transferID = request.transferID
-        let requestGeneration = request.generation
-        let maxAccept = request.maxAcceptByteCount
-        let progress = self.progress
-        let label = self.label
-        let connectionTag = self.connectionTag
-        // Built on the main actor so the off-main dispatch never references the
-        // main-actor `self`. `totalBytes` replaces the rep's stat-walk estimate:
-        // what crosses the wire is an LZFSE archive of the folder.
-        let onProgress: @Sendable (Int, Int) -> Void = { sent, total in
-            progress.unitProgressed(
-                session: session, id: transferID, bytesTransferred: UInt64(max(0, sent)),
-                totalBytes: UInt64(max(0, total)))
-        }
-        let onComplete: @Sendable (Bool) -> Void = { success in
-            progress.unitEnded(session: session, id: transferID, succeeded: success)
-        }
-        DispatchQueue.global(qos: .userInitiated).async {
-            // First statement of the closure, so the timestamp marks the archive
-            // starting rather than its enqueue; `.notice` so a hang inside the
-            // walk still leaves a record on disk.
-            Self.logger.notice(
-                "Archiving clipboard folder '\(folderName, privacy: .public)' for '\(label, privacy: .public)' (gen=\(requestGeneration, privacy: .public), conn=\(connectionTag, privacy: .public), rep \(repIndex, privacy: .public), estimate \(estimatedByteCount, privacy: .public) bytes)"
-            )
-            guard
-                let rep = try? ClipboardDirectoryArchive.archivedRepresentation(
-                    ofDirectoryAt: sourceURL, named: folderName, into: staging,
-                    generation: archiveGeneration)
-            else {
-                Self.logger.error(
-                    "Failed to archive folder '\(folderName, privacy: .public)' for '\(label, privacy: .public)' at request time"
-                )
-                sender.rejectRequest(
-                    transferID: transferID, code: "archive.error",
-                    message: "Could not archive the folder")
-                // The unit began when the request was accepted, so it must end here
-                // too — one left active keeps the session from ever going idle.
-                progress.unitEnded(session: session, id: transferID, succeeded: false)
-                return
-            }
-            sender.startTransfer(
-                transferID: transferID, generation: requestGeneration, representation: rep,
-                maxAcceptByteCount: maxAccept, isInline: false,
-                isCurrent: { value in isCurrent.isCurrent(value) },
-                onProgress: onProgress, onComplete: onComplete)
-            Self.logger.debug(
-                "Streaming clipboard rep \(repIndex, privacy: .public) to '\(label, privacy: .public)' (gen=\(requestGeneration, privacy: .public), conn=\(connectionTag, privacy: .public), \(rep.byteCount, privacy: .public) bytes)"
-            )
-        }
     }
 
     // MARK: - Inbound (we are the receiver)
@@ -1197,6 +1160,10 @@ final class VsockClipboardService: ClipboardServicing {
                 })
             receiver.awaitTransfer(
                 transferID,
+                // A folder's bytes are an archive of its tree, extracted as they
+                // arrive: the stream layer learns that here, from the offer this
+                // side already read, rather than from the wire.
+                extractsDirectoryNamed: info.isDirectory ? info.filename : nil,
                 onComplete: { pull.resume($0) },
                 onAbort: { [weak self] info in
                     // A volume that fills *during* the transfer; the pre-flight
@@ -1258,13 +1225,6 @@ final class VsockClipboardService: ClipboardServicing {
             case .diskFull, .localFailure: break
             case .peerReportedError, .staleCopyRetracted, .none: lastTransferIssue = nil
             }
-        }
-        // `is_directory` rides the ClipboardOffer, not ClipboardStreamBegin, so
-        // this offer-aware layer re-tags the delivered rep — the window then
-        // extracts the staged `.aar` into a real folder instead of pasting it.
-        if let rep, info.isDirectory {
-            return ClipboardContent.Representation(
-                uti: rep.uti, source: rep.source, filename: rep.filename, isDirectory: true)
         }
         return rep
     }
@@ -1400,6 +1360,10 @@ final class VsockClipboardService: ClipboardServicing {
         let generation = snapshot.generation
         receiver.awaitTransfer(
             transferID,
+            // A folder's bytes are an archive of its tree, extracted as they
+            // arrive: the stream layer learns that here, from the offer this side
+            // already read, rather than from the wire.
+            extractsDirectoryNamed: snapshot.isDirectory ? snapshot.filename : nil,
             onComplete: { rep in coordinator.deliver(transferID, rep) },
             onAbort: { abort in coordinator.abort(transferID, abort) },
             // Re-arm the inactivity backstop on each chunk so a large still-
@@ -1436,10 +1400,6 @@ final class VsockClipboardService: ClipboardServicing {
         }
         switch outcome {
         case .delivered(let rep):
-            if snapshot.isDirectory {
-                return ClipboardContent.Representation(
-                    uti: rep.uti, source: rep.source, filename: rep.filename, isDirectory: true)
-            }
             return rep
         case .aborted(let abort):
             Self.logger.warning(
@@ -1447,6 +1407,8 @@ final class VsockClipboardService: ClipboardServicing {
             )
             if abort.code == "disk.full" {
                 recordPasteIssue(.diskFull(from: abort))
+            } else if abort.code == "extract.error" {
+                recordPasteIssue(.pasteFolderUnpackFailed())
             } else if !Self.retiringAbortCodes.contains(abort.code) {
                 recordPasteIssue(.pasteTransferFailed())
             }
@@ -1614,34 +1576,17 @@ extension VsockClipboardService: ClipboardPasteboardRepProviding {
         return rep
     }
 
-    /// The `public.file-url` value for a pulled (or cached) rep: an extracted
-    /// folder for a directory rep, the staged/spilled file when one exists, else
-    /// resident bytes staged to a fresh sink so the URL a paste consumes points at
-    /// a real file.
+    /// The `public.file-url` value for a pulled (or cached) rep: the staged file
+    /// or extracted folder when one exists, else resident bytes staged to a fresh
+    /// sink so the URL a paste consumes points at a real file.
+    ///
+    /// A folder rep arrives already unpacked — its transfer extracted the tree as
+    /// the archive streamed — so serving it costs nothing inside the paste
+    /// deadline, and a repeated paste re-serves the same tree.
     nonisolated private func pasteFileURL(
         for rep: ClipboardContent.Representation, generation: UInt64
     ) -> URL? {
         let staging = onMain { self.staging }
-        // A directory rep's pull streams the request-time archive; extract it into
-        // a real folder so a Finder paste recreates the tree, not the `.aar`.
-        if rep.isDirectory {
-            // `.notice` and before the call: the extract runs inside the paste's
-            // promise deadline, so a hang here has to leave a record on disk.
-            Self.logger.notice(
-                "Extracting clipboard folder '\(rep.filename, privacy: .public)' from '\(self.label, privacy: .public)' (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public), \(rep.byteCount, privacy: .public) archive bytes)"
-            )
-            guard
-                let url = ClipboardDirectoryArchive.extractedDirectoryURL(
-                    for: rep, into: staging, generation: generation)
-            else {
-                Self.logger.error(
-                    "Failed to unpack clipboard folder '\(rep.filename, privacy: .public)' from '\(self.label, privacy: .public)' (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public)) — serving nothing"
-                )
-                recordPasteIssue(.pasteFolderUnpackFailed())
-                return nil
-            }
-            return url
-        }
         if let url = rep.fileURL { return url }
         // A named inline rep (an image file) reassembles in memory — stage it so
         // the `.fileURL` flavor serves a durable path.

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -490,6 +490,16 @@ final class VsockClipboardService: ClipboardServicing {
             )
         }
         let content = capped.content
+        // Filtering can empty the list. Send nothing rather than an offer with no
+        // representations: the peer would drop its promise and be left with a
+        // pasteboard item nothing can serve, where leaving the previous offer
+        // standing keeps a working clipboard. The digest still advances, so this
+        // buffer isn't re-examined every poll; a reconnect builds a fresh service
+        // and re-offers under whatever the peer advertises then.
+        guard !content.representations.isEmpty else {
+            lastGrabbedDigest = clipboardContent.digest
+            return
+        }
 
         var offer = Frame()
         offer.protocolVersion = 1
@@ -1170,6 +1180,10 @@ final class VsockClipboardService: ClipboardServicing {
                     // above covers the up-front case. Fires off the main actor.
                     if info.code == "disk.full" {
                         Task { @MainActor [weak self] in self?.recordPullDiskFull(info) }
+                    } else if info.code == "extract.error" {
+                        Task { @MainActor [weak self] in
+                            self?.lastTransferIssue = .pasteFolderUnpackFailed()
+                        }
                     }
                     pull.resume(nil)
                 },

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -76,9 +76,13 @@ final class VsockClipboardService: ClipboardServicing {
     /// check rather than captured, so a Settings change reaches a live session.
     private let maxPasteBytes: @MainActor () -> Int
 
-    /// The buffer digest whose offer was last skipped for lacking anything the
-    /// peer can take, so the skip is reported once rather than every poll tick.
-    @ObservationIgnored private var skippedOfferDigest: Data?
+    /// The buffer digest whose folders were last left out of what this peer was
+    /// offered — whether that emptied the offer or only shortened it.
+    ///
+    /// Two jobs: the skip is reported once rather than every poll tick, and the
+    /// buffer is re-offered once the peer advertises the capability it lacked,
+    /// which `lastGrabbedDigest` alone cannot notice.
+    @ObservationIgnored private var folderSkippedDigest: Data?
 
     /// Whether the connected guest can receive a folder archived straight onto
     /// the wire (`clipboard.stream.directory.v1`).
@@ -413,6 +417,7 @@ final class VsockClipboardService: ClipboardServicing {
     func clearBuffer() {
         clipboardContent = .empty
         lastGrabbedDigest = nil
+        folderSkippedDigest = nil
         // The user emptied the buffer — any guest offer it was showing is stale.
         dropInboundPromise()
         retireUnreferencedDropDirectories()
@@ -482,12 +487,22 @@ final class VsockClipboardService: ClipboardServicing {
         guard !clipboardContent.representations.contains(where: { $0.isPendingRemote }) else {
             return
         }
-        guard clipboardContent.digest != lastGrabbedDigest else { return }
+        if clipboardContent.digest == lastGrabbedDigest {
+            // The dedup key above is the *whole* buffer's digest, so it cannot
+            // tell that the last offer went out short of this buffer's folders.
+            // Re-enter for exactly that case, once the peer advertises the
+            // capability it lacked — the same stranding the emptied-offer branch
+            // below avoids by never latching.
+            guard folderSkippedDigest == clipboardContent.digest, peerStreamsDirectories() else {
+                return
+            }
+        }
 
         let generation = nextLocalGeneration
         // Cap to the 16-bit rep-index limit; the buffer's own (uncapped) digest
         // stays the dedup key so an unchanged buffer isn't re-offered.
-        let capped = offerableContent().cappedToOfferLimit()
+        let offerable = offerableContent()
+        let capped = offerable.content.cappedToOfferLimit()
         if let originalCount = capped.truncatedFrom {
             Self.logger.warning(
                 "Clipboard offer truncated from \(originalCount, privacy: .public) to \(ClipboardContent.maxOfferableRepresentations, privacy: .public) representations (16-bit transfer-id limit)"
@@ -504,16 +519,11 @@ final class VsockClipboardService: ClipboardServicing {
             // clears it, so latching would strand this buffer for the rest of the
             // session even once the guest advertises it again. Reported once per
             // buffer instead, since the poll re-enters here every tick.
-            if skippedOfferDigest != clipboardContent.digest {
-                skippedOfferDigest = clipboardContent.digest
-                lastTransferIssue = .folderSkippedForOutdatedGuest()
-                Self.logger.notice(
-                    "Offering nothing to '\(self.label, privacy: .public)' — every representation is a folder and the guest agent lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public) (agent needs updating)"
-                )
-            }
+            noteFoldersSkipped(
+                "Offering nothing to '\(label)' — every representation is a folder and the guest agent lacks \(KernovaCapability.clipboardStreamDirectoryV1) (agent needs updating)"
+            )
             return
         }
-        skippedOfferDigest = nil
 
         var offer = Frame()
         offer.protocolVersion = 1
@@ -531,6 +541,14 @@ final class VsockClipboardService: ClipboardServicing {
             currentOutboundGeneration.set(generation)
             lastGrabbedDigest = clipboardContent.digest
             lastTransferIssue = nil
+            if offerable.droppedFolders > 0 {
+                // Ordered after the clear above, which would otherwise wipe it.
+                noteFoldersSkipped(
+                    "Dropped \(offerable.droppedFolders) folder representation(s) from the clipboard offer to '\(label)' — the guest agent lacks \(KernovaCapability.clipboardStreamDirectoryV1) (agent needs updating)"
+                )
+            } else {
+                folderSkippedDigest = nil
+            }
             // The offer just replaced supersedes whatever drop it was reading
             // from, so that drop's files can go.
             retireUnreferencedDropDirectories()
@@ -544,23 +562,36 @@ final class VsockClipboardService: ClipboardServicing {
         }
     }
 
-    /// The buffer's content as this peer can consume it: folder representations
-    /// are dropped for a guest agent that predates
-    /// `clipboard.stream.directory.v1`, which cannot receive one.
+    /// The buffer's content as this peer can consume it, and how many folder
+    /// representations that cost: a guest agent predating
+    /// `clipboard.stream.directory.v1` cannot receive one.
     ///
     /// Filtering here rather than at the wire keeps `pendingOutbound` and the
     /// offer built from the same list, so a `transfer_id`'s low 16 bits keep
     /// addressing the representation the guest asked for.
-    private func offerableContent() -> ClipboardContent {
-        guard !peerStreamsDirectories() else { return clipboardContent }
+    private func offerableContent() -> (content: ClipboardContent, droppedFolders: Int) {
+        guard !peerStreamsDirectories() else { return (clipboardContent, 0) }
         let kept = clipboardContent.representations.filter { !$0.isDirectory }
-        guard kept.count != clipboardContent.representations.count else { return clipboardContent }
-        if skippedOfferDigest != clipboardContent.digest {
-            Self.logger.notice(
-                "Dropping \(self.clipboardContent.representations.count - kept.count, privacy: .public) folder representation(s) from the clipboard offer to '\(self.label, privacy: .public)' — the guest agent lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public) (agent needs updating)"
-            )
-        }
-        return ClipboardContent(representations: kept, isConcealed: clipboardContent.isConcealed)
+        let dropped = clipboardContent.representations.count - kept.count
+        guard dropped > 0 else { return (clipboardContent, 0) }
+        return (
+            ClipboardContent(representations: kept, isConcealed: clipboardContent.isConcealed),
+            dropped
+        )
+    }
+
+    /// Reports, once per buffer, that folders were left out of what this peer was
+    /// offered.
+    ///
+    /// The user's copy came up short whether the filter emptied the offer or only
+    /// shortened it, so both raise the same notice — and the latch is what lets
+    /// `grabIfChanged` re-offer the buffer when the capability appears.
+    private func noteFoldersSkipped(_ message: @autoclosure () -> String) {
+        guard folderSkippedDigest != clipboardContent.digest else { return }
+        folderSkippedDigest = clipboardContent.digest
+        lastTransferIssue = .folderSkippedForOutdatedGuest()
+        let text = message()
+        Self.logger.notice("\(text, privacy: .public)")
     }
 
     // MARK: - Frame consumer
@@ -869,6 +900,8 @@ final class VsockClipboardService: ClipboardServicing {
         clipboardContent = content
         lastGrabbedDigest = content.digest
         lastInboundPublishedDigest = content.digest
+        // The buffer this described has been replaced wholesale.
+        folderSkippedDigest = nil
     }
 
     /// Drops the current inbound promise and its per-generation lazy-pull state.

--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -179,6 +179,16 @@ final class VsockControlService {
     /// clipboard-channel admission check requires.
     var guestSupportsClipboardStreaming: Bool { guestSupportsClipboardStreamingStorage }
 
+    /// Whether the connected guest agent advertised
+    /// `clipboard.stream.directory.v1` in its `Hello`.
+    ///
+    /// Set on Hello, reset on stop. An agent without it cannot receive a folder
+    /// streamed with an undeclared size, so the host does not offer one.
+    private var guestSupportsDirectoryStreamingStorage = false
+
+    /// Whether the guest can receive a folder archived straight onto the wire.
+    var guestSupportsDirectoryStreaming: Bool { guestSupportsDirectoryStreamingStorage }
+
     /// Whether the connected guest agent advertised `clipboard.paste.limit.v1`
     /// in its `Hello`.
     ///
@@ -307,6 +317,7 @@ final class VsockControlService {
         isUnresponsive = false
         lastInboundFrame = nil
         guestSupportsClipboardStreamingStorage = false
+        guestSupportsDirectoryStreamingStorage = false
         guestSupportsPasteLimitStorage = false
         Self.logger.info("Vsock control service stopped for '\(self.label, privacy: .public)'")
         // Last, so the owner observes fully-settled state — notably a nil
@@ -508,6 +519,8 @@ final class VsockControlService {
             let reportedOSVersion = ObservedAgentInfo.boundedField(hello.agentInfo.osVersion)
             guestSupportsClipboardStreamingStorage = hello.capabilities.contains(
                 KernovaCapability.clipboardStreamV1)
+            guestSupportsDirectoryStreamingStorage = hello.capabilities.contains(
+                KernovaCapability.clipboardStreamDirectoryV1)
             guestSupportsPasteLimitStorage = hello.capabilities.contains(
                 KernovaCapability.clipboardPasteLimitV1)
             // Every peer-supplied piece of this line is filtered first — the

--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -604,12 +604,15 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
     private func message(for issue: ClipboardTransferIssue) -> String {
         switch issue.kind {
         case .diskFull(let needed, let available):
-            if let available {
-                return
-                    "Not enough disk space to receive the clipboard file (\(DataFormatters.formatBytes(UInt64(needed))) needed, \(DataFormatters.formatBytes(UInt64(available))) free)"
-            }
-            return
-                "Not enough disk space to receive the clipboard file (\(DataFormatters.formatBytes(UInt64(needed))) needed)"
+            let detail =
+                [
+                    needed.map { "\(DataFormatters.formatBytes(UInt64($0))) needed" },
+                    available.map { "\(DataFormatters.formatBytes(UInt64($0))) free" },
+                ]
+                .compactMap { $0 }
+                .joined(separator: ", ")
+            let base = "Not enough disk space to receive the clipboard payload"
+            return detail.isEmpty ? base : "\(base) (\(detail))"
         case .peerReportedError(let code, _):
             switch ClipboardErrorCode(rawValue: code) {
             case .pasteDiskFull:

--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -622,7 +622,8 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
                     "Too large to paste into the guest — over the \(ClipboardPasteLimit.displayLimit(instance.effectiveClipboardMaxPasteBytes)) clipboard transfer limit"
             case .pasteTimeout:
                 return "The clipboard transfer to the guest timed out"
-            case .pasteFailed, .copyTooLarge, .pasteIncompleteSet, .forwardItemsSkipped, .none:
+            case .pasteFailed, .copyTooLarge, .pasteIncompleteSet, .forwardItemsSkipped,
+                .folderPeerOutdated, .none:
                 return "Clipboard transfer failed on the guest side"
             }
         case .localFailure(_, let message):

--- a/KernovaKit/Proto/kernova.proto
+++ b/KernovaKit/Proto/kernova.proto
@@ -141,12 +141,11 @@ message ClipboardRepresentationInfo {
   // Size of the representation's bytes. For a copied file this is the file's
   // size from a stat — the bytes themselves are never read to build the offer.
   // For a directory rep (`is_directory`) it is the producer's stat-walk size
-  // ESTIMATE of the source tree: no archive exists at offer time, so the
-  // receiver's paste cap and free-space preflight gate on this estimate. The
-  // wire-exact archive size arrives later as the reply's
-  // `ClipboardStreamBegin.total_bytes`, and the stream layer re-enforces
-  // reality: `max_accept_byte_count` on the request, a per-chunk disk check,
-  // and the End frame's size + SHA-256 verification.
+  // ESTIMATE of the *uncompressed* source tree, which is what a streamed
+  // extract writes, so the receiver's paste cap and free-space preflight gate
+  // on it. The stream layer re-enforces reality: `max_accept_byte_count` on the
+  // request, a per-chunk disk check, and the End frame's size + SHA-256
+  // verification.
   uint64 byte_count = 2;
 
   // Suggested filename when this representation is a file payload (e.g. a
@@ -170,17 +169,19 @@ message ClipboardRepresentationInfo {
   // package such as .app/.rtfd). Implies a non-empty `filename` (the folder
   // name, without an archive suffix) and `is_inline = false`.
   //
-  // A directory rep rides the plain-file stream path: the producer packs the
-  // source tree into an in-process AppleArchive (.aar, LZFSE) when the
-  // representation is *requested* — never at copy time — and the receiver
-  // extracts the streamed archive back into a real directory. `byte_count`
-  // is the producer's stat-walk estimate; the archive's exact size rides in
-  // the reply's `ClipboardStreamBegin.total_bytes`.
+  // A directory rep rides the plain-file stream path, carrying an in-process
+  // AppleArchive (LZFSE) of the tree. The producer encodes the source tree
+  // straight onto the wire when the representation is *requested* — never at
+  // copy time, and never through an archive file — and the receiver extracts
+  // the arriving bytes straight into a real directory. Its compressed size is
+  // therefore unknown when the transfer starts, so the reply's
+  // `ClipboardStreamBegin.total_bytes` is 0 and the End frame carries the true
+  // count.
   //
-  // The stream layer is offer-agnostic, so this flag is re-applied to the
-  // delivered representation by the offer-aware layer on the receiver. Excluded
-  // from the content digest — the archive's SHA-256 and the folded filename
-  // already identify it.
+  // The stream layer is offer-agnostic: the requester tells its own receiver
+  // that a transfer carries a directory when it sends the `ClipboardRequest`,
+  // so nothing on the wire repeats this flag. Excluded from the content digest
+  // — the archive's SHA-256 and the folded filename already identify it.
   bool is_directory = 5;
 }
 
@@ -263,9 +264,13 @@ message ClipboardStreamBegin {
   // The representation's UTI.
   string uti = 3;
 
-  // Total payload size in bytes; the receiver verifies the reassembled byte
-  // count against this at `ClipboardStreamEnd`, and sizes its free-space
-  // pre-flight check from it for a file rep.
+  // Total payload size in bytes, or 0 for a payload whose size is only known
+  // once it has been produced — a directory archived onto the wire. When
+  // declared, the receiver bounds the arriving bytes by it and sizes its
+  // free-space pre-flight check from it for a file rep. When 0, the requester's
+  // free-space pre-flight against the offer's uncompressed estimate and a
+  // per-window disk re-check stand in, and `ClipboardStreamEnd` carries the
+  // authoritative count.
   uint64 total_bytes = 4;
 
   // Suggested filename for a file rep (see `ClipboardRepresentationInfo`);
@@ -296,7 +301,8 @@ message ClipboardChunk {
 message ClipboardStreamEnd {
   uint64 transfer_id = 1;
 
-  // Total bytes the sender streamed; must equal the Begin's `total_bytes`.
+  // Total bytes the sender streamed — the authoritative count, and the Begin's
+  // `total_bytes` whenever that declared one.
   uint64 total_bytes = 2;
 
   // SHA-256 over the streamed bytes, computed incrementally as the sender read

--- a/KernovaKit/Sources/KernovaKit/ClipboardContent.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardContent.swift
@@ -90,8 +90,9 @@ public struct ClipboardContent: Equatable, Sendable {
         ///
         /// `sha256` is the byte digest once a transfer has computed it — reused as
         /// the content digest so a multi-GB file is never re-hashed — and `nil`
-        /// when the file is only named. For `isDirectory`, the URL points at the
-        /// `.aar`, not the original folder.
+        /// when the file is only named. For `isDirectory` the URL is the folder
+        /// itself and `byteCount` its tree, while `sha256` stays the digest of
+        /// the archive that carried it over the wire.
         public init(
             uti: String, fileURL: URL, byteCount: Int, sha256: Data? = nil, filename: String,
             isDirectory: Bool = false

--- a/KernovaKit/Sources/KernovaKit/ClipboardDirectoryArchive.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardDirectoryArchive.swift
@@ -1,15 +1,15 @@
-import AppleArchive
 import Foundation
-import System
 
-/// In-process directory archiving for clipboard folder transfers.
+/// Shared parameters for clipboard folder transfers, which cross the wire as an
+/// AppleArchive (LZFSE) of the tree.
 ///
-/// A copied folder rides the same `.file` streaming path as a plain file by
-/// first being packed into a single AppleArchive (`.aar`, LZFSE) of the tree;
-/// the receiver unpacks it back into a real directory. Archiving must stay
-/// in-process via Apple's `AppleArchive` framework — never shelling out to
-/// `ditto`/`tar`/`zip`, which the App Sandbox blocks. This type never logs;
-/// callers log at their own subsystem.
+/// The archive itself is never materialized: ``ClipboardDirectoryArchiveReader``
+/// encodes the source tree straight onto the wire and
+/// ``ClipboardDirectoryExtractSink`` extracts the arriving bytes straight into
+/// the destination tree. Archiving must stay in-process via Apple's
+/// `AppleArchive` framework — never shelling out to `ditto`/`tar`/`zip`, which
+/// the App Sandbox blocks. This type never logs; callers log at their own
+/// subsystem.
 public enum ClipboardDirectoryArchive {
     /// A stream in the archive pipeline could not be opened, or the field-key
     /// set failed to parse.
@@ -30,90 +30,7 @@ public enum ClipboardDirectoryArchive {
     /// RATIONALE: extended attributes (`XAT`) are deliberately omitted — the
     /// plain-file streaming path cannot carry them, and a folder carrying them
     /// alone would break CLIPBOARD.md §6's uniform xattr gap.
-    private static let fieldKeys = "TYP,PAT,LNK,DEV,DAT,UID,GID,MOD,FLG,MTM,CTM,SH2"
-
-    /// Packs the directory tree at `directoryURL` into a single LZFSE-compressed
-    /// `.aar` at `archiveURL`.
-    ///
-    /// Entries are stored relative to `directoryURL`, so the source folder's own
-    /// name is not embedded; a partial archive is removed on any throw.
-    ///
-    /// - Throws: ``ArchiveError`` if a pipeline stream can't be opened, or any
-    ///   error AppleArchive raises while walking/reading the tree.
-    public static func archive(directoryAt directoryURL: URL, to archiveURL: URL) throws {
-        do {
-            // Streams close in reverse creation order on scope exit, flushing the
-            // encode trailer before the catch below removes a partial archive.
-            guard
-                let writeStream = ArchiveByteStream.fileStream(
-                    path: FilePath(archiveURL.path),
-                    mode: .writeOnly,
-                    options: [.create],
-                    permissions: FilePermissions(rawValue: 0o644))
-            else { throw ArchiveError.openWriteStream }
-            defer { try? writeStream.close() }
-
-            guard
-                let compressStream = ArchiveByteStream.compressionStream(
-                    using: .lzfse, writingTo: writeStream)
-            else { throw ArchiveError.openCompressionStream }
-            defer { try? compressStream.close() }
-
-            guard let encodeStream = ArchiveStream.encodeStream(writingTo: compressStream)
-            else { throw ArchiveError.openEncodeStream }
-            defer { try? encodeStream.close() }
-
-            guard let keySet = ArchiveHeader.FieldKeySet(fieldKeys)
-            else { throw ArchiveError.invalidFieldKeySet }
-
-            try encodeStream.writeDirectoryContents(
-                archiveFrom: FilePath(directoryURL.path), keySet: keySet)
-        } catch {
-            try? FileManager.default.removeItem(at: archiveURL)
-            throw error
-        }
-    }
-
-    /// Extracts the LZFSE `.aar` at `archiveURL` into `directoryURL`, which must
-    /// already exist (the caller reserves it under the staging root).
-    ///
-    /// On any throw the destination directory is removed.
-    ///
-    /// - Throws: ``ArchiveError`` if a pipeline stream can't be opened, or any
-    ///   error AppleArchive raises while decoding/extracting.
-    public static func extract(archiveAt archiveURL: URL, to directoryURL: URL) throws {
-        do {
-            guard
-                let readStream = ArchiveByteStream.fileStream(
-                    path: FilePath(archiveURL.path),
-                    mode: .readOnly,
-                    options: [],
-                    permissions: FilePermissions(rawValue: 0o644))
-            else { throw ArchiveError.openReadStream }
-            defer { try? readStream.close() }
-
-            guard
-                let decompressStream = ArchiveByteStream.decompressionStream(
-                    readingFrom: readStream)
-            else { throw ArchiveError.openDecompressionStream }
-            defer { try? decompressStream.close() }
-
-            guard let decodeStream = ArchiveStream.decodeStream(readingFrom: decompressStream)
-            else { throw ArchiveError.openDecodeStream }
-            defer { try? decodeStream.close() }
-
-            guard
-                let extractStream = ArchiveStream.extractStream(
-                    extractingTo: FilePath(directoryURL.path))
-            else { throw ArchiveError.openExtractStream }
-            defer { try? extractStream.close() }
-
-            _ = try ArchiveStream.process(readingFrom: decodeStream, writingTo: extractStream)
-        } catch {
-            try? FileManager.default.removeItem(at: directoryURL)
-            throw error
-        }
-    }
+    static let fieldKeys = "TYP,PAT,LNK,DEV,DAT,UID,GID,MOD,FLG,MTM,CTM,SH2"
 }
 
 extension ClipboardDirectoryArchive {
@@ -127,9 +44,10 @@ extension ClipboardDirectoryArchive {
 
     /// A stat-walk size estimate (sum of regular-file sizes) for a source folder.
     ///
-    /// The directory rep's offer `byte_count`, which the receiver's paste cap
-    /// and free-space preflight gate on. The request-time archive carries its
-    /// exact size in its own `ClipboardStreamBegin`.
+    /// The directory rep's offer `byte_count`, which the receiver's paste cap and
+    /// free-space preflight gate on. It describes the *uncompressed* tree — what
+    /// a streamed extract actually writes — while the compressed archive's size is
+    /// unknown until the last byte has been encoded.
     public static func estimatedByteCount(at root: URL) -> Int {
         guard
             let enumerator = FileManager.default.enumerator(
@@ -147,52 +65,5 @@ extension ClipboardDirectoryArchive {
             }
         }
         return total
-    }
-
-    /// Archives the directory at `directoryURL` into a single `.aar` staged under
-    /// `staging`/`generation` and returns a file representation describing it, or
-    /// `nil` if the archive has no readable size.
-    ///
-    /// The folder name (not the `.aar`) rides in `filename`, the UTI is
-    /// `directoryUTI`, and `isDirectory` is set, so the receiver extracts it back
-    /// into a real folder.
-    public static func archivedRepresentation(
-        ofDirectoryAt directoryURL: URL, named folderName: String,
-        into staging: ClipboardFileStaging, generation: UInt64
-    ) throws -> ClipboardContent.Representation? {
-        let archiveURL = try staging.reserveURL(
-            generation: generation, filename: folderName + ".aar")
-        try archive(directoryAt: directoryURL, to: archiveURL)
-        guard
-            let size = try? archiveURL.resourceValues(forKeys: [.fileSizeKey]).fileSize, size > 0
-        else { return nil }
-        return ClipboardContent.Representation(
-            uti: directoryUTI, fileURL: archiveURL, byteCount: size, filename: folderName,
-            isDirectory: true)
-    }
-
-    /// Extracts a directory representation's staged `.aar` into a real folder
-    /// under `staging`/`generation`, returning the folder URL, or `nil` if the
-    /// rep isn't a directory, its archive URL is missing, the volume lacks room,
-    /// or extraction fails.
-    ///
-    /// The free-space check is a best-effort **floor**: `representation.byteCount`
-    /// is the LZFSE-compressed archive size, while extraction writes the larger
-    /// uncompressed tree, so a volume that passes it can still fill mid-extract.
-    public static func extractedDirectoryURL(
-        for representation: ClipboardContent.Representation,
-        into staging: ClipboardFileStaging, generation: UInt64
-    ) -> URL? {
-        guard representation.isDirectory, let archiveURL = representation.fileURL,
-            staging.hasCapacity(forByteCount: representation.byteCount),
-            let directory = try? staging.reserveDirectory(
-                generation: generation, name: representation.filename)
-        else { return nil }
-        do {
-            try extract(archiveAt: archiveURL, to: directory)
-            return directory
-        } catch {
-            return nil
-        }
     }
 }

--- a/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
@@ -654,7 +654,7 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
         // Remember a refusal on the way out: the archive will rewrap it, and the
         // caller needs to know the volume filled or the tree outgrew its offer,
         // not merely that the extract failed.
-        var guarded: (@Sendable (Int) throws -> Void)?
+        let guarded: (@Sendable (Int) throws -> Void)?
         if let onOutputAdvanced {
             guarded = { total in
                 do {
@@ -664,6 +664,8 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
                     throw error
                 }
             }
+        } else {
+            guarded = nil
         }
         let queue = DispatchQueue(
             label: "app.kernova.clipboard.archive-extract.\(label)", qos: .userInitiated)

--- a/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
@@ -1,0 +1,557 @@
+import AppleArchive
+import Foundation
+import System
+
+/// Why a streamed directory archive stopped.
+public enum ClipboardArchiveStreamError: Error, Equatable {
+    /// A seek or random-access operation on a purely sequential stream.
+    ///
+    /// AppleArchive drives both pipelines here with sequential reads and writes
+    /// only; anything else means the codec wants a seekable stream, which the
+    /// chunk transport cannot be.
+    case unsupportedOperation
+    /// Bytes were offered after the stream had already ended.
+    case streamClosed
+    /// The transfer was torn down — superseded, aborted, or the channel closed.
+    case cancelled
+}
+
+// MARK: - Byte pipe
+
+/// A bounded, blocking byte pipe between an AppleArchive stream callback and the
+/// chunk transport.
+///
+/// One side appends bytes and parks while at least `capacity` of them are still
+/// undelivered; the other drains them and parks while it is empty. That parking
+/// *is* the flow control: on the sending side the encoder runs no further ahead
+/// than the credit window allows, and on the receiving side an ack is only sent
+/// once the extract pipeline has taken the bytes.
+///
+/// Either side ends the pipe — `finish()` for a clean end of stream, `fail(_:)`
+/// to abandon it — and both endings wake the other side at once, which is what
+/// lets an abort unwind an archive pipeline parked in a callback that has no
+/// timeout of its own.
+///
+/// `@unchecked Sendable`: every field is guarded by `condition`.
+final class ClipboardArchiveBytePipe: @unchecked Sendable {
+    private let condition = NSCondition()
+    private let capacity: Int
+
+    private var chunks: [Data] = []
+    /// Bytes of `chunks.first` already handed out.
+    private var headOffset = 0
+    private var pendingBytes = 0
+    private var finished = false
+    private var failure: Error?
+
+    /// - Parameter capacity: how many undelivered bytes park the writer. A single
+    ///   write larger than this still goes through whole — parking a writer whose
+    ///   buffer can never fit would deadlock the pipeline — so the peak held is
+    ///   `capacity` plus one callback's buffer.
+    init(capacity: Int) {
+        self.capacity = max(1, capacity)
+    }
+
+    /// Appends `data`, parking while the pipe is at capacity.
+    ///
+    /// - Throws: the failure that ended the pipe, or
+    ///   ``ClipboardArchiveStreamError/streamClosed`` after `finish()`.
+    func write(_ data: Data) throws {
+        guard !data.isEmpty else { return }
+        condition.lock()
+        defer { condition.unlock() }
+        while pendingBytes >= capacity, failure == nil, !finished {
+            condition.wait()
+        }
+        if let failure { throw failure }
+        guard !finished else { throw ClipboardArchiveStreamError.streamClosed }
+        chunks.append(data)
+        pendingBytes += data.count
+        condition.broadcast()
+    }
+
+    /// Appends the bytes of a raw buffer, parking while the pipe is at capacity.
+    func write(_ buffer: UnsafeRawBufferPointer) throws {
+        guard !buffer.isEmpty else { return }
+        try write(Data(buffer))
+    }
+
+    /// Fills `buffer` with as much as is available, parking while the pipe is
+    /// empty.
+    ///
+    /// Returns 0 at end of stream.
+    ///
+    /// - Throws: the failure that ended the pipe.
+    func read(into buffer: UnsafeMutableRawBufferPointer) throws -> Int {
+        guard let base = buffer.baseAddress, !buffer.isEmpty else { return 0 }
+        condition.lock()
+        defer { condition.unlock() }
+        while pendingBytes == 0, failure == nil, !finished {
+            condition.wait()
+        }
+        if let failure { throw failure }
+        guard pendingBytes > 0 else { return 0 }
+        var copied = 0
+        while copied < buffer.count, let head = chunks.first {
+            let take = min(head.count - headOffset, buffer.count - copied)
+            head.withUnsafeBytes { raw in
+                guard let source = raw.baseAddress else { return }
+                base.advanced(by: copied).copyMemory(
+                    from: source.advanced(by: headOffset), byteCount: take)
+            }
+            copied += take
+            headOffset += take
+            if headOffset == head.count {
+                chunks.removeFirst()
+                headOffset = 0
+            }
+        }
+        pendingBytes -= copied
+        condition.broadcast()
+        return copied
+    }
+
+    /// Removes up to `count` bytes, parking while the pipe is empty.
+    ///
+    /// Returns an empty `Data` at end of stream.
+    ///
+    /// - Throws: the failure that ended the pipe.
+    func read(upTo count: Int) throws -> Data {
+        guard count > 0 else { return Data() }
+        condition.lock()
+        defer { condition.unlock() }
+        while pendingBytes == 0, failure == nil, !finished {
+            condition.wait()
+        }
+        if let failure { throw failure }
+        guard pendingBytes > 0 else { return Data() }
+        var result = Data()
+        result.reserveCapacity(min(count, pendingBytes))
+        while result.count < count, let head = chunks.first {
+            let take = min(head.count - headOffset, count - result.count)
+            let start = head.index(head.startIndex, offsetBy: headOffset)
+            result.append(head[start..<head.index(start, offsetBy: take)])
+            headOffset += take
+            if headOffset == head.count {
+                chunks.removeFirst()
+                headOffset = 0
+            }
+        }
+        pendingBytes -= result.count
+        condition.broadcast()
+        return result
+    }
+
+    /// Ends the stream cleanly: the reader drains what is left and then sees end
+    /// of stream.
+    func finish() {
+        condition.lock()
+        finished = true
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    /// Abandons the stream: both sides wake and throw `error`, and the buffered
+    /// bytes are dropped.
+    ///
+    /// The first failure wins, so a late duplicate abort is harmless.
+    func fail(_ error: Error) {
+        condition.lock()
+        if failure == nil { failure = error }
+        finished = true
+        chunks.removeAll()
+        headOffset = 0
+        pendingBytes = 0
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    /// The failure that ended the pipe, if any.
+    var failureError: Error? {
+        condition.lock()
+        defer { condition.unlock() }
+        return failure
+    }
+}
+
+// MARK: - AppleArchive stream adapters
+
+/// Write-only sequential `ArchiveByteStreamProtocol` handing every encoded byte
+/// to a ``ClipboardArchiveBytePipe``.
+///
+/// `write` accepts the **whole** buffer before returning `buffer.count`:
+/// AppleArchive never re-offers a tail a short write left behind, so a partial
+/// accept silently truncates the archive. The pipe's write is all-or-nothing,
+/// which is what makes that hold.
+///
+/// `close()` deliberately does **not** end the pipe. AppleArchive surfaces an
+/// encode failure only from the stream closes, so end of stream has to be
+/// declared by the driver *after* every close has been checked — otherwise the
+/// reader can see a clean end of stream for an archive whose final flush failed.
+final class ClipboardArchivePipeSink: ArchiveByteStreamProtocol, @unchecked Sendable {
+    private let pipe: ClipboardArchiveBytePipe
+
+    init(pipe: ClipboardArchiveBytePipe) {
+        self.pipe = pipe
+    }
+
+    func write(from buffer: UnsafeRawBufferPointer) throws -> Int {
+        try pipe.write(buffer)
+        return buffer.count
+    }
+
+    func close() throws {}
+
+    func cancel() {
+        pipe.fail(ClipboardArchiveStreamError.cancelled)
+    }
+
+    func read(into buffer: UnsafeMutableRawBufferPointer) throws -> Int {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+
+    func read(into buffer: UnsafeMutableRawBufferPointer, atOffset offset: Int64) throws -> Int {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+
+    func write(from buffer: UnsafeRawBufferPointer, atOffset offset: Int64) throws -> Int {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+
+    func seek(toOffset offset: Int64, relativeTo origin: FileDescriptor.SeekOrigin) throws -> Int64 {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+}
+
+/// Read-only sequential `ArchiveByteStreamProtocol` pulling archive bytes out of
+/// a ``ClipboardArchiveBytePipe``.
+///
+/// `close()` is a no-op for the same reason as the sink's: the pipe's ends are
+/// declared by the driver, not by the codec tearing its streams down.
+final class ClipboardArchivePipeSource: ArchiveByteStreamProtocol, @unchecked Sendable {
+    private let pipe: ClipboardArchiveBytePipe
+
+    init(pipe: ClipboardArchiveBytePipe) {
+        self.pipe = pipe
+    }
+
+    func read(into buffer: UnsafeMutableRawBufferPointer) throws -> Int {
+        try pipe.read(into: buffer)
+    }
+
+    func close() throws {}
+
+    func cancel() {
+        pipe.fail(ClipboardArchiveStreamError.cancelled)
+    }
+
+    func write(from buffer: UnsafeRawBufferPointer) throws -> Int {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+
+    func read(into buffer: UnsafeMutableRawBufferPointer, atOffset offset: Int64) throws -> Int {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+
+    func write(from buffer: UnsafeRawBufferPointer, atOffset offset: Int64) throws -> Int {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+
+    func seek(toOffset offset: Int64, relativeTo origin: FileDescriptor.SeekOrigin) throws -> Int64 {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+}
+
+// MARK: - Pipeline outcome
+
+/// The terminal state of one archive pipeline, published by its worker and
+/// awaited by whoever tears the transfer down.
+///
+/// `wait()` is idempotent, so a `commit()` that already collected the outcome
+/// and a later `abort()` both resolve.
+private final class ClipboardArchivePipelineOutcome: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var done = false
+    private var error: Error?
+
+    func complete(_ error: Error?) {
+        condition.lock()
+        if !done {
+            done = true
+            self.error = error
+        }
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    /// Blocks until the pipeline's worker has exited; returns its failure, if any.
+    func wait() -> Error? {
+        condition.lock()
+        defer { condition.unlock() }
+        while !done { condition.wait() }
+        return error
+    }
+}
+
+// MARK: - Producer
+
+/// Streams a source directory as LZFSE archive bytes, with no archive ever
+/// landing on disk.
+///
+/// The AppleArchive encode pipeline runs on its own queue and pushes into a
+/// bounded pipe; the caller pulls chunks off the other end with `read(upTo:)`,
+/// which parks it until bytes are available. Never drive this from the main
+/// actor: both ends park, and AppleArchive's callbacks have no timeout.
+///
+/// An empty result from `read(upTo:)` is end of archive, and is reached **only**
+/// when the whole pipeline — including every stream close, which is where
+/// AppleArchive surfaces a failed write — succeeded. Any failure surfaces as a
+/// throw instead, so a truncated archive can never be mistaken for a complete
+/// one.
+public final class ClipboardDirectoryArchiveReader: @unchecked Sendable {
+    private let pipe: ClipboardArchiveBytePipe
+    private let outcome = ClipboardArchivePipelineOutcome()
+
+    /// Starts archiving `directoryURL` immediately.
+    ///
+    /// - Parameters:
+    ///   - directoryURL: the source folder; its entries are stored relative to
+    ///     it, so the folder's own name is not embedded.
+    ///   - label: distinguishes this transfer's worker queue in a stack trace.
+    ///   - capacityBytes: how far the encoder may run ahead of the transport.
+    public init(
+        directoryURL: URL, label: String,
+        capacityBytes: Int = ClipboardStreamTuning.defaultWindowBytes
+    ) {
+        let pipe = ClipboardArchiveBytePipe(capacity: capacityBytes)
+        self.pipe = pipe
+        let outcome = self.outcome
+        let queue = DispatchQueue(
+            label: "app.kernova.clipboard.archive-encode.\(label)", qos: .userInitiated)
+        queue.async {
+            let failure = Self.encode(directoryAt: directoryURL, into: pipe)
+            // Declare the end of stream only after every close has been checked,
+            // so the reader's end of stream means "complete and flushed".
+            if let failure {
+                pipe.fail(failure)
+            } else {
+                pipe.finish()
+            }
+            outcome.complete(failure)
+        }
+    }
+
+    /// Pulls up to `count` archive bytes, parking until some are available.
+    ///
+    /// Returns an empty `Data` once the whole archive has been handed over.
+    ///
+    /// - Throws: whatever failed the encode pipeline or the transport.
+    public func read(upTo count: Int) throws -> Data {
+        try pipe.read(upTo: count)
+    }
+
+    /// Abandons the archive, unblocking the encode pipeline so its worker unwinds.
+    ///
+    /// Idempotent, and safe to call from any thread — including after the archive
+    /// has already been read to its end.
+    public func cancel() {
+        pipe.fail(ClipboardArchiveStreamError.cancelled)
+    }
+
+    /// Runs the encode pipeline, returning the failure that ended it.
+    ///
+    /// Streams close in reverse creation order, and a close failure **is** a
+    /// failed archive: AppleArchive reports a failed write from `close()` and not
+    /// from `writeDirectoryContents`, so swallowing one hands out a silently
+    /// truncated archive.
+    private static func encode(directoryAt directoryURL: URL, into pipe: ClipboardArchiveBytePipe)
+        -> Error?
+    {
+        var closeFailure: Error?
+        var failure: Error?
+        func recordClose(_ close: () throws -> Void) {
+            do {
+                try close()
+            } catch {
+                if closeFailure == nil { closeFailure = error }
+            }
+        }
+        do {
+            guard
+                let writeStream = ArchiveByteStream.customStream(
+                    instance: ClipboardArchivePipeSink(pipe: pipe))
+            else { throw ClipboardDirectoryArchive.ArchiveError.openWriteStream }
+            defer { recordClose { try writeStream.close() } }
+
+            guard
+                let compressStream = ArchiveByteStream.compressionStream(
+                    using: .lzfse, writingTo: writeStream)
+            else { throw ClipboardDirectoryArchive.ArchiveError.openCompressionStream }
+            defer { recordClose { try compressStream.close() } }
+
+            guard let encodeStream = ArchiveStream.encodeStream(writingTo: compressStream)
+            else { throw ClipboardDirectoryArchive.ArchiveError.openEncodeStream }
+            defer { recordClose { try encodeStream.close() } }
+
+            guard let keySet = ArchiveHeader.FieldKeySet(ClipboardDirectoryArchive.fieldKeys)
+            else { throw ClipboardDirectoryArchive.ArchiveError.invalidFieldKeySet }
+
+            try encodeStream.writeDirectoryContents(
+                archiveFrom: FilePath(directoryURL.path), keySet: keySet)
+        } catch {
+            failure = error
+        }
+        // The pipe's own failure outranks a pipeline that returned normally: a
+        // transport that died mid-archive can leave `writeDirectoryContents`
+        // looking successful.
+        return failure ?? closeFailure ?? pipe.failureError
+    }
+}
+
+// MARK: - Consumer
+
+/// A `StagingSink` that extracts a directory archive **as it arrives**, rather
+/// than spooling the archive and unpacking it afterwards.
+///
+/// Bytes written here feed an AppleArchive extract pipeline running on its own
+/// queue, which writes the tree straight into `destinationURL`. `write` parks
+/// while the pipeline is more than a window behind, so the receiver's ack — sent
+/// once `write` returns — follows extraction rather than arrival, and memory
+/// stays bounded however large the tree is.
+///
+/// A streamed extract has always written part of the destination tree by the time
+/// anything can be verified, so **every** failure path removes it: `commit()`
+/// deletes the tree when the pipeline failed, and `abort()` deletes it outright.
+public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendable {
+    /// The folder the tree is extracted into — the URL a paste is served.
+    public let destinationURL: URL
+
+    private let pipe: ClipboardArchiveBytePipe
+    private let outcome = ClipboardArchivePipelineOutcome()
+    private let terminalLock = NSLock()
+    private var terminal = false
+
+    /// Opens the extract pipeline, which begins consuming as soon as bytes are
+    /// written.
+    ///
+    /// - Parameters:
+    ///   - destinationURL: an existing empty directory to extract into.
+    ///   - label: distinguishes this transfer's worker queue in a stack trace.
+    ///   - capacityBytes: how far arriving bytes may run ahead of extraction.
+    public init(
+        destinationURL: URL, label: String,
+        capacityBytes: Int = ClipboardStreamTuning.defaultWindowBytes
+    ) {
+        self.destinationURL = destinationURL
+        let pipe = ClipboardArchiveBytePipe(capacity: capacityBytes)
+        self.pipe = pipe
+        let outcome = self.outcome
+        let queue = DispatchQueue(
+            label: "app.kernova.clipboard.archive-extract.\(label)", qos: .userInitiated)
+        queue.async {
+            let failure = Self.extract(from: pipe, into: destinationURL)
+            // Wake a writer parked on a pipeline that has stopped consuming,
+            // rather than let it block until the transfer's own watchdog fires.
+            pipe.fail(failure ?? ClipboardArchiveStreamError.streamClosed)
+            outcome.complete(failure)
+        }
+    }
+
+    /// Hands `data` to the extract pipeline, parking while it is a window behind.
+    ///
+    /// - Throws: whatever failed the pipeline, so the transfer aborts on the
+    ///   receiver's own write lane instead of running to completion over a tree
+    ///   that was never written.
+    public func write(_ data: Data) throws {
+        try pipe.write(data)
+    }
+
+    /// Ends the stream, waits for the pipeline to drain, and returns the
+    /// extracted folder.
+    ///
+    /// - Throws: whatever failed the pipeline — a truncated or corrupt archive, or
+    ///   the volume filling mid-extract. The partial tree is removed first.
+    @discardableResult
+    public func commit() throws -> URL {
+        guard claimTerminal() else { return destinationURL }
+        pipe.finish()
+        if let failure = outcome.wait() {
+            try? FileManager.default.removeItem(at: destinationURL)
+            throw failure
+        }
+        return destinationURL
+    }
+
+    /// Wakes a writer parked in `write(_:)` and stops the pipeline, without
+    /// waiting for it to unwind.
+    ///
+    /// Idempotent, and safe from any thread. The tree is removed by `abort()`,
+    /// which can then run on the woken lane rather than queue behind it.
+    public func cancel() {
+        pipe.fail(ClipboardArchiveStreamError.cancelled)
+    }
+
+    /// Tears the pipeline down and removes the partial tree.
+    ///
+    /// Idempotent, and a no-op once `commit()` has succeeded.
+    public func abort() {
+        guard claimTerminal() else { return }
+        pipe.fail(ClipboardArchiveStreamError.cancelled)
+        _ = outcome.wait()
+        try? FileManager.default.removeItem(at: destinationURL)
+    }
+
+    private func claimTerminal() -> Bool {
+        terminalLock.withLock {
+            if terminal { return false }
+            terminal = true
+            return true
+        }
+    }
+
+    /// Runs the extract pipeline, returning the failure that ended it.
+    ///
+    /// Same close discipline as the encode side: streams close in reverse
+    /// creation order and a close failure is a failed extract.
+    private static func extract(from pipe: ClipboardArchiveBytePipe, into destinationURL: URL)
+        -> Error?
+    {
+        var closeFailure: Error?
+        var failure: Error?
+        func recordClose(_ close: () throws -> Void) {
+            do {
+                try close()
+            } catch {
+                if closeFailure == nil { closeFailure = error }
+            }
+        }
+        do {
+            guard
+                let readStream = ArchiveByteStream.customStream(
+                    instance: ClipboardArchivePipeSource(pipe: pipe))
+            else { throw ClipboardDirectoryArchive.ArchiveError.openReadStream }
+            defer { recordClose { try readStream.close() } }
+
+            guard
+                let decompressStream = ArchiveByteStream.decompressionStream(
+                    readingFrom: readStream)
+            else { throw ClipboardDirectoryArchive.ArchiveError.openDecompressionStream }
+            defer { recordClose { try decompressStream.close() } }
+
+            guard let decodeStream = ArchiveStream.decodeStream(readingFrom: decompressStream)
+            else { throw ClipboardDirectoryArchive.ArchiveError.openDecodeStream }
+            defer { recordClose { try decodeStream.close() } }
+
+            guard
+                let extractStream = ArchiveStream.extractStream(
+                    extractingTo: FilePath(destinationURL.path))
+            else { throw ClipboardDirectoryArchive.ArchiveError.openExtractStream }
+            defer { recordClose { try extractStream.close() } }
+
+            _ = try ArchiveStream.process(readingFrom: decodeStream, writingTo: extractStream)
+        } catch {
+            failure = error
+        }
+        return failure ?? closeFailure
+    }
+}

--- a/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
@@ -2,6 +2,14 @@ import AppleArchive
 import Foundation
 import System
 
+/// Why an extract was stopped by the consumer rather than by the archive.
+public enum ClipboardArchiveOutputRefusal: Equatable, Sendable {
+    /// The staging volume no longer has room for the tree being written.
+    case diskFull
+    /// The tree outgrew the size the offer advertised for it.
+    case overAdvertisedSize
+}
+
 /// Why a streamed directory archive stopped.
 public enum ClipboardArchiveStreamError: Error, Equatable {
     /// A seek or random-access operation on a purely sequential stream.
@@ -14,6 +22,9 @@ public enum ClipboardArchiveStreamError: Error, Equatable {
     case streamClosed
     /// The transfer was torn down — superseded, aborted, or the channel closed.
     case cancelled
+    /// The consumer stopped the extract: what it was about to write is more than
+    /// it agreed to take.
+    case outputRefused(ClipboardArchiveOutputRefusal)
 }
 
 // MARK: - Byte pipe
@@ -83,32 +94,13 @@ final class ClipboardArchiveBytePipe: @unchecked Sendable {
     ///
     /// - Throws: the failure that ended the pipe.
     func read(into buffer: UnsafeMutableRawBufferPointer) throws -> Int {
-        guard let base = buffer.baseAddress, !buffer.isEmpty else { return 0 }
-        condition.lock()
-        defer { condition.unlock() }
-        while pendingBytes == 0, failure == nil, !finished {
-            condition.wait()
-        }
-        if let failure { throw failure }
-        guard pendingBytes > 0 else { return 0 }
+        guard let destination = buffer.baseAddress else { return 0 }
         var copied = 0
-        while copied < buffer.count, let head = chunks.first {
-            let take = min(head.count - headOffset, buffer.count - copied)
-            head.withUnsafeBytes { raw in
-                guard let source = raw.baseAddress else { return }
-                base.advanced(by: copied).copyMemory(
-                    from: source.advanced(by: headOffset), byteCount: take)
-            }
-            copied += take
-            headOffset += take
-            if headOffset == head.count {
-                chunks.removeFirst()
-                headOffset = 0
-            }
+        return try drain(upTo: buffer.count) { run in
+            guard let source = run.baseAddress else { return }
+            destination.advanced(by: copied).copyMemory(from: source, byteCount: run.count)
+            copied += run.count
         }
-        pendingBytes -= copied
-        condition.broadcast()
-        return copied
     }
 
     /// Removes up to `count` bytes, parking while the pipe is empty.
@@ -117,29 +109,51 @@ final class ClipboardArchiveBytePipe: @unchecked Sendable {
     ///
     /// - Throws: the failure that ended the pipe.
     func read(upTo count: Int) throws -> Data {
-        guard count > 0 else { return Data() }
+        var result = Data()
+        result.reserveCapacity(count)
+        _ = try drain(upTo: count) { run in
+            guard let source = run.baseAddress else { return }
+            result.append(source.assumingMemoryBound(to: UInt8.self), count: run.count)
+        }
+        return result
+    }
+
+    /// Hands each contiguous run of up to `count` buffered bytes to `consume`,
+    /// parking while the pipe is empty.
+    ///
+    /// The one place the chunk-consumption arithmetic lives: an off-by-one here
+    /// silently corrupts archive bytes, so both readers share it and differ only
+    /// in where they put the run.
+    ///
+    /// - Returns: bytes drained; 0 means end of stream.
+    private func drain(upTo count: Int, into consume: (UnsafeRawBufferPointer) -> Void) throws
+        -> Int
+    {
+        guard count > 0 else { return 0 }
         condition.lock()
         defer { condition.unlock() }
         while pendingBytes == 0, failure == nil, !finished {
             condition.wait()
         }
         if let failure { throw failure }
-        guard pendingBytes > 0 else { return Data() }
-        var result = Data()
-        result.reserveCapacity(min(count, pendingBytes))
-        while result.count < count, let head = chunks.first {
-            let take = min(head.count - headOffset, count - result.count)
-            let start = head.index(head.startIndex, offsetBy: headOffset)
-            result.append(head[start..<head.index(start, offsetBy: take)])
+        guard pendingBytes > 0 else { return 0 }
+        var drained = 0
+        while drained < count, let head = chunks.first {
+            let take = min(head.count - headOffset, count - drained)
+            head.withUnsafeBytes { raw in
+                guard let base = raw.baseAddress else { return }
+                consume(UnsafeRawBufferPointer(start: base.advanced(by: headOffset), count: take))
+            }
+            drained += take
             headOffset += take
             if headOffset == head.count {
                 chunks.removeFirst()
                 headOffset = 0
             }
         }
-        pendingBytes -= result.count
+        pendingBytes -= drained
         condition.broadcast()
-        return result
+        return drained
     }
 
     /// Ends the stream cleanly: the reader drains what is left and then sees end
@@ -176,20 +190,57 @@ final class ClipboardArchiveBytePipe: @unchecked Sendable {
 
 // MARK: - AppleArchive stream adapters
 
-/// Write-only sequential `ArchiveByteStreamProtocol` handing every encoded byte
-/// to a ``ClipboardArchiveBytePipe``.
+/// An AppleArchive stream that moves bytes in one direction only.
 ///
-/// `write` accepts the **whole** buffer before returning `buffer.count`:
-/// AppleArchive never re-offers a tail a short write left behind, so a partial
-/// accept silently truncates the archive. The pipe's write is all-or-nothing,
-/// which is what makes that hold.
+/// The defaults below are what keep each adapter to the single method it really
+/// implements; everything else is a hard error, because a codec asking a chunk
+/// transport to seek cannot be served.
 ///
 /// `close()` deliberately does **not** end the pipe. AppleArchive surfaces an
 /// encode failure only from the stream closes, so end of stream has to be
 /// declared by the driver *after* every close has been checked — otherwise the
 /// reader can see a clean end of stream for an archive whose final flush failed.
-final class ClipboardArchivePipeSink: ArchiveByteStreamProtocol, @unchecked Sendable {
-    private let pipe: ClipboardArchiveBytePipe
+protocol ClipboardSequentialArchiveStream: ArchiveByteStreamProtocol, AnyObject {
+    /// The pipe this adapter reads from or writes to.
+    var pipe: ClipboardArchiveBytePipe { get }
+}
+
+extension ClipboardSequentialArchiveStream {
+    func read(into buffer: UnsafeMutableRawBufferPointer) throws -> Int {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+
+    func write(from buffer: UnsafeRawBufferPointer) throws -> Int {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+
+    func read(into buffer: UnsafeMutableRawBufferPointer, atOffset offset: Int64) throws -> Int {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+
+    func write(from buffer: UnsafeRawBufferPointer, atOffset offset: Int64) throws -> Int {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+
+    func seek(toOffset offset: Int64, relativeTo origin: FileDescriptor.SeekOrigin) throws -> Int64 {
+        throw ClipboardArchiveStreamError.unsupportedOperation
+    }
+
+    func close() throws {}
+
+    func cancel() {
+        pipe.fail(ClipboardArchiveStreamError.cancelled)
+    }
+}
+
+/// Write-only adapter handing every encoded byte to the pipe.
+///
+/// `write` accepts the **whole** buffer before returning `buffer.count`:
+/// AppleArchive never re-offers a tail a short write left behind, so a partial
+/// accept silently truncates the archive. The pipe's write is all-or-nothing,
+/// which is what makes that hold.
+final class ClipboardArchivePipeSink: ClipboardSequentialArchiveStream, @unchecked Sendable {
+    let pipe: ClipboardArchiveBytePipe
 
     init(pipe: ClipboardArchiveBytePipe) {
         self.pipe = pipe
@@ -199,37 +250,11 @@ final class ClipboardArchivePipeSink: ArchiveByteStreamProtocol, @unchecked Send
         try pipe.write(buffer)
         return buffer.count
     }
-
-    func close() throws {}
-
-    func cancel() {
-        pipe.fail(ClipboardArchiveStreamError.cancelled)
-    }
-
-    func read(into buffer: UnsafeMutableRawBufferPointer) throws -> Int {
-        throw ClipboardArchiveStreamError.unsupportedOperation
-    }
-
-    func read(into buffer: UnsafeMutableRawBufferPointer, atOffset offset: Int64) throws -> Int {
-        throw ClipboardArchiveStreamError.unsupportedOperation
-    }
-
-    func write(from buffer: UnsafeRawBufferPointer, atOffset offset: Int64) throws -> Int {
-        throw ClipboardArchiveStreamError.unsupportedOperation
-    }
-
-    func seek(toOffset offset: Int64, relativeTo origin: FileDescriptor.SeekOrigin) throws -> Int64 {
-        throw ClipboardArchiveStreamError.unsupportedOperation
-    }
 }
 
-/// Read-only sequential `ArchiveByteStreamProtocol` pulling archive bytes out of
-/// a ``ClipboardArchiveBytePipe``.
-///
-/// `close()` is a no-op for the same reason as the sink's: the pipe's ends are
-/// declared by the driver, not by the codec tearing its streams down.
-final class ClipboardArchivePipeSource: ArchiveByteStreamProtocol, @unchecked Sendable {
-    private let pipe: ClipboardArchiveBytePipe
+/// Read-only adapter pulling archive bytes out of the pipe.
+final class ClipboardArchivePipeSource: ClipboardSequentialArchiveStream, @unchecked Sendable {
+    let pipe: ClipboardArchiveBytePipe
 
     init(pipe: ClipboardArchiveBytePipe) {
         self.pipe = pipe
@@ -238,31 +263,137 @@ final class ClipboardArchivePipeSource: ArchiveByteStreamProtocol, @unchecked Se
     func read(into buffer: UnsafeMutableRawBufferPointer) throws -> Int {
         try pipe.read(into: buffer)
     }
+}
 
-    func close() throws {}
+/// A transparent stage that forwards to `upstream` and counts the bytes crossing
+/// it.
+///
+/// Interposed between the encode/decode stage and the compression stage, so what
+/// it counts is **uncompressed** archive bytes — the unit the offer's stat-walk
+/// estimate, the paste ceiling and the free-space guard are all expressed in.
+/// Compressed wire bytes answer none of those questions: LZFSE reaches ~100:1 on
+/// text, so a guard paced by them admits ~100× the tree it thinks it does.
+///
+/// Every operation forwards, including the random-access ones: staying
+/// transparent means an unexpected seek from the codec still works and only
+/// makes the count approximate, instead of failing a transfer.
+final class ClipboardArchiveCountingStream: ArchiveByteStreamProtocol, @unchecked Sendable {
+    private let upstream: ArchiveByteStream
+    /// Called once the running total has advanced by at least `pacingBytes`.
+    ///
+    /// Throwing from it stops the pipeline.
+    private let onAdvance: ((Int) throws -> Void)?
+    private let pacingBytes: Int
 
-    func cancel() {
-        pipe.fail(ClipboardArchiveStreamError.cancelled)
+    private let lock = NSLock()
+    private var total = 0
+    private var reportedAt = 0
+
+    /// Total bytes forwarded so far.
+    var byteCount: Int { lock.withLock { total } }
+
+    init(
+        upstream: ArchiveByteStream, pacingBytes: Int = 1 << 20,
+        onAdvance: ((Int) throws -> Void)? = nil
+    ) {
+        self.upstream = upstream
+        self.pacingBytes = max(1, pacingBytes)
+        self.onAdvance = onAdvance
+    }
+
+    private func advance(_ count: Int) throws {
+        let due: Int? = lock.withLock {
+            total += count
+            guard total - reportedAt >= pacingBytes else { return nil }
+            reportedAt = total
+            return total
+        }
+        if let due { try onAdvance?(due) }
+    }
+
+    func read(into buffer: UnsafeMutableRawBufferPointer) throws -> Int {
+        let count = try upstream.read(into: buffer)
+        try advance(count)
+        return count
     }
 
     func write(from buffer: UnsafeRawBufferPointer) throws -> Int {
-        throw ClipboardArchiveStreamError.unsupportedOperation
+        // Forward the whole buffer: a short write here would truncate the archive
+        // exactly as one to the pipe would.
+        var written = 0
+        while written < buffer.count {
+            let slice = UnsafeRawBufferPointer(rebasing: buffer[written...])
+            let count = try upstream.write(from: slice)
+            guard count > 0 else { throw ClipboardArchiveStreamError.streamClosed }
+            written += count
+        }
+        try advance(written)
+        return written
     }
 
     func read(into buffer: UnsafeMutableRawBufferPointer, atOffset offset: Int64) throws -> Int {
-        throw ClipboardArchiveStreamError.unsupportedOperation
+        try upstream.read(into: buffer, atOffset: offset)
     }
 
     func write(from buffer: UnsafeRawBufferPointer, atOffset offset: Int64) throws -> Int {
-        throw ClipboardArchiveStreamError.unsupportedOperation
+        try upstream.write(from: buffer, atOffset: offset)
     }
 
     func seek(toOffset offset: Int64, relativeTo origin: FileDescriptor.SeekOrigin) throws -> Int64 {
-        throw ClipboardArchiveStreamError.unsupportedOperation
+        try upstream.seek(toOffset: offset, relativeTo: origin)
+    }
+
+    func cancel() { upstream.cancel() }
+
+    /// A no-op for the same reason the pipe adapters' is: the driver owns when
+    /// the stack is torn down and in what order.
+    func close() throws {}
+}
+
+// MARK: - Pipeline scaffolding
+
+/// A lock-guarded counter shared between an archive pipeline's worker thread and
+/// whoever reads its progress.
+private final class ArchiveByteCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored = 0
+    var value: Int {
+        get { lock.withLock { stored } }
+        set { lock.withLock { stored = newValue } }
     }
 }
 
-// MARK: - Pipeline outcome
+/// The consumer's own reason for stopping a pipeline, kept apart from whatever
+/// the archive reports.
+///
+/// AppleArchive wraps an error thrown out of a stream callback in one of its
+/// own, so the reason the *consumer* refused would otherwise reach the caller as
+/// a generic archive failure — and a refusal has to be reported as what it is.
+private final class ArchiveRefusalBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Error?
+    var value: Error? {
+        get { lock.withLock { stored } }
+        set { lock.withLock { if stored == nil { stored = newValue } } }
+    }
+}
+
+/// Collects the first failure raised while closing a stack of archive streams.
+///
+/// A close failure **is** a failed archive: AppleArchive reports a failed write
+/// from `close()` and not from the write call, so swallowing one hands out a
+/// silently truncated archive.
+private struct ArchiveCloseTracker {
+    private(set) var failure: Error?
+
+    mutating func close(_ body: () throws -> Void) {
+        do {
+            try body()
+        } catch {
+            if failure == nil { failure = error }
+        }
+    }
+}
 
 /// The terminal state of one archive pipeline, published by its worker and
 /// awaited by whoever tears the transfer down.
@@ -311,6 +442,15 @@ private final class ClipboardArchivePipelineOutcome: @unchecked Sendable {
 public final class ClipboardDirectoryArchiveReader: @unchecked Sendable {
     private let pipe: ClipboardArchiveBytePipe
     private let outcome = ClipboardArchivePipelineOutcome()
+    /// Counts uncompressed archive bytes, so a caller reporting progress has a
+    /// figure in the same unit as the offer's stat-walk estimate.
+    private let counted = ArchiveByteCounter()
+
+    /// Uncompressed archive bytes encoded so far.
+    ///
+    /// The honest progress numerator: compressed wire bytes are in a different
+    /// unit from the estimate every readout's denominator comes from.
+    public var uncompressedByteCount: Int { counted.value }
 
     /// Starts archiving `directoryURL` immediately.
     ///
@@ -326,10 +466,11 @@ public final class ClipboardDirectoryArchiveReader: @unchecked Sendable {
         let pipe = ClipboardArchiveBytePipe(capacity: capacityBytes)
         self.pipe = pipe
         let outcome = self.outcome
+        let counted = self.counted
         let queue = DispatchQueue(
             label: "app.kernova.clipboard.archive-encode.\(label)", qos: .userInitiated)
         queue.async {
-            let failure = Self.encode(directoryAt: directoryURL, into: pipe)
+            let failure = Self.encode(directoryAt: directoryURL, into: pipe, counted: counted)
             // Declare the end of stream only after every close has been checked,
             // so the reader's end of stream means "complete and flushed".
             if let failure {
@@ -352,50 +493,51 @@ public final class ClipboardDirectoryArchiveReader: @unchecked Sendable {
 
     /// Abandons the archive, unblocking the encode pipeline so its worker unwinds.
     ///
-    /// Idempotent, and safe to call from any thread — including after the archive
-    /// has already been read to its end.
+    /// Idempotent, and safe to call from any thread — including from an abort
+    /// while another thread is parked in `read(upTo:)`, which is what makes that
+    /// park cancellable.
     public func cancel() {
         pipe.fail(ClipboardArchiveStreamError.cancelled)
     }
 
     /// Runs the encode pipeline, returning the failure that ended it.
     ///
-    /// Streams close in reverse creation order, and a close failure **is** a
-    /// failed archive: AppleArchive reports a failed write from `close()` and not
-    /// from `writeDirectoryContents`, so swallowing one hands out a silently
-    /// truncated archive.
-    ///
-    /// The `defer`s belong to the `do` block, not to this function, so every
-    /// close has already run and recorded itself by the time the result below is
-    /// computed.
-    private static func encode(directoryAt directoryURL: URL, into pipe: ClipboardArchiveBytePipe)
-        -> Error?
-    {
-        var closeFailure: Error?
+    /// Streams close in reverse creation order. The `defer`s belong to the `do`
+    /// block, not to this function, so every close has already run and recorded
+    /// itself by the time the result below is computed.
+    private static func encode(
+        directoryAt directoryURL: URL, into pipe: ClipboardArchiveBytePipe, counted: ArchiveByteCounter
+    ) -> Error? {
+        var closes = ArchiveCloseTracker()
         var failure: Error?
-        func recordClose(_ close: () throws -> Void) {
-            do {
-                try close()
-            } catch {
-                if closeFailure == nil { closeFailure = error }
-            }
-        }
         do {
             guard
                 let writeStream = ArchiveByteStream.customStream(
                     instance: ClipboardArchivePipeSink(pipe: pipe))
             else { throw ClipboardDirectoryArchive.ArchiveError.openWriteStream }
-            defer { recordClose { try writeStream.close() } }
+            defer { closes.close { try writeStream.close() } }
 
             guard
                 let compressStream = ArchiveByteStream.compressionStream(
                     using: .lzfse, writingTo: writeStream)
             else { throw ClipboardDirectoryArchive.ArchiveError.openCompressionStream }
-            defer { recordClose { try compressStream.close() } }
+            defer { closes.close { try compressStream.close() } }
 
-            guard let encodeStream = ArchiveStream.encodeStream(writingTo: compressStream)
+            // Above the compressor, so what it sees is the uncompressed archive.
+            let counter = ClipboardArchiveCountingStream(upstream: compressStream) { total in
+                counted.value = total
+            }
+            guard let countedStream = ArchiveByteStream.customStream(instance: counter) else {
+                throw ClipboardDirectoryArchive.ArchiveError.openWriteStream
+            }
+            defer {
+                closes.close { try countedStream.close() }
+                counted.value = counter.byteCount
+            }
+
+            guard let encodeStream = ArchiveStream.encodeStream(writingTo: countedStream)
             else { throw ClipboardDirectoryArchive.ArchiveError.openEncodeStream }
-            defer { recordClose { try encodeStream.close() } }
+            defer { closes.close { try encodeStream.close() } }
 
             guard let keySet = ArchiveHeader.FieldKeySet(ClipboardDirectoryArchive.fieldKeys)
             else { throw ClipboardDirectoryArchive.ArchiveError.invalidFieldKeySet }
@@ -408,7 +550,7 @@ public final class ClipboardDirectoryArchiveReader: @unchecked Sendable {
         // The pipe's own failure outranks a pipeline that returned normally: a
         // transport that died mid-archive can leave `writeDirectoryContents`
         // looking successful.
-        return failure ?? closeFailure ?? pipe.failureError
+        return failure ?? closes.failure ?? pipe.failureError
     }
 }
 
@@ -434,6 +576,18 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
     private let outcome = ClipboardArchivePipelineOutcome()
     private let terminalLock = NSLock()
     private var terminal = false
+    /// Set when this side stopped the extract, so the reason survives
+    /// AppleArchive rewrapping it.
+    private let refusal = ArchiveRefusalBox()
+    /// Uncompressed archive bytes consumed — what the extract has written, near
+    /// enough for a guard and a readout, and in the same unit as the estimate.
+    private let counted = ArchiveByteCounter()
+
+    /// Uncompressed archive bytes extracted so far.
+    public var uncompressedByteCount: Int { counted.value }
+
+    /// An extract failure names the extract, not a disk write.
+    public var writeErrorCode: String { "extract.error" }
 
     /// Opens the extract pipeline, which begins consuming as soon as bytes are
     /// written.
@@ -442,18 +596,43 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
     ///   - destinationURL: an existing empty directory to extract into.
     ///   - label: distinguishes this transfer's worker queue in a stack trace.
     ///   - capacityBytes: how far arriving bytes may run ahead of extraction.
+    ///   - pacingBytes: how much output accumulates between `onOutputAdvanced`
+    ///     calls.
+    ///   - onOutputAdvanced: consulted with the running uncompressed total;
+    ///     throwing from it stops the extract and removes the tree. Runs on the
+    ///     pipeline's own thread, so it must not touch a lane's state.
     public init(
         destinationURL: URL, label: String,
-        capacityBytes: Int = ClipboardStreamTuning.defaultWindowBytes
+        capacityBytes: Int = ClipboardStreamTuning.defaultWindowBytes,
+        pacingBytes: Int = ClipboardStreamTuning.defaultWindowBytes,
+        onOutputAdvanced: (@Sendable (Int) throws -> Void)? = nil
     ) {
         self.destinationURL = destinationURL
         let pipe = ClipboardArchiveBytePipe(capacity: capacityBytes)
         self.pipe = pipe
         let outcome = self.outcome
+        let counted = self.counted
+        let refusal = self.refusal
+        // Remember a refusal on the way out: the archive will rewrap it, and the
+        // caller needs to know the volume filled or the tree outgrew its offer,
+        // not merely that the extract failed.
+        var guarded: (@Sendable (Int) throws -> Void)?
+        if let onOutputAdvanced {
+            guarded = { total in
+                do {
+                    try onOutputAdvanced(total)
+                } catch {
+                    refusal.value = error
+                    throw error
+                }
+            }
+        }
         let queue = DispatchQueue(
             label: "app.kernova.clipboard.archive-extract.\(label)", qos: .userInitiated)
         queue.async {
-            let failure = Self.extract(from: pipe, into: destinationURL)
+            let failure = Self.extract(
+                from: pipe, into: destinationURL, counted: counted, pacingBytes: pacingBytes,
+                onOutputAdvanced: guarded)
             // Wake a writer parked on a pipeline that has stopped consuming,
             // rather than let it block until the transfer's own watchdog fires.
             pipe.fail(failure ?? ClipboardArchiveStreamError.streamClosed)
@@ -467,7 +646,11 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
     ///   receiver's own write lane instead of running to completion over a tree
     ///   that was never written.
     public func write(_ data: Data) throws {
-        try pipe.write(data)
+        do {
+            try pipe.write(data)
+        } catch {
+            throw refusal.value ?? error
+        }
     }
 
     /// Ends the stream, waits for the pipeline to drain, and returns the
@@ -481,7 +664,7 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
         pipe.finish()
         if let failure = outcome.wait() {
             try? FileManager.default.removeItem(at: destinationURL)
-            throw failure
+            throw refusal.value ?? failure
         }
         return destinationURL
     }
@@ -518,45 +701,55 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
     /// Same close discipline, and same scoping, as the encode side: streams close
     /// in reverse creation order when the `do` block exits, so a close failure is
     /// recorded before the result below is computed.
-    private static func extract(from pipe: ClipboardArchiveBytePipe, into destinationURL: URL)
-        -> Error?
-    {
-        var closeFailure: Error?
+    private static func extract(
+        from pipe: ClipboardArchiveBytePipe, into destinationURL: URL, counted: ArchiveByteCounter,
+        pacingBytes: Int, onOutputAdvanced: (@Sendable (Int) throws -> Void)?
+    ) -> Error? {
+        var closes = ArchiveCloseTracker()
         var failure: Error?
-        func recordClose(_ close: () throws -> Void) {
-            do {
-                try close()
-            } catch {
-                if closeFailure == nil { closeFailure = error }
-            }
-        }
         do {
             guard
                 let readStream = ArchiveByteStream.customStream(
                     instance: ClipboardArchivePipeSource(pipe: pipe))
             else { throw ClipboardDirectoryArchive.ArchiveError.openReadStream }
-            defer { recordClose { try readStream.close() } }
+            defer { closes.close { try readStream.close() } }
 
             guard
                 let decompressStream = ArchiveByteStream.decompressionStream(
                     readingFrom: readStream)
             else { throw ClipboardDirectoryArchive.ArchiveError.openDecompressionStream }
-            defer { recordClose { try decompressStream.close() } }
+            defer { closes.close { try decompressStream.close() } }
 
-            guard let decodeStream = ArchiveStream.decodeStream(readingFrom: decompressStream)
+            // Below the decompressor, so what it sees — and what the guard is
+            // paced by — is the uncompressed tree about to be written.
+            let counter = ClipboardArchiveCountingStream(
+                upstream: decompressStream, pacingBytes: pacingBytes
+            ) { total in
+                counted.value = total
+                try onOutputAdvanced?(total)
+            }
+            guard let countedStream = ArchiveByteStream.customStream(instance: counter) else {
+                throw ClipboardDirectoryArchive.ArchiveError.openReadStream
+            }
+            defer {
+                closes.close { try countedStream.close() }
+                counted.value = counter.byteCount
+            }
+
+            guard let decodeStream = ArchiveStream.decodeStream(readingFrom: countedStream)
             else { throw ClipboardDirectoryArchive.ArchiveError.openDecodeStream }
-            defer { recordClose { try decodeStream.close() } }
+            defer { closes.close { try decodeStream.close() } }
 
             guard
                 let extractStream = ArchiveStream.extractStream(
                     extractingTo: FilePath(destinationURL.path))
             else { throw ClipboardDirectoryArchive.ArchiveError.openExtractStream }
-            defer { recordClose { try extractStream.close() } }
+            defer { closes.close { try extractStream.close() } }
 
             _ = try ArchiveStream.process(readingFrom: decodeStream, writingTo: extractStream)
         } catch {
             failure = error
         }
-        return failure ?? closeFailure
+        return failure ?? closes.failure
     }
 }

--- a/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
@@ -38,10 +38,12 @@ public enum ClipboardArchiveStreamError: Error, Equatable {
 /// than the credit window allows, and on the receiving side an ack is only sent
 /// once the extract pipeline has taken the bytes.
 ///
-/// Either side ends the pipe — `finish()` for a clean end of stream, `fail(_:)`
-/// to abandon it — and both endings wake the other side at once, which is what
-/// lets an abort unwind an archive pipeline parked in a callback that has no
-/// timeout of its own.
+/// Three endings wake the other side at once, which is what lets an abort unwind
+/// an archive pipeline parked in a callback that has no timeout of its own:
+/// `finish()` declares a clean end of stream from the writing side, `fail(_:)`
+/// abandons the pipe, and `complete()` reports that the reading side has finished
+/// its work — after which further writes are accepted and dropped rather than
+/// refused, since there is no longer anything they could break.
 ///
 /// `@unchecked Sendable`: every field is guarded by `condition`.
 final class ClipboardArchiveBytePipe: @unchecked Sendable {
@@ -53,6 +55,11 @@ final class ClipboardArchiveBytePipe: @unchecked Sendable {
     private var headOffset = 0
     private var pendingBytes = 0
     private var finished = false
+    /// Whether the reader finished its work successfully, so a later write has
+    /// nothing left to feed.
+    ///
+    /// Implies `finished`.
+    private var completed = false
     private var failure: Error?
 
     /// - Parameter capacity: how many undelivered bytes park the writer. A single
@@ -65,6 +72,8 @@ final class ClipboardArchiveBytePipe: @unchecked Sendable {
 
     /// Appends `data`, parking while the pipe is at capacity.
     ///
+    /// Accepted and discarded once `complete()` has been called.
+    ///
     /// - Throws: the failure that ended the pipe, or
     ///   ``ClipboardArchiveStreamError/streamClosed`` after `finish()`.
     func write(_ data: Data) throws {
@@ -75,6 +84,7 @@ final class ClipboardArchiveBytePipe: @unchecked Sendable {
             condition.wait()
         }
         if let failure { throw failure }
+        guard !completed else { return }
         guard !finished else { throw ClipboardArchiveStreamError.streamClosed }
         chunks.append(data)
         pendingBytes += data.count
@@ -161,6 +171,23 @@ final class ClipboardArchiveBytePipe: @unchecked Sendable {
     func finish() {
         condition.lock()
         finished = true
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    /// Ends the stream from the *reading* side, which has finished successfully:
+    /// a parked writer wakes, and every write from here on is accepted and
+    /// dropped instead of refused.
+    ///
+    /// Distinct from `fail(_:)`, which reports that the pipeline gave up and so
+    /// must keep refusing writes.
+    func complete() {
+        condition.lock()
+        completed = true
+        finished = true
+        chunks.removeAll()
+        headOffset = 0
+        pendingBytes = 0
         condition.broadcast()
         condition.unlock()
     }
@@ -524,7 +551,12 @@ public final class ClipboardDirectoryArchiveReader: @unchecked Sendable {
             defer { closes.close { try compressStream.close() } }
 
             // Above the compressor, so what it sees is the uncompressed archive.
-            let counter = ClipboardArchiveCountingStream(upstream: compressStream) { total in
+            // Unpaced, because the closure is a store and the count is read as a
+            // live figure — the sender's ceiling is enforced against it, and a
+            // paced snapshot would sit a whole quantum of tree behind.
+            let counter = ClipboardArchiveCountingStream(
+                upstream: compressStream, pacingBytes: 1
+            ) { total in
                 counted.value = total
             }
             guard let countedStream = ArchiveByteStream.customStream(instance: counter) else {
@@ -572,10 +604,16 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
     /// The folder the tree is extracted into — the URL a paste is served.
     public let destinationURL: URL
 
+    /// Which of the two mutually exclusive endings a caller claimed.
+    private enum Terminal {
+        case committed
+        case aborted
+    }
+
     private let pipe: ClipboardArchiveBytePipe
     private let outcome = ClipboardArchivePipelineOutcome()
     private let terminalLock = NSLock()
-    private var terminal = false
+    private var terminal: Terminal?
     /// Set when this side stopped the extract, so the reason survives
     /// AppleArchive rewrapping it.
     private let refusal = ArchiveRefusalBox()
@@ -633,14 +671,26 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
             let failure = Self.extract(
                 from: pipe, into: destinationURL, counted: counted, pacingBytes: pacingBytes,
                 onOutputAdvanced: guarded)
-            // Wake a writer parked on a pipeline that has stopped consuming,
-            // rather than let it block until the transfer's own watchdog fires.
-            pipe.fail(failure ?? ClipboardArchiveStreamError.streamClosed)
+            // Both endings wake a writer parked on a pipeline that has stopped
+            // consuming, and differ in what a *later* write means: after a
+            // failure it must be refused, but after a complete extract the
+            // archive is already unpacked, so trailing bytes are dropped rather
+            // than made to fail a good transfer. Dropping them loses no integrity
+            // check — the receiver takes the digest over what arrives on the
+            // wire, outside this sink.
+            if let failure {
+                pipe.fail(failure)
+            } else {
+                pipe.complete()
+            }
             outcome.complete(failure)
         }
     }
 
     /// Hands `data` to the extract pipeline, parking while it is a window behind.
+    ///
+    /// Bytes offered after the pipeline has unpacked the whole archive are
+    /// accepted and dropped, not refused.
     ///
     /// - Throws: whatever failed the pipeline, so the transfer aborts on the
     ///   receiver's own write lane instead of running to completion over a tree
@@ -656,11 +706,22 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
     /// Ends the stream, waits for the pipeline to drain, and returns the
     /// extracted folder.
     ///
+    /// Idempotent: a repeat commit reports the same outcome the first one did.
+    ///
     /// - Throws: whatever failed the pipeline — a truncated or corrupt archive, or
     ///   the volume filling mid-extract. The partial tree is removed first.
+    ///   ``ClipboardArchiveStreamError/cancelled`` when `abort()` got there
+    ///   first, since the folder this would otherwise name has been deleted.
     @discardableResult
     public func commit() throws -> URL {
-        guard claimTerminal() else { return destinationURL }
+        if let claimed = claimTerminal(.committed) {
+            guard claimed == .committed else { throw ClipboardArchiveStreamError.cancelled }
+            // Re-read the latched outcome rather than assume success: a first
+            // commit that failed took the tree with it, so handing back its URL
+            // would name a folder that is gone.
+            if let failure = outcome.wait() { throw refusal.value ?? failure }
+            return destinationURL
+        }
         pipe.finish()
         if let failure = outcome.wait() {
             try? FileManager.default.removeItem(at: destinationURL)
@@ -682,17 +743,23 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
     ///
     /// Idempotent, and a no-op once `commit()` has succeeded.
     public func abort() {
-        guard claimTerminal() else { return }
+        guard claimTerminal(.aborted) == nil else { return }
         pipe.fail(ClipboardArchiveStreamError.cancelled)
         _ = outcome.wait()
         try? FileManager.default.removeItem(at: destinationURL)
     }
 
-    private func claimTerminal() -> Bool {
+    /// Claims the terminal transition for `kind`, or reports which one was
+    /// already claimed.
+    ///
+    /// The two endings are mutually exclusive rather than merely once-only:
+    /// `abort()` deletes the tree `commit()` would hand back, so a `commit()`
+    /// that lost the race must not read as success.
+    private func claimTerminal(_ kind: Terminal) -> Terminal? {
         terminalLock.withLock {
-            if terminal { return false }
-            terminal = true
-            return true
+            if let terminal { return terminal }
+            terminal = kind
+            return nil
         }
     }
 

--- a/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
@@ -364,6 +364,10 @@ public final class ClipboardDirectoryArchiveReader: @unchecked Sendable {
     /// failed archive: AppleArchive reports a failed write from `close()` and not
     /// from `writeDirectoryContents`, so swallowing one hands out a silently
     /// truncated archive.
+    ///
+    /// The `defer`s belong to the `do` block, not to this function, so every
+    /// close has already run and recorded itself by the time the result below is
+    /// computed.
     private static func encode(directoryAt directoryURL: URL, into pipe: ClipboardArchiveBytePipe)
         -> Error?
     {
@@ -511,8 +515,9 @@ public final class ClipboardDirectoryExtractSink: StagingSink, @unchecked Sendab
 
     /// Runs the extract pipeline, returning the failure that ended it.
     ///
-    /// Same close discipline as the encode side: streams close in reverse
-    /// creation order and a close failure is a failed extract.
+    /// Same close discipline, and same scoping, as the encode side: streams close
+    /// in reverse creation order when the `do` block exits, so a close failure is
+    /// recorded before the result below is computed.
     private static func extract(from pipe: ClipboardArchiveBytePipe, into destinationURL: URL)
         -> Error?
     {

--- a/KernovaKit/Sources/KernovaKit/ClipboardErrorCode.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardErrorCode.swift
@@ -40,4 +40,8 @@ public enum ClipboardErrorCode: String, CaseIterable, Sendable {
     /// Never crosses the wire: like `copyTooLarge`, the host both skips and
     /// reports it.
     case forwardItemsSkipped = "clipboard.forward.items.skipped"
+
+    /// A copied folder was not offered because the peer's agent cannot receive a
+    /// folder streamed with no declared size.
+    case folderPeerOutdated = "clipboard.folder.peer.outdated"
 }

--- a/KernovaKit/Sources/KernovaKit/ClipboardFileStaging.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileStaging.swift
@@ -13,6 +13,19 @@ public protocol StagingSink: Sendable {
 
     /// Closes the file and deletes the partial. Idempotent.
     func abort()
+
+    /// Wakes a writer parked inside `write(_:)`, without waiting for the sink to
+    /// finish tearing itself down.
+    ///
+    /// A sink that consumes bytes asynchronously applies backpressure by parking
+    /// its writer, which would otherwise put an abort in line *behind* the very
+    /// write it is aborting. Idempotent; `abort()` still does the teardown.
+    func cancel()
+}
+
+extension StagingSink {
+    /// A sink whose `write(_:)` never parks has no writer to wake.
+    public func cancel() {}
 }
 
 /// Materializes streamed file representations to real local temp files so a
@@ -206,7 +219,7 @@ public final class ClipboardFileStaging: @unchecked Sendable {
     /// generation directory, for the receiver to extract a directory tree into.
     ///
     /// Nested under a fresh UUID parent so the folder keeps its *exact* name: a
-    /// sibling staged `.aar` of the same name would otherwise force a
+    /// same-named sibling in the generation directory would otherwise force a
     /// Finder-style ` (n)` suffix onto it. `name` is sanitized to one path
     /// component so a crafted offer can't escape the generation directory.
     ///
@@ -232,23 +245,6 @@ public final class ClipboardFileStaging: @unchecked Sendable {
         let url = try directory(for: generation)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        return url
-    }
-
-    /// Reserves a unique destination URL under the generation directory for the
-    /// sender's directory archive before it is offered.
-    ///
-    /// Unlike `makeSink`, no `Sink` is returned: the caller writes the bytes
-    /// itself. An empty placeholder claims the name so a later
-    /// reserve/sink/adopt in the same generation can't collide on it.
-    ///
-    /// - Throws: a filesystem error if the directory can't be created.
-    public func reserveURL(generation: UInt64, filename: String) throws -> URL {
-        lock.lock()
-        defer { lock.unlock() }
-        let dir = try directory(for: generation)
-        let url = Self.uniqueDestination(in: dir, filename: filename)
-        FileManager.default.createFile(atPath: url.path, contents: nil)
         return url
     }
 

--- a/KernovaKit/Sources/KernovaKit/ClipboardFileStaging.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileStaging.swift
@@ -21,11 +21,20 @@ public protocol StagingSink: Sendable {
     /// its writer, which would otherwise put an abort in line *behind* the very
     /// write it is aborting. Idempotent; `abort()` still does the teardown.
     func cancel()
+
+    /// The abort code a caller reports when `write(_:)` or `commit()` fails.
+    ///
+    /// The sink names its own failure, so a caller need not know which kind it
+    /// holds to describe what went wrong.
+    var writeErrorCode: String { get }
 }
 
 extension StagingSink {
     /// A sink whose `write(_:)` never parks has no writer to wake.
     public func cancel() {}
+
+    /// A sink that writes bytes to a file fails as a write.
+    public var writeErrorCode: String { "write.error" }
 }
 
 /// Materializes streamed file representations to real local temp files so a

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
@@ -419,10 +419,16 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
                 failSinkError(transfer, sink: sink, error: error)
                 return
             }
+            // The rep's bytes are the tree at `url`, so its size is the tree's,
+            // not the compressed count the wire carried — which can be ~100×
+            // lower and disagrees with the uncompressed estimate the offer
+            // advertised for the same folder. `sha256` stays the wire digest:
+            // it is the transfer's integrity gate, already verified above.
+            let treeByteCount = transfer.extractedByteCount ?? byteCount
             deliver(
                 transfer,
                 ClipboardContent.Representation(
-                    uti: transfer.uti, fileURL: url, byteCount: byteCount, sha256: digest,
+                    uti: transfer.uti, fileURL: url, byteCount: treeByteCount, sha256: digest,
                     filename: transfer.filename, isDirectory: true),
                 byteCount: byteCount)
             return

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
@@ -13,7 +13,9 @@ public typealias ClipboardSinkFactory =
 /// and an inline one past `maxResidentInlineBytes` — streams to a temp file
 /// under the free-space guard, never resident whole. A spilled inline rep is
 /// mmapped back at End and delivered as a resident `.inMemory` payload, so
-/// inline content has no Kernova-imposed size cap.
+/// inline content has no Kernova-imposed size cap. A transfer primed as a folder
+/// (`awaitTransfer(_:extractsDirectoryNamed:…)`) streams into an extract pipeline
+/// instead, so the tree grows as the archive arrives and no archive is staged.
 ///
 /// One receiver drives all inbound transfers on a channel, keyed by
 /// `transfer_id`: the owning service routes `ClipboardStreamBegin` /
@@ -101,6 +103,10 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// Begins an inbound transfer: free-space check, sink open, and the initial
     /// ack that tells the sender to go.
     public func handleBegin(_ begin: Kernova_V1_ClipboardStreamBegin) {
+        // Directory-ness rides the offer, not the wire: the side that registered
+        // this pull is the same side that sent the `ClipboardRequest`, so it
+        // primes the expectation here rather than the sender re-declaring it.
+        let directoryName = lock.withLock { awaiters[begin.transferID]?.extractsDirectoryNamed }
         let transfer = Transfer(
             transferID: begin.transferID,
             generation: begin.generation,
@@ -114,6 +120,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             totalBytes: Int(
                 clamping: min(begin.totalBytes, ClipboardOfferBounds.maxDeclaredByteCount)),
             maxResidentInlineBytes: maxResidentInlineBytes,
+            extractsDirectoryNamed: directoryName,
             now: self.clock.now
         )
         // Ignore a duplicate transfer_id rather than overwrite an in-flight
@@ -132,7 +139,28 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             // than open a sink nobody will close and start a stall timer that
             // outlives a transfer no longer reachable through the table. [L4]
             guard !transfer.isFinished else { return }
-            if transfer.streamsToDisk {
+            if let folderName = transfer.extractsDirectoryNamed {
+                // A streamed directory archive declares no total (its compressed
+                // size isn't known until the last byte is encoded), so the
+                // free-space gate is the requester's pre-flight against the
+                // offer's uncompressed estimate plus the mid-extract re-check in
+                // `performWrite`. Only the margin is worth asserting up front.
+                guard self.staging.hasCapacity(forByteCount: 0) else {
+                    self.failDiskFull(transfer)
+                    return
+                }
+                do {
+                    let destination = try self.staging.reserveDirectory(
+                        generation: transfer.generation, name: folderName)
+                    transfer.sink = ClipboardDirectoryExtractSink(
+                        destinationURL: destination, label: "\(transfer.transferID)",
+                        capacityBytes: self.windowBytes)
+                } catch {
+                    self.fail(
+                        transfer, code: "stage.error", message: "Cannot open the extract folder")
+                    return
+                }
+            } else if transfer.streamsToDisk {
                 // The disk free-space guard, not a heap ceiling, bounds a
                 // misbehaving peer's declared size: create no temp file when it
                 // can't fit. [H1]
@@ -198,8 +226,13 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
                 return
             }
             // Reject a peer streaming past its declared total — bounds both the
-            // inline RAM buffer and the file sink to total_bytes. [H1]
-            guard transfer.receivedBytes + chunk.data.count <= transfer.totalBytes else {
+            // inline RAM buffer and the file sink to total_bytes. [H1] A streamed
+            // directory archive declares none, and is bounded instead by the
+            // free-space re-check on its write lane.
+            guard
+                transfer.extractsDirectoryNamed != nil
+                    || transfer.receivedBytes + chunk.data.count <= transfer.totalBytes
+            else {
                 self.fail(
                     transfer, code: "size.overrun",
                     message: "Chunk exceeds declared total of \(transfer.totalBytes)")
@@ -295,8 +328,9 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             byteCount: transfer.receivedBytes)
     }
 
-    /// Commits a disk-streamed transfer's staging file and completes it, on the
-    /// write lane behind the transfer's whole write backlog.
+    /// Commits a disk-streamed transfer's staging file — or the tree its extract
+    /// pipeline has been writing — and completes it, on the write lane behind the
+    /// transfer's whole write backlog.
     private func finishStaged(_ transfer: Transfer, byteCount: Int, digest: Data) {
         // Final ack: every byte is durably written now, so this closes the
         // sender's cumulative credit ledger even if the tail sat below one
@@ -306,6 +340,28 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
         }
         guard let sink = transfer.sink else {
             fail(transfer, code: "stage.error", message: "Missing staging sink at End")
+            return
+        }
+        if transfer.extractsDirectoryNamed != nil {
+            // Committing is what drains the extract pipeline, so this is where a
+            // truncated or corrupt archive surfaces — and it takes the partial
+            // tree with it. There is no staged file to stat afterwards: the
+            // payload's size lives in the tree, not in one file.
+            let url: URL
+            do {
+                url = try sink.commit()
+            } catch {
+                fail(
+                    transfer, code: "extract.error",
+                    message: "Unpacking the folder failed: \(error.localizedDescription)")
+                return
+            }
+            deliver(
+                transfer,
+                ClipboardContent.Representation(
+                    uti: transfer.uti, fileURL: url, byteCount: byteCount, sha256: digest,
+                    filename: transfer.filename, isDirectory: true),
+                byteCount: byteCount)
             return
         }
         let url: URL
@@ -442,14 +498,22 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// of the transfer's own lanes **in place of** the channel-wide
     /// `onComplete`/`onAbort`, and is one-shot — removed when it fires, or via
     /// `cancelAwait`.
+    ///
+    /// `extractsDirectoryNamed` primes the transfer: the bytes are a folder
+    /// archive to extract into a folder of that name as they stream, rather than
+    /// a file to stage. Directory-ness rides the `ClipboardOffer`, and this
+    /// registration happens on the same side that read the offer and sent the
+    /// request, so the stream layer never needs it on the wire.
     public func awaitTransfer(
         _ transferID: UInt64,
+        extractsDirectoryNamed: String? = nil,
         onComplete: @escaping @Sendable (ClipboardContent.Representation) -> Void,
         onAbort: @escaping @Sendable (ClipboardStreamAbortInfo) -> Void,
         onProgress: (@Sendable (_ bytesReceived: Int, _ totalBytes: Int) -> Void)? = nil
     ) {
         lock.withLock {
             awaiters[transferID] = Awaiter(
+                extractsDirectoryNamed: extractsDirectoryNamed,
                 onComplete: onComplete, onAbort: onAbort, onProgress: onProgress)
         }
     }
@@ -585,8 +649,11 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
         do {
             try sink.write(data)
         } catch {
+            // A directory sink's write only fails once its extract pipeline has
+            // already given up, so name that rather than a disk write.
             fail(
-                transfer, code: "write.error",
+                transfer,
+                code: transfer.extractsDirectoryNamed == nil ? "write.error" : "extract.error",
                 message: "Chunk write failed: \(error.localizedDescription)")
             return
         }
@@ -598,10 +665,22 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
         transfer.bytesSinceCheck += data.count
         if transfer.bytesSinceCheck >= windowBytes {
             transfer.bytesSinceCheck = 0
-            let remaining = transfer.totalBytes - transfer.writtenBytes
-            if remaining > 0 && !staging.hasCapacity(forByteCount: remaining) {
-                failDiskFull(transfer)
-                return
+            if transfer.extractsDirectoryNamed != nil {
+                // A streamed directory archive has no remaining count to check
+                // against — what it expands to isn't knowable — so the guard
+                // becomes "is the margin still free", on the same cadence.
+                // Running the volume out anyway fails the extract itself, which
+                // is what removes the partial tree.
+                if !staging.hasCapacity(forByteCount: 0) {
+                    failDiskFull(transfer)
+                    return
+                }
+            } else {
+                let remaining = transfer.totalBytes - transfer.writtenBytes
+                if remaining > 0 && !staging.hasCapacity(forByteCount: remaining) {
+                    failDiskFull(transfer)
+                    return
+                }
             }
         }
         ackIfDue(transfer, upTo: transfer.writtenBytes, now: clock.now)
@@ -663,7 +742,10 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             info: ClipboardStreamAbortInfo(
                 transferID: transfer.transferID, code: "disk.full",
                 message: "Not enough disk space",
-                neededBytes: transfer.totalBytes, availableBytes: available))
+                // A streamed directory archive declares no total, so there is no
+                // honest figure to report as "needed".
+                neededBytes: transfer.extractsDirectoryNamed == nil ? transfer.totalBytes : nil,
+                availableBytes: available))
     }
 
     /// Fails a transfer from **either** lane: sends the abort frame and tears
@@ -698,6 +780,10 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// sink and nothing to clean up.
     private func abortSink(_ transfer: Transfer) {
         guard let writeQueue = transfer.writeQueue else { return }
+        // Wake the write lane first: a sink that consumes asynchronously parks it
+        // inside `write`, and the teardown below would then sit in line behind
+        // the very write it is aborting.
+        transfer.sink?.cancel()
         writeQueue.async { transfer.sink?.abort() }
     }
 
@@ -795,6 +881,9 @@ public struct ClipboardStreamAbortInfo: Sendable, Equatable {
 
 /// Off-actor delivery handlers for a single awaited transfer.
 private struct Awaiter {
+    /// The folder name a streamed directory archive extracts into, or `nil` for
+    /// an ordinary file/inline transfer.
+    let extractsDirectoryNamed: String?
     let onComplete: @Sendable (ClipboardContent.Representation) -> Void
     let onAbort: @Sendable (ClipboardStreamAbortInfo) -> Void
     /// Fired (off the owning actor) on each accepted chunk with the cumulative
@@ -821,6 +910,14 @@ private final class InboundTransfer: @unchecked Sendable {
     let filename: String
     let isInline: Bool
     let totalBytes: Int
+    /// The folder name this transfer's archive extracts into, or `nil` when the
+    /// payload is an ordinary file or inline rep.
+    ///
+    /// Set from the pull's own registration, never from the wire. When set, the
+    /// transfer declares no total (`total_bytes = 0` means unknown), so the
+    /// overrun bound and the remaining-space check are replaced by the extract
+    /// pipeline's own failure and a margin check.
+    let extractsDirectoryNamed: String?
     /// Receive lane: validation, hashing, the stall anchor, progress delivery.
     let queue: DispatchQueue
     /// Write lane: staging appends and the acks that open credit for them.
@@ -908,7 +1005,8 @@ private final class InboundTransfer: @unchecked Sendable {
 
     init(
         transferID: UInt64, generation: UInt64, uti: String, filename: String, isInline: Bool,
-        totalBytes: Int, maxResidentInlineBytes: Int, now: EngineInstant
+        totalBytes: Int, maxResidentInlineBytes: Int, extractsDirectoryNamed: String?,
+        now: EngineInstant
     ) {
         self.transferID = transferID
         self.generation = generation
@@ -916,13 +1014,17 @@ private final class InboundTransfer: @unchecked Sendable {
         self.filename = filename
         self.isInline = isInline
         self.totalBytes = totalBytes
+        self.extractsDirectoryNamed = extractsDirectoryNamed
         self.beganAt = now
         self.lastAckAt = now
         self.lastChunkAt = now
         self.queue = DispatchQueue(
             label: "app.kernova.clipboard.stream-recv.\(transferID)", qos: .userInitiated)
+        // A primed directory transfer always takes the write lane: its sink is
+        // the extract pipeline, so a peer claiming `is_inline` must not divert it
+        // into the RAM buffer, where nothing would ever unpack it.
         self.writeQueue =
-            (!isInline || totalBytes > maxResidentInlineBytes)
+            (extractsDirectoryNamed != nil || !isInline || totalBytes > maxResidentInlineBytes)
             ? DispatchQueue(
                 label: "app.kernova.clipboard.stream-recv.write.\(transferID)", qos: .userInitiated)
             : nil

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
@@ -41,6 +41,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     private let ackQuantum: Int
     private let ackLatencyBound: TimeInterval
     private let stallTimeout: TimeInterval
+    private let maxBacklogBytes: Int
 
     /// Inline payloads at/below this size reassemble in RAM; larger ones spill to
     /// the staging file and are mmapped back (so there is no inline size cap).
@@ -92,6 +93,8 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             }
         self.windowBytes = min(max(windowBytes, 1), ClipboardStreamTuning.maxWindowBytes)
         self.ackQuantum = ClipboardStreamTuning.ackQuantum(forWindowBytes: self.windowBytes)
+        self.maxBacklogBytes = ClipboardStreamTuning.maxBacklogBytes(
+            forWindowBytes: self.windowBytes)
         self.ackLatencyBound = ackLatencyBound
         self.stallTimeout = stallTimeout
         self.maxResidentInlineBytes = max(maxResidentInlineBytes, 0)
@@ -227,8 +230,8 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             }
             // Reject a peer streaming past its declared total — bounds both the
             // inline RAM buffer and the file sink to total_bytes. [H1] A streamed
-            // directory archive declares none, and is bounded instead by the
-            // free-space re-check on its write lane.
+            // directory archive declares none; the backlog bound below is what
+            // stands in for it.
             guard
                 transfer.extractsDirectoryNamed != nil
                     || transfer.receivedBytes + chunk.data.count <= transfer.totalBytes
@@ -246,8 +249,18 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             if let writeQueue {
                 // Hand the bytes to the write lane and keep going. `Data` is
                 // copy-on-write, so the hand-off retains the buffer rather than
-                // copying it, and the sender's credit window bounds how far the
-                // backlog can run ahead of the writes.
+                // copying it. This lane never blocks, so the credit window is
+                // *enforced* here rather than trusted: a peer that ignores it
+                // would otherwise queue chunks on a parked write lane until the
+                // heap ran out.
+                guard transfer.addBacklog(chunk.data.count) <= self.maxBacklogBytes else {
+                    self.fail(
+                        transfer, code: "flow.overrun",
+                        message:
+                            "Peer streamed more than \(self.maxBacklogBytes) bytes past its credit window"
+                    )
+                    return
+                }
                 let data = chunk.data
                 writeQueue.async { [weak self] in
                     self?.performWrite(transfer, data)
@@ -637,6 +650,9 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// transfer, so `writtenBytes` is always a true durable *prefix* of the
     /// payload — which is what lets its ack carry credit.
     private func performWrite(_ transfer: Transfer, _ data: Data) {
+        // Paired with the receive lane's `addBacklog`, so the bound tracks bytes
+        // still waiting to be written rather than bytes ever received.
+        defer { transfer.drainBacklog(data.count) }
         guard !transfer.isFinished else { return }
         guard let sink = transfer.sink else {
             // Fail loudly rather than drop the bytes: the receive lane has
@@ -980,6 +996,27 @@ private final class InboundTransfer: @unchecked Sendable {
     /// `queue` that checks `lastChunkAt` — started once per transfer, cancelled
     /// on finish, never re-armed per chunk.
     var stallTimer: DispatchSourceTimer?
+
+    /// Bytes handed to the write lane that it has not finished writing — the
+    /// receive lane's view of how far ahead the peer is running.
+    ///
+    /// The one counter both lanes touch, so it carries its own lock rather than
+    /// belonging to either.
+    private let backlogLock = NSLock()
+    private var backlogBytes = 0
+
+    /// Records `count` bytes as handed over, returning the new backlog.
+    func addBacklog(_ count: Int) -> Int {
+        backlogLock.withLock {
+            backlogBytes += count
+            return backlogBytes
+        }
+    }
+
+    /// Records `count` bytes as written, releasing their share of the backlog.
+    func drainBacklog(_ count: Int) {
+        backlogLock.withLock { backlogBytes -= count }
+    }
 
     private let finishLock = NSLock()
     private var finished = false

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
@@ -47,6 +47,10 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// the staging file and are mmapped back (so there is no inline size cap).
     private let maxResidentInlineBytes: Int
 
+    /// Floor on what a streamed folder may extract whatever its offer advertised
+    /// — the behavior under test when a suite shrinks it.
+    private let minimumExtractAllowance: Int
+
     private let onComplete: @Sendable (UInt64, ClipboardContent.Representation) -> Void
 
     private let onAbort: @Sendable (ClipboardStreamAbortInfo) -> Void
@@ -56,6 +60,16 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
 
     private let lock = NSLock()
     private var transfers: [UInt64: Transfer] = [:]
+
+    /// How many cancelled `transfer_id`s are remembered so a reply that races the
+    /// cancellation can be named as ours rather than blamed on the peer.
+    private static let maxRememberedCancellations = 64
+
+    /// Ids this side cancelled whose reply has not arrived, newest last.
+    ///
+    /// Guarded by `lock`.
+    private var cancelledTransfers: Set<UInt64> = []
+    private var cancelledOrder: [UInt64] = []
 
     /// Off-actor delivery handlers registered per `transfer_id` by a lazy pull
     /// coordinator.
@@ -78,6 +92,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
         ackLatencyBound: TimeInterval = ClipboardStreamTuning.ackLatencyBound,
         stallTimeout: TimeInterval = ClipboardStreamTuning.inboundStallTimeout,
         maxResidentInlineBytes: Int = ClipboardStreamTuning.maxResidentInlineBytes,
+        minimumExtractAllowance: Int = ClipboardStreamTuning.minimumExtractAllowance,
         sinkFactory: ClipboardSinkFactory? = nil,
         onTransferTimed: (@Sendable (ClipboardTransferMetrics) -> Void)? = nil,
         onComplete: @escaping @Sendable (UInt64, ClipboardContent.Representation) -> Void,
@@ -98,6 +113,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
         self.ackLatencyBound = ackLatencyBound
         self.stallTimeout = stallTimeout
         self.maxResidentInlineBytes = max(maxResidentInlineBytes, 0)
+        self.minimumExtractAllowance = max(minimumExtractAllowance, 1)
         self.onTransferTimed = onTransferTimed
         self.onComplete = onComplete
         self.onAbort = onAbort
@@ -109,7 +125,21 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
         // Directory-ness rides the offer, not the wire: the side that registered
         // this pull is the same side that sent the `ClipboardRequest`, so it
         // primes the expectation here rather than the sender re-declaring it.
-        let directoryName = lock.withLock { awaiters[begin.transferID]?.extractsDirectoryNamed }
+        let expectation = lock.withLock { () -> (folder: String, advertised: Int)? in
+            guard let awaiter = awaiters[begin.transferID],
+                let name = awaiter.extractsDirectoryNamed
+            else { return nil }
+            return (name, awaiter.advertisedByteCount)
+        }
+        // A pull this side cancelled leaves no awaiter, so refuse its reply
+        // rather than re-classify a folder as a plain file and then blame the
+        // peer for the first chunk. [cancelled-pull]
+        if expectation == nil, wasCancelled(begin.transferID) {
+            sendAbortFrame(
+                begin.transferID, code: "request.cancelled",
+                message: "The pull for this transfer was cancelled")
+            return
+        }
         let transfer = Transfer(
             transferID: begin.transferID,
             generation: begin.generation,
@@ -119,11 +149,15 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             // The sender's declared total is peer-supplied and never
             // cross-checked against the chunks that follow: bound it here, the
             // one place it enters, so the disk pre-flight and the inline reserve
-            // below are handed a size that can be reasoned about.
-            totalBytes: Int(
-                clamping: min(begin.totalBytes, ClipboardOfferBounds.maxDeclaredByteCount)),
+            // below are handed a size that can be reasoned about. A 0 means
+            // "unknown" only from a transfer this side primed as a folder; from
+            // anyone else it is a declared zero-byte payload, and holding it to
+            // that is what refuses an unbounded stream nobody asked for.
+            declaredTotalBytes: (expectation != nil && begin.totalBytes == 0)
+                ? nil
+                : Int(clamping: min(begin.totalBytes, ClipboardOfferBounds.maxDeclaredByteCount)),
             maxResidentInlineBytes: maxResidentInlineBytes,
-            extractsDirectoryNamed: directoryName,
+            extractsDirectoryNamed: expectation?.folder,
             now: self.clock.now
         )
         // Ignore a duplicate transfer_id rather than overwrite an in-flight
@@ -143,21 +177,34 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             // outlives a transfer no longer reachable through the table. [L4]
             guard !transfer.isFinished else { return }
             if let folderName = transfer.extractsDirectoryNamed {
-                // A streamed directory archive declares no total (its compressed
-                // size isn't known until the last byte is encoded), so the
-                // free-space gate is the requester's pre-flight against the
-                // offer's uncompressed estimate plus the mid-extract re-check in
-                // `performWrite`. Only the margin is worth asserting up front.
+                // A streamed folder's compressed size isn't known until its last
+                // byte, so the up-front gate can only assert the margin; the tree
+                // it expands to is bounded as it is written, below.
                 guard self.staging.hasCapacity(forByteCount: 0) else {
                     self.failDiskFull(transfer)
                     return
                 }
+                let ceiling = self.extractCeiling(
+                    forAdvertisedByteCount: expectation?.advertised ?? 0)
+                let staging = self.staging
                 do {
                     let destination = try self.staging.reserveDirectory(
                         generation: transfer.generation, name: folderName)
                     transfer.sink = ClipboardDirectoryExtractSink(
                         destinationURL: destination, label: "\(transfer.transferID)",
-                        capacityBytes: self.windowBytes)
+                        capacityBytes: self.windowBytes, pacingBytes: self.windowBytes
+                    ) { written in
+                        // Paced by the *tree* being written, not by the archive
+                        // arriving: LZFSE reaches ~100:1, so a guard clocked on
+                        // wire bytes lets ~100 MB of tree land between checks and
+                        // the margin never fires.
+                        guard written <= ceiling else {
+                            throw ClipboardArchiveStreamError.outputRefused(.overAdvertisedSize)
+                        }
+                        guard staging.hasCapacity(forByteCount: 0) else {
+                            throw ClipboardArchiveStreamError.outputRefused(.diskFull)
+                        }
+                    }
                 } catch {
                     self.fail(
                         transfer, code: "stage.error", message: "Cannot open the extract folder")
@@ -167,7 +214,8 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
                 // The disk free-space guard, not a heap ceiling, bounds a
                 // misbehaving peer's declared size: create no temp file when it
                 // can't fit. [H1]
-                guard self.staging.hasCapacity(forByteCount: transfer.totalBytes) else {
+                guard self.staging.hasCapacity(forByteCount: transfer.declaredTotalBytes ?? 0)
+                else {
                     self.failDiskFull(transfer)
                     return
                 }
@@ -183,7 +231,9 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
                 // window size.
                 transfer.buffer = Data()
                 transfer.buffer?.reserveCapacity(
-                    min(transfer.totalBytes, ClipboardStreamTuning.maxInlineReserveBytes))
+                    min(
+                        transfer.declaredTotalBytes ?? 0,
+                        ClipboardStreamTuning.maxInlineReserveBytes))
             }
             // Go-signal: tell the sender we're ready and advertise the window.
             self.sendAck(transfer, upTo: transfer.receivedBytes)
@@ -229,16 +279,15 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
                 return
             }
             // Reject a peer streaming past its declared total — bounds both the
-            // inline RAM buffer and the file sink to total_bytes. [H1] A streamed
-            // directory archive declares none; the backlog bound below is what
-            // stands in for it.
-            guard
-                transfer.extractsDirectoryNamed != nil
-                    || transfer.receivedBytes + chunk.data.count <= transfer.totalBytes
-            else {
+            // inline RAM buffer and the file sink to it. [H1] A payload that
+            // declares none is bounded by the backlog bound below, and its output
+            // by the extract's own ceiling.
+            if let declared = transfer.declaredTotalBytes,
+                transfer.receivedBytes + chunk.data.count > declared
+            {
                 self.fail(
                     transfer, code: "size.overrun",
-                    message: "Chunk exceeds declared total of \(transfer.totalBytes)")
+                    message: "Chunk exceeds declared total of \(declared)")
                 return
             }
 
@@ -280,10 +329,13 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             // Tell a parked lazy pull the transfer is alive so it re-arms its
             // inactivity backstop instead of timing out a slow-but-progressing
             // large transfer. [large-paste]
+            // For a folder the wire count is compressed while every readout's
+            // denominator is the offer's uncompressed estimate, so report what the
+            // extract has actually written instead — same unit, same scale.
             self.deliverProgress(
                 transfer.transferID,
-                bytesReceived: transfer.receivedBytes,
-                totalBytes: transfer.totalBytes)
+                bytesReceived: transfer.extractedByteCount ?? transfer.receivedBytes,
+                totalBytes: transfer.declaredTotalBytes ?? 0)
         }
     }
 
@@ -364,9 +416,7 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             do {
                 url = try sink.commit()
             } catch {
-                fail(
-                    transfer, code: "extract.error",
-                    message: "Unpacking the folder failed: \(error.localizedDescription)")
+                failSinkError(transfer, sink: sink, error: error)
                 return
             }
             deliver(
@@ -517,29 +567,67 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// a file to stage. Directory-ness rides the `ClipboardOffer`, and this
     /// registration happens on the same side that read the offer and sent the
     /// request, so the stream layer never needs it on the wire.
+    /// `advertisedByteCount` is that offer's uncompressed estimate, which the
+    /// extract is then held to — nothing on the wire states a folder's size.
     public func awaitTransfer(
         _ transferID: UInt64,
         extractsDirectoryNamed: String? = nil,
+        advertisedByteCount: Int = 0,
         onComplete: @escaping @Sendable (ClipboardContent.Representation) -> Void,
         onAbort: @escaping @Sendable (ClipboardStreamAbortInfo) -> Void,
         onProgress: (@Sendable (_ bytesReceived: Int, _ totalBytes: Int) -> Void)? = nil
     ) {
         lock.withLock {
+            // A transfer id is derivable from `(generation, repIndex, direction)`,
+            // so a fresh pull reuses the id of one this side gave up on. Clearing
+            // the cancellation record here is what keeps the retry from being
+            // refused as that abandoned pull's late reply.
+            cancelledTransfers.remove(transferID)
+            cancelledOrder.removeAll { $0 == transferID }
             awaiters[transferID] = Awaiter(
                 extractsDirectoryNamed: extractsDirectoryNamed,
+                advertisedByteCount: max(0, advertisedByteCount),
                 onComplete: onComplete, onAbort: onAbort, onProgress: onProgress)
         }
     }
 
     /// Deregisters a per-transfer delivery handler without firing it.
     public func cancelAwait(_ transferID: UInt64) {
-        lock.withLock { awaiters[transferID] = nil }
+        lock.withLock {
+            guard awaiters.removeValue(forKey: transferID) != nil else { return }
+            noteCancelled(transferID)
+        }
     }
 
     // MARK: - Private
 
     private func transfer(_ id: UInt64) -> Transfer? {
         lock.withLock { transfers[id] }
+    }
+
+    /// Remembers that this side gave up on `transferID` before its reply arrived.
+    ///
+    /// A `Begin` can still be in flight for it, and without this the receiver
+    /// cannot tell that reply apart from an unsolicited one — it would open a
+    /// sink, ack the sender to start, and then blame the peer for the first
+    /// chunk. Bounded and oldest-evicted: it only ever holds ids whose reply
+    /// never arrived. Caller holds `lock`.
+    private func noteCancelled(_ transferID: UInt64) {
+        guard !cancelledTransfers.contains(transferID) else { return }
+        cancelledTransfers.insert(transferID)
+        cancelledOrder.append(transferID)
+        while cancelledOrder.count > Self.maxRememberedCancellations {
+            cancelledTransfers.remove(cancelledOrder.removeFirst())
+        }
+    }
+
+    /// Reports, and clears, whether this side cancelled the pull for `transferID`.
+    private func wasCancelled(_ transferID: UInt64) -> Bool {
+        lock.withLock {
+            guard cancelledTransfers.remove(transferID) != nil else { return false }
+            cancelledOrder.removeAll { $0 == transferID }
+            return true
+        }
     }
 
     private func remove(_ id: UInt64) {
@@ -586,7 +674,11 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
     /// entry in `transfers` for `teardown` to reach. Idempotent with `teardown`'s
     /// own awaiter notification — whichever removes the awaiter first wins.
     private func failAwaiters(_ predicate: (UInt64) -> Bool) {
-        let ids = lock.withLock { awaiters.keys.filter(predicate) }
+        let ids = lock.withLock { () -> [UInt64] in
+            let matched = awaiters.keys.filter(predicate)
+            for id in matched { noteCancelled(id) }
+            return matched
+        }
         for id in ids {
             deliverAbortToAwaiterOnly(
                 ClipboardStreamAbortInfo(
@@ -665,34 +757,21 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
         do {
             try sink.write(data)
         } catch {
-            // A directory sink's write only fails once its extract pipeline has
-            // already given up, so name that rather than a disk write.
-            fail(
-                transfer,
-                code: transfer.extractsDirectoryNamed == nil ? "write.error" : "extract.error",
-                message: "Chunk write failed: \(error.localizedDescription)")
+            failSinkError(transfer, sink: sink, error: error)
             return
         }
         transfer.writtenBytes += data.count
 
-        // Incremental disk guard: re-check the remaining bytes once per window
-        // so a volume filling mid-stream aborts cleanly, keyed on written bytes
-        // because writes, not arrivals, consume the volume.
+        // Incremental disk guard for a payload whose size is declared: re-check
+        // the remaining bytes once per window, keyed on written bytes because
+        // writes, not arrivals, consume the volume. A folder's guard cannot live
+        // here — these are compressed bytes — so it rides the extract's own
+        // output pacing instead.
         transfer.bytesSinceCheck += data.count
         if transfer.bytesSinceCheck >= windowBytes {
             transfer.bytesSinceCheck = 0
-            if transfer.extractsDirectoryNamed != nil {
-                // A streamed directory archive has no remaining count to check
-                // against — what it expands to isn't knowable — so the guard
-                // becomes "is the margin still free", on the same cadence.
-                // Running the volume out anyway fails the extract itself, which
-                // is what removes the partial tree.
-                if !staging.hasCapacity(forByteCount: 0) {
-                    failDiskFull(transfer)
-                    return
-                }
-            } else {
-                let remaining = transfer.totalBytes - transfer.writtenBytes
+            if let declared = transfer.declaredTotalBytes {
+                let remaining = declared - transfer.writtenBytes
                 if remaining > 0 && !staging.hasCapacity(forByteCount: remaining) {
                     failDiskFull(transfer)
                     return
@@ -750,6 +829,47 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             })
     }
 
+    /// How much tree an extract may write for a folder the offer advertised at
+    /// `advertisedByteCount`.
+    ///
+    /// Nothing on the wire states a folder's size, so the estimate the paste
+    /// ceiling and the free-space pre-flight were computed from is the only
+    /// figure to hold it to. The allowance is generous on purpose: the archive
+    /// container adds a header per entry to the file bytes the estimate sums, and
+    /// a tree can legitimately grow a little between the copy-time walk and the
+    /// paste-time encode. Doubling covers header overhead for any tree whose file
+    /// bytes dominate, and the floor covers one whose estimate is zero or tiny —
+    /// a scaffold of empty files — while staying far below any paste ceiling.
+    func extractCeiling(forAdvertisedByteCount advertisedByteCount: Int) -> Int {
+        let doubled = advertisedByteCount.saturatingAdding(advertisedByteCount)
+        return max(doubled, minimumExtractAllowance)
+    }
+
+    /// Fails a transfer whose sink rejected the bytes, naming the failure the way
+    /// the sink does — and re-checking the volume first, because a write that
+    /// failed on a full disk must read as `disk.full` rather than as a corrupt
+    /// payload the user would only retry.
+    private func failSinkError(_ transfer: Transfer, sink: StagingSink, error: Error) {
+        if case ClipboardArchiveStreamError.outputRefused(let refusal) = error {
+            switch refusal {
+            case .diskFull:
+                failDiskFull(transfer)
+            case .overAdvertisedSize:
+                fail(
+                    transfer, code: "size.overrun",
+                    message: "The folder unpacked to more than its offer advertised")
+            }
+            return
+        }
+        guard staging.hasCapacity(forByteCount: 0) else {
+            failDiskFull(transfer)
+            return
+        }
+        fail(
+            transfer, code: sink.writeErrorCode,
+            message: "Writing the payload failed: \(error.localizedDescription)")
+    }
+
     private func failDiskFull(_ transfer: Transfer) {
         let available = staging.availableCapacity().map { Int(clamping: $0) }
         sendAbortFrame(transfer.transferID, code: "disk.full", message: "Not enough disk space")
@@ -758,9 +878,9 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             info: ClipboardStreamAbortInfo(
                 transferID: transfer.transferID, code: "disk.full",
                 message: "Not enough disk space",
-                // A streamed directory archive declares no total, so there is no
-                // honest figure to report as "needed".
-                neededBytes: transfer.extractsDirectoryNamed == nil ? transfer.totalBytes : nil,
+                // A payload that declared no total has no honest figure to
+                // report as "needed".
+                neededBytes: transfer.declaredTotalBytes,
                 availableBytes: available))
     }
 
@@ -900,6 +1020,10 @@ private struct Awaiter {
     /// The folder name a streamed directory archive extracts into, or `nil` for
     /// an ordinary file/inline transfer.
     let extractsDirectoryNamed: String?
+    /// The uncompressed size the offer advertised for that folder — the figure
+    /// the paste ceiling and the free-space pre-flight were computed from, and
+    /// so the figure the extract is held to.
+    let advertisedByteCount: Int
     let onComplete: @Sendable (ClipboardContent.Representation) -> Void
     let onAbort: @Sendable (ClipboardStreamAbortInfo) -> Void
     /// Fired (off the owning actor) on each accepted chunk with the cumulative
@@ -925,14 +1049,17 @@ private final class InboundTransfer: @unchecked Sendable {
     let uti: String
     let filename: String
     let isInline: Bool
-    let totalBytes: Int
+    /// The size the sender declared, or `nil` when it declared none — a folder
+    /// compressed straight onto the wire cannot know its own size until its last
+    /// byte (`total_bytes = 0` on the wire means unknown).
+    ///
+    /// The one axis the size-dependent guards branch on, so none of them has to
+    /// re-derive "unknown" from what kind of payload this is.
+    let declaredTotalBytes: Int?
     /// The folder name this transfer's archive extracts into, or `nil` when the
     /// payload is an ordinary file or inline rep.
     ///
-    /// Set from the pull's own registration, never from the wire. When set, the
-    /// transfer declares no total (`total_bytes = 0` means unknown), so the
-    /// overrun bound and the remaining-space check are replaced by the extract
-    /// pipeline's own failure and a margin check.
+    /// Set from the pull's own registration, never from the wire.
     let extractsDirectoryNamed: String?
     /// Receive lane: validation, hashing, the stall anchor, progress delivery.
     let queue: DispatchQueue
@@ -941,6 +1068,12 @@ private final class InboundTransfer: @unchecked Sendable {
     /// `nil` for a RAM-resident inline rep, which has no sink and runs entirely
     /// on `queue`.
     let writeQueue: DispatchQueue?
+
+    /// Uncompressed bytes the extract has written, or `nil` when the sink is not
+    /// an extract — the progress figure in the offer's own unit.
+    var extractedByteCount: Int? {
+        (sink as? ClipboardDirectoryExtractSink)?.uncompressedByteCount
+    }
 
     /// Whether this transfer streams to a staging file instead of a RAM buffer:
     /// every file rep, plus an inline rep past `maxResidentInlineBytes`.
@@ -1042,7 +1175,7 @@ private final class InboundTransfer: @unchecked Sendable {
 
     init(
         transferID: UInt64, generation: UInt64, uti: String, filename: String, isInline: Bool,
-        totalBytes: Int, maxResidentInlineBytes: Int, extractsDirectoryNamed: String?,
+        declaredTotalBytes: Int?, maxResidentInlineBytes: Int, extractsDirectoryNamed: String?,
         now: EngineInstant
     ) {
         self.transferID = transferID
@@ -1050,7 +1183,7 @@ private final class InboundTransfer: @unchecked Sendable {
         self.uti = uti
         self.filename = filename
         self.isInline = isInline
-        self.totalBytes = totalBytes
+        self.declaredTotalBytes = declaredTotalBytes
         self.extractsDirectoryNamed = extractsDirectoryNamed
         self.beganAt = now
         self.lastAckAt = now
@@ -1059,9 +1192,12 @@ private final class InboundTransfer: @unchecked Sendable {
             label: "app.kernova.clipboard.stream-recv.\(transferID)", qos: .userInitiated)
         // A primed directory transfer always takes the write lane: its sink is
         // the extract pipeline, so a peer claiming `is_inline` must not divert it
-        // into the RAM buffer, where nothing would ever unpack it.
+        // into the RAM buffer, where nothing would ever unpack it. An undeclared
+        // size spills for the same reason a large one does — nothing bounds what
+        // would accumulate in RAM.
         self.writeQueue =
-            (extractsDirectoryNamed != nil || !isInline || totalBytes > maxResidentInlineBytes)
+            (extractsDirectoryNamed != nil || !isInline
+                || (declaredTotalBytes.map { $0 > maxResidentInlineBytes } ?? true))
             ? DispatchQueue(
                 label: "app.kernova.clipboard.stream-recv.write.\(transferID)", qos: .userInitiated)
             : nil

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
@@ -134,8 +134,9 @@ public final class ClipboardStreamSender: @unchecked Sendable {
     ///   - folderName: the folder's own name, mirrored into
     ///     `ClipboardStreamBegin.filename`.
     ///   - uti: the folder's content type (a package UTI for a bundle).
-    ///   - maxAcceptByteCount: the requester's payload ceiling; exceeding it
-    ///     mid-stream aborts with `Abort{disk.full}`.
+    ///   - maxAcceptByteCount: the requester's payload ceiling, measured against
+    ///     the tree the archive expands to rather than the compressed bytes on
+    ///     the wire; exceeding it mid-stream aborts with `Abort{disk.full}`.
     ///   - isCurrent: supersession check, evaluated between chunks off the
     ///     caller's actor.
     ///   - onProgress: cumulative `(bytesSent, 0)` — a streamed transfer has no
@@ -440,13 +441,19 @@ public final class ClipboardStreamSender: @unchecked Sendable {
 
             // The requester's ceiling, enforced as bytes are produced. A declared
             // payload was already refused up front, so this only ever fires for a
-            // stream whose size wasn't knowable then.
+            // stream whose size wasn't knowable then — and it is measured in the
+            // unit the ceiling is stated in: the tree the requester will write,
+            // not the archive on the wire, which LZFSE can make ~100× smaller. A
+            // source whose wire bytes are its payload reports no offer-unit count.
+            let producedBytes = reader.offerUnitProgress ?? (offset + chunk.count)
             if maxAcceptByteCount != ClipboardStreamTuning.unlimitedAcceptByteCount,
-                UInt64(offset) + UInt64(chunk.count) > maxAcceptByteCount
+                UInt64(producedBytes) > maxAcceptByteCount
             {
                 sendAbort(
                     transfer: transfer, code: "disk.full",
-                    message: "Requester cannot accept more than \(maxAcceptByteCount) bytes")
+                    message:
+                        "Requester cannot accept more than \(maxAcceptByteCount) bytes; the payload has produced \(producedBytes)"
+                )
                 return false
             }
             hasher.update(data: chunk)

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
@@ -94,6 +94,71 @@ public final class ClipboardStreamSender: @unchecked Sendable {
         }
     }
 
+    /// Begins streaming the folder at `sourceDirectoryURL` as an archive of its
+    /// tree, encoded straight onto the wire.
+    ///
+    /// The archive's compressed size isn't known until its last byte, so the
+    /// `ClipboardStreamBegin` declares `total_bytes = 0` — unknown — and the
+    /// `ClipboardStreamEnd` carries the true count alongside the digest. The
+    /// requester's `maxAcceptByteCount` is therefore enforced cumulatively, as
+    /// bytes stream, rather than refused up front.
+    ///
+    /// - Parameters:
+    ///   - transferID: identifies this transfer across its frames.
+    ///   - generation: the offer generation the folder rep belongs to.
+    ///   - sourceDirectoryURL: the folder to archive; it must stay readable for
+    ///     the whole transfer, exactly as a plain file rep's source must.
+    ///   - folderName: the folder's own name, mirrored into
+    ///     `ClipboardStreamBegin.filename`.
+    ///   - uti: the folder's content type (a package UTI for a bundle).
+    ///   - maxAcceptByteCount: the requester's payload ceiling; exceeding it
+    ///     mid-stream aborts with `Abort{disk.full}`.
+    ///   - isCurrent: supersession check, evaluated between chunks off the
+    ///     caller's actor.
+    ///   - onProgress: cumulative `(bytesSent, 0)` — a streamed transfer has no
+    ///     total to report, and the progress tracker keeps the offer's estimate.
+    ///   - onComplete: fired exactly once when the transfer ends.
+    public func startDirectoryTransfer(
+        transferID: UInt64,
+        generation: UInt64,
+        sourceDirectoryURL: URL,
+        folderName: String,
+        uti: String,
+        maxAcceptByteCount: UInt64,
+        isCurrent: @escaping @Sendable (UInt64) -> Bool,
+        onProgress: (@Sendable (_ bytesSent: Int, _ totalBytes: Int) -> Void)? = nil,
+        onComplete: (@Sendable (_ success: Bool) -> Void)? = nil
+    ) {
+        let transfer = OutboundTransfer(
+            transferID: transferID, generation: generation, windowBytes: windowBytes)
+        let inserted = lock.withLock { () -> Bool in
+            guard transfers[transferID] == nil else { return false }
+            transfers[transferID] = transfer
+            return true
+        }
+        guard inserted else { return }
+
+        transfer.queue.async { [weak self] in
+            guard let self else { return }
+            var didComplete = false
+            defer { onComplete?(didComplete) }
+            defer { self.remove(transfer.transferID) }
+
+            let reader = DirectoryArchiveChunkReader(
+                directoryURL: sourceDirectoryURL, label: "\(transferID)",
+                capacityBytes: self.windowBytes)
+            // Covers every exit below — abort, supersession, credit timeout, a
+            // dead channel — by unblocking the encode pipeline so its worker
+            // unwinds instead of parking in a callback that has no timeout.
+            defer { reader.close() }
+
+            didComplete = self.stream(
+                transfer: transfer, reader: reader, declaredByteCount: nil, uti: uti,
+                filename: folderName, isInline: false, maxAcceptByteCount: maxAcceptByteCount,
+                isCurrent: isCurrent, onProgress: onProgress)
+        }
+    }
+
     /// Advances a transfer's credit from an inbound `ClipboardStreamAck`.
     ///
     /// `bytesConsumed` is cumulative, so a lost or reordered ack is self-healing
@@ -210,6 +275,30 @@ public final class ClipboardStreamSender: @unchecked Sendable {
         }
         defer { reader.close() }
 
+        didComplete = stream(
+            transfer: transfer, reader: reader, declaredByteCount: totalBytes,
+            uti: representation.uti, filename: representation.filename, isInline: isInline,
+            maxAcceptByteCount: maxAcceptByteCount, isCurrent: isCurrent, onProgress: onProgress)
+    }
+
+    /// Announces a transfer and streams its source to the peer under the credit
+    /// window, returning whether every byte was handed to the socket.
+    ///
+    /// `declaredByteCount` is `nil` for a payload whose size is only known once
+    /// it has been produced — a folder archived onto the wire. Such a transfer
+    /// announces `total_bytes = 0` (unknown), runs until its source reports the
+    /// end, and reports the true count in its `ClipboardStreamEnd`.
+    private func stream(
+        transfer: OutboundTransfer,
+        reader: ChunkReader,
+        declaredByteCount: Int?,
+        uti: String,
+        filename: String,
+        isInline: Bool,
+        maxAcceptByteCount: UInt64,
+        isCurrent: @escaping @Sendable (UInt64) -> Bool,
+        onProgress: (@Sendable (_ bytesSent: Int, _ totalBytes: Int) -> Void)?
+    ) -> Bool {
         // Retirement is checked per chunk in the loop below, which a zero-byte
         // payload never enters — so check once here, before anything is
         // announced. Every transfer then honors an abort or supersession that
@@ -218,12 +307,12 @@ public final class ClipboardStreamSender: @unchecked Sendable {
         let retirement = transfer.retirement()
         if retirement.retired {
             notifyPeerOfRetirement(transfer, reason: retirement.reason)
-            return
+            return false
         }
         guard isCurrent(transfer.generation) else {
             transfer.markAborted(.superseded)
             notifyPeerOfRetirement(transfer, reason: .superseded)
-            return
+            return false
         }
 
         guard
@@ -233,30 +322,65 @@ public final class ClipboardStreamSender: @unchecked Sendable {
                     $0.clipboardStreamBegin = .with {
                         $0.generation = transfer.generation
                         $0.transferID = transfer.transferID
-                        $0.uti = representation.uti
-                        $0.totalBytes = UInt64(totalBytes)
-                        $0.filename = representation.filename
+                        $0.uti = uti
+                        $0.totalBytes = UInt64(declaredByteCount ?? 0)
+                        $0.filename = filename
                         $0.isInline = isInline
                     }
                 })
-        else { return }  // channel dead — nothing more to do
+        else { return false }  // channel dead — nothing more to do
 
         var hasher = SHA256()
         var offset = 0
-        while offset < totalBytes {
-            let nextChunkSize = min(chunkSize, totalBytes - offset)
+        while declaredByteCount.map({ offset < $0 }) ?? true {
+            let nextChunkSize = declaredByteCount.map { min(chunkSize, $0 - offset) } ?? chunkSize
+
+            // Read before asking for credit, and ask for exactly what came back.
+            // A source that produces bytes as it goes — a folder being archived
+            // onto the wire — only reveals its end by returning nothing, and its
+            // tail is usually shorter than a chunk. Reserving a whole chunk's
+            // credit for either would park the sender on credit for bytes it is
+            // never going to send, which nothing else can then unblock.
+            guard var chunk = reader.read(upTo: nextChunkSize) else {
+                sendAbort(transfer: transfer, code: "read.error", message: "Source read failed at offset \(offset)")
+                return false
+            }
+            // Fill the chunk: a partial read otherwise puts one frame on the wire
+            // per dribble from the source. A reader that satisfies the whole
+            // request pays nothing here — the loop body never runs.
+            while !chunk.isEmpty, chunk.count < nextChunkSize {
+                guard let more = reader.read(upTo: nextChunkSize - chunk.count) else {
+                    sendAbort(
+                        transfer: transfer, code: "read.error",
+                        message: "Source read failed at offset \(offset + chunk.count)")
+                    return false
+                }
+                if more.isEmpty { break }
+                chunk.append(more)
+            }
+            if chunk.isEmpty {
+                // A declared payload that runs dry early is a failed read; an
+                // undeclared one has simply reached its end.
+                guard declaredByteCount == nil else {
+                    sendAbort(
+                        transfer: transfer, code: "read.error",
+                        message: "Source read failed at offset \(offset)")
+                    return false
+                }
+                break
+            }
 
             // Wait for the go-signal (first ack) and then for credit, bounded by
             // the no-ack deadline; bail on abort.
             let outcome = transfer.awaitCredit(
-                offset: offset, chunkSize: nextChunkSize, timeout: noAckTimeout)
+                offset: offset, chunkSize: chunk.count, timeout: noAckTimeout)
             switch outcome {
             case .aborted(let reason):
                 notifyPeerOfRetirement(transfer, reason: reason)
-                return
+                return false
             case .timedOut:
                 sendAbort(transfer: transfer, code: "ack.timeout", message: "Peer stopped acknowledging")
-                return
+                return false
             case .proceed:
                 break
             }
@@ -265,12 +389,19 @@ public final class ClipboardStreamSender: @unchecked Sendable {
             guard isCurrent(transfer.generation) else {
                 transfer.markAborted(.superseded)
                 notifyPeerOfRetirement(transfer, reason: .superseded)
-                return
+                return false
             }
 
-            guard let chunk = reader.read(upTo: nextChunkSize), !chunk.isEmpty else {
-                sendAbort(transfer: transfer, code: "read.error", message: "Source read failed at offset \(offset)")
-                return
+            // The requester's ceiling, enforced as bytes are produced. A declared
+            // payload was already refused up front, so this only ever fires for a
+            // stream whose size wasn't knowable then.
+            if maxAcceptByteCount != ClipboardStreamTuning.unlimitedAcceptByteCount,
+                UInt64(offset) + UInt64(chunk.count) > maxAcceptByteCount
+            {
+                sendAbort(
+                    transfer: transfer, code: "disk.full",
+                    message: "Requester cannot accept more than \(maxAcceptByteCount) bytes")
+                return false
             }
             hasher.update(data: chunk)
 
@@ -284,11 +415,12 @@ public final class ClipboardStreamSender: @unchecked Sendable {
                             $0.data = chunk
                         }
                     })
-            else { return }  // channel dead
+            else { return false }  // channel dead
             offset += chunk.count
             // Report bytes handed to the socket (not yet acked) so the owner can
-            // surface outbound progress.
-            onProgress?(offset, totalBytes)
+            // surface outbound progress. A `0` total leaves the tracker on the
+            // expectation the unit was opened with — the offer's estimate.
+            onProgress?(offset, declaredByteCount ?? 0)
         }
 
         let digest = Data(hasher.finalize())
@@ -297,13 +429,13 @@ public final class ClipboardStreamSender: @unchecked Sendable {
                 $0.protocolVersion = 1
                 $0.clipboardStreamEnd = .with {
                     $0.transferID = transfer.transferID
-                    $0.totalBytes = UInt64(totalBytes)
+                    $0.totalBytes = UInt64(offset)
                     $0.sha256 = digest
                 }
             })
         // All bytes were streamed; a failed End-send still counts as success —
         // delivery is then the receiver's stall concern, not a send failure.
-        didComplete = true
+        return true
     }
 
     /// Writes a frame; returns `false` if the channel is dead (the transfer
@@ -438,7 +570,11 @@ private final class OutboundTransfer: @unchecked Sendable {
 
 // MARK: - Chunk readers
 
-/// Reads a source sequentially in chunks. `read(upTo:)` returns `nil` on error.
+/// Reads a source sequentially in chunks.
+///
+/// `read(upTo:)` returns `nil` on error and an empty `Data` at the end of the
+/// source — which is the end of the payload for a source whose size was never
+/// declared, and a short read for one that was.
 private protocol ChunkReader {
     func read(upTo count: Int) -> Data?
     func close()
@@ -462,6 +598,29 @@ private final class InMemoryChunkReader: ChunkReader {
         return slice
     }
     func close() {}
+}
+
+/// Reads a folder as archive bytes produced on demand, so nothing larger than
+/// the credit window is ever held and no archive lands on disk.
+///
+/// The empty result that ends the stream is reached only once the encode
+/// pipeline has closed cleanly; a failure anywhere in it surfaces as `nil`, the
+/// transfer's `read.error` abort.
+private final class DirectoryArchiveChunkReader: ChunkReader {
+    private let reader: ClipboardDirectoryArchiveReader
+
+    init(directoryURL: URL, label: String, capacityBytes: Int) {
+        reader = ClipboardDirectoryArchiveReader(
+            directoryURL: directoryURL, label: label, capacityBytes: capacityBytes)
+    }
+
+    func read(upTo count: Int) -> Data? {
+        try? reader.read(upTo: count)
+    }
+
+    func close() {
+        reader.cancel()
+    }
 }
 
 private final class FileChunkReader: ChunkReader {

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
@@ -18,6 +18,8 @@ public final class ClipboardStreamSender: @unchecked Sendable {
     private let windowBytes: Int
     private let noAckTimeout: TimeInterval
 
+    private let directorySource: ClipboardDirectorySourceFactory
+
     private let lock = NSLock()
     private var transfers: [UInt64: OutboundTransfer] = [:]
 
@@ -28,16 +30,37 @@ public final class ClipboardStreamSender: @unchecked Sendable {
     ///     chunk so a transfer can always make progress.
     ///   - noAckTimeout: how long a transfer waits for credit to advance before
     ///     aborting a hung peer.
-    public init(
+    public convenience init(
         channel: VsockChannel,
         chunkSize: Int = ClipboardStreamTuning.defaultChunkPayloadSize,
         windowBytes: Int = ClipboardStreamTuning.defaultWindowBytes,
         noAckTimeout: TimeInterval = 10
     ) {
+        self.init(
+            channel: channel, chunkSize: chunkSize, windowBytes: windowBytes,
+            noAckTimeout: noAckTimeout,
+            directorySource: { url, label, capacity in
+                DirectoryArchiveChunkReader(
+                    directoryURL: url, label: label, capacityBytes: capacity)
+            })
+    }
+
+    /// Creates a sender whose folder transfers read through `directorySource`.
+    ///
+    /// A test stands in a source that parks, which is the only way to exercise
+    /// an abort landing while the transfer thread is inside a read.
+    init(
+        channel: VsockChannel,
+        chunkSize: Int = ClipboardStreamTuning.defaultChunkPayloadSize,
+        windowBytes: Int = ClipboardStreamTuning.defaultWindowBytes,
+        noAckTimeout: TimeInterval = 10,
+        directorySource: @escaping ClipboardDirectorySourceFactory
+    ) {
         self.channel = channel
         self.chunkSize = max(1, chunkSize)
         self.windowBytes = max(windowBytes, max(1, chunkSize))
         self.noAckTimeout = noAckTimeout
+        self.directorySource = directorySource
     }
 
     /// Begins streaming `representation` in reply to a request.
@@ -144,13 +167,29 @@ public final class ClipboardStreamSender: @unchecked Sendable {
             defer { onComplete?(didComplete) }
             defer { self.remove(transfer.transferID) }
 
-            let reader = DirectoryArchiveChunkReader(
-                directoryURL: sourceDirectoryURL, label: "\(transferID)",
-                capacityBytes: self.windowBytes)
+            // Opening the source starts the walk-and-compress, so check for a
+            // retirement that landed between registration and here before paying
+            // for a tree nobody is waiting on.
+            let retirement = transfer.retirement()
+            if retirement.retired {
+                self.notifyPeerOfRetirement(transfer, reason: retirement.reason)
+                return
+            }
+            let reader = self.directorySource(
+                sourceDirectoryURL, "\(transferID)", self.windowBytes)
             // Covers every exit below — abort, supersession, credit timeout, a
             // dead channel — by unblocking the encode pipeline so its worker
             // unwinds instead of parking in a callback that has no timeout.
             defer { reader.close() }
+            // An archive source parks this thread inside `read` when the encoder
+            // has produced nothing yet, and no abort path signals the transfer's
+            // own condition into *that* wait. Route retirement to the source too,
+            // or a stalled encode outlives every abort, supersession and channel
+            // teardown — and, because a transfer id is derivable, silently
+            // swallows the peer's retry as a duplicate.
+            if transfer.setAbortHook({ [weak reader] in reader?.close() }) {
+                reader.close()
+            }
 
             didComplete = self.stream(
                 transfer: transfer, reader: reader, declaredByteCount: nil, uti: uti,
@@ -342,6 +381,13 @@ public final class ClipboardStreamSender: @unchecked Sendable {
             // credit for either would park the sender on credit for bytes it is
             // never going to send, which nothing else can then unblock.
             guard var chunk = reader.read(upTo: nextChunkSize) else {
+                // A retirement is what woke this read when it was parked, so it
+                // is the peer's news rather than a source failure.
+                let retirement = transfer.retirement()
+                if retirement.retired {
+                    notifyPeerOfRetirement(transfer, reason: retirement.reason)
+                    return false
+                }
                 sendAbort(transfer: transfer, code: "read.error", message: "Source read failed at offset \(offset)")
                 return false
             }
@@ -419,8 +465,10 @@ public final class ClipboardStreamSender: @unchecked Sendable {
             offset += chunk.count
             // Report bytes handed to the socket (not yet acked) so the owner can
             // surface outbound progress. A `0` total leaves the tracker on the
-            // expectation the unit was opened with — the offer's estimate.
-            onProgress?(offset, declaredByteCount ?? 0)
+            // expectation the unit was opened with — the offer's estimate — so
+            // the numerator has to be in that unit too, which for a folder is
+            // what the source has encoded, not what the wire has carried.
+            onProgress?(reader.offerUnitProgress ?? offset, declaredByteCount ?? 0)
         }
 
         let digest = Data(hasher.finalize())
@@ -498,6 +546,11 @@ private final class OutboundTransfer: @unchecked Sendable {
     var started = false
     /// Set on inbound abort / supersession / teardown.
     var aborted = false
+    /// Wakes a source parked outside `awaitCredit`, run once retirement is
+    /// claimed.
+    ///
+    /// Idempotent by contract, so a duplicate abort is harmless.
+    var abortHook: (@Sendable () -> Void)?
     /// Why the transfer was aborted (decides whether to notify the peer).
     var abortReason: AbortReason?
 
@@ -563,8 +616,22 @@ private final class OutboundTransfer: @unchecked Sendable {
             aborted = true
             abortReason = reason
         }
+        let hook = abortHook
         condition.signal()
         condition.unlock()
+        // Outside the lock: the hook takes the source's own lock, and nothing
+        // should hold two.
+        hook?()
+    }
+
+    /// Registers the retirement hook, reporting whether retirement already
+    /// happened — in which case the caller runs it itself, since `markAborted`
+    /// has been and gone.
+    func setAbortHook(_ hook: @escaping @Sendable () -> Void) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        abortHook = hook
+        return aborted
     }
 }
 
@@ -575,12 +642,32 @@ private final class OutboundTransfer: @unchecked Sendable {
 /// `read(upTo:)` returns `nil` on error and an empty `Data` at the end of the
 /// source — which is the end of the payload for a source whose size was never
 /// declared, and a short read for one that was.
-private protocol ChunkReader {
+///
+/// `close()` must be safe to call from another thread while a read is in
+/// flight, and must make that read return: it is how an abort reaches a source
+/// that parks.
+protocol ChunkReader: AnyObject {
     func read(upTo count: Int) -> Data?
     func close()
+    /// Bytes of the *payload the offer described* produced so far, when the
+    /// source can say — a folder's wire bytes are compressed and so are in a
+    /// different unit from every readout's denominator. `nil` leaves the caller
+    /// to report wire bytes.
+    var offerUnitProgress: Int? { get }
 }
 
-private final class InMemoryChunkReader: ChunkReader {
+extension ChunkReader {
+    /// A source whose wire bytes *are* the payload needs no translation.
+    var offerUnitProgress: Int? { nil }
+}
+
+/// Opens the archive source for a folder transfer.
+typealias ClipboardDirectorySourceFactory =
+    @Sendable (
+        _ directoryURL: URL, _ label: String, _ capacityBytes: Int
+    ) -> ChunkReader
+
+final class InMemoryChunkReader: ChunkReader {
     private let data: Data
     private var offset: Int
     init(data: Data) {
@@ -606,7 +693,7 @@ private final class InMemoryChunkReader: ChunkReader {
 /// The empty result that ends the stream is reached only once the encode
 /// pipeline has closed cleanly; a failure anywhere in it surfaces as `nil`, the
 /// transfer's `read.error` abort.
-private final class DirectoryArchiveChunkReader: ChunkReader {
+final class DirectoryArchiveChunkReader: ChunkReader {
     private let reader: ClipboardDirectoryArchiveReader
 
     init(directoryURL: URL, label: String, capacityBytes: Int) {
@@ -618,12 +705,16 @@ private final class DirectoryArchiveChunkReader: ChunkReader {
         try? reader.read(upTo: count)
     }
 
+    /// Uncompressed archive bytes, which is the unit the folder's offer estimate
+    /// is in — the compressed wire count would read as a stalled transfer.
+    var offerUnitProgress: Int? { reader.uncompressedByteCount }
+
     func close() {
         reader.cancel()
     }
 }
 
-private final class FileChunkReader: ChunkReader {
+final class FileChunkReader: ChunkReader {
     private let handle: FileHandle
     init?(url: URL) {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamSender.swift
@@ -668,11 +668,25 @@ extension ChunkReader {
     var offerUnitProgress: Int? { nil }
 }
 
+/// A `ChunkReader` whose `close()` is safe to call from another thread while a
+/// `read(upTo:)` is parked on it, and whose reads and closes may therefore be
+/// interleaved across threads.
+///
+/// A source that produces its bytes on its own schedule parks its caller inside
+/// `read(upTo:)`, and nothing else can reach that park — so retirement runs
+/// `close()` from whichever thread claimed it. Conforming is the promise that
+/// this is sound; `ChunkReader` alone does not carry it, and the readers backed
+/// by an unguarded cursor or a `FileHandle` cannot make it.
+protocol CancellableChunkReader: ChunkReader, Sendable {}
+
 /// Opens the archive source for a folder transfer.
+///
+/// The result is cancellable because a folder's encode runs ahead of the
+/// transport and parks the transfer thread, which only `close()` can release.
 typealias ClipboardDirectorySourceFactory =
     @Sendable (
         _ directoryURL: URL, _ label: String, _ capacityBytes: Int
-    ) -> ChunkReader
+    ) -> CancellableChunkReader
 
 final class InMemoryChunkReader: ChunkReader {
     private let data: Data
@@ -700,7 +714,7 @@ final class InMemoryChunkReader: ChunkReader {
 /// The empty result that ends the stream is reached only once the encode
 /// pipeline has closed cleanly; a failure anywhere in it surfaces as `nil`, the
 /// transfer's `read.error` abort.
-final class DirectoryArchiveChunkReader: ChunkReader {
+final class DirectoryArchiveChunkReader: CancellableChunkReader {
     private let reader: ClipboardDirectoryArchiveReader
 
     init(directoryURL: URL, label: String, capacityBytes: Int) {

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamTuning.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamTuning.swift
@@ -64,6 +64,18 @@ public enum ClipboardStreamTuning {
     /// bounds what a misbehaving peer can apply between disk re-checks.
     public static let maxChunkBytes = 16 * 1024 * 1024
 
+    /// The most a receiver lets arrive ahead of what it has written: one credit
+    /// window plus one maximum-size chunk.
+    ///
+    /// A sender honoring the window it was advertised can never reach this — its
+    /// in-flight bytes are bounded by that window — so it bounds only a peer that
+    /// ignores the protocol, whose chunks would otherwise queue on the write lane
+    /// without limit. A declared payload is bounded by its own size; one that
+    /// declares none (a folder archived onto the wire) has only this.
+    public static func maxBacklogBytes(forWindowBytes windowBytes: Int) -> Int {
+        windowBytes + maxChunkBytes
+    }
+
     /// How long an inbound transfer waits for its next chunk before aborting a
     /// silent sender: 30 s.
     ///

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamTuning.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamTuning.swift
@@ -64,6 +64,15 @@ public enum ClipboardStreamTuning {
     /// bounds what a misbehaving peer can apply between disk re-checks.
     public static let maxChunkBytes = 16 * 1024 * 1024
 
+    /// Floor on how much tree a streamed folder may extract regardless of the
+    /// size its offer advertised: 64 MiB.
+    ///
+    /// A folder's estimate sums file bytes only, so a tree of directories and
+    /// empty files advertises zero while its archive still carries a header per
+    /// entry. This is the allowance that keeps such a tree extractable while
+    /// still bounding one whose advertised size is a fabrication.
+    public static let minimumExtractAllowance = 64 * 1024 * 1024
+
     /// The most a receiver lets arrive ahead of what it has written: one credit
     /// window plus one maximum-size chunk.
     ///

--- a/KernovaKit/Sources/KernovaKit/Generated/kernova.pb.swift
+++ b/KernovaKit/Sources/KernovaKit/Generated/kernova.pb.swift
@@ -357,12 +357,11 @@ public nonisolated struct Kernova_V1_ClipboardRepresentationInfo: Sendable {
   /// Size of the representation's bytes. For a copied file this is the file's
   /// size from a stat — the bytes themselves are never read to build the offer.
   /// For a directory rep (`is_directory`) it is the producer's stat-walk size
-  /// ESTIMATE of the source tree: no archive exists at offer time, so the
-  /// receiver's paste cap and free-space preflight gate on this estimate. The
-  /// wire-exact archive size arrives later as the reply's
-  /// `ClipboardStreamBegin.total_bytes`, and the stream layer re-enforces
-  /// reality: `max_accept_byte_count` on the request, a per-chunk disk check,
-  /// and the End frame's size + SHA-256 verification.
+  /// ESTIMATE of the *uncompressed* source tree, which is what a streamed
+  /// extract writes, so the receiver's paste cap and free-space preflight gate
+  /// on it. The stream layer re-enforces reality: `max_accept_byte_count` on the
+  /// request, a per-chunk disk check, and the End frame's size + SHA-256
+  /// verification.
   public var byteCount: UInt64 = 0
 
   /// Suggested filename when this representation is a file payload (e.g. a
@@ -386,17 +385,19 @@ public nonisolated struct Kernova_V1_ClipboardRepresentationInfo: Sendable {
   /// package such as .app/.rtfd). Implies a non-empty `filename` (the folder
   /// name, without an archive suffix) and `is_inline = false`.
   ///
-  /// A directory rep rides the plain-file stream path: the producer packs the
-  /// source tree into an in-process AppleArchive (.aar, LZFSE) when the
-  /// representation is *requested* — never at copy time — and the receiver
-  /// extracts the streamed archive back into a real directory. `byte_count`
-  /// is the producer's stat-walk estimate; the archive's exact size rides in
-  /// the reply's `ClipboardStreamBegin.total_bytes`.
+  /// A directory rep rides the plain-file stream path, carrying an in-process
+  /// AppleArchive (LZFSE) of the tree. The producer encodes the source tree
+  /// straight onto the wire when the representation is *requested* — never at
+  /// copy time, and never through an archive file — and the receiver extracts
+  /// the arriving bytes straight into a real directory. Its compressed size is
+  /// therefore unknown when the transfer starts, so the reply's
+  /// `ClipboardStreamBegin.total_bytes` is 0 and the End frame carries the true
+  /// count.
   ///
-  /// The stream layer is offer-agnostic, so this flag is re-applied to the
-  /// delivered representation by the offer-aware layer on the receiver. Excluded
-  /// from the content digest — the archive's SHA-256 and the folded filename
-  /// already identify it.
+  /// The stream layer is offer-agnostic: the requester tells its own receiver
+  /// that a transfer carries a directory when it sends the `ClipboardRequest`,
+  /// so nothing on the wire repeats this flag. Excluded from the content digest
+  /// — the archive's SHA-256 and the folded filename already identify it.
   public var isDirectory: Bool = false
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -499,9 +500,13 @@ public nonisolated struct Kernova_V1_ClipboardStreamBegin: Sendable {
   /// The representation's UTI.
   public var uti: String = String()
 
-  /// Total payload size in bytes; the receiver verifies the reassembled byte
-  /// count against this at `ClipboardStreamEnd`, and sizes its free-space
-  /// pre-flight check from it for a file rep.
+  /// Total payload size in bytes, or 0 for a payload whose size is only known
+  /// once it has been produced — a directory archived onto the wire. When
+  /// declared, the receiver bounds the arriving bytes by it and sizes its
+  /// free-space pre-flight check from it for a file rep. When 0, the requester's
+  /// free-space pre-flight against the offer's uncompressed estimate and a
+  /// per-window disk re-check stand in, and `ClipboardStreamEnd` carries the
+  /// authoritative count.
   public var totalBytes: UInt64 = 0
 
   /// Suggested filename for a file rep (see `ClipboardRepresentationInfo`);
@@ -548,7 +553,8 @@ public nonisolated struct Kernova_V1_ClipboardStreamEnd: Sendable {
 
   public var transferID: UInt64 = 0
 
-  /// Total bytes the sender streamed; must equal the Begin's `total_bytes`.
+  /// Total bytes the sender streamed — the authoritative count, and the Begin's
+  /// `total_bytes` whenever that declared one.
   public var totalBytes: UInt64 = 0
 
   /// SHA-256 over the streamed bytes, computed incrementally as the sender read

--- a/KernovaKit/Sources/KernovaKit/KernovaCapability.swift
+++ b/KernovaKit/Sources/KernovaKit/KernovaCapability.swift
@@ -18,6 +18,15 @@ public enum KernovaCapability {
     /// Required on both sides for clipboard sharing to be enabled.
     public static let clipboardStreamV1 = "clipboard.stream.v1"
 
+    /// Receiving a folder as an archive streamed straight into the destination
+    /// tree, announced with `ClipboardStreamBegin.total_bytes = 0` because the
+    /// compressed size is not known when the transfer starts.
+    ///
+    /// A peer without it bounds arriving bytes by that declared total and aborts
+    /// the transfer on the first chunk, so a folder is simply not offered to one
+    /// — every other representation is unaffected.
+    public static let clipboardStreamDirectoryV1 = "clipboard.stream.directory.v1"
+
     /// Honoring `PolicyUpdate.clipboard_max_paste_bytes` — the user-selected
     /// ceiling on a paste's file-representation total.
     ///
@@ -29,7 +38,8 @@ public enum KernovaCapability {
     /// The capabilities advertised by both the host control service and the
     /// guest control agent today.
     public static let controlChannelDefaults = [
-        controlV1, controlHeartbeatV1, clipboardStreamV1, clipboardPasteLimitV1,
+        controlV1, controlHeartbeatV1, clipboardStreamV1, clipboardStreamDirectoryV1,
+        clipboardPasteLimitV1,
     ]
 
     /// Every capability tag this build recognizes — the allowlist for

--- a/KernovaKit/Sources/KernovaTestSupport/ClipboardDirectoryArchiveFixtures.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/ClipboardDirectoryArchiveFixtures.swift
@@ -1,0 +1,38 @@
+import Foundation
+import KernovaKit
+
+/// The wire bytes a folder transfer carries for `directoryURL` — what
+/// `ClipboardStreamSender.startDirectoryTransfer` puts on the channel.
+///
+/// A test standing in for the producing side builds its payload with this, and
+/// one standing in for the consuming side checks the bytes it collected against
+/// `extractedClipboardArchive(_:)`.
+public func clipboardArchiveBytes(ofDirectoryAt directoryURL: URL) throws -> Data {
+    let reader = ClipboardDirectoryArchiveReader(directoryURL: directoryURL, label: "fixture")
+    var bytes = Data()
+    while true {
+        let chunk = try reader.read(upTo: 64 << 10)
+        if chunk.isEmpty { break }
+        bytes.append(chunk)
+    }
+    return bytes
+}
+
+/// Extracts folder-transfer wire bytes into a fresh directory, which it returns.
+///
+/// - Throws: whatever the extract pipeline reports for a truncated or corrupt
+///   archive; the partial tree is removed in that case.
+public func extractedClipboardArchive(_ bytes: Data, named name: String = "out") throws -> URL {
+    let destination = FileManager.default.temporaryDirectory
+        .appendingPathComponent("archive-fixture-\(UUID().uuidString)", isDirectory: true)
+        .appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+    let sink = ClipboardDirectoryExtractSink(destinationURL: destination, label: "fixture")
+    do {
+        try sink.write(bytes)
+        return try sink.commit()
+    } catch {
+        sink.abort()
+        throw error
+    }
+}

--- a/KernovaKit/Sources/KernovaTestSupport/StagingInspection.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/StagingInspection.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Every regular file anywhere under `directory` (recursive).
+///
+/// What a test asserts against to prove a transfer staged nothing it shouldn't
+/// have — an intermediate archive, or a partial left behind by an abort.
+public func materializedFiles(under directory: URL) -> [URL] {
+    guard
+        let enumerator = FileManager.default.enumerator(
+            at: directory, includingPropertiesForKeys: [.isRegularFileKey])
+    else { return [] }
+    return enumerator.compactMap { $0 as? URL }.filter {
+        (try? $0.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true
+    }
+}

--- a/KernovaKit/Sources/KernovaTestSupport/StagingInspection.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/StagingInspection.swift
@@ -1,5 +1,22 @@
 import Foundation
 
+/// A `@Sendable`-safe mutable cell — lets a synchronous test closure record what
+/// it observed from a concurrency-checked context.
+///
+/// One copy for every test target, since all three need it.
+public final class Box<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: T
+    /// Creates a cell holding `value`.
+    public init(_ value: T) { stored = value }
+
+    /// The current value; reads and writes are serialized.
+    public var value: T {
+        get { lock.withLock { stored } }
+        set { lock.withLock { stored = newValue } }
+    }
+}
+
 /// Every regular file anywhere under `directory` (recursive).
 ///
 /// What a test asserts against to prove a transfer staged nothing it shouldn't

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryAccountingTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryAccountingTests.swift
@@ -237,11 +237,93 @@ struct ClipboardDirectoryAccountingTests {
         // The readout's denominator is the offer's uncompressed estimate, so a
         // numerator counting compressed wire bytes crawls to a fraction and then
         // snaps — which reads as a hung paste. Both ends must exceed what
-        // actually crossed the wire.
-        let wireBytes = try #require(harness.collector.representation(id)?.byteCount)
+        // actually crossed the wire, which the transfer metrics report.
+        let wireBytes = try #require(
+            harness.collector.timedMetrics.first { $0.transferID == id }?.byteCount)
         #expect(wireBytes < 4 * 1024 * 1024)
         #expect(sent.value > wireBytes)
         #expect(received.value > wireBytes)
+    }
+
+    @Test("the delivered folder is sized by its tree, not by the archive that carried it")
+    func deliveredFolderCarriesTheTreesSize() async throws {
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeCompressibleTree(uncompressedBytes: 512 * 1024)
+        defer { try? fm.removeItem(at: scratch) }
+        let bytes = try archiveBytes(of: source)
+
+        let id: UInt64 = 68
+        prime(harness, id: id, named: "Logs", advertised: 512 * 1024)
+        begin(harness, id: id, named: "Logs")
+        feed(harness, id: id, bytes: bytes)
+        harness.receiver.handleEnd(
+            .with {
+                $0.transferID = id
+                $0.totalBytes = UInt64(bytes.count)
+                $0.sha256 = Data(SHA256.hash(data: bytes))
+            })
+
+        try await harness.collector.gate.wait { harness.collector.representation(id) != nil }
+        let rep = try #require(harness.collector.representation(id))
+        // The rep's bytes are the tree at its URL, and the offer advertised that
+        // figure too — the compressed count is a different unit and, here, ~100×
+        // smaller.
+        #expect(rep.byteCount >= 512 * 1024)
+        #expect(rep.byteCount > bytes.count)
+        // The digest still covers the wire bytes: it is the transfer's integrity
+        // gate, and re-hashing the tree would prove nothing about what arrived.
+        guard case .file(_, _, let sha256) = rep.source else {
+            Issue.record("Expected a file-backed representation, got \(rep.source)")
+            return
+        }
+        #expect(sha256 == Data(SHA256.hash(data: bytes)))
+    }
+
+    @Test("the requester's ceiling stops a folder by the tree it unpacks to, not by the wire")
+    func senderCeilingIsMeasuredInTheTreesUnit() async throws {
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeCompressibleTree(uncompressedBytes: 512 * 1024)
+        defer { try? fm.removeItem(at: scratch) }
+        // A ceiling the wire never comes close to: the whole archive is a couple
+        // of KiB, so a guard counting wire bytes lets the half-megabyte tree
+        // through to a requester that said it had room for 64 KiB.
+        let ceiling = 64 * 1024
+        #expect(try archiveBytes(of: source).count < ceiling)
+
+        let id: UInt64 = 69
+        prime(harness, id: id, named: "Logs", advertised: 512 * 1024)
+        harness.sender.startDirectoryTransfer(
+            transferID: id, generation: 1, sourceDirectoryURL: source, folderName: "Logs",
+            uti: ClipboardDirectoryArchive.directoryUTI, maxAcceptByteCount: UInt64(ceiling),
+            isCurrent: { _ in true })
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        #expect(harness.collector.abortInfos.first?.code == "disk.full")
+        #expect(harness.collector.representation(id) == nil)
+    }
+
+    @Test("a folder whose tree fits the requester's ceiling still arrives")
+    func senderCeilingPassesATreeThatFits() async throws {
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeCompressibleTree(uncompressedBytes: 512 * 1024)
+        defer { try? fm.removeItem(at: scratch) }
+
+        let id: UInt64 = 70
+        prime(harness, id: id, named: "Logs", advertised: 512 * 1024)
+        harness.sender.startDirectoryTransfer(
+            transferID: id, generation: 1, sourceDirectoryURL: source, folderName: "Logs",
+            uti: ClipboardDirectoryArchive.directoryUTI, maxAcceptByteCount: 4 * 1024 * 1024,
+            isCurrent: { _ in true })
+
+        try await harness.collector.gate.wait { harness.collector.representation(id) != nil }
+        let tree = try #require(harness.collector.representation(id)?.fileURL)
+        #expect(try Data(contentsOf: tree.appendingPathComponent("big.log")).count == 512 * 1024)
     }
 
     @Test("a fresh pull reusing an abandoned transfer id is served, not refused")

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryAccountingTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryAccountingTests.swift
@@ -1,0 +1,327 @@
+import CryptoKit
+import Foundation
+import KernovaTestSupport
+import Testing
+
+@testable import KernovaKit
+
+/// What a folder transfer is measured in.
+///
+/// Its wire bytes are compressed and its tree is not, and LZFSE reaches ~100:1
+/// on text — so every guard and every readout that reasons about "how big is
+/// this" has to be expressed in the tree's unit, not the wire's. These are the
+/// tests that fail when one of them slips back to counting wire bytes.
+@Suite("ClipboardDirectoryAccounting")
+struct ClipboardDirectoryAccountingTests {
+    private static let chunk = 4096
+    private static let window = 16384
+
+    private func makeScratch() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(
+            "diraccounting-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    /// A tree whose archive is a fraction of the tree it unpacks to.
+    ///
+    /// `symbols` is how many distinct byte values the content draws from. One is
+    /// maximally compressible — a whole tree in a couple of KiB, which is what
+    /// makes a wire-paced guard miss entirely. A small alphabet compresses a
+    /// few-fold instead, which is what puts many chunks on the wire for the
+    /// progress tests to observe.
+    private func makeCompressibleTree(uncompressedBytes: Int, symbols: Int = 1) throws -> (
+        scratch: URL, source: URL
+    ) {
+        let fm = FileManager.default
+        let scratch = makeScratch()
+        let source = scratch.appendingPathComponent("Logs", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        let content: Data
+        if symbols <= 1 {
+            content = Data(repeating: 0x20, count: uncompressedBytes)
+        } else {
+            var generator = SystemRandomNumberGenerator()
+            var bytes = Data(count: uncompressedBytes)
+            bytes.withUnsafeMutableBytes { raw in
+                guard let base = raw.bindMemory(to: UInt8.self).baseAddress else { return }
+                for index in 0..<raw.count {
+                    base[index] = UInt8.random(in: 0..<UInt8(symbols), using: &generator)
+                }
+            }
+            content = bytes
+        }
+        try content.write(to: source.appendingPathComponent("big.log"))
+        return (scratch, source)
+    }
+
+    private func harness(
+        freeSpace: @escaping @Sendable () -> Int64 = { 100 << 30 },
+        minimumExtractAllowance: Int = ClipboardStreamTuning.minimumExtractAllowance
+    ) throws -> StreamHarness {
+        try StreamHarness(
+            chunkSize: Self.chunk, windowBytes: Self.window,
+            minimumExtractAllowance: minimumExtractAllowance,
+            freeSpaceProvider: { _ in freeSpace() })
+    }
+
+    private func prime(
+        _ harness: StreamHarness, id: UInt64, named name: String, advertised: Int
+    ) {
+        let collector = harness.collector
+        harness.receiver.awaitTransfer(
+            id, extractsDirectoryNamed: name, advertisedByteCount: advertised,
+            onComplete: { collector.complete(id, $0) },
+            onAbort: { collector.abort($0) })
+    }
+
+    private func begin(_ harness: StreamHarness, id: UInt64, named name: String) {
+        harness.receiver.handleBegin(
+            .with {
+                $0.generation = 1
+                $0.transferID = id
+                $0.uti = ClipboardDirectoryArchive.directoryUTI
+                $0.totalBytes = 0
+                $0.filename = name
+                $0.isInline = false
+            })
+    }
+
+    private func archiveBytes(of source: URL) throws -> Data {
+        let reader = ClipboardDirectoryArchiveReader(directoryURL: source, label: "test")
+        var bytes = Data()
+        while true {
+            let chunk = try reader.read(upTo: 64 << 10)
+            if chunk.isEmpty { break }
+            bytes.append(chunk)
+        }
+        return bytes
+    }
+
+    private func feed(_ harness: StreamHarness, id: UInt64, bytes: Data) {
+        var offset = 0
+        while offset < bytes.count {
+            let end = min(offset + Self.chunk, bytes.count)
+            let slice = Data(bytes[bytes.startIndex + offset..<bytes.startIndex + end])
+            harness.receiver.handleChunk(
+                .with {
+                    $0.transferID = id
+                    $0.offset = UInt64(offset)
+                    $0.data = slice
+                })
+            offset = end
+        }
+    }
+
+    @Test("a volume that fills is caught while the tree is being written, not per wire byte")
+    func diskGuardIsPacedByTheTreeNotTheWire() async throws {
+        let fm = FileManager.default
+        // Below the free-space margin, so any check that actually runs refuses.
+        let harness = try harness(freeSpace: { 1024 })
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeCompressibleTree(uncompressedBytes: 512 * 1024)
+        defer { try? fm.removeItem(at: scratch) }
+        let bytes = try archiveBytes(of: source)
+        // The point: this archive is far smaller than one credit window, so a
+        // guard clocked on arriving wire bytes never fires at all, while the tree
+        // it writes is many windows long.
+        #expect(bytes.count < Self.window)
+
+        let id: UInt64 = 61
+        prime(harness, id: id, named: "Logs", advertised: 512 * 1024)
+        begin(harness, id: id, named: "Logs")
+        feed(harness, id: id, bytes: bytes)
+        harness.receiver.handleEnd(
+            .with {
+                $0.transferID = id
+                $0.totalBytes = UInt64(bytes.count)
+                $0.sha256 = Data(SHA256.hash(data: bytes))
+            })
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        let info = try #require(harness.collector.abortInfos.first)
+        #expect(info.code == "disk.full")
+        #expect(harness.collector.representation(id) == nil)
+        // RATIONALE: filesystem-appearance poll (docs/TESTING.md) — the tree is
+        // removed on the write lane after the abort is delivered.
+        try await waitUntil { materializedFiles(under: harness.stagingTempRoot).isEmpty }
+    }
+
+    @Test("a folder that unpacks past what its offer advertised is refused")
+    func extractIsHeldToTheAdvertisedSize() async throws {
+        let fm = FileManager.default
+        // A small allowance so the floor doesn't swallow the test; the floor's
+        // production value exists for byte-free trees, not for this shape.
+        let harness = try harness(minimumExtractAllowance: 4096)
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeCompressibleTree(uncompressedBytes: 512 * 1024)
+        defer { try? fm.removeItem(at: scratch) }
+        let bytes = try archiveBytes(of: source)
+
+        let id: UInt64 = 62
+        // The peer advertised 1 KiB and is delivering half a megabyte: the paste
+        // ceiling and the free-space pre-flight were both computed from that
+        // figure, so nothing else is holding it to anything.
+        prime(harness, id: id, named: "Logs", advertised: 1024)
+        begin(harness, id: id, named: "Logs")
+        feed(harness, id: id, bytes: bytes)
+        harness.receiver.handleEnd(
+            .with {
+                $0.transferID = id
+                $0.totalBytes = UInt64(bytes.count)
+                $0.sha256 = Data(SHA256.hash(data: bytes))
+            })
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        #expect(harness.collector.abortInfos.first?.code == "size.overrun")
+        #expect(harness.collector.representation(id) == nil)
+        // RATIONALE: filesystem-appearance poll (docs/TESTING.md) — same ordering
+        // as the disk-full case.
+        try await waitUntil { materializedFiles(under: harness.stagingTempRoot).isEmpty }
+    }
+
+    @Test("a folder within its advertised size plus the container's overhead still arrives")
+    func extractAllowsContainerOverhead() async throws {
+        let fm = FileManager.default
+        let harness = try harness(minimumExtractAllowance: 4096)
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeCompressibleTree(uncompressedBytes: 256 * 1024)
+        defer { try? fm.removeItem(at: scratch) }
+        let bytes = try archiveBytes(of: source)
+
+        let id: UInt64 = 63
+        // Advertised honestly: the archive still carries per-entry headers on top
+        // of the file bytes the estimate sums, so the allowance has to have room
+        // for them or every honest folder would be refused.
+        prime(harness, id: id, named: "Logs", advertised: 256 * 1024)
+        begin(harness, id: id, named: "Logs")
+        feed(harness, id: id, bytes: bytes)
+        harness.receiver.handleEnd(
+            .with {
+                $0.transferID = id
+                $0.totalBytes = UInt64(bytes.count)
+                $0.sha256 = Data(SHA256.hash(data: bytes))
+            })
+
+        try await harness.collector.gate.wait { harness.collector.representation(id) != nil }
+        let tree = try #require(harness.collector.representation(id)?.fileURL)
+        #expect(
+            try Data(contentsOf: tree.appendingPathComponent("big.log")).count == 256 * 1024)
+    }
+
+    @Test("progress is reported in the tree's unit, not the wire's")
+    func progressIsReportedInTheOfferUnit() async throws {
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        // A four-symbol alphabet compresses several-fold, so the wire carries
+        // many chunks and both readouts have something to climb through.
+        let (scratch, source) = try makeCompressibleTree(
+            uncompressedBytes: 4 * 1024 * 1024, symbols: 4)
+        defer { try? fm.removeItem(at: scratch) }
+
+        let id: UInt64 = 64
+        let sent = Box(0)
+        let received = Box(0)
+        let collector = harness.collector
+        harness.receiver.awaitTransfer(
+            id, extractsDirectoryNamed: "Logs", advertisedByteCount: 4 * 1024 * 1024,
+            onComplete: { collector.complete(id, $0) },
+            onAbort: { collector.abort($0) },
+            onProgress: { bytes, _ in received.value = max(received.value, bytes) })
+        harness.sender.startDirectoryTransfer(
+            transferID: id, generation: 1, sourceDirectoryURL: source, folderName: "Logs",
+            uti: ClipboardDirectoryArchive.directoryUTI, maxAcceptByteCount: .max,
+            isCurrent: { _ in true },
+            onProgress: { bytes, _ in sent.value = max(sent.value, bytes) })
+
+        try await harness.collector.gate.wait { harness.collector.representation(id) != nil }
+        // The readout's denominator is the offer's uncompressed estimate, so a
+        // numerator counting compressed wire bytes crawls to a fraction and then
+        // snaps — which reads as a hung paste. Both ends must exceed what
+        // actually crossed the wire.
+        let wireBytes = try #require(harness.collector.representation(id)?.byteCount)
+        #expect(wireBytes < 4 * 1024 * 1024)
+        #expect(sent.value > wireBytes)
+        #expect(received.value > wireBytes)
+    }
+
+    @Test("a fresh pull reusing an abandoned transfer id is served, not refused")
+    func retryAfterACancelledPullIsServed() async throws {
+        // Transfer ids are derivable from (generation, repIndex, direction), so a
+        // second paste of the same representation reuses the id of a pull that
+        // timed out. The record of that cancellation must not outlive the
+        // registration that replaces it.
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeCompressibleTree(uncompressedBytes: 4096)
+        defer { try? fm.removeItem(at: scratch) }
+        let bytes = try archiveBytes(of: source)
+
+        let id: UInt64 = 67
+        prime(harness, id: id, named: "Logs", advertised: 4096)
+        harness.receiver.cancelAwait(id)
+
+        prime(harness, id: id, named: "Logs", advertised: 4096)
+        begin(harness, id: id, named: "Logs")
+        feed(harness, id: id, bytes: bytes)
+        harness.receiver.handleEnd(
+            .with {
+                $0.transferID = id
+                $0.totalBytes = UInt64(bytes.count)
+                $0.sha256 = Data(SHA256.hash(data: bytes))
+            })
+
+        try await harness.collector.gate.wait { harness.collector.representation(id) != nil }
+        let tree = try #require(harness.collector.representation(id)?.fileURL)
+        #expect(try Data(contentsOf: tree.appendingPathComponent("big.log")).count == 4096)
+    }
+
+    @Test("an extract that fails on a full volume reports disk space, not a corrupt archive")
+    func extractFailureOnAFullVolumeReportsDiskFull() async throws {
+        // Once the margin is outrun the extract's own writes are what fail, and
+        // AppleArchive reports that as an archive error. Calling it a corrupt
+        // folder sends the user off to retry instead of to free space.
+        let harness = try harness(freeSpace: { 1024 })
+        defer { harness.tearDown() }
+        let id: UInt64 = 66
+        prime(harness, id: id, named: "Logs", advertised: 4096)
+        begin(harness, id: id, named: "Logs")
+        let garbage = Data("not an archive".utf8)
+        feed(harness, id: id, bytes: garbage)
+        harness.receiver.handleEnd(
+            .with {
+                $0.transferID = id
+                $0.totalBytes = UInt64(garbage.count)
+                $0.sha256 = Data(SHA256.hash(data: garbage))
+            })
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        #expect(harness.collector.abortInfos.first?.code == "disk.full")
+    }
+
+    @Test("a Begin for a pull this side cancelled is refused, not restaged as a file")
+    func cancelledPullRefusesItsReply() async throws {
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let id: UInt64 = 65
+        prime(harness, id: id, named: "Logs", advertised: 4096)
+        // The lazy pull gives up (a backstop timeout, a cancelled generation)
+        // while the peer's reply is already in flight.
+        harness.receiver.cancelAwait(id)
+        begin(harness, id: id, named: "Logs")
+
+        // No transfer exists, so nothing was staged and no chunk can be blamed on
+        // the peer for overrunning a total this side invented.
+        #expect(harness.receiver.lastChunkAtForTesting(id) == nil)
+        harness.receiver.handleChunk(
+            .with {
+                $0.transferID = id; $0.offset = 0; $0.data = Data([1, 2, 3])
+            })
+        // RATIONALE: negative assertion (docs/TESTING.md) — proving nothing was
+        // created needs a fixed observation window, not a wait for a signal.
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(harness.collector.abortCount == 0)
+        #expect(harness.collector.completedCount == 0)
+        #expect(materializedFiles(under: harness.stagingTempRoot).isEmpty)
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryArchiveTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryArchiveTests.swift
@@ -13,47 +13,6 @@ struct ClipboardDirectoryArchiveTests {
         return url
     }
 
-    @Test("archive → extract preserves a nested tree, contents, empty dir, and exec bit")
-    func roundTripFidelity() throws {
-        let fm = FileManager.default
-        let scratch = try makeScratch()
-        defer { try? fm.removeItem(at: scratch) }
-
-        let source = scratch.appendingPathComponent("source", isDirectory: true)
-        let nested = source.appendingPathComponent("a/b/c", isDirectory: true)
-        try fm.createDirectory(at: nested, withIntermediateDirectories: true)
-        try "top".write(to: source.appendingPathComponent("top.txt"), atomically: true, encoding: .utf8)
-        try "deep".write(to: nested.appendingPathComponent("deep.txt"), atomically: true, encoding: .utf8)
-        try fm.createDirectory(
-            at: source.appendingPathComponent("emptydir", isDirectory: true),
-            withIntermediateDirectories: true)
-        let exe = source.appendingPathComponent("run.sh")
-        try "#!/bin/sh\n".write(to: exe, atomically: true, encoding: .utf8)
-        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: exe.path)
-
-        let archive = scratch.appendingPathComponent("tree.aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: source, to: archive)
-        #expect(fm.fileExists(atPath: archive.path))
-
-        let dest = scratch.appendingPathComponent("extracted", isDirectory: true)
-        try fm.createDirectory(at: dest, withIntermediateDirectories: true)
-        try ClipboardDirectoryArchive.extract(archiveAt: archive, to: dest)
-
-        #expect(
-            try String(contentsOf: dest.appendingPathComponent("top.txt"), encoding: .utf8) == "top")
-        #expect(
-            try String(contentsOf: dest.appendingPathComponent("a/b/c/deep.txt"), encoding: .utf8)
-                == "deep")
-        var isDir: ObjCBool = false
-        #expect(
-            fm.fileExists(atPath: dest.appendingPathComponent("emptydir").path, isDirectory: &isDir)
-                && isDir.boolValue)
-        let perms =
-            (try fm.attributesOfItem(atPath: dest.appendingPathComponent("run.sh").path)[
-                .posixPermissions] as? NSNumber)?.intValue ?? 0
-        #expect(perms & 0o111 != 0)
-    }
-
     @Test("estimatedByteCount sums regular-file sizes only")
     func estimateSumsFiles() throws {
         let fm = FileManager.default
@@ -74,7 +33,7 @@ struct ClipboardDirectoryArchiveTests {
         #expect(ClipboardDirectoryArchive.estimatedByteCount(at: root) == 11)
     }
 
-    @Test("estimatedByteCount is 0 for a tree carrying no file bytes, which still archives")
+    @Test("estimatedByteCount is 0 for a tree carrying no file bytes")
     func estimateZeroForByteFreeTrees() throws {
         let fm = FileManager.default
         let scratch = try makeScratch()
@@ -85,7 +44,7 @@ struct ClipboardDirectoryArchiveTests {
         #expect(ClipboardDirectoryArchive.estimatedByteCount(at: empty) == 0)
 
         // Only subdirectories and zero-byte files: nothing to sum, yet the tree
-        // is real and its archive carries it.
+        // is real and streams intact (ClipboardDirectoryStreamTests).
         let scaffold = scratch.appendingPathComponent("scaffold", isDirectory: true)
         try fm.createDirectory(
             at: scaffold.appendingPathComponent("sub", isDirectory: true),
@@ -93,178 +52,5 @@ struct ClipboardDirectoryArchiveTests {
         try Data().write(to: scaffold.appendingPathComponent(".keep"))
         try Data().write(to: scaffold.appendingPathComponent("sub/.keep"))
         #expect(ClipboardDirectoryArchive.estimatedByteCount(at: scaffold) == 0)
-
-        let archive = scratch.appendingPathComponent("scaffold.aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: scaffold, to: archive)
-        let dest = scratch.appendingPathComponent("extracted", isDirectory: true)
-        try fm.createDirectory(at: dest, withIntermediateDirectories: true)
-        try ClipboardDirectoryArchive.extract(archiveAt: archive, to: dest)
-        #expect(fm.fileExists(atPath: dest.appendingPathComponent(".keep").path))
-        #expect(fm.fileExists(atPath: dest.appendingPathComponent("sub/.keep").path))
-    }
-
-    @Test("a symlink is preserved, not followed")
-    func symlinkPreserved() throws {
-        let fm = FileManager.default
-        let scratch = try makeScratch()
-        defer { try? fm.removeItem(at: scratch) }
-
-        let source = scratch.appendingPathComponent("source", isDirectory: true)
-        try fm.createDirectory(at: source, withIntermediateDirectories: true)
-        try "target".write(
-            to: source.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
-        try fm.createSymbolicLink(
-            atPath: source.appendingPathComponent("link.txt").path, withDestinationPath: "file.txt")
-
-        let archive = scratch.appendingPathComponent("tree.aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: source, to: archive)
-        let dest = scratch.appendingPathComponent("extracted", isDirectory: true)
-        try fm.createDirectory(at: dest, withIntermediateDirectories: true)
-        try ClipboardDirectoryArchive.extract(archiveAt: archive, to: dest)
-
-        let linkPath = dest.appendingPathComponent("link.txt").path
-        let attrs = try fm.attributesOfItem(atPath: linkPath)
-        #expect((attrs[.type] as? FileAttributeType) == .typeSymbolicLink)
-        #expect(try fm.destinationOfSymbolicLink(atPath: linkPath) == "file.txt")
-    }
-
-    @Test("a package-shaped directory (.rtfd) round-trips as a directory")
-    func bundleRoundTrips() throws {
-        let fm = FileManager.default
-        let scratch = try makeScratch()
-        defer { try? fm.removeItem(at: scratch) }
-
-        let source = scratch.appendingPathComponent("source", isDirectory: true)
-        let rtfd = source.appendingPathComponent("note.rtfd", isDirectory: true)
-        try fm.createDirectory(at: rtfd, withIntermediateDirectories: true)
-        try "{\\rtf1}".write(
-            to: rtfd.appendingPathComponent("TXT.rtf"), atomically: true, encoding: .utf8)
-
-        let archive = scratch.appendingPathComponent("tree.aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: source, to: archive)
-        let dest = scratch.appendingPathComponent("extracted", isDirectory: true)
-        try fm.createDirectory(at: dest, withIntermediateDirectories: true)
-        try ClipboardDirectoryArchive.extract(archiveAt: archive, to: dest)
-
-        #expect(
-            try String(
-                contentsOf: dest.appendingPathComponent("note.rtfd/TXT.rtf"), encoding: .utf8)
-                == "{\\rtf1}")
-    }
-
-    @Test("an empty directory archives to a non-empty file and extracts cleanly")
-    func emptyDirectoryArchives() throws {
-        let fm = FileManager.default
-        let scratch = try makeScratch()
-        defer { try? fm.removeItem(at: scratch) }
-
-        let source = scratch.appendingPathComponent("empty", isDirectory: true)
-        try fm.createDirectory(at: source, withIntermediateDirectories: true)
-
-        let archive = scratch.appendingPathComponent("empty.aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: source, to: archive)
-        // An empty folder still produces archive-header bytes (so the offer's
-        // byteCount > 0 and the size guard must key on isDirectory, not size).
-        let size = try #require(fm.attributesOfItem(atPath: archive.path)[.size] as? Int)
-        #expect(size > 0)
-
-        let dest = scratch.appendingPathComponent("out", isDirectory: true)
-        try fm.createDirectory(at: dest, withIntermediateDirectories: true)
-        try ClipboardDirectoryArchive.extract(archiveAt: archive, to: dest)
-        #expect(try fm.contentsOfDirectory(atPath: dest.path).isEmpty)
-    }
-
-    // MARK: - Staging-aware helpers (shared by host + guest)
-
-    private func makeStaging(
-        in scratch: URL, freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil
-    ) -> ClipboardFileStaging {
-        ClipboardFileStaging(
-            label: "archive-test-\(UUID().uuidString)",
-            tempRoot: scratch.appendingPathComponent("staging-\(UUID().uuidString)", isDirectory: true),
-            freeSpaceProvider: freeSpaceProvider)
-    }
-
-    @Test("archivedRepresentation builds a directory rep whose archive round-trips")
-    func archivedRepresentationRoundTrips() throws {
-        let fm = FileManager.default
-        let scratch = try makeScratch()
-        defer { try? fm.removeItem(at: scratch) }
-        let src = scratch.appendingPathComponent("Photos", isDirectory: true)
-        try fm.createDirectory(at: src, withIntermediateDirectories: true)
-        try "p".write(to: src.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
-
-        let staging = makeStaging(in: scratch)
-        defer { staging.sweep() }
-
-        let rep = try #require(
-            try ClipboardDirectoryArchive.archivedRepresentation(
-                ofDirectoryAt: src, named: "Photos", into: staging, generation: 1))
-        #expect(rep.isDirectory)
-        #expect(rep.uti == ClipboardDirectoryArchive.directoryUTI)
-        #expect(rep.filename == "Photos")
-        #expect(rep.byteCount > 0)
-
-        // extractedDirectoryURL turns the rep back into the real tree.
-        let dir = try #require(
-            ClipboardDirectoryArchive.extractedDirectoryURL(for: rep, into: staging, generation: 2))
-        #expect(dir.lastPathComponent == "Photos")
-        #expect(try String(contentsOf: dir.appendingPathComponent("a.txt"), encoding: .utf8) == "p")
-    }
-
-    @Test("extractedDirectoryURL returns nil for a non-directory rep")
-    func extractedDirectoryURLRejectsNonDirectory() throws {
-        let scratch = try makeScratch()
-        defer { try? FileManager.default.removeItem(at: scratch) }
-        let staging = makeStaging(in: scratch)
-        defer { staging.sweep() }
-        let fileRep = ClipboardContent.Representation(
-            uti: "public.data", fileURL: URL(fileURLWithPath: "/tmp/x"), byteCount: 1,
-            filename: "x", isDirectory: false)
-        #expect(
-            ClipboardDirectoryArchive.extractedDirectoryURL(
-                for: fileRep, into: staging, generation: 1) == nil)
-    }
-
-    @Test("extractedDirectoryURL returns nil when the volume lacks capacity")
-    func extractedDirectoryURLRespectsCapacity() throws {
-        let fm = FileManager.default
-        let scratch = try makeScratch()
-        defer { try? fm.removeItem(at: scratch) }
-        let src = scratch.appendingPathComponent("Big", isDirectory: true)
-        try fm.createDirectory(at: src, withIntermediateDirectories: true)
-        try "x".write(to: src.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
-        let archive = scratch.appendingPathComponent("big.aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: src, to: archive)
-        let size = try #require(fm.attributesOfItem(atPath: archive.path)[.size] as? Int)
-        let rep = ClipboardContent.Representation(
-            uti: ClipboardDirectoryArchive.directoryUTI, fileURL: archive, byteCount: size,
-            filename: "Big", isDirectory: true)
-
-        // 1 byte free → the floor check fails before any extraction is attempted.
-        let tightStaging = makeStaging(in: scratch, freeSpaceProvider: { _ in 1 })
-        defer { tightStaging.sweep() }
-        #expect(
-            ClipboardDirectoryArchive.extractedDirectoryURL(
-                for: rep, into: tightStaging, generation: 1) == nil)
-    }
-
-    @Test("extracting a non-archive file throws and removes the destination")
-    func extractGarbageThrowsAndCleansUp() throws {
-        let fm = FileManager.default
-        let scratch = try makeScratch()
-        defer { try? fm.removeItem(at: scratch) }
-
-        let notAnArchive = scratch.appendingPathComponent("garbage.aar")
-        try Data("not a valid archive".utf8).write(to: notAnArchive)
-        let dest = scratch.appendingPathComponent("dest", isDirectory: true)
-        try fm.createDirectory(at: dest, withIntermediateDirectories: true)
-
-        #expect(throws: (any Error).self) {
-            try ClipboardDirectoryArchive.extract(archiveAt: notAnArchive, to: dest)
-        }
-        // The destination is removed so a partial/failed extraction never reaches
-        // the pasteboard.
-        #expect(!fm.fileExists(atPath: dest.path))
     }
 }

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryStreamTests.swift
@@ -344,6 +344,74 @@ struct ClipboardDirectoryStreamTests {
         #expect(throws: (any Error).self) { try sink.write(Data([0])) }
     }
 
+    @Test("a write landing after the archive is unpacked is dropped, and commit stays idempotent")
+    func writeAfterASuccessfulExtractIsDropped() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        try fm.createDirectory(
+            at: source.appendingPathComponent("sub", isDirectory: true),
+            withIntermediateDirectories: true)
+        try "hello".write(
+            to: source.appendingPathComponent("sub/a.txt"), atomically: true, encoding: .utf8)
+
+        let dest = try makeDestination(in: scratch)
+        let sink = ClipboardDirectoryExtractSink(destinationURL: dest, label: "test")
+        try sink.write(try archiveBytes(of: source))
+        let url = try sink.commit()
+
+        // Whatever the wire still carries once the tree is out is surplus to the
+        // decoder — accepting and dropping it is what keeps a straggling chunk
+        // from turning a good folder into an `extract.error`.
+        try sink.write(Data([0x00]))
+        #expect(try sink.commit() == url)
+        #expect(
+            try String(contentsOf: url.appendingPathComponent("sub/a.txt"), encoding: .utf8)
+                == "hello")
+    }
+
+    @Test("a write after the pipeline failed is still refused")
+    func writeAfterAFailedExtractStillThrows() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+        let dest = try makeDestination(in: scratch)
+
+        let sink = ClipboardDirectoryExtractSink(destinationURL: dest, label: "test")
+        try sink.write(Data("not a valid archive".utf8))
+        #expect(throws: (any Error).self) { _ = try sink.commit() }
+        // A failed pipeline has nothing to feed, so the refusal has to stand.
+        #expect(throws: (any Error).self) { try sink.write(Data([0])) }
+        // And a repeat commit reports the same failure rather than handing back
+        // the folder the first one deleted.
+        #expect(throws: (any Error).self) { _ = try sink.commit() }
+        #expect(!fm.fileExists(atPath: dest.path))
+    }
+
+    @Test("committing after an abort throws rather than naming a folder that was deleted")
+    func commitAfterAbortThrows() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        try Data(repeating: 0xCD, count: 256 * 1024)
+            .write(to: source.appendingPathComponent("big.bin"))
+        let bytes = try archiveBytes(of: source)
+
+        let dest = try makeDestination(in: scratch)
+        let sink = ClipboardDirectoryExtractSink(destinationURL: dest, label: "test")
+        try sink.write(bytes.prefix(bytes.count / 2))
+        sink.abort()
+        #expect(!fm.fileExists(atPath: dest.path))
+        // The two endings are mutually exclusive: the tree a commit would hand
+        // back is gone, so reporting success would hand out a dead URL.
+        #expect(throws: ClipboardArchiveStreamError.cancelled) { _ = try sink.commit() }
+    }
+
     @Test("cancelling the extract sink refuses further writes and fails the commit")
     func cancelRefusesFurtherWrites() throws {
         let fm = FileManager.default
@@ -376,6 +444,34 @@ struct ClipboardDirectoryStreamTests {
         }
         pipe.fail(ClipboardArchiveStreamError.cancelled)
         try await released.wait { threw.value }
+    }
+
+    @Test("completing the byte pipe releases a writer it will never read from")
+    func completingThePipeReleasesTheWriter() async throws {
+        // Filled past capacity with nothing draining it, so the write below can
+        // only end when the pipe does.
+        let pipe = ClipboardArchiveBytePipe(capacity: 16)
+        try pipe.write(Data(repeating: 0, count: 64))
+        let released = AsyncGate()
+        let threw = Box(false)
+        let returned = Box(false)
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try pipe.write(Data([1]))
+            } catch {
+                threw.value = true
+            }
+            returned.value = true
+            released.notify()
+        }
+        pipe.complete()
+        try await released.wait { returned.value }
+        // Woken, like a failure — but the reader succeeded, so nothing is wrong
+        // and the writer must not be told otherwise.
+        #expect(!threw.value)
+        // Later bytes are taken and dropped; the reader is finished with them.
+        try pipe.write(Data([2]))
+        #expect(try pipe.read(upTo: 8).isEmpty)
     }
 
     @Test("the byte pipe drains what it holds before reporting end of stream")

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryStreamTests.swift
@@ -1,0 +1,416 @@
+import Foundation
+import KernovaTestSupport
+import Testing
+
+@testable import KernovaKit
+
+/// The folder-transfer pipeline with no archive file anywhere: a source tree is
+/// encoded on demand by `ClipboardDirectoryArchiveReader` and extracted as it
+/// arrives by `ClipboardDirectoryExtractSink`.
+@Suite("ClipboardDirectoryStream")
+struct ClipboardDirectoryStreamTests {
+    /// A unique scratch directory removed when the test ends.
+    private func makeScratch() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dirstream-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makeDestination(in scratch: URL, named name: String = "out") throws -> URL {
+        let url = scratch.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Every byte the encoder produces for `directory`.
+    private func archiveBytes(of directory: URL, chunkSize: Int = 64 << 10) throws -> Data {
+        let reader = ClipboardDirectoryArchiveReader(directoryURL: directory, label: "test")
+        var bytes = Data()
+        while true {
+            let chunk = try reader.read(upTo: chunkSize)
+            if chunk.isEmpty { break }
+            bytes.append(chunk)
+        }
+        return bytes
+    }
+
+    /// Feeds `bytes` through a fresh extract sink in `chunkSize` slices.
+    @discardableResult
+    private func extract(_ bytes: Data, into destination: URL, chunkSize: Int = 64 << 10) throws
+        -> URL
+    {
+        let sink = ClipboardDirectoryExtractSink(destinationURL: destination, label: "test")
+        do {
+            var offset = 0
+            while offset < bytes.count {
+                let end = min(offset + chunkSize, bytes.count)
+                try sink.write(bytes[offset..<end])
+                offset = end
+            }
+            return try sink.commit()
+        } catch {
+            sink.abort()
+            throw error
+        }
+    }
+
+    /// Pipes the encoder straight into the extract sink — both ends live at once,
+    /// as they are in a real transfer — and returns the streamed byte count.
+    @discardableResult
+    private func stream(
+        from source: URL, into destination: URL, chunkSize: Int = 64 << 10,
+        capacityBytes: Int = 1 << 20
+    ) throws -> Int {
+        let reader = ClipboardDirectoryArchiveReader(
+            directoryURL: source, label: "test", capacityBytes: capacityBytes)
+        let sink = ClipboardDirectoryExtractSink(
+            destinationURL: destination, label: "test", capacityBytes: capacityBytes)
+        var streamed = 0
+        do {
+            while true {
+                let chunk = try reader.read(upTo: chunkSize)
+                if chunk.isEmpty { break }
+                streamed += chunk.count
+                try sink.write(chunk)
+            }
+            _ = try sink.commit()
+        } catch {
+            reader.cancel()
+            sink.abort()
+            throw error
+        }
+        return streamed
+    }
+
+    // MARK: - Fidelity
+
+    @Test("streaming preserves a nested tree, contents, an empty dir, and the exec bit")
+    func roundTripFidelity() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        let nested = source.appendingPathComponent("a/b/c", isDirectory: true)
+        try fm.createDirectory(at: nested, withIntermediateDirectories: true)
+        try "top".write(
+            to: source.appendingPathComponent("top.txt"), atomically: true, encoding: .utf8)
+        try "deep".write(
+            to: nested.appendingPathComponent("deep.txt"), atomically: true, encoding: .utf8)
+        try fm.createDirectory(
+            at: source.appendingPathComponent("emptydir", isDirectory: true),
+            withIntermediateDirectories: true)
+        let exe = source.appendingPathComponent("run.sh")
+        try "#!/bin/sh\n".write(to: exe, atomically: true, encoding: .utf8)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: exe.path)
+
+        let dest = try makeDestination(in: scratch)
+        let streamed = try stream(from: source, into: dest)
+        #expect(streamed > 0)
+
+        #expect(
+            try String(contentsOf: dest.appendingPathComponent("top.txt"), encoding: .utf8) == "top")
+        #expect(
+            try String(contentsOf: dest.appendingPathComponent("a/b/c/deep.txt"), encoding: .utf8)
+                == "deep")
+        var isDir: ObjCBool = false
+        #expect(
+            fm.fileExists(atPath: dest.appendingPathComponent("emptydir").path, isDirectory: &isDir)
+                && isDir.boolValue)
+        let perms =
+            (try fm.attributesOfItem(atPath: dest.appendingPathComponent("run.sh").path)[
+                .posixPermissions] as? NSNumber)?.intValue ?? 0
+        #expect(perms & 0o111 != 0)
+        // Nothing but the tree: no archive is ever materialized on either side.
+        #expect(try fm.contentsOfDirectory(atPath: scratch.path).sorted() == ["out", "source"])
+    }
+
+    @Test("a symlink is preserved, not followed")
+    func symlinkPreserved() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        try "target".write(
+            to: source.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        try fm.createSymbolicLink(
+            atPath: source.appendingPathComponent("link.txt").path, withDestinationPath: "file.txt")
+
+        let dest = try makeDestination(in: scratch)
+        try stream(from: source, into: dest)
+
+        let linkPath = dest.appendingPathComponent("link.txt").path
+        let attrs = try fm.attributesOfItem(atPath: linkPath)
+        #expect((attrs[.type] as? FileAttributeType) == .typeSymbolicLink)
+        #expect(try fm.destinationOfSymbolicLink(atPath: linkPath) == "file.txt")
+    }
+
+    @Test("a package-shaped directory (.rtfd) round-trips as a directory")
+    func bundleRoundTrips() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        let rtfd = source.appendingPathComponent("note.rtfd", isDirectory: true)
+        try fm.createDirectory(at: rtfd, withIntermediateDirectories: true)
+        try "{\\rtf1}".write(
+            to: rtfd.appendingPathComponent("TXT.rtf"), atomically: true, encoding: .utf8)
+
+        let dest = try makeDestination(in: scratch)
+        try stream(from: source, into: dest)
+
+        #expect(
+            try String(
+                contentsOf: dest.appendingPathComponent("note.rtfd/TXT.rtf"), encoding: .utf8)
+                == "{\\rtf1}")
+    }
+
+    @Test("unicode names survive the round trip")
+    func unicodeNamesRoundTrip() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        let folder = source.appendingPathComponent("Ünïcødé 🎉", isDirectory: true)
+        try fm.createDirectory(at: folder, withIntermediateDirectories: true)
+        try "ok".write(
+            to: folder.appendingPathComponent("naïve — файл.txt"), atomically: true, encoding: .utf8)
+
+        let dest = try makeDestination(in: scratch)
+        try stream(from: source, into: dest)
+
+        #expect(
+            try String(
+                contentsOf: dest.appendingPathComponent("Ünïcødé 🎉/naïve — файл.txt"),
+                encoding: .utf8) == "ok")
+    }
+
+    @Test("an empty directory streams real bytes and extracts to an empty tree")
+    func emptyDirectoryStreams() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("empty", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+
+        let dest = try makeDestination(in: scratch)
+        // Archive-header bytes, so a streamed folder is never legitimately
+        // zero-length — which is what lets `End.total_bytes > 0` hold.
+        #expect(try stream(from: source, into: dest) > 0)
+        #expect(try fm.contentsOfDirectory(atPath: dest.path).isEmpty)
+    }
+
+    @Test("a tree carrying no file bytes still round-trips")
+    func byteFreeTreeRoundTrips() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("scaffold", isDirectory: true)
+        try fm.createDirectory(
+            at: source.appendingPathComponent("sub", isDirectory: true),
+            withIntermediateDirectories: true)
+        try Data().write(to: source.appendingPathComponent(".keep"))
+        try Data().write(to: source.appendingPathComponent("sub/.keep"))
+        #expect(ClipboardDirectoryArchive.estimatedByteCount(at: source) == 0)
+
+        let dest = try makeDestination(in: scratch)
+        try stream(from: source, into: dest)
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent(".keep").path))
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent("sub/.keep").path))
+    }
+
+    @Test("one byte per write still produces the exact tree")
+    func byteAtATimeFramingRoundTrips() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        try fm.createDirectory(
+            at: source.appendingPathComponent("sub", isDirectory: true),
+            withIntermediateDirectories: true)
+        try "hello".write(
+            to: source.appendingPathComponent("sub/a.txt"), atomically: true, encoding: .utf8)
+
+        let dest = try makeDestination(in: scratch)
+        // Wire framing carries no meaning to the codec: the archive is one byte
+        // stream however it is chopped up.
+        try extract(try archiveBytes(of: source), into: dest, chunkSize: 1)
+        #expect(
+            try String(contentsOf: dest.appendingPathComponent("sub/a.txt"), encoding: .utf8)
+                == "hello")
+    }
+
+    @Test("a tiny pipe capacity forces both ends to park and still round-trips")
+    func tinyCapacityRoundTrips() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        // Incompressible, so the archive is large enough to fill a 4 KiB pipe
+        // many times over.
+        var payload = Data(count: 512 * 1024)
+        payload.withUnsafeMutableBytes { raw in
+            guard let base = raw.bindMemory(to: UInt8.self).baseAddress else { return }
+            for index in 0..<raw.count { base[index] = UInt8.random(in: 0...255) }
+        }
+        try payload.write(to: source.appendingPathComponent("random.bin"))
+
+        let dest = try makeDestination(in: scratch)
+        try stream(from: source, into: dest, chunkSize: 4096, capacityBytes: 4096)
+        #expect(try Data(contentsOf: dest.appendingPathComponent("random.bin")) == payload)
+    }
+
+    // MARK: - Failure and cleanup
+
+    @Test("encoding a nonexistent folder fails rather than ending the stream")
+    func missingSourceFails() throws {
+        let scratch = try makeScratch()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let missing = scratch.appendingPathComponent("nope", isDirectory: true)
+        let reader = ClipboardDirectoryArchiveReader(directoryURL: missing, label: "test")
+        #expect(throws: (any Error).self) {
+            // Drains until the encode pipeline reports its failure; an end of
+            // stream here would mean a valid empty archive.
+            while try !reader.read(upTo: 64 << 10).isEmpty {}
+        }
+    }
+
+    @Test("a truncated archive fails the commit and leaves no tree behind")
+    func truncatedArchiveLeavesNoTree() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        try Data(repeating: 0xAB, count: 256 * 1024)
+            .write(to: source.appendingPathComponent("big.bin"))
+
+        let bytes = try archiveBytes(of: source)
+        let dest = try makeDestination(in: scratch)
+        #expect(throws: (any Error).self) {
+            try extract(bytes.prefix(bytes.count / 2), into: dest)
+        }
+        // A streamed extract has always written part of the tree by the time
+        // anything can be verified, so the cleanup is not optional.
+        #expect(!fm.fileExists(atPath: dest.path))
+    }
+
+    @Test("garbage in place of an archive fails the commit and leaves no tree behind")
+    func garbageInputLeavesNoTree() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+        let dest = try makeDestination(in: scratch)
+        #expect(throws: (any Error).self) {
+            try extract(Data("not a valid archive".utf8), into: dest)
+        }
+        #expect(!fm.fileExists(atPath: dest.path))
+    }
+
+    @Test("aborting mid-stream tears the pipeline down and removes the partial tree")
+    func abortMidStreamRemovesPartialTree() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        for index in 0..<8 {
+            try Data(repeating: UInt8(index), count: 64 * 1024)
+                .write(to: source.appendingPathComponent("f\(index).bin"))
+        }
+
+        let bytes = try archiveBytes(of: source)
+        let dest = try makeDestination(in: scratch)
+        let sink = ClipboardDirectoryExtractSink(destinationURL: dest, label: "test")
+        try sink.write(bytes.prefix(bytes.count / 2))
+        // Blocks until the extract pipeline has unwound, so the assertion below
+        // needs no wait of its own.
+        sink.abort()
+        #expect(!fm.fileExists(atPath: dest.path))
+        // Idempotent, and a write afterwards is refused rather than parking.
+        sink.abort()
+        #expect(throws: (any Error).self) { try sink.write(Data([0])) }
+    }
+
+    @Test("cancelling the extract sink refuses further writes and fails the commit")
+    func cancelRefusesFurtherWrites() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+        let dest = try makeDestination(in: scratch)
+
+        let sink = ClipboardDirectoryExtractSink(destinationURL: dest, label: "test")
+        sink.cancel()
+        #expect(throws: (any Error).self) { try sink.write(Data(repeating: 0, count: 4096)) }
+        #expect(throws: (any Error).self) { _ = try sink.commit() }
+        #expect(!fm.fileExists(atPath: dest.path))
+    }
+
+    @Test("failing the byte pipe releases a writer it cannot take from")
+    func failingThePipeReleasesTheWriter() async throws {
+        // Filled past capacity with nothing draining it, so the write below can
+        // only end when the pipe does.
+        let pipe = ClipboardArchiveBytePipe(capacity: 16)
+        try pipe.write(Data(repeating: 0, count: 64))
+        let released = AsyncGate()
+        let threw = Box(false)
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try pipe.write(Data([1]))
+            } catch {
+                threw.value = true
+            }
+            released.notify()
+        }
+        pipe.fail(ClipboardArchiveStreamError.cancelled)
+        try await released.wait { threw.value }
+    }
+
+    @Test("the byte pipe drains what it holds before reporting end of stream")
+    func pipeDrainsBeforeEndOfStream() throws {
+        let pipe = ClipboardArchiveBytePipe(capacity: 1024)
+        try pipe.write(Data([1, 2, 3]))
+        try pipe.write(Data([4, 5]))
+        pipe.finish()
+        #expect(try pipe.read(upTo: 4) == Data([1, 2, 3, 4]))
+        #expect(try pipe.read(upTo: 4) == Data([5]))
+        #expect(try pipe.read(upTo: 4).isEmpty)
+        // A failure after the fact still surfaces to the reader rather than
+        // looking like a clean end of stream.
+        pipe.fail(ClipboardArchiveStreamError.cancelled)
+        #expect(throws: (any Error).self) { _ = try pipe.read(upTo: 4) }
+    }
+
+    @Test("cancelling the reader ends the encode instead of leaving it parked")
+    func cancelEndsTheEncode() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        try Data(repeating: 0x5A, count: 4 * 1024 * 1024)
+            .write(to: source.appendingPathComponent("big.bin"))
+
+        let reader = ClipboardDirectoryArchiveReader(
+            directoryURL: source, label: "test", capacityBytes: 4096)
+        #expect(try !reader.read(upTo: 512).isEmpty)
+        reader.cancel()
+        // Never an empty result, which would mean a complete archive.
+        #expect(throws: (any Error).self) {
+            while try !reader.read(upTo: 512).isEmpty {}
+        }
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryTransferTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryTransferTests.swift
@@ -1,0 +1,364 @@
+import CryptoKit
+import Foundation
+import KernovaTestSupport
+import Testing
+
+@testable import KernovaKit
+
+/// A folder crossing the real sender and receiver over a socketpair, with no
+/// archive file at either end.
+@Suite("ClipboardDirectoryTransfer")
+struct ClipboardDirectoryTransferTests {
+    private static let chunk = 4096
+    private static let window = 16384  // 4 chunks
+
+    private func harness(
+        windowBytes: Int = window, freeSpace: Int64 = 100 * 1024 * 1024 * 1024
+    ) throws -> StreamHarness {
+        try StreamHarness(
+            chunkSize: Self.chunk, windowBytes: windowBytes,
+            freeSpaceProvider: { _ in freeSpace })
+    }
+
+    private func makeScratch() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(
+            "dirtransfer-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    /// A small source tree with nesting, a symlink, and an empty folder.
+    private func makeSourceTree() throws -> (scratch: URL, source: URL) {
+        let fm = FileManager.default
+        let scratch = makeScratch()
+        let source = scratch.appendingPathComponent("Project", isDirectory: true)
+        try fm.createDirectory(
+            at: source.appendingPathComponent("sub", isDirectory: true),
+            withIntermediateDirectories: true)
+        try fm.createDirectory(
+            at: source.appendingPathComponent("empty", isDirectory: true),
+            withIntermediateDirectories: true)
+        try "readme".write(
+            to: source.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        try "nested".write(
+            to: source.appendingPathComponent("sub/n.txt"), atomically: true, encoding: .utf8)
+        try fm.createSymbolicLink(
+            atPath: source.appendingPathComponent("link").path, withDestinationPath: "README.md")
+        return (scratch, source)
+    }
+
+    /// Every archive byte a real transfer of `source` puts on the wire.
+    private func archiveBytes(of source: URL) throws -> Data {
+        let reader = ClipboardDirectoryArchiveReader(directoryURL: source, label: "test")
+        var bytes = Data()
+        while true {
+            let chunk = try reader.read(upTo: 64 << 10)
+            if chunk.isEmpty { break }
+            bytes.append(chunk)
+        }
+        return bytes
+    }
+
+    /// The priming a requester performs before it sends its `ClipboardRequest`,
+    /// funnelling delivery into the harness collector.
+    private func prime(_ harness: StreamHarness, id: UInt64, named name: String) {
+        let collector = harness.collector
+        harness.receiver.awaitTransfer(
+            id, extractsDirectoryNamed: name,
+            onComplete: { collector.complete(id, $0) },
+            onAbort: { collector.abort($0) })
+    }
+
+    /// Announces a folder transfer with no declared total, exactly as
+    /// `startDirectoryTransfer` does.
+    private func begin(_ harness: StreamHarness, id: UInt64, named name: String) {
+        harness.receiver.handleBegin(
+            .with {
+                $0.generation = 1
+                $0.transferID = id
+                $0.uti = ClipboardDirectoryArchive.directoryUTI
+                $0.totalBytes = 0
+                $0.filename = name
+                $0.isInline = false
+            })
+    }
+
+    private func feed(_ harness: StreamHarness, id: UInt64, bytes: Data) {
+        var offset = 0
+        while offset < bytes.count {
+            let end = min(offset + Self.chunk, bytes.count)
+            let slice = Data(bytes[bytes.startIndex + offset..<bytes.startIndex + end])
+            harness.receiver.handleChunk(
+                .with {
+                    $0.transferID = id
+                    $0.offset = UInt64(offset)
+                    $0.data = slice
+                })
+            offset = end
+        }
+    }
+
+    // MARK: - Round trips
+
+    @Test("a folder streams end to end and is delivered as an extracted tree")
+    func folderRoundTrips() async throws {
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeSourceTree()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let id: UInt64 = 41
+        prime(harness, id: id, named: "Project")
+        harness.sender.startDirectoryTransfer(
+            transferID: id, generation: 1, sourceDirectoryURL: source, folderName: "Project",
+            uti: ClipboardDirectoryArchive.directoryUTI, maxAcceptByteCount: .max,
+            isCurrent: { _ in true })
+
+        try await harness.collector.gate.wait { harness.collector.representation(id) != nil }
+        let rep = try #require(harness.collector.representation(id))
+        #expect(rep.isDirectory)
+        #expect(rep.filename == "Project")
+        // The streamed archive's size, which End declared and the digest covered.
+        #expect(rep.byteCount > 0)
+
+        let tree = try #require(rep.fileURL)
+        #expect(tree.lastPathComponent == "Project")
+        #expect(
+            try String(contentsOf: tree.appendingPathComponent("README.md"), encoding: .utf8)
+                == "readme")
+        #expect(
+            try String(contentsOf: tree.appendingPathComponent("sub/n.txt"), encoding: .utf8)
+                == "nested")
+        var isDir: ObjCBool = false
+        #expect(
+            fm.fileExists(atPath: tree.appendingPathComponent("empty").path, isDirectory: &isDir)
+                && isDir.boolValue)
+        #expect(
+            try fm.destinationOfSymbolicLink(atPath: tree.appendingPathComponent("link").path)
+                == "README.md")
+        // The point of the exercise: no archive lands anywhere.
+        #expect(
+            materializedFiles(under: harness.stagingTempRoot).allSatisfy {
+                $0.pathExtension != "aar"
+            })
+    }
+
+    @Test("an empty folder still streams and delivers an empty tree")
+    func emptyFolderRoundTrips() async throws {
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let scratch = makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+        let source = scratch.appendingPathComponent("Empty", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+
+        let id: UInt64 = 42
+        prime(harness, id: id, named: "Empty")
+        harness.sender.startDirectoryTransfer(
+            transferID: id, generation: 1, sourceDirectoryURL: source, folderName: "Empty",
+            uti: ClipboardDirectoryArchive.directoryUTI, maxAcceptByteCount: .max,
+            isCurrent: { _ in true })
+
+        try await harness.collector.gate.wait { harness.collector.representation(id) != nil }
+        let rep = try #require(harness.collector.representation(id))
+        // Archive-header bytes, so `End.total_bytes` is never legitimately zero.
+        #expect(rep.byteCount > 0)
+        #expect(try fm.contentsOfDirectory(atPath: #require(rep.fileURL).path).isEmpty)
+    }
+
+    @Test("a folder completes under a one-chunk credit window")
+    func folderCompletesUnderTinyWindow() async throws {
+        let fm = FileManager.default
+        let harness = try harness(windowBytes: Self.chunk)
+        defer { harness.tearDown() }
+        let scratch = makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+        let source = scratch.appendingPathComponent("Big", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        // Random, so LZFSE cannot shrink it and the archive runs to many
+        // windows: the encode side then parks on credit repeatedly.
+        var generator = SystemRandomNumberGenerator()
+        var payload = Data(count: 512 * 1024)
+        payload.withUnsafeMutableBytes { raw in
+            guard let base = raw.bindMemory(to: UInt8.self).baseAddress else { return }
+            for index in 0..<raw.count { base[index] = UInt8.random(in: 0...255, using: &generator) }
+        }
+        try payload.write(to: source.appendingPathComponent("random.bin"))
+
+        let id: UInt64 = 43
+        prime(harness, id: id, named: "Big")
+        harness.sender.startDirectoryTransfer(
+            transferID: id, generation: 1, sourceDirectoryURL: source, folderName: "Big",
+            uti: ClipboardDirectoryArchive.directoryUTI, maxAcceptByteCount: .max,
+            isCurrent: { _ in true })
+
+        try await harness.collector.gate.wait {
+            harness.collector.representation(id) != nil || harness.collector.abortCount > 0
+        }
+        #expect(harness.collector.abortInfos.map(\.code) == [])
+        let tree = try #require(harness.collector.representation(id)?.fileURL)
+        #expect(try Data(contentsOf: tree.appendingPathComponent("random.bin")) == payload)
+    }
+
+    // MARK: - Failure and cleanup
+
+    @Test("an unprimed transfer declaring no total aborts on its first chunk")
+    func unprimedUndeclaredTotalAborts() async throws {
+        // The version-skew failure mode: a peer that has not been told the
+        // transfer is a folder bounds it by the declared total and refuses,
+        // rather than accepting an unbounded stream.
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let id: UInt64 = 44
+        begin(harness, id: id, named: "Project")
+        harness.receiver.handleChunk(
+            .with {
+                $0.transferID = id; $0.offset = 0; $0.data = Data([1, 2, 3])
+            })
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        #expect(harness.collector.abortInfos.first?.code == "size.overrun")
+    }
+
+    @Test("a digest mismatch at End deletes the extracted tree")
+    func digestMismatchDeletesTree() async throws {
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeSourceTree()
+        defer { try? fm.removeItem(at: scratch) }
+        let bytes = try archiveBytes(of: source)
+
+        let id: UInt64 = 45
+        prime(harness, id: id, named: "Project")
+        begin(harness, id: id, named: "Project")
+        feed(harness, id: id, bytes: bytes)
+        harness.receiver.handleEnd(
+            .with {
+                $0.transferID = id
+                $0.totalBytes = UInt64(bytes.count)
+                $0.sha256 = Data(repeating: 0xAA, count: 32)
+            })
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        #expect(harness.collector.abortInfos.first?.code == "digest.mismatch")
+        #expect(harness.collector.representation(id) == nil)
+        // The tree was already on disk when the digest — the only detector of a
+        // corrupted archive — failed, so it has to be removed.
+        // RATIONALE: filesystem-appearance poll (docs/TESTING.md) — the tree is
+        // deleted on the write lane after the abort is delivered, so no collector
+        // signal covers it.
+        try await waitUntil { materializedFiles(under: harness.stagingTempRoot).isEmpty }
+    }
+
+    @Test("a truncated archive aborts with extract.error and leaves no tree")
+    func truncationAborts() async throws {
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeSourceTree()
+        defer { try? fm.removeItem(at: scratch) }
+        let half = Data(try archiveBytes(of: source).prefix(while: { _ in true }).dropLast(64))
+
+        let id: UInt64 = 46
+        prime(harness, id: id, named: "Project")
+        begin(harness, id: id, named: "Project")
+        feed(harness, id: id, bytes: half)
+        // Size and digest both agree with what arrived: only the extract itself
+        // can tell that the archive is incomplete.
+        harness.receiver.handleEnd(
+            .with {
+                $0.transferID = id
+                $0.totalBytes = UInt64(half.count)
+                $0.sha256 = Data(SHA256.hash(data: half))
+            })
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        #expect(harness.collector.abortInfos.first?.code == "extract.error")
+        #expect(harness.collector.representation(id) == nil)
+        #expect(materializedFiles(under: harness.stagingTempRoot).isEmpty)
+    }
+
+    @Test("cancelling the generation mid-extract deletes the partial tree")
+    func cancelDeletesPartialTree() async throws {
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeSourceTree()
+        defer { try? fm.removeItem(at: scratch) }
+        let bytes = try archiveBytes(of: source)
+
+        let id: UInt64 = 47
+        prime(harness, id: id, named: "Project")
+        begin(harness, id: id, named: "Project")
+        feed(harness, id: id, bytes: Data(bytes.prefix(bytes.count / 2)))
+        harness.receiver.cancel(generation: 1)
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        #expect(harness.collector.abortInfos.first?.code == "cancelled")
+        // RATIONALE: filesystem-appearance poll (docs/TESTING.md) — the teardown
+        // runs on the write lane after the abort is delivered.
+        try await waitUntil { materializedFiles(under: harness.stagingTempRoot).isEmpty }
+    }
+
+    @Test("a peer abort mid-extract deletes the partial tree")
+    func peerAbortDeletesPartialTree() async throws {
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeSourceTree()
+        defer { try? fm.removeItem(at: scratch) }
+        let bytes = try archiveBytes(of: source)
+
+        let id: UInt64 = 48
+        prime(harness, id: id, named: "Project")
+        begin(harness, id: id, named: "Project")
+        feed(harness, id: id, bytes: Data(bytes.prefix(bytes.count / 2)))
+        harness.receiver.handleAbort(
+            .with {
+                $0.transferID = id; $0.code = "read.error"; $0.message = "gone"
+            })
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        // RATIONALE: filesystem-appearance poll (docs/TESTING.md) — same ordering
+        // as the cancellation case above.
+        try await waitUntil { materializedFiles(under: harness.stagingTempRoot).isEmpty }
+    }
+
+    @Test("a volume below the free-space margin refuses a folder at Begin")
+    func refusedWhenVolumeIsFull() async throws {
+        let harness = try harness(freeSpace: 1024)
+        defer { harness.tearDown() }
+        let id: UInt64 = 49
+        prime(harness, id: id, named: "Project")
+        begin(harness, id: id, named: "Project")
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        let info = try #require(harness.collector.abortInfos.first)
+        #expect(info.code == "disk.full")
+        // A streamed folder declares no size, so there is no honest figure to
+        // report as "needed".
+        #expect(info.neededBytes == nil)
+    }
+
+    @Test("the sender aborts a folder that outgrows the requester's ceiling")
+    func abortsPastAcceptCeiling() async throws {
+        let fm = FileManager.default
+        let harness = try harness()
+        defer { harness.tearDown() }
+        let (scratch, source) = try makeSourceTree()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let id: UInt64 = 50
+        prime(harness, id: id, named: "Project")
+        // The ceiling can only be enforced as bytes are produced: the archive's
+        // size is not knowable when the transfer starts.
+        harness.sender.startDirectoryTransfer(
+            transferID: id, generation: 1, sourceDirectoryURL: source, folderName: "Project",
+            uti: ClipboardDirectoryArchive.directoryUTI, maxAcceptByteCount: 64,
+            isCurrent: { _ in true })
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        #expect(harness.collector.abortInfos.first?.code == "disk.full")
+        #expect(harness.collector.representation(id) == nil)
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryTransferTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryTransferTests.swift
@@ -13,11 +13,29 @@ struct ClipboardDirectoryTransferTests {
     private static let window = 16384  // 4 chunks
 
     private func harness(
-        windowBytes: Int = window, freeSpace: Int64 = 100 * 1024 * 1024 * 1024
+        windowBytes: Int = window, freeSpace: @escaping @Sendable () -> Int64 = { 100 << 30 },
+        minimumExtractAllowance: Int = ClipboardStreamTuning.minimumExtractAllowance,
+        directorySource: ClipboardDirectorySourceFactory? = nil
     ) throws -> StreamHarness {
         try StreamHarness(
             chunkSize: Self.chunk, windowBytes: windowBytes,
-            freeSpaceProvider: { _ in freeSpace })
+            minimumExtractAllowance: minimumExtractAllowance,
+            freeSpaceProvider: { _ in freeSpace() },
+            directorySource: directorySource)
+    }
+
+    /// A tree whose archive is far smaller than the tree it unpacks to — the
+    /// shape every compressed-vs-decompressed accounting bug hides in.
+    private func makeCompressibleTree(uncompressedBytes: Int = 512 * 1024) throws -> (
+        scratch: URL, source: URL
+    ) {
+        let fm = FileManager.default
+        let scratch = makeScratch()
+        let source = scratch.appendingPathComponent("Logs", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        try Data(repeating: 0x20, count: uncompressedBytes)
+            .write(to: source.appendingPathComponent("big.log"))
+        return (scratch, source)
     }
 
     private func makeScratch() -> URL {
@@ -324,9 +342,100 @@ struct ClipboardDirectoryTransferTests {
         try await waitUntil { materializedFiles(under: harness.stagingTempRoot).isEmpty }
     }
 
+    @Test("an abort reaches a transfer parked reading its source, and frees its id")
+    func abortUnwindsAParkedSourceRead() async throws {
+        // Nothing signals the transfer's own condition into a park that happens
+        // *inside* the source, so before this the receiver's stall abort,
+        // supersession and channel teardown all woke the wrong object — the
+        // transfer stayed registered, and the peer's retry (transfer ids are
+        // derivable, so it reuses this one) was dropped as a duplicate.
+        let source = ParkingChunkReader()
+        let first = try harness(directorySource: { _, _, _ in source })
+        defer { first.tearDown() }
+        let fm = FileManager.default
+        let (scratch, tree) = try makeSourceTree()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let id: UInt64 = 51
+        let firstOutcome = Box<Bool?>(nil)
+        let firstGate = AsyncGate()
+        prime(first, id: id, named: "Project")
+        first.sender.startDirectoryTransfer(
+            transferID: id, generation: 1, sourceDirectoryURL: tree, folderName: "Project",
+            uti: ClipboardDirectoryArchive.directoryUTI, maxAcceptByteCount: .max,
+            isCurrent: { _ in true },
+            onComplete: { success in
+                firstOutcome.value = success
+                firstGate.notify()
+            })
+        try await source.parked.wait { source.parkedReads > 0 }
+
+        first.sender.cancel(generation: 1)
+        // Unwinds promptly rather than sitting until the source happens to
+        // produce something, which for a stalled encoder is never.
+        try await firstGate.wait { firstOutcome.value != nil }
+        #expect(firstOutcome.value == false)
+
+        // The id is free again, so the peer's retry is served rather than
+        // swallowed by the duplicate-transfer guard.
+        let retry = ParkingChunkReader()
+        let retryHarness = try self.harness(directorySource: { _, _, _ in retry })
+        defer { retryHarness.tearDown() }
+        prime(retryHarness, id: id, named: "Project")
+        retryHarness.sender.startDirectoryTransfer(
+            transferID: id, generation: 1, sourceDirectoryURL: tree, folderName: "Project",
+            uti: ClipboardDirectoryArchive.directoryUTI, maxAcceptByteCount: .max,
+            isCurrent: { _ in true })
+        try await retry.parked.wait { retry.parkedReads > 0 }
+        retry.close()
+    }
+
+    @Test("a second transfer for a freed id is accepted by the same sender")
+    func abortedTransferFreesItsIdOnTheSameSender() async throws {
+        let source = ParkingChunkReader()
+        let second = ParkingChunkReader()
+        let sources = Box<[ParkingChunkReader]>([second, source])
+        let rig = try harness(directorySource: { _, _, _ in
+            var remaining = sources.value
+            let next = remaining.removeLast()
+            sources.value = remaining
+            return next
+        })
+        defer { rig.tearDown() }
+        let fm = FileManager.default
+        let (scratch, tree) = try makeSourceTree()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let id: UInt64 = 52
+        let done = AsyncGate()
+        let outcome = Box<Bool?>(nil)
+        prime(rig, id: id, named: "Project")
+        rig.sender.startDirectoryTransfer(
+            transferID: id, generation: 1, sourceDirectoryURL: tree, folderName: "Project",
+            uti: ClipboardDirectoryArchive.directoryUTI, maxAcceptByteCount: .max,
+            isCurrent: { _ in true },
+            onComplete: { success in
+                outcome.value = success
+                done.notify()
+            })
+        try await source.parked.wait { source.parkedReads > 0 }
+        rig.sender.handleAbort(transferID: id)
+        try await done.wait { outcome.value != nil }
+
+        // Same sender, same id: the table entry has to be gone, or this call is
+        // silently dropped and the peer waits for a Begin that never comes.
+        prime(rig, id: id, named: "Project")
+        rig.sender.startDirectoryTransfer(
+            transferID: id, generation: 1, sourceDirectoryURL: tree, folderName: "Project",
+            uti: ClipboardDirectoryArchive.directoryUTI, maxAcceptByteCount: .max,
+            isCurrent: { _ in true })
+        try await second.parked.wait { second.parkedReads > 0 }
+        second.close()
+    }
+
     @Test("a volume below the free-space margin refuses a folder at Begin")
     func refusedWhenVolumeIsFull() async throws {
-        let harness = try harness(freeSpace: 1024)
+        let harness = try harness(freeSpace: { 1024 })
         defer { harness.tearDown() }
         let id: UInt64 = 49
         prime(harness, id: id, named: "Project")

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryTransferTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryTransferTests.swift
@@ -135,7 +135,8 @@ struct ClipboardDirectoryTransferTests {
         let rep = try #require(harness.collector.representation(id))
         #expect(rep.isDirectory)
         #expect(rep.filename == "Project")
-        // The streamed archive's size, which End declared and the digest covered.
+        // The tree the rep names, not the archive that carried it
+        // (ClipboardDirectoryAccounting pins the two apart).
         #expect(rep.byteCount > 0)
 
         let tree = try #require(rep.fileURL)
@@ -179,7 +180,7 @@ struct ClipboardDirectoryTransferTests {
 
         try await harness.collector.gate.wait { harness.collector.representation(id) != nil }
         let rep = try #require(harness.collector.representation(id))
-        // Archive-header bytes, so `End.total_bytes` is never legitimately zero.
+        // Archive-container bytes, so even an empty folder is never sized zero.
         #expect(rep.byteCount > 0)
         #expect(try fm.contentsOfDirectory(atPath: #require(rep.fileURL).path).isEmpty)
     }

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardFileStagingTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardFileStagingTests.swift
@@ -128,29 +128,31 @@ struct ClipboardFileStagingTests {
         #expect(sink.url.path.hasPrefix(labelRoot.path + "/"))
     }
 
-    @Test("same-generation send and receive roots never share a directory; one sweep leaves the other")
-    func sendAndReceiveRootsAreDisjoint() throws {
-        // The send/receive split: both counters start at 1, so the same
-        // generation number must land in different roots.
+    @Test("same-generation roots of two labels never share a directory; one sweep leaves the other")
+    func perLabelRootsAreDisjoint() throws {
+        // Every label's counter starts at 1, so the same generation number must
+        // land in different roots.
         let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
             UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
         let receive = ClipboardFileStaging(label: "host-vm", tempRoot: tempRoot)
-        let send = ClipboardFileStaging(label: "host-send-vm", tempRoot: tempRoot)
+        let drops = ClipboardFileStaging(label: "host-drops-vm", tempRoot: tempRoot)
 
         let received = try receive.makeSink(generation: 1, filename: "in.bin")
         try received.write(Data("in".utf8))
         try received.commit()
-        let sent = try send.reserveURL(generation: 1, filename: "out.aar")
+        let dropped = try drops.makeSink(generation: 1, filename: "out.bin")
+        try dropped.write(Data("out".utf8))
+        try dropped.commit()
 
         #expect(
-            received.url.deletingLastPathComponent() != sent.deletingLastPathComponent())
+            received.url.deletingLastPathComponent() != dropped.url.deletingLastPathComponent())
         // A sibling label extending this one is not "inside" this root.
-        #expect(!receive.isInStagingRoot(sent))
+        #expect(!receive.isInStagingRoot(dropped.url))
 
-        // Sweeping the send root leaves the receive root's file intact.
-        send.sweep()
-        #expect(!FileManager.default.fileExists(atPath: sent.path))
+        // Sweeping one root leaves the other's file intact.
+        drops.sweep()
+        #expect(!FileManager.default.fileExists(atPath: dropped.url.path))
         #expect(FileManager.default.fileExists(atPath: received.url.path))
     }
 
@@ -277,21 +279,6 @@ struct ClipboardFileStagingTests {
 
     // MARK: - Directory / tree reservations (Phase 2)
 
-    @Test("reserveURL claims a placeholder; same-named reserves get distinct paths")
-    func reserveURLClaimsAndDedups() throws {
-        let staging = makeStaging()
-        defer { staging.sweep() }
-
-        let a = try staging.reserveURL(generation: 1, filename: "Folder.aar")
-        // An empty placeholder claims the name so a later reserve can't collide.
-        #expect(FileManager.default.fileExists(atPath: a.path))
-        #expect(a.lastPathComponent == "Folder.aar")
-
-        let b = try staging.reserveURL(generation: 1, filename: "Folder.aar")
-        #expect(a != b)
-        #expect(b.lastPathComponent == "Folder (2).aar")
-    }
-
     @Test("reserveDirectory creates an empty directory named exactly `name`")
     func reserveDirectoryKeepsName() throws {
         let staging = makeStaging()
@@ -305,17 +292,19 @@ struct ClipboardFileStagingTests {
         #expect(dir.lastPathComponent == "MyFolder")
     }
 
-    @Test("reserveDirectory keeps the exact name despite a sibling archive of the same base")
-    func reserveDirectoryNameSurvivesSiblingArchive() throws {
-        // The receive path stages the streamed `.aar` (named after the folder)
-        // beside the extracted tree. Nesting the directory under a fresh UUID
-        // parent keeps its name exact instead of degrading to "MyFolder (2)".
+    @Test("two same-named folders in one generation both keep the exact name")
+    func reserveDirectoryNameSurvivesSameNamedSibling() throws {
+        // One copy can carry two folders of the same name. Nesting each under a
+        // fresh UUID parent keeps both names exact instead of degrading the
+        // second to "MyFolder (2)".
         let staging = makeStaging()
         defer { staging.sweep() }
 
-        _ = try staging.reserveURL(generation: 5, filename: "MyFolder")  // the staged archive
-        let dir = try staging.reserveDirectory(generation: 5, name: "MyFolder")
-        #expect(dir.lastPathComponent == "MyFolder")
+        let first = try staging.reserveDirectory(generation: 5, name: "MyFolder")
+        let second = try staging.reserveDirectory(generation: 5, name: "MyFolder")
+        #expect(first != second)
+        #expect(first.lastPathComponent == "MyFolder")
+        #expect(second.lastPathComponent == "MyFolder")
     }
 
     @Test("reserveDirectory sanitizes a path-traversal name")

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
@@ -792,6 +792,37 @@ struct ClipboardStreamTests {
         #expect(harness.collector.representation(id) == nil)
     }
 
+    @Test("a peer that ignores the credit window is cut off before its backlog can grow")
+    func backlogOverrunAborts() async throws {
+        // The receive lane never blocks — it hands each chunk to the write lane
+        // and returns — so a peer that ignores the window would otherwise queue
+        // chunks on a parked lane until the heap ran out.
+        let (harness, sinkBox) = try gatedHarness()
+        defer { harness.tearDown() }
+        let id: UInt64 = 707
+        let ceiling = ClipboardStreamTuning.maxBacklogBytes(forWindowBytes: Self.window)
+        // Declared far past the ceiling, so the overrun guard can't fire first.
+        try await beginFileTransfer(
+            harness, id: id, totalBytes: ceiling * 4, filename: "flood.bin")
+
+        // The gated sink parks the write lane, so nothing drains the backlog.
+        let flood = Data(repeating: 0x11, count: ClipboardStreamTuning.maxChunkBytes / 2)
+        var offset = 0
+        while offset <= ceiling {
+            harness.receiver.handleChunk(
+                .with {
+                    $0.transferID = id
+                    $0.offset = UInt64(offset)
+                    $0.data = flood
+                })
+            offset += flood.count
+        }
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        #expect(harness.collector.abortInfos.first?.code == "flow.overrun")
+        try #require(sinkBox.value).allowAll()
+    }
+
     @Test("a volume that fills mid-stream aborts from the write lane with disk.full")
     func midStreamDiskFullOnWriteLane() async throws {
         // Roomy at Begin, then nearly full: the write lane's once-per-window

--- a/KernovaKit/Tests/KernovaKitTests/LazyClipboardDataProviderTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/LazyClipboardDataProviderTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import Testing
+import KernovaTestSupport
 
 @testable import KernovaKit
 

--- a/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
+++ b/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
@@ -173,7 +173,7 @@ final class FailingSink: StagingSink, @unchecked Sendable {
 /// a slow walk over a network or removable volume — and that park is only
 /// escapable because an abort reaches the source. Standing this in makes the
 /// window as wide as a test needs instead of racing a real encoder.
-final class ParkingChunkReader: ChunkReader, @unchecked Sendable {
+final class ParkingChunkReader: CancellableChunkReader, @unchecked Sendable {
     private let condition = NSCondition()
     private var closed = false
     private var reads = 0

--- a/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
+++ b/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
@@ -42,19 +42,6 @@ func makeStartedChannelPair() throws -> (a: VsockChannel, b: VsockChannel) {
     return (a, b)
 }
 
-// MARK: - File helpers
-
-/// Every regular file anywhere under `directory` (recursive).
-func materializedFiles(under directory: URL) -> [URL] {
-    guard
-        let enumerator = FileManager.default.enumerator(
-            at: directory, includingPropertiesForKeys: [.isRegularFileKey])
-    else { return [] }
-    return enumerator.compactMap { $0 as? URL }.filter {
-        (try? $0.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true
-    }
-}
-
 // MARK: - Staging sink doubles
 
 /// A `StagingSink` that parks every `write` until the test allows it through,

--- a/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
+++ b/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
@@ -11,21 +11,6 @@ struct StreamTestFailure: Error, CustomStringConvertible {
     var description: String { message }
 }
 
-/// A `@Sendable`-safe mutable cell — lets a synchronous test closure record what it
-/// observed from a concurrency-checked context.
-///
-/// Shared across the package test suites (`@testable import` visibility) so the
-/// lock-guarded cell has one source of truth.
-final class Box<T>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var stored: T
-    init(_ value: T) { stored = value }
-    var value: T {
-        get { lock.withLock { stored } }
-        set { lock.withLock { stored = newValue } }
-    }
-}
-
 // MARK: - Socket pair
 
 /// Two `VsockChannel`s connected by a started `socketpair(AF_UNIX, SOCK_STREAM)`.
@@ -182,6 +167,45 @@ final class FailingSink: StagingSink, @unchecked Sendable {
     func abort() { wrapped.abort() }
 }
 
+/// A `ChunkReader` that parks every read until it is closed.
+///
+/// A real archive source parks whenever its encoder has produced nothing yet —
+/// a slow walk over a network or removable volume — and that park is only
+/// escapable because an abort reaches the source. Standing this in makes the
+/// window as wide as a test needs instead of racing a real encoder.
+final class ParkingChunkReader: ChunkReader, @unchecked Sendable {
+    private let condition = NSCondition()
+    private var closed = false
+    private var reads = 0
+    /// Notified once a read has parked, so a test can abort at a known point.
+    let parked = AsyncGate()
+
+    /// Reads that have entered and not yet returned.
+    var parkedReads: Int {
+        condition.lock()
+        defer { condition.unlock() }
+        return reads
+    }
+
+    func read(upTo count: Int) -> Data? {
+        condition.lock()
+        reads += 1
+        condition.unlock()
+        parked.notify()
+        condition.lock()
+        while !closed { condition.wait() }
+        condition.unlock()
+        return nil
+    }
+
+    func close() {
+        condition.lock()
+        closed = true
+        condition.broadcast()
+        condition.unlock()
+    }
+}
+
 // MARK: - Collector
 
 /// Gathers the completed representations and aborts a receiver delivers.
@@ -249,9 +273,11 @@ final class StreamHarness: @unchecked Sendable {
         ackLatencyBound: TimeInterval = ClipboardStreamTuning.ackLatencyBound,
         stallTimeout: TimeInterval = ClipboardStreamTuning.inboundStallTimeout,
         maxResidentInlineBytes: Int = ClipboardStreamTuning.maxResidentInlineBytes,
+        minimumExtractAllowance: Int = ClipboardStreamTuning.minimumExtractAllowance,
         suppressAcks: Bool = false,
         freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
-        sinkFactory: ClipboardSinkFactory? = nil
+        sinkFactory: ClipboardSinkFactory? = nil,
+        directorySource: ClipboardDirectorySourceFactory? = nil
     ) throws {
         (a, b) = try makeStartedChannelPair()
         stagingTempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
@@ -260,14 +286,24 @@ final class StreamHarness: @unchecked Sendable {
             label: "harness-\(UUID().uuidString)",
             tempRoot: stagingTempRoot,
             freeSpaceProvider: freeSpaceProvider)
-        sender = ClipboardStreamSender(
-            channel: a, chunkSize: chunkSize, windowBytes: windowBytes, noAckTimeout: noAckTimeout)
+        let builtSender: ClipboardStreamSender
+        if let directorySource {
+            builtSender = ClipboardStreamSender(
+                channel: a, chunkSize: chunkSize, windowBytes: windowBytes,
+                noAckTimeout: noAckTimeout, directorySource: directorySource)
+        } else {
+            builtSender = ClipboardStreamSender(
+                channel: a, chunkSize: chunkSize, windowBytes: windowBytes,
+                noAckTimeout: noAckTimeout)
+        }
+        sender = builtSender
         let collector = self.collector
         receiver = ClipboardStreamReceiver(
             clock: clock,
             channel: b, staging: staging, windowBytes: windowBytes,
             ackLatencyBound: ackLatencyBound, stallTimeout: stallTimeout,
             maxResidentInlineBytes: maxResidentInlineBytes,
+            minimumExtractAllowance: minimumExtractAllowance,
             sinkFactory: sinkFactory,
             onTransferTimed: { metrics in collector.timed(metrics) },
             onComplete: { id, rep in collector.complete(id, rep) },

--- a/KernovaKit/Tests/KernovaKitTests/VsockChannelTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/VsockChannelTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import Darwin
+import KernovaTestSupport
 @testable import KernovaKit
 
 @Suite("VsockChannel")

--- a/KernovaMacOSAgent/AgentAppDelegate.swift
+++ b/KernovaMacOSAgent/AgentAppDelegate.swift
@@ -129,6 +129,9 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
         )
 
         self.vsockConnection = vsockConnection
+        clipboardAgent.hostStreamsDirectories = { [weak controlAgent] in
+            controlAgent?.hostSupportsDirectoryStreaming ?? false
+        }
         self.clipboardAgent = clipboardAgent
         self.controlAgent = controlAgent
 

--- a/KernovaMacOSAgent/AgentMenuText.swift
+++ b/KernovaMacOSAgent/AgentMenuText.swift
@@ -39,9 +39,9 @@ enum AgentMenuText {
 
     /// Why a paste of the host's clipboard did not happen, per failure code.
     ///
-    /// `copyTooLarge`, `pasteIncompleteSet`, and `forwardItemsSkipped` are
-    /// host-only outcomes that never reach the guest, so they read as the generic
-    /// failure.
+    /// `copyTooLarge`, `pasteIncompleteSet`, `forwardItemsSkipped` and
+    /// `folderPeerOutdated` are host-only outcomes that never reach the guest, so
+    /// they read as the generic failure.
     private static func pasteRefusalDetail(
         _ code: ClipboardErrorCode, pasteLimitBytes: Int?
     ) -> String {
@@ -52,7 +52,8 @@ enum AgentMenuText {
                 "too large to paste — over the \(ClipboardPasteLimit.displayLimit(pasteLimitBytes)) transfer limit"
         case .pasteDiskFull: return "not enough disk space to paste"
         case .pasteTimeout: return "paste timed out"
-        case .pasteFailed, .copyTooLarge, .pasteIncompleteSet, .forwardItemsSkipped:
+        case .pasteFailed, .copyTooLarge, .pasteIncompleteSet, .forwardItemsSkipped,
+            .folderPeerOutdated:
             return "paste failed"
         }
     }

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -190,6 +190,11 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// `allowsFileURLPull` gate inside it — runs on the agent's main thread.
     private var maxPasteBytes: Int = ClipboardPasteLimit.defaultBytes
 
+    /// The pasteboard change count whose snapshot was last skipped for holding
+    /// only folders the host cannot take, so the skip is logged once rather than
+    /// every poll tick.
+    private var skippedFolderChangeCount: Int?
+
     /// Whether the connected host can receive a folder archived straight onto the
     /// wire (`clipboard.stream.directory.v1`).
     ///
@@ -528,7 +533,26 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         // Copied *files* (Finder ⌘C) leave one file URL per pasteboard item —
         // build a disk-backed rep from each (a stat, no read, no size cap); the
         // bytes stream later when the host requests them.
-        let fileCandidates = fileExpansionCandidates()
+        let expansion = fileExpansionCandidates()
+        let fileCandidates = expansion.candidates
+        if fileCandidates.isEmpty, expansion.unsupportedFolders > 0 {
+            // Every copied item was a folder this host cannot receive. Falling
+            // through would offer the pasteboard's leftover non-file flavors —
+            // Finder's `com.apple.finder.node` and friends — so the host would
+            // get guest-local junk for what the user copied as a folder.
+            //
+            // The change count is deliberately *not* advanced: the capability is
+            // re-read from every `Hello`, so this copy becomes offerable the
+            // moment the host advertises it. Reported once per snapshot, since
+            // the poll re-enters here every tick.
+            if skippedFolderChangeCount != currentCount {
+                skippedFolderChangeCount = currentCount
+                Self.logger.notice(
+                    "Offering nothing — all \(expansion.unsupportedFolders, privacy: .public) copied item(s) are folders and the host lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public)"
+                )
+            }
+            return
+        }
         if !fileCandidates.isEmpty {
             if fileCandidates.contains(where: { $0.isDirectory }) {
                 // A folder's stat-walk size estimate runs off the main queue
@@ -642,7 +666,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// staging root (materialized from a prior inbound paste) is skipped so it
     /// can't be offered back to the host — that one is by design, so only the
     /// unreadable items below are counted and logged.
-    private func fileExpansionCandidates() -> [FileCandidate] {
+    private func fileExpansionCandidates() -> (
+        candidates: [FileCandidate], unsupportedFolders: Int
+    ) {
         var candidates: [FileCandidate] = []
         var unreadable = 0
         var unsupportedFolders = 0
@@ -684,12 +710,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                 "Skipped \(unreadable, privacy: .public) unreadable copied item(s) — not offered to the host"
             )
         }
-        if unsupportedFolders > 0 {
-            Self.logger.notice(
-                "Skipped \(unsupportedFolders, privacy: .public) copied folder(s) — the host lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public)"
-            )
-        }
-        return candidates
+        return (candidates, unsupportedFolders)
     }
 
     /// Sizes any folder candidate off the main queue — a stat-walk estimate, no
@@ -1002,13 +1023,14 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// holds.
     private func awaitPull(
         transferID: UInt64, receiver: ClipboardStreamReceiver,
-        extractsDirectoryNamed: String? = nil,
+        extractsDirectoryNamed: String? = nil, advertisedByteCount: Int = 0,
         sendRequest: @escaping () throws -> Void
     ) -> LazyPullOutcome {
         let coordinator = lazyCoordinator
         receiver.awaitTransfer(
             transferID,
             extractsDirectoryNamed: extractsDirectoryNamed,
+            advertisedByteCount: advertisedByteCount,
             onComplete: { rep in coordinator.deliver(transferID, rep) },
             onAbort: { abort in coordinator.abort(transferID, abort) },
             // Re-arm the pull's inactivity backstop on every chunk so a large
@@ -1092,10 +1114,12 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         let uti = info.uti
         // A folder's bytes are an archive of its tree, extracted as they arrive:
         // the stream layer learns that here, from the offer this side already
-        // read, rather than from the wire.
+        // read, rather than from the wire — including the size the extract is
+        // held to.
         let outcome = awaitPull(
             transferID: transferID, receiver: receiver,
-            extractsDirectoryNamed: info.isDirectory ? info.filename : nil
+            extractsDirectoryNamed: info.isDirectory ? info.filename : nil,
+            advertisedByteCount: Int(clamping: info.byteCount)
         ) {
             var request = Frame()
             request.protocolVersion = 1

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -190,10 +190,13 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// `allowsFileURLPull` gate inside it — runs on the agent's main thread.
     private var maxPasteBytes: Int = ClipboardPasteLimit.defaultBytes
 
-    /// The pasteboard change count whose snapshot was last skipped for holding
-    /// only folders the host cannot take, so the skip is logged once rather than
-    /// every poll tick.
-    private var skippedFolderChangeCount: Int?
+    /// The pasteboard change count whose copied folders the host could not take —
+    /// whether that left nothing to offer or only shortened the offer.
+    ///
+    /// Two jobs: the skip is logged once rather than every poll tick, and the
+    /// snapshot is re-offered once the host advertises the capability it lacked,
+    /// which neither `lastPasteboardChangeCount` nor `lastSeenDigest` can notice.
+    private var folderSkippedChangeCount: Int?
 
     /// Whether the connected host can receive a folder archived straight onto the
     /// wire (`clipboard.stream.directory.v1`).
@@ -445,6 +448,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             // A brand-new host has no record of prior offers; re-announce.
             self.lastSeenDigest = nil
             self.lastPasteboardChangeCount = -1
+            self.folderSkippedChangeCount = nil
         }
         Self.logger.notice(
             "Vsock clipboard connected to host (conn=\(connectionTag, privacy: .public))")
@@ -512,7 +516,15 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     func checkClipboardChange() {
         guard let channel = liveChannel else { return }
         let currentCount = pasteboard.changeCount
-        guard currentCount != lastPasteboardChangeCount else { return }
+        if currentCount == lastPasteboardChangeCount {
+            // Both dedup keys above describe what was *offered*, so neither can
+            // tell that the offer went out short of this snapshot's folders.
+            // Re-enter for exactly that case, once the host advertises the
+            // capability it lacked.
+            guard folderSkippedChangeCount == currentCount, hostStreamsDirectories() else {
+                return
+            }
+        }
 
         // `org.nspasteboard.*` marker handling, from the unfiltered first-item
         // type list: a transient/auto-generated snapshot is never offered; a
@@ -535,6 +547,11 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         // bytes stream later when the host requests them.
         let expansion = fileExpansionCandidates()
         let fileCandidates = expansion.candidates
+        if expansion.unsupportedFolders > 0 {
+            noteFoldersSkipped(
+                count: expansion.unsupportedFolders, offeringAnything: !fileCandidates.isEmpty,
+                changeCount: currentCount)
+        }
         if fileCandidates.isEmpty, expansion.unsupportedFolders > 0 {
             // Every copied item was a folder this host cannot receive. Falling
             // through would offer the pasteboard's leftover non-file flavors —
@@ -543,14 +560,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             //
             // The change count is deliberately *not* advanced: the capability is
             // re-read from every `Hello`, so this copy becomes offerable the
-            // moment the host advertises it. Reported once per snapshot, since
-            // the poll re-enters here every tick.
-            if skippedFolderChangeCount != currentCount {
-                skippedFolderChangeCount = currentCount
-                Self.logger.notice(
-                    "Offering nothing — all \(expansion.unsupportedFolders, privacy: .public) copied item(s) are folders and the host lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public)"
-                )
-            }
+            // moment the host advertises it.
             return
         }
         if !fileCandidates.isEmpty {
@@ -593,6 +603,26 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         // marker called for it.
         let content = outcome.content.withConcealed(isConcealed)
         sendOfferIfNeeded(content, channel: channel, changeCount: currentCount)
+    }
+
+    /// Records, once per snapshot, that `count` copied folders were left out
+    /// because the host cannot receive one.
+    ///
+    /// The user's copy came up short whether that emptied the offer or only
+    /// shortened it, so both latch here — and the latch is what lets
+    /// `checkClipboardChange` re-offer the snapshot when the capability appears.
+    private func noteFoldersSkipped(count: Int, offeringAnything: Bool, changeCount: Int) {
+        guard folderSkippedChangeCount != changeCount else { return }
+        folderSkippedChangeCount = changeCount
+        if offeringAnything {
+            Self.logger.notice(
+                "Leaving \(count, privacy: .public) copied folder(s) out of the offer — the host lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public)"
+            )
+        } else {
+            Self.logger.notice(
+                "Offering nothing — all \(count, privacy: .public) copied item(s) are folders and the host lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public)"
+            )
+        }
     }
 
     /// Announces `content` to the host when it's non-empty and not an echo of
@@ -724,6 +754,11 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     ) {
         guard !estimateInFlight else { return }
         estimateInFlight = true
+        // A folder candidate reaching here means the host takes folders, so
+        // nothing is being left out of this snapshot any more. Cleared only once
+        // the walk is actually under way: clearing it earlier would strand a
+        // re-offer the guard above turned back.
+        folderSkippedChangeCount = nil
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             let reps: [ClipboardContent.Representation] = candidates.map { candidate in
                 if candidate.isDirectory {

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -166,15 +166,6 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// agent launch clears earlier processes' roots.
     private let staging: ClipboardFileStaging
 
-    /// Holds folder archives built to *send* to the host, kept separate from
-    /// `staging` so an outbound archive's generation can't share a directory
-    /// with an inbound transfer (which keys on the host's offer generation).
-    private let sendStaging: ClipboardFileStaging
-
-    /// Monotonic generation for outbound folder archives in `sendStaging`, so a
-    /// new send supersedes older archive temps instead of accumulating.
-    private var sendArchiveGeneration: UInt64 = 1
-
     /// `true` while an off-main folder estimate walk for an outbound offer is
     /// running, so overlapping 0.5 s polls don't kick off a second walk of the
     /// same content.
@@ -198,6 +189,14 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// Main-queue confined, like `enabled`: `provideData` — and the
     /// `allowsFileURLPull` gate inside it — runs on the agent's main thread.
     private var maxPasteBytes: Int = ClipboardPasteLimit.defaultBytes
+
+    /// Whether the connected host can receive a folder archived straight onto the
+    /// wire (`clipboard.stream.directory.v1`).
+    ///
+    /// Read at each offer, so a host upgraded between connections starts getting
+    /// folders without restarting the agent. Defaults to refusing, so a
+    /// connection whose `Hello` hasn't been read yet never offers one.
+    var hostStreamsDirectories: @Sendable () -> Bool = { false }
 
     #if DEBUG
     /// Test seam.
@@ -282,8 +281,6 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             revealDelay: progressRevealDelay, idleLinger: progressIdleLinger, emit: onProgress)
         self.staging = ClipboardFileStaging(
             label: "agent", tempRoot: stagingTempRoot, freeSpaceProvider: freeSpaceProvider)
-        self.sendStaging = ClipboardFileStaging(
-            label: "agent-send", tempRoot: stagingTempRoot, freeSpaceProvider: freeSpaceProvider)
         self.lastPasteboardChangeCount = pasteboard.changeCount
         // Default-disabled: pause the reconnect loop until the host enables.
         self.client.pause()
@@ -326,11 +323,10 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             pollingTimer?.cancel()
             pollingTimer = nil
             teardownConnectionState()
-            // Only the outbound archives: receive staging survives a disable —
-            // its files may still back `public.file-url`s the guest pasteboard
-            // vended, and a URL vended to a pasteboard outlives the session
-            // that staged it (mirrors the host's stop()).
-            sendStaging.sweep()
+            // Receive staging survives a disable: its files may still back
+            // `public.file-url`s the guest pasteboard vended, and a URL vended to
+            // a pasteboard outlives the session that staged it (mirrors the
+            // host's stop()).
             clipboardActivityStorage = .disabled
             Self.logger.notice("Clipboard sharing disabled by host policy")
         }
@@ -345,7 +341,6 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             self?.pollingTimer?.cancel()
             self?.pollingTimer = nil
             self?.teardownConnectionState()
-            self?.sendStaging.sweep()
         }
         Self.logger.notice("Vsock clipboard agent stopped")
     }
@@ -650,6 +645,8 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     private func fileExpansionCandidates() -> [FileCandidate] {
         var candidates: [FileCandidate] = []
         var unreadable = 0
+        var unsupportedFolders = 0
+        let hostTakesFolders = hostStreamsDirectories()
         for url in pasteboard.itemFileURLs where !staging.isInStagingRoot(url) {
             guard
                 let values = try? url.resourceValues(forKeys: [
@@ -660,6 +657,13 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                 continue
             }
             if values.isDirectory == true {
+                // A host that predates `clipboard.stream.directory.v1` bounds
+                // arriving bytes by the declared total, which a streamed folder
+                // does not have — so don't offer one.
+                guard hostTakesFolders else {
+                    unsupportedFolders += 1
+                    continue
+                }
                 candidates.append(
                     FileCandidate(
                         url: url, type: values.contentType ?? .folder,
@@ -680,6 +684,11 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                 "Skipped \(unreadable, privacy: .public) unreadable copied item(s) — not offered to the host"
             )
         }
+        if unsupportedFolders > 0 {
+            Self.logger.notice(
+                "Skipped \(unsupportedFolders, privacy: .public) copied folder(s) — the host lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public)"
+            )
+        }
         return candidates
     }
 
@@ -687,8 +696,8 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// archive — then offers the mixed file/folder content back on main.
     ///
     /// A large tree's walk would freeze the agent's run loop, so it hops to a
-    /// global queue and back; the archive is built only when the host requests
-    /// the rep (`archiveAndStream`).
+    /// global queue and back; the tree is encoded only when the host requests the
+    /// rep, and then straight onto the wire.
     private func estimateAndOffer(
         _ candidates: [FileCandidate], channel: VsockChannel, changeCount: Int
     ) {
@@ -796,11 +805,29 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             session: session, id: xid, expectedBytes: UInt64(max(0, representation.byteCount)),
             name: name)
         let tracker = progressTracker
+        // A directory rep is offered as a source URL plus an estimate — no
+        // archive exists. Archive the tree straight onto the wire, so nothing
+        // larger than the credit window is ever held (docs/CLIPBOARD.md §2).
         if case .directory(let sourceURL, let estimatedByteCount) = representation.source {
-            archiveAndStream(
-                sourceURL: sourceURL, folderName: representation.filename, repIndex: repIndex,
-                estimatedByteCount: estimatedByteCount, request: request,
-                isCurrent: generation, session: session, sender: sender)
+            Self.logger.notice(
+                "Streaming clipboard folder '\(representation.filename, privacy: .public)' (gen=\(request.generation, privacy: .public), conn=\(self.connectionTag, privacy: .public), rep \(repIndex, privacy: .public), estimate \(estimatedByteCount, privacy: .public) bytes)"
+            )
+            sender.startDirectoryTransfer(
+                transferID: request.transferID,
+                generation: request.generation,
+                sourceDirectoryURL: sourceURL,
+                folderName: representation.filename,
+                uti: representation.uti,
+                maxAcceptByteCount: request.maxAcceptByteCount,
+                isCurrent: { value in generation.isCurrent(value) },
+                onProgress: { sent, total in
+                    tracker.unitProgressed(
+                        session: session, id: xid, bytesTransferred: UInt64(max(0, sent)),
+                        totalBytes: UInt64(max(0, total)))
+                },
+                onComplete: { success in
+                    tracker.unitEnded(session: session, id: xid, succeeded: success)
+                })
             clipboardActivityStorage = .sentToHost
             return
         }
@@ -823,64 +850,6 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         Self.logger.debug(
             "Streaming clipboard rep \(repIndex, privacy: .public) (gen=\(request.generation, privacy: .public), conn=\(self.connectionTag, privacy: .public), \(representation.byteCount, privacy: .public) bytes)"
         )
-    }
-
-    /// Archives a source directory at request time and streams the `.aar` — the
-    /// serving path for every folder rep the host pulls.
-    ///
-    /// Runs off the main run loop (walk + LZFSE compress).
-    private func archiveAndStream(
-        sourceURL: URL, folderName: String, repIndex: Int, estimatedByteCount: Int,
-        request: Kernova_V1_ClipboardRequest,
-        isCurrent: AtomicGeneration, session: ClipboardProgressTracker.SessionToken,
-        sender: ClipboardStreamSender
-    ) {
-        let staging = self.sendStaging
-        let archiveGeneration = sendArchiveGeneration
-        sendArchiveGeneration += 1
-        let transferID = request.transferID
-        let requestGeneration = request.generation
-        let maxAccept = request.maxAcceptByteCount
-        let tracker = progressTracker
-        let connectionTag = self.connectionTag
-        DispatchQueue.global(qos: .userInitiated).async {
-            // First statement of the closure, so the timestamp marks the archive
-            // starting rather than its enqueue; `.notice` so a hang inside the
-            // walk still leaves a record on disk.
-            Self.logger.notice(
-                "Archiving clipboard folder '\(folderName, privacy: .public)' (gen=\(requestGeneration, privacy: .public), conn=\(connectionTag, privacy: .public), rep \(repIndex, privacy: .public), estimate \(estimatedByteCount, privacy: .public) bytes)"
-            )
-            guard
-                let rep = try? ClipboardDirectoryArchive.archivedRepresentation(
-                    ofDirectoryAt: sourceURL, named: folderName, into: staging,
-                    generation: archiveGeneration)
-            else {
-                Self.logger.error(
-                    "Failed to archive folder '\(folderName, privacy: .public)' at request time")
-                sender.rejectRequest(
-                    transferID: transferID, code: "archive.error",
-                    message: "Could not archive the folder")
-                // The unit began when the request was accepted, so it must end here
-                // too — a unit left active keeps the session from ever going idle.
-                tracker.unitEnded(session: session, id: transferID, succeeded: false)
-                return
-            }
-            sender.startTransfer(
-                transferID: transferID, generation: requestGeneration, representation: rep,
-                maxAcceptByteCount: maxAccept, isInline: false,
-                isCurrent: { value in isCurrent.isCurrent(value) },
-                onProgress: { sent, total in
-                    tracker.unitProgressed(
-                        session: session, id: transferID, bytesTransferred: UInt64(max(0, sent)),
-                        totalBytes: UInt64(max(0, total)))
-                },
-                onComplete: { success in
-                    tracker.unitEnded(session: session, id: transferID, succeeded: success)
-                })
-            Self.logger.debug(
-                "Streaming clipboard rep \(repIndex, privacy: .public) (gen=\(requestGeneration, privacy: .public), conn=\(connectionTag, privacy: .public), \(rep.byteCount, privacy: .public) bytes)"
-            )
-        }
     }
 
     // MARK: - Inbound (we are the receiver)
@@ -1033,11 +1002,13 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// holds.
     private func awaitPull(
         transferID: UInt64, receiver: ClipboardStreamReceiver,
+        extractsDirectoryNamed: String? = nil,
         sendRequest: @escaping () throws -> Void
     ) -> LazyPullOutcome {
         let coordinator = lazyCoordinator
         receiver.awaitTransfer(
             transferID,
+            extractsDirectoryNamed: extractsDirectoryNamed,
             onComplete: { rep in coordinator.deliver(transferID, rep) },
             onAbort: { abort in coordinator.abort(transferID, abort) },
             // Re-arm the pull's inactivity backstop on every chunk so a large
@@ -1119,7 +1090,13 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
 
         let generation = promise.generation
         let uti = info.uti
-        let outcome = awaitPull(transferID: transferID, receiver: receiver) {
+        // A folder's bytes are an archive of its tree, extracted as they arrive:
+        // the stream layer learns that here, from the offer this side already
+        // read, rather than from the wire.
+        let outcome = awaitPull(
+            transferID: transferID, receiver: receiver,
+            extractsDirectoryNamed: info.isDirectory ? info.filename : nil
+        ) {
             var request = Frame()
             request.protocolVersion = 1
             request.clipboardRequest = Kernova_V1_ClipboardRequest.with {
@@ -1134,14 +1111,6 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         switch outcome {
         case .delivered(let representation):
             recordReceivedFromHost()
-            // `is_directory` rides the offer, not `ClipboardStreamBegin`, so the
-            // offer-aware layer re-tags the delivered rep here; `fileURLData`
-            // then extracts the `.aar` into a real folder.
-            if info.isDirectory {
-                return ClipboardContent.Representation(
-                    uti: representation.uti, source: representation.source,
-                    filename: representation.filename, isDirectory: true)
-            }
             return representation
         case .aborted(let abort):
             Self.logger.warning(
@@ -1283,27 +1252,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         from representation: ClipboardContent.Representation, repIndex: Int,
         promise: InboundPromise, generation: UInt64
     ) -> Data? {
-        if representation.isDirectory {
-            // A directory rep's bytes are an `.aar` of the tree. Extract it into a
-            // real folder and offer that folder's URL so a Finder paste recreates
-            // the tree, not the archive file.
-            if let cached = promise.stagedInlineURLs[repIndex],
-                FileManager.default.fileExists(atPath: cached.path)
-            {
-                return Data(cached.absoluteString.utf8)
-            }
-            // `.notice` and before the call: the extract runs inside the paste's
-            // promise deadline, so a hang here has to leave a record on disk.
-            Self.logger.notice(
-                "Extracting clipboard folder '\(representation.filename, privacy: .public)' (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public), \(representation.byteCount, privacy: .public) archive bytes)"
-            )
-            guard
-                let directory = ClipboardDirectoryArchive.extractedDirectoryURL(
-                    for: representation, into: staging, generation: generation)
-            else { return nil }
-            promise.stagedInlineURLs[repIndex] = directory
-            return Data(directory.absoluteString.utf8)
-        }
+        // A folder rep arrives already unpacked — its transfer extracted the tree
+        // as the archive streamed — so `fileURL` below is the tree itself and
+        // serving it costs nothing inside the paste deadline.
         if let url = representation.fileURL {
             return Data(url.absoluteString.utf8)
         }

--- a/KernovaMacOSAgent/VsockGuestControlAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestControlAgent.swift
@@ -51,6 +51,13 @@ final class VsockGuestControlAgent: @unchecked Sendable {
     /// every inbound `PolicyUpdate`, symmetric with the host's own gate.
     private var hostSupportsClipboardStreaming = false
 
+    /// Whether the host advertised the streamed-folder capability.
+    ///
+    /// Guarded by `lock` and reset per connection; a host without it cannot
+    /// receive a folder streamed with an undeclared size, so the guest does not
+    /// offer one.
+    private var hostSupportsDirectoryStreamingStorage = false
+
     /// Creates the control agent; tests inject a socketpair-backed client and
     /// small cadences.
     init(
@@ -91,6 +98,12 @@ final class VsockGuestControlAgent: @unchecked Sendable {
         lock.withLock { hostBundledAgentVersionStorage }
     }
 
+    /// Thread-safe read of whether the host can receive a folder archived
+    /// straight onto the wire.
+    var hostSupportsDirectoryStreaming: Bool {
+        lock.withLock { hostSupportsDirectoryStreamingStorage }
+    }
+
     /// Transitions `connectionState`, firing `onStateChange` only on a real
     /// change.
     ///
@@ -129,6 +142,7 @@ final class VsockGuestControlAgent: @unchecked Sendable {
             lastInboundFrame = nil
             unresponsiveLogged = false
             hostSupportsClipboardStreaming = false
+            hostSupportsDirectoryStreamingStorage = false
         }
         updateConnectionState(.connected)
 
@@ -197,8 +211,11 @@ final class VsockGuestControlAgent: @unchecked Sendable {
         switch frame.payload {
         case .hello(let hello):
             let hostStreams = hello.capabilities.contains(KernovaCapability.clipboardStreamV1)
+            let hostStreamsDirectories = hello.capabilities.contains(
+                KernovaCapability.clipboardStreamDirectoryV1)
             lock.withLock {
                 hostSupportsClipboardStreaming = hostStreams
+                hostSupportsDirectoryStreamingStorage = hostStreamsDirectories
                 hostBundledAgentVersionStorage = hello.bundledAgentVersion
             }
             // `logDescription` bounds the peer-supplied capability strings; these

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -791,8 +791,9 @@ struct VsockGuestClipboardAgentTests {
         hostChannel.start()
         defer { hostChannel.close() }
 
-        let agent = makeAgent(
-            pasteboard: pasteboard, agentFd: agentFd, hostStreamsDirectories: false)
+        let capable = Box(false)
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        agent.hostStreamsDirectories = { capable.value }
         defer { agent.stop() }
         try await startAgentAndWaitForLiveChannel(agent: agent)
 
@@ -809,6 +810,16 @@ struct VsockGuestClipboardAgentTests {
         let offer = try await awaitOffer(on: hostChannel)
         #expect(offer.repInfo.map(\.filename) == ["note.txt"])
         #expect(offer.repInfo.allSatisfy { !$0.isDirectory })
+
+        // Both dedup keys describe what was offered — the change count and the
+        // offered content's digest — so neither notices the host catching up.
+        // The dropped folder has to be re-offered once it can be received.
+        capable.value = true
+        await MainActor.run { agent.checkClipboardChange() }
+        let second = try await awaitOffer(on: hostChannel)
+        #expect(second.repInfo.map(\.filename) == ["Project", "note.txt"])
+        #expect(second.repInfo.map(\.isDirectory) == [true, false])
+        #expect(second.generation > offer.generation)
     }
 
     /// Requests representation `repIndex` of `offer` and collects its stream.

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -261,6 +261,8 @@ struct VsockGuestClipboardAgentTests {
     private func makeAgent(
         pasteboard: FakePasteboard, agentFd: Int32,
         clock: any EngineClock = MonotonicEngineClock(),
+        stagingTempRoot: URL? = nil,
+        hostStreamsDirectories: Bool = true,
         freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
         progressRevealDelay: TimeInterval = ClipboardProgressTracker.defaultRevealDelay,
         progressIdleLinger: TimeInterval = ClipboardProgressTracker.defaultIdleLinger,
@@ -276,13 +278,18 @@ struct VsockGuestClipboardAgentTests {
         ) { _, _ in
             provided.increment() == 1 ? .success(agentFd) : .failure(.transient("test: no fd"))
         }
-        return VsockGuestClipboardAgent(
+        let agent = VsockGuestClipboardAgent(
             pasteboard: pasteboard, client: client, clock: clock,
             freeSpaceProvider: freeSpaceProvider,
-            stagingTempRoot: FileManager.default.temporaryDirectory.appendingPathComponent(
-                UUID().uuidString, isDirectory: true),
+            stagingTempRoot: stagingTempRoot
+                ?? FileManager.default.temporaryDirectory.appendingPathComponent(
+                    UUID().uuidString, isDirectory: true),
             progressRevealDelay: progressRevealDelay, progressIdleLinger: progressIdleLinger,
             onProgress: onProgress, onClipboardNotice: onClipboardNotice)
+        // Production reads this from the control agent's `Hello`; a test host is
+        // current unless it says otherwise.
+        agent.hostStreamsDirectories = { hostStreamsDirectories }
+        return agent
     }
 
     /// Starts the agent, enables it (production agents are default-disabled
@@ -622,7 +629,7 @@ struct VsockGuestClipboardAgentTests {
     // MARK: - Folders
 
     @Test(
-        "outbound copied folder: offered on a stat-walk estimate, archived at request time, streamed as a valid archive"
+        "outbound copied folder: offered on a stat-walk estimate, streamed as an archive with no total"
     )
     func outboundCopiedFolderOfferAndStream() async throws {
         let pasteboard = FakePasteboard()
@@ -631,7 +638,11 @@ struct VsockGuestClipboardAgentTests {
         hostChannel.start()
         defer { hostChannel.close() }
 
-        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        let agentStagingRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: agentStagingRoot) }
+        let agent = makeAgent(
+            pasteboard: pasteboard, agentFd: agentFd, stagingTempRoot: agentStagingRoot)
         defer { agent.stop() }
         try await startAgentAndWaitForLiveChannel(agent: agent)
 
@@ -664,18 +675,16 @@ struct VsockGuestClipboardAgentTests {
             transferID: transferID, from: hostChannel)
         #expect(!transfer.begin.isInline)
         #expect(transfer.begin.filename == "Project")
-        // The Begin carries the archive's wire-exact size, superseding the
-        // offer's estimate.
-        #expect(transfer.begin.totalBytes == UInt64(transfer.bytes.count))
+        // The tree is compressed straight onto the wire, so its size is unknown
+        // at Begin; End carries the authoritative count.
+        #expect(transfer.begin.totalBytes == 0)
+        #expect(transfer.end.totalBytes == UInt64(transfer.bytes.count))
         #expect(transfer.end.sha256 == Data(SHA256.hash(data: transfer.bytes)))
+        // The tree was compressed onto the wire, so nothing was staged to send it.
+        #expect(materializedFiles(under: agentStagingRoot).isEmpty)
 
-        let aar = try writeTempFile(name: "got.aar", data: transfer.bytes)
-        defer { try? FileManager.default.removeItem(at: aar.deletingLastPathComponent()) }
-        let dest = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: dest, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: dest) }
-        try ClipboardDirectoryArchive.extract(archiveAt: aar, to: dest)
+        let dest = try extractedClipboardArchive(transfer.bytes)
+        defer { try? FileManager.default.removeItem(at: dest.deletingLastPathComponent()) }
         #expect(
             try String(contentsOf: dest.appendingPathComponent("README.md"), encoding: .utf8)
                 == "readme")
@@ -685,7 +694,7 @@ struct VsockGuestClipboardAgentTests {
     }
 
     @Test(
-        "outbound: a folder carrying no file bytes is offered at 0 bytes and still archives on request"
+        "outbound: a folder carrying no file bytes is offered at 0 bytes and still streams its tree"
     )
     func outboundByteFreeFolderOfferAndStream() async throws {
         let pasteboard = FakePasteboard()
@@ -715,23 +724,51 @@ struct VsockGuestClipboardAgentTests {
         #expect(offer.repInfo.map(\.isDirectory) == [true, true])
         #expect(offer.repInfo.map(\.byteCount) == [0, 0])
 
-        // The zero estimate gates nothing: each rep archives at request time and
-        // the streamed `.aar` rebuilds its tree.
+        // The zero estimate gates nothing: each rep streams its tree on request
+        // and the arriving archive bytes rebuild it.
         let emptyTransfer = try await requestOutboundRep(
             offer: offer, repIndex: 0, from: hostChannel)
         #expect(emptyTransfer.begin.filename == "Empty")
-        let emptyOut = try extractArchiveBytes(emptyTransfer.bytes)
+        let emptyOut = try extractedClipboardArchive(emptyTransfer.bytes)
         defer { try? FileManager.default.removeItem(at: emptyOut.deletingLastPathComponent()) }
         #expect(try FileManager.default.contentsOfDirectory(atPath: emptyOut.path).isEmpty)
 
         let scaffoldTransfer = try await requestOutboundRep(
             offer: offer, repIndex: 1, from: hostChannel)
         #expect(scaffoldTransfer.begin.filename == "Scaffold")
-        let scaffoldOut = try extractArchiveBytes(scaffoldTransfer.bytes)
+        let scaffoldOut = try extractedClipboardArchive(scaffoldTransfer.bytes)
         defer { try? FileManager.default.removeItem(at: scaffoldOut.deletingLastPathComponent()) }
         #expect(
             FileManager.default.fileExists(
                 atPath: scaffoldOut.appendingPathComponent("sub/.keep").path))
+    }
+
+    @Test("outbound: a copied folder is left out of the offer for a host that can't receive one")
+    func outboundFolderDroppedForAnOlderHost() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(
+            pasteboard: pasteboard, agentFd: agentFd, hostStreamsDirectories: false)
+        defer { agent.stop() }
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        let folder = try writeTempFolder(name: "Project", files: [("f.txt", Data("x".utf8))])
+        defer { try? FileManager.default.removeItem(at: folder.deletingLastPathComponent()) }
+        let file = try writeTempFile(name: "note.txt", data: Data("hi".utf8))
+        defer { try? FileManager.default.removeItem(at: file.deletingLastPathComponent()) }
+        pasteboard.setItems([
+            [(type: .fileURL, data: Data(folder.absoluteString.utf8))],
+            [(type: .fileURL, data: Data(file.absoluteString.utf8))],
+        ])
+        await MainActor.run { agent.checkClipboardChange() }
+
+        let offer = try await awaitOffer(on: hostChannel)
+        #expect(offer.repInfo.map(\.filename) == ["note.txt"])
+        #expect(offer.repInfo.allSatisfy { !$0.isDirectory })
     }
 
     /// Requests representation `repIndex` of `offer` and collects its stream.
@@ -744,16 +781,6 @@ struct VsockGuestClipboardAgentTests {
                 generation: offer.generation, transferID: transferID,
                 uti: offer.repInfo[Int(repIndex)].uti))
         return try await collectOutboundTransfer(transferID: transferID, from: channel)
-    }
-
-    /// Writes `bytes` as an `.aar` and extracts it into a fresh directory, which
-    /// it returns.
-    private func extractArchiveBytes(_ bytes: Data) throws -> URL {
-        let aar = try writeTempFile(name: "got.aar", data: bytes)
-        let dest = aar.deletingLastPathComponent().appendingPathComponent("out", isDirectory: true)
-        try FileManager.default.createDirectory(at: dest, withIntermediateDirectories: true)
-        try ClipboardDirectoryArchive.extract(archiveAt: aar, to: dest)
-        return dest
     }
 
     @Test("inbound directory offer: promises only .fileURL and extracts into a real folder")
@@ -773,13 +800,7 @@ struct VsockGuestClipboardAgentTests {
             name: "Shared",
             files: [("hello.txt", Data("hi".utf8)), ("d/inner.txt", Data("deep".utf8))])
         defer { try? FileManager.default.removeItem(at: src.deletingLastPathComponent()) }
-        let aarDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: aarDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: aarDir) }
-        let aar = aarDir.appendingPathComponent("Shared.aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: src, to: aar)
-        let aarBytes = try Data(contentsOf: aar)
+        let aarBytes = try clipboardArchiveBytes(ofDirectoryAt: src)
 
         // The host offers one directory rep.
         try hostChannel.send(
@@ -835,14 +856,8 @@ struct VsockGuestClipboardAgentTests {
         defer { try? FileManager.default.removeItem(at: empty.deletingLastPathComponent()) }
         let scaffold = try writeTempFolder(name: "Scaffold", files: [("sub/.keep", Data())])
         defer { try? FileManager.default.removeItem(at: scaffold.deletingLastPathComponent()) }
-        let aarDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: aarDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: aarDir) }
-        let emptyAAR = aarDir.appendingPathComponent("Empty.aar")
-        let scaffoldAAR = aarDir.appendingPathComponent("Scaffold.aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: empty, to: emptyAAR)
-        try ClipboardDirectoryArchive.archive(directoryAt: scaffold, to: scaffoldAAR)
+        let emptyBytes = try clipboardArchiveBytes(ofDirectoryAt: empty)
+        let scaffoldBytes = try clipboardArchiveBytes(ofDirectoryAt: scaffold)
 
         // Both reps declare the estimate the wire carries — 0 — and must still be
         // promised rather than mistaken for empty payloads.
@@ -863,7 +878,7 @@ struct VsockGuestClipboardAgentTests {
         let emptyPull = lazyPull(pasteboard, forType: .fileURL, itemIndex: 0)
         try await driveInboundStream(
             generation: 13, uti: UTType.folder.identifier, filename: "Empty",
-            payload: try Data(contentsOf: emptyAAR), isInline: false, on: hostChannel)
+            payload: emptyBytes, isInline: false, on: hostChannel)
         let emptyURL = try #require(
             (await emptyPull.value).flatMap { String(data: $0, encoding: .utf8) }
                 .flatMap(URL.init(string:)))
@@ -877,7 +892,7 @@ struct VsockGuestClipboardAgentTests {
         let scaffoldPull = lazyPull(pasteboard, forType: .fileURL, itemIndex: 1)
         try await driveInboundStream(
             generation: 13, uti: UTType.folder.identifier, filename: "Scaffold",
-            payload: try Data(contentsOf: scaffoldAAR), isInline: false, on: hostChannel)
+            payload: scaffoldBytes, isInline: false, on: hostChannel)
         let scaffoldURL = try #require(
             (await scaffoldPull.value).flatMap { String(data: $0, encoding: .utf8) }
                 .flatMap(URL.init(string:)))
@@ -902,13 +917,7 @@ struct VsockGuestClipboardAgentTests {
         // A valid archive whose stream will nonetheless end with a wrong digest.
         let src = try writeTempFolder(name: "Broken", files: [("f.txt", Data("x".utf8))])
         defer { try? FileManager.default.removeItem(at: src.deletingLastPathComponent()) }
-        let aarDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: aarDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: aarDir) }
-        let aar = aarDir.appendingPathComponent("Broken.aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: src, to: aar)
-        let aarBytes = try Data(contentsOf: aar)
+        let aarBytes = try clipboardArchiveBytes(ofDirectoryAt: src)
 
         try hostChannel.send(
             makeOfferFrame(
@@ -3213,6 +3222,7 @@ struct VsockGuestClipboardAgentTests {
     /// frames and let it reassemble.
     private func driveInboundStream(
         generation: UInt64, uti: String, filename: String, payload: Data, isInline: Bool,
+        declaredTotalBytes: Int? = nil,
         chunkSize: Int = 64 * 1024, on channel: VsockChannel,
         validate: (Kernova_V1_ClipboardRequest) -> Void = { _ in }
     ) async throws {
@@ -3220,7 +3230,8 @@ struct VsockGuestClipboardAgentTests {
         validate(req)
         try streamInbound(
             generation: generation, transferID: req.transferID, uti: uti, filename: filename,
-            payload: payload, isInline: isInline, chunkSize: chunkSize, on: channel)
+            payload: payload, isInline: isInline, declaredTotalBytes: declaredTotalBytes,
+            chunkSize: chunkSize, on: channel)
     }
 
     /// Streams `Begin`/`Chunk`(s)/`End` for one inbound transfer to the agent.
@@ -3230,12 +3241,14 @@ struct VsockGuestClipboardAgentTests {
     /// reason.
     private func streamInbound(
         generation: UInt64, transferID: UInt64, uti: String, filename: String = "", payload: Data,
-        isInline: Bool, chunkSize: Int = 64 * 1024, on channel: VsockChannel
+        isInline: Bool, declaredTotalBytes: Int? = nil, chunkSize: Int = 64 * 1024,
+        on channel: VsockChannel
     ) throws {
         try channel.send(
             makeBeginFrame(
                 generation: generation, transferID: transferID, uti: uti,
-                totalBytes: payload.count, filename: filename, isInline: isInline))
+                totalBytes: declaredTotalBytes ?? payload.count, filename: filename,
+                isInline: isInline))
         var offset = 0
         while offset < payload.count {
             let end = min(offset + chunkSize, payload.count)

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -743,6 +743,46 @@ struct VsockGuestClipboardAgentTests {
                 atPath: scaffoldOut.appendingPathComponent("sub/.keep").path))
     }
 
+    @Test("outbound: a folder-only copy offers nothing rather than the pasteboard's leftovers")
+    func outboundFolderOnlyCopyOffersNothingToAnOlderHost() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(
+            pasteboard: pasteboard, agentFd: agentFd, hostStreamsDirectories: false)
+        defer { agent.stop() }
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        let folder = try writeTempFolder(name: "Project", files: [("f.txt", Data("x".utf8))])
+        defer { try? FileManager.default.removeItem(at: folder.deletingLastPathComponent()) }
+        // A Finder folder copy leaves a file URL *plus* Finder's own private
+        // flavors. With the folder filtered out there is no file candidate left,
+        // and falling through to the raw snapshot would ship those leftovers to
+        // the host as if they were the copy.
+        pasteboard.setItems([
+            [
+                (type: .fileURL, data: Data(folder.absoluteString.utf8)),
+                (type: .init("com.apple.finder.node"), data: Data([0xDE, 0xAD])),
+            ]
+        ])
+        await MainActor.run { agent.checkClipboardChange() }
+
+        // A later, offerable copy: the first offer to reach the host proves what
+        // the folder-only snapshot did — anything it had sent would be sitting
+        // ahead of this one on the channel.
+        pasteboard.setItems([
+            [(type: .string, data: Data("plain".utf8))]
+        ])
+        await MainActor.run { agent.checkClipboardChange() }
+
+        let offer = try await awaitOffer(on: hostChannel)
+        #expect(offer.repInfo.map(\.uti) == [ClipboardContent.utf8TextUTI])
+        #expect(offer.repInfo.allSatisfy { !$0.isDirectory })
+    }
+
     @Test("outbound: a copied folder is left out of the offer for a host that can't receive one")
     func outboundFolderDroppedForAnOlderHost() async throws {
         let pasteboard = FakePasteboard()

--- a/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
@@ -10,16 +10,20 @@ struct VsockGuestControlAgentTests {
 
     /// Builds a host-side Hello frame for the agent to consume.
     private func makeHostHelloFrame(
-        streamingCapable: Bool = true, bundledAgentVersion: String = ""
+        streamingCapable: Bool = true, directoryStreamCapable: Bool = true,
+        bundledAgentVersion: String = ""
     ) -> Frame {
         var frame = Frame()
         frame.protocolVersion = 1
         frame.hello = Kernova_V1_Hello.with {
             $0.serviceVersion = 1
             $0.capabilities =
-                streamingCapable
+                (streamingCapable
                 ? KernovaCapability.controlChannelDefaults
-                : [KernovaCapability.controlV1, KernovaCapability.controlHeartbeatV1]
+                : [KernovaCapability.controlV1, KernovaCapability.controlHeartbeatV1])
+                .filter {
+                    directoryStreamCapable || $0 != KernovaCapability.clipboardStreamDirectoryV1
+                }
             $0.bundledAgentVersion = bundledAgentVersion
             $0.agentInfo = Kernova_V1_AgentInfo.with {
                 $0.os = "macOS"
@@ -445,6 +449,41 @@ struct VsockGuestControlAgentTests {
         }
 
         try await counts.changed.wait { counts.value >= 3 }
+    }
+
+    /// Whether the agent recorded the host's streamed-folder capability from a
+    /// Hello advertising `directoryStreamCapable`.
+    private func observeHostDirectoryStreaming(directoryStreamCapable: Bool) async throws -> Bool {
+        let (agentFd, hostFd) = try makeRawSocketPair()
+        let host = VsockChannel(fileDescriptor: hostFd)
+        host.start()
+        defer { host.close() }
+
+        let received = PolicyBox()
+        let agent = makeAgent(agentFd: agentFd, onPolicy: { policy in received.set(policy) })
+        agent.start()
+        defer { agent.stop() }
+
+        _ = try await nextFrame(from: host)  // drain outbound Hello
+        try host.send(makeHostHelloFrame(directoryStreamCapable: directoryStreamCapable))
+        // The Hello has no observable of its own; a policy that follows it is
+        // handled after it on the same channel, so it pins the read.
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.policyUpdate = Kernova_V1_PolicyUpdate.with { $0.clipboardSharingEnabled = true }
+        try host.send(frame)
+        try await received.changed.wait { received.value != nil }
+        return agent.hostSupportsDirectoryStreaming
+    }
+
+    @Test("a host advertising the streamed-folder capability is recorded as supporting it")
+    func hostDirectoryStreamingObservedFromHello() async throws {
+        #expect(try await observeHostDirectoryStreaming(directoryStreamCapable: true))
+    }
+
+    @Test("a host without the streamed-folder capability is recorded as lacking it")
+    func hostDirectoryStreamingAbsentFromHello() async throws {
+        #expect(try await observeHostDirectoryStreaming(directoryStreamCapable: false) == false)
     }
 
     @Test("clipboard enable is forwarded only when the host advertised streaming")

--- a/KernovaTests/ClipboardHostPasteboardItemsTests.swift
+++ b/KernovaTests/ClipboardHostPasteboardItemsTests.swift
@@ -152,27 +152,22 @@ struct ClipboardHostPasteboardItemsTests {
         let staging = makeStaging()
         defer { staging.sweep() }
 
-        // Build a source tree, archive it (mirroring what the receiver staged),
-        // and point a directory rep at the `.aar`.
-        let src = fm.temporaryDirectory
+        // A folder rep arrives already unpacked: its transfer extracted the tree
+        // as the archive streamed, so the rep points at the tree itself.
+        let tree = fm.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
             .appendingPathComponent("Project", isDirectory: true)
         try fm.createDirectory(
-            at: src.appendingPathComponent("sub"), withIntermediateDirectories: true)
+            at: tree.appendingPathComponent("sub"), withIntermediateDirectories: true)
         try "readme".write(
-            to: src.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+            to: tree.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
         try "nested".write(
-            to: src.appendingPathComponent("sub/n.txt"), atomically: true, encoding: .utf8)
-        defer { try? fm.removeItem(at: src.deletingLastPathComponent()) }
-
-        let archive = fm.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: src, to: archive)
-        defer { try? fm.removeItem(at: archive) }
-        let size = try #require(fm.attributesOfItem(atPath: archive.path)[.size] as? Int)
+            to: tree.appendingPathComponent("sub/n.txt"), atomically: true, encoding: .utf8)
+        defer { try? fm.removeItem(at: tree.deletingLastPathComponent()) }
 
         let content = ClipboardContent(representations: [
             .init(
-                uti: UTType.folder.identifier, fileURL: archive, byteCount: size,
+                uti: UTType.folder.identifier, fileURL: tree, byteCount: 1024,
                 filename: "Project", isDirectory: true)
         ])
         let specs = await HostClipboardPublisher.hostPasteboardItems(
@@ -184,7 +179,9 @@ struct ClipboardHostPasteboardItemsTests {
         let dirURL = try #require(fileURL(in: specs[0]))
         var isDir: ObjCBool = false
         #expect(fm.fileExists(atPath: dirURL.path, isDirectory: &isDir) && isDir.boolValue)
-        // The pasted folder keeps its exact name and contains the extracted tree.
+        // The pasted folder is served as-is, with no extract step inside the
+        // paste deadline.
+        #expect(dirURL == tree)
         #expect(dirURL.lastPathComponent == "Project")
         #expect(
             try String(contentsOf: dirURL.appendingPathComponent("README.md"), encoding: .utf8)
@@ -282,25 +279,5 @@ struct ClipboardHostPasteboardItemsTests {
         // A type the item never promised serves nothing and fires nothing.
         #expect(spec.provide(.init("public.rtf")) == nil)
         #expect(provider.totalCallCount == 2)
-    }
-
-    @Test("a directory payload whose archive can't be extracted is dropped (no item)")
-    func directoryExtractionFailureDropsItem() async throws {
-        let staging = makeStaging()
-        defer { staging.sweep() }
-
-        // A directory rep pointing at a non-existent `.aar` — extraction fails, so
-        // no spec is produced. copyToMac counts this shortfall as a dropped
-        // payload and warns instead of claiming success.
-        let missing = FileManager.default.temporaryDirectory
-            .appendingPathComponent("\(UUID().uuidString)-missing.aar")
-        let content = ClipboardContent(representations: [
-            .init(
-                uti: UTType.folder.identifier, fileURL: missing, byteCount: 100, filename: "Gone",
-                isDirectory: true)
-        ])
-        let specs = await HostClipboardPublisher.hostPasteboardItems(
-            for: content, generation: 1, staging: staging)
-        #expect(specs.isEmpty)
     }
 }

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -1616,7 +1616,10 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let capable = Box(false)
+        let service = VsockClipboardService(
+            channel: host, label: "test-\(UUID().uuidString)",
+            peerStreamsDirectories: { capable.value })
         service.start()
         defer { service.stop() }
 
@@ -1641,6 +1644,33 @@ struct VsockClipboardServiceTests {
         // holding and leave it a pasteboard item nothing can serve; sending
         // nothing leaves the previous, still-working clipboard in place.
         try await expectNoNewFrames(on: recorder, sinceCount: snapshot)
+        // The window is the only surface that can explain why the copy did
+        // nothing, so the skip has to reach it.
+        #expect(
+            service.lastTransferIssue?.kind
+                == ClipboardTransferIssue.folderSkippedForOutdatedGuest().kind)
+
+        // The capability is re-read from every `Hello`, and a control-channel
+        // blip alone clears it — so latching the buffer's digest here would
+        // strand this copy for the rest of the session.
+        capable.value = true
+        service.grabIfChanged()
+        try await waitForFrames(recorder) {
+            recorder.first {
+                if case .clipboardOffer = $0.payload { return true }
+                return false
+            } != nil
+        }
+        let offerFrame = try #require(
+            recorder.first {
+                if case .clipboardOffer = $0.payload { return true }
+                return false
+            })
+        guard case .clipboardOffer(let offer) = offerFrame.payload else {
+            Issue.record("Expected clipboardOffer, got \(String(describing: offerFrame.payload))")
+            return
+        }
+        #expect(offer.repInfo.map(\.filename) == ["OnlyFolder"])
     }
 
     @Test("a folder is left out of the offer for a guest that can't receive one")

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -1609,6 +1609,40 @@ struct VsockClipboardServiceTests {
         #expect(responder.requests.count == 1)
     }
 
+    @Test("a folders-only copy sends no offer at all to a guest that can't receive one")
+    func foldersOnlyCopySendsNoOfferToAnOlderGuest() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        service.start()
+        defer { service.stop() }
+
+        let recorder = FrameRecorder(channel: guest)
+        defer { recorder.cancel() }
+
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let folder = parent.appendingPathComponent("OnlyFolder", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+
+        service.clipboardContent = ClipboardContent(representations: [
+            ClipboardContent.Representation(
+                directorySourceURL: folder, estimatedByteCount: 0, filename: "OnlyFolder",
+                uti: "public.folder")
+        ])
+        let snapshot = recorder.frames.count
+        service.grabIfChanged()
+
+        // An offer with no representations would retire whatever the guest is
+        // holding and leave it a pasteboard item nothing can serve; sending
+        // nothing leaves the previous, still-working clipboard in place.
+        try await expectNoNewFrames(on: recorder, sinceCount: snapshot)
+    }
+
     @Test("a folder is left out of the offer for a guest that can't receive one")
     func offerDropsFoldersForAnOlderGuest() async throws {
         let (guest, host) = try makePair()

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -1680,8 +1680,10 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        // The default: no capability information, so no folder is offered.
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let capable = Box(false)
+        let service = VsockClipboardService(
+            channel: host, label: "test-\(UUID().uuidString)",
+            peerStreamsDirectories: { capable.value })
         service.start()
         defer { service.stop() }
 
@@ -1709,6 +1711,12 @@ struct VsockClipboardServiceTests {
         }
         #expect(offer.repInfo.map(\.filename) == ["note.txt"])
         #expect(offer.repInfo.allSatisfy { !$0.isDirectory })
+        // Losing the folder is the same news to the user whether it emptied the
+        // offer or only shortened it — a copy that quietly arrives short is the
+        // one thing the window has to say.
+        #expect(
+            service.lastTransferIssue?.kind
+                == ClipboardTransferIssue.folderSkippedForOutdatedGuest().kind)
 
         // The surviving rep keeps the index the offer gave it, so the request's
         // low 16 bits still address it.
@@ -1733,6 +1741,43 @@ struct VsockClipboardServiceTests {
         }
         #expect(begin.filename == "note.txt")
         #expect(begin.totalBytes == 2)
+
+        // The buffer's own digest is the send-dedup key and it was latched by the
+        // shortened offer, so nothing else can notice the guest catching up. The
+        // dropped folder has to be re-offered once it can be received.
+        capable.value = true
+        service.grabIfChanged()
+        try await waitForFrames(recorder) {
+            recorder.first {
+                if case .clipboardOffer = $0.payload { return true }
+                return false
+            } != nil
+        }
+        let secondFrame = try #require(
+            recorder.first {
+                if case .clipboardOffer = $0.payload { return true }
+                return false
+            })
+        guard case .clipboardOffer(let second) = secondFrame.payload else {
+            Issue.record("Expected clipboardOffer, got \(String(describing: secondFrame.payload))")
+            return
+        }
+        #expect(second.repInfo.map(\.filename) == ["Project", "note.txt"])
+        #expect(second.generation > offer.generation)
+        // The re-offer retires the generation whose `note.txt` transfer is still
+        // parked on credit, so its abort is on the way; let that land before the
+        // observation window below, which would otherwise catch it.
+        try await waitForFrames(recorder) {
+            recorder.first {
+                if case .clipboardStreamAbort = $0.payload { return true }
+                return false
+            } != nil
+        }
+
+        // ...and once, not on every poll tick that follows.
+        let snapshot = recorder.frames.count
+        service.grabIfChanged()
+        try await expectNoNewFrames(on: recorder, sinceCount: snapshot)
     }
 
     @Test("a folder streamed with a declared total still extracts, so an older peer interoperates")

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -509,7 +509,7 @@ struct VsockClipboardServiceTests {
     }
 
     @Test(
-        "An offered folder is estimate-only until requested, then archived at request time and streamed as a valid archive"
+        "An offered folder is estimate-only until requested, then compressed straight onto the wire"
     )
     func requestArchivesFolderAtRequestTime() async throws {
         let (guest, host) = try makePair()
@@ -517,7 +517,12 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let stagingRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: stagingRoot) }
+        let service = VsockClipboardService(
+            channel: host, label: "test-\(UUID().uuidString)",
+            peerStreamsDirectories: { true }, stagingTempRoot: stagingRoot)
         service.start()
         defer { service.stop() }
 
@@ -553,8 +558,8 @@ struct VsockClipboardServiceTests {
         let recorder = FrameRecorder(channel: guest)
         defer { recorder.cancel() }
 
-        // The request triggers the off-main request-time archive, then the
-        // stream of the resulting `.aar`.
+        // The request starts the walk-and-compress, whose bytes go straight to
+        // the wire — no archive is ever staged.
         try guest.send(makeRequest(generation: offer.generation, repIndex: 0, uti: info.uti))
         try await waitForFrames(recorder) {
             recorder.first {
@@ -580,20 +585,25 @@ struct VsockClipboardServiceTests {
             } != nil
         }
         let reassembled = reassemble(recorder.chunks(for: xid))
-        // The Begin carries the archive's wire-exact size, superseding the
-        // offer's estimate.
-        #expect(begin.totalBytes == UInt64(reassembled.count))
+        // The tree is compressed straight onto the wire, so its size is unknown
+        // at Begin; the End frame carries the authoritative count.
+        #expect(begin.totalBytes == 0)
+        let endFrame = try #require(
+            recorder.first {
+                if case .clipboardStreamEnd = $0.payload { return true }
+                return false
+            })
+        guard case .clipboardStreamEnd(let end) = endFrame.payload else {
+            Issue.record("Expected clipboardStreamEnd")
+            return
+        }
+        #expect(end.totalBytes == UInt64(reassembled.count))
+        // Nothing was staged to send it.
+        #expect(materializedFiles(under: stagingRoot).isEmpty)
 
-        // The streamed bytes are an `.aar` that extracts back to the tree.
-        let aarDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: aarDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: aarDir) }
-        let aar = aarDir.appendingPathComponent("got.aar")
-        try reassembled.write(to: aar)
-        let dest = aarDir.appendingPathComponent("out", isDirectory: true)
-        try FileManager.default.createDirectory(at: dest, withIntermediateDirectories: true)
-        try ClipboardDirectoryArchive.extract(archiveAt: aar, to: dest)
+        // The streamed bytes are the archive, and they extract back to the tree.
+        let dest = try extractedClipboardArchive(reassembled)
+        defer { try? FileManager.default.removeItem(at: dest.deletingLastPathComponent()) }
         #expect(
             try String(contentsOf: dest.appendingPathComponent("README.md"), encoding: .utf8)
                 == "readme")
@@ -611,7 +621,8 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(
+            channel: host, label: "test-\(UUID().uuidString)", peerStreamsDirectories: { true })
         service.start()
         defer { service.stop() }
 
@@ -695,14 +706,7 @@ struct VsockClipboardServiceTests {
                 return false
             } != nil
         }
-        let scratch = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let dest = scratch.appendingPathComponent("out", isDirectory: true)
-        try FileManager.default.createDirectory(at: dest, withIntermediateDirectories: true)
-        let aar = scratch.appendingPathComponent("got.aar")
-        try reassemble(recorder.chunks(for: xid)).write(to: aar)
-        try ClipboardDirectoryArchive.extract(archiveAt: aar, to: dest)
-        return dest
+        return try extractedClipboardArchive(reassemble(recorder.chunks(for: xid)))
     }
 
     @Test("A large outbound payload streams as multiple chunks that reassemble exactly")
@@ -1050,6 +1054,11 @@ struct VsockClipboardServiceTests {
             /// Used to create a live receiver-side transfer that a later
             /// supersession/release can cancel while the host's pull is parked.
             let beginOnly: Bool
+            /// What `Begin` declares as the total, or `nil` to declare the real
+            /// payload size.
+            ///
+            /// A streamed folder declares 0 — unknown.
+            let declaredTotalBytes: Int?
         }
 
         private let guest: VsockChannel
@@ -1082,12 +1091,14 @@ struct VsockClipboardServiceTests {
         /// `(generation, repIndex)`.
         func register(
             generation: UInt64, repIndex: UInt64, uti: String, bytes: Data,
-            filename: String = "", isInline: Bool, beginOnly: Bool = false
+            filename: String = "", isInline: Bool, beginOnly: Bool = false,
+            declaredTotalBytes: Int? = nil
         ) {
             let xid = ClipboardTransferID.make(
                 generation: generation, repIndex: Int(repIndex), hostMinted: true)
             replies[xid] = Reply(
-                uti: uti, bytes: bytes, filename: filename, isInline: isInline, beginOnly: beginOnly)
+                uti: uti, bytes: bytes, filename: filename, isInline: isInline,
+                beginOnly: beginOnly, declaredTotalBytes: declaredTotalBytes)
         }
 
         /// Starts draining the channel and answering requests.
@@ -1124,7 +1135,7 @@ struct VsockClipboardServiceTests {
                 $0.generation = req.generation
                 $0.transferID = req.transferID
                 $0.uti = reply.uti
-                $0.totalBytes = UInt64(reply.bytes.count)
+                $0.totalBytes = UInt64(reply.declaredTotalBytes ?? reply.bytes.count)
                 $0.filename = reply.filename
                 $0.isInline = reply.isInline
             }
@@ -1526,41 +1537,40 @@ struct VsockClipboardServiceTests {
         #expect(responder.requests.count == 2)
     }
 
-    @Test("a promised directory rep extracts into a real folder at paste time")
-    func copyReTagsDirectoryRep() async throws {
+    @Test("a promised directory rep arrives as a real folder, served unchanged on every paste")
+    func copyServesStreamedDirectoryRep() async throws {
         let (guest, host) = try makePair()
         guest.start()
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let stagingRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: stagingRoot) }
+        let service = VsockClipboardService(
+            channel: host, label: "test-\(UUID().uuidString)", stagingTempRoot: stagingRoot)
         service.start()
         defer { service.stop() }
 
-        // The bytes the "guest" streams are an `.aar` of a small tree.
+        // The bytes the "guest" streams are the archive of a small tree, sent
+        // with no declared total — the compressed size isn't knowable up front.
         let src = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
             .appendingPathComponent("MyFolder", isDirectory: true)
         try FileManager.default.createDirectory(at: src, withIntermediateDirectories: true)
         try "x".write(to: src.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: src.deletingLastPathComponent()) }
-        let aarDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: aarDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: aarDir) }
-        let aar = aarDir.appendingPathComponent("MyFolder.aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: src, to: aar)
-        let aarBytes = try Data(contentsOf: aar)
+        let aarBytes = try clipboardArchiveBytes(ofDirectoryAt: src)
 
         let responder = FakeGuestResponder(guest: guest)
         defer { responder.cancel() }
         responder.register(
             generation: 11, repIndex: 0, uti: UTType.folder.identifier, bytes: aarBytes,
-            filename: "MyFolder", isInline: false)
+            filename: "MyFolder", isInline: false, declaredTotalBytes: 0)
         responder.start()
 
-        // The offer carries the directory flag; the offer-agnostic stream layer
-        // does not, so the service must re-tag the delivered rep from it.
+        // The offer carries the directory flag; the stream layer stays
+        // offer-agnostic, so the service primes its receiver from it.
         try guest.send(
             makeDirectoryOffer(
                 generation: 11,
@@ -1580,8 +1590,8 @@ struct VsockClipboardServiceTests {
         #expect(items.promised.first?.filename == "MyFolder")
         #expect(responder.requests.isEmpty)
 
-        // The paste-time `.fileURL` fire pulls the streamed `.aar` and extracts it
-        // into a real folder, so a Finder paste recreates the tree.
+        // The paste-time `.fileURL` fire pulls the archive, which the transfer
+        // extracted as it arrived, so a Finder paste recreates the tree.
         let url = try #require(
             await offCooperativePool { service.copyToMacFileURL(generation: 11, repIndex: 0) })
         var isDir: ObjCBool = false
@@ -1590,6 +1600,121 @@ struct VsockClipboardServiceTests {
         #expect(url.lastPathComponent == "MyFolder")
         #expect(
             try String(contentsOf: url.appendingPathComponent("f.txt"), encoding: .utf8) == "x")
+        // No archive was staged on the way in.
+        #expect(materializedFiles(under: stagingRoot).allSatisfy { $0.pathExtension != "aar" })
+        // A second paste re-serves the same tree rather than unpacking again.
+        let again = try #require(
+            await offCooperativePool { service.copyToMacFileURL(generation: 11, repIndex: 0) })
+        #expect(again == url)
+        #expect(responder.requests.count == 1)
+    }
+
+    @Test("a folder is left out of the offer for a guest that can't receive one")
+    func offerDropsFoldersForAnOlderGuest() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        // The default: no capability information, so no folder is offered.
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        service.start()
+        defer { service.stop() }
+
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let folder = parent.appendingPathComponent("Project", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let file = parent.appendingPathComponent("note.txt")
+        try Data("hi".utf8).write(to: file)
+
+        service.clipboardContent = ClipboardContent(representations: [
+            ClipboardContent.Representation(
+                directorySourceURL: folder, estimatedByteCount: 0, filename: "Project",
+                uti: "public.folder"),
+            ClipboardContent.Representation(
+                uti: "public.plain-text", fileURL: file, byteCount: 2, filename: "note.txt"),
+        ])
+        service.grabIfChanged()
+
+        let offerFrame = try await nextFrame(from: guest)
+        guard case .clipboardOffer(let offer) = offerFrame.payload else {
+            Issue.record("Expected clipboardOffer, got \(String(describing: offerFrame.payload))")
+            return
+        }
+        #expect(offer.repInfo.map(\.filename) == ["note.txt"])
+        #expect(offer.repInfo.allSatisfy { !$0.isDirectory })
+
+        // The surviving rep keeps the index the offer gave it, so the request's
+        // low 16 bits still address it.
+        let recorder = FrameRecorder(channel: guest)
+        defer { recorder.cancel() }
+        try guest.send(
+            makeRequest(generation: offer.generation, repIndex: 0, uti: offer.repInfo[0].uti))
+        try await waitForFrames(recorder) {
+            recorder.first {
+                if case .clipboardStreamBegin = $0.payload { return true }
+                return false
+            } != nil
+        }
+        let beginFrame = try #require(
+            recorder.first {
+                if case .clipboardStreamBegin = $0.payload { return true }
+                return false
+            })
+        guard case .clipboardStreamBegin(let begin) = beginFrame.payload else {
+            Issue.record("Expected clipboardStreamBegin")
+            return
+        }
+        #expect(begin.filename == "note.txt")
+        #expect(begin.totalBytes == 2)
+    }
+
+    @Test("a folder streamed with a declared total still extracts, so an older peer interoperates")
+    func copyAcceptsDirectoryWithDeclaredTotal() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        service.start()
+        defer { service.stop() }
+
+        let src = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("Legacy", isDirectory: true)
+        try FileManager.default.createDirectory(at: src, withIntermediateDirectories: true)
+        try "y".write(to: src.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: src.deletingLastPathComponent()) }
+        let aarBytes = try clipboardArchiveBytes(ofDirectoryAt: src)
+
+        let responder = FakeGuestResponder(guest: guest)
+        defer { responder.cancel() }
+        // A peer that spools the whole archive first knows its size and declares
+        // it. A primed receiver ignores the declared total either way.
+        responder.register(
+            generation: 12, repIndex: 0, uti: UTType.folder.identifier, bytes: aarBytes,
+            filename: "Legacy", isInline: false)
+        responder.start()
+
+        try guest.send(
+            makeDirectoryOffer(
+                generation: 12,
+                reps: [
+                    (
+                        uti: UTType.folder.identifier, byteCount: UInt64(aarBytes.count),
+                        filename: "Legacy"
+                    )
+                ]))
+        try await waitForChange { service.clipboardContent.representations.count == 1 }
+
+        let url = try #require(
+            await offCooperativePool { service.copyToMacFileURL(generation: 12, repIndex: 0) })
+        #expect(url.lastPathComponent == "Legacy")
+        #expect(
+            try String(contentsOf: url.appendingPathComponent("f.txt"), encoding: .utf8) == "y")
     }
 
     @Test("a directory rep offered at 0 bytes is promised and pastes as a real tree")
@@ -1616,19 +1741,17 @@ struct VsockClipboardServiceTests {
             at: scaffold.appendingPathComponent("sub", isDirectory: true),
             withIntermediateDirectories: true)
         try Data().write(to: scaffold.appendingPathComponent("sub/.keep"))
-        let emptyAAR = src.appendingPathComponent("Empty.aar")
-        let scaffoldAAR = src.appendingPathComponent("Scaffold.aar")
-        try ClipboardDirectoryArchive.archive(directoryAt: empty, to: emptyAAR)
-        try ClipboardDirectoryArchive.archive(directoryAt: scaffold, to: scaffoldAAR)
+        let emptyBytes = try clipboardArchiveBytes(ofDirectoryAt: empty)
+        let scaffoldBytes = try clipboardArchiveBytes(ofDirectoryAt: scaffold)
 
         let responder = FakeGuestResponder(guest: guest)
         defer { responder.cancel() }
         responder.register(
-            generation: 12, repIndex: 0, uti: UTType.folder.identifier,
-            bytes: try Data(contentsOf: emptyAAR), filename: "Empty", isInline: false)
+            generation: 12, repIndex: 0, uti: UTType.folder.identifier, bytes: emptyBytes,
+            filename: "Empty", isInline: false, declaredTotalBytes: 0)
         responder.register(
-            generation: 12, repIndex: 1, uti: UTType.folder.identifier,
-            bytes: try Data(contentsOf: scaffoldAAR), filename: "Scaffold", isInline: false)
+            generation: 12, repIndex: 1, uti: UTType.folder.identifier, bytes: scaffoldBytes,
+            filename: "Scaffold", isInline: false, declaredTotalBytes: 0)
         responder.start()
 
         // The estimate is 0 for both, which is what the wire carries — neither rep
@@ -3672,18 +3795,22 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let stagingRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: stagingRoot) }
+        let service = VsockClipboardService(
+            channel: host, label: "test-\(UUID().uuidString)", stagingTempRoot: stagingRoot)
         service.start()
         defer { service.stop() }
 
-        // The bytes stream and stage fine; they just aren't an `.aar`, so the
-        // extract inside the paste's deadline is what fails.
+        // Size and digest both agree with what arrived, so only the extract
+        // itself can reject the payload.
         let notAnArchive = Data("not an archive".utf8)
         let responder = FakeGuestResponder(guest: guest)
         defer { responder.cancel() }
         responder.register(
             generation: 23, repIndex: 0, uti: UTType.folder.identifier, bytes: notAnArchive,
-            filename: "MyFolder", isInline: false)
+            filename: "MyFolder", isInline: false, declaredTotalBytes: 0)
         responder.start()
 
         try guest.send(
@@ -3702,6 +3829,9 @@ struct VsockClipboardServiceTests {
         #expect(
             service.lastTransferIssue?.kind
                 == ClipboardTransferIssue.pasteFolderUnpackFailed().kind)
+        // A streamed extract writes as it goes, so a failed one must leave
+        // nothing behind for a later paste to pick up.
+        #expect(materializedFiles(under: stagingRoot).isEmpty)
     }
 
     // MARK: - Drop staging

--- a/KernovaTests/VsockControlServiceTests.swift
+++ b/KernovaTests/VsockControlServiceTests.swift
@@ -21,7 +21,7 @@ struct VsockControlServiceTests {
     /// this to drive the `agentStatus` numeric-comparison matrix.
     private func makeGuestHello(
         agentVersion: String, osVersion: String = "26.0", streamingCapable: Bool = true,
-        pasteLimitCapable: Bool = true
+        directoryStreamCapable: Bool = true, pasteLimitCapable: Bool = true
     ) -> Frame {
         var frame = Frame()
         frame.protocolVersion = 1
@@ -29,6 +29,9 @@ struct VsockControlServiceTests {
             $0.serviceVersion = 1
             var capabilities = [KernovaCapability.controlV1, KernovaCapability.controlHeartbeatV1]
             if streamingCapable { capabilities.append(KernovaCapability.clipboardStreamV1) }
+            if directoryStreamCapable {
+                capabilities.append(KernovaCapability.clipboardStreamDirectoryV1)
+            }
             if pasteLimitCapable { capabilities.append(KernovaCapability.clipboardPasteLimitV1) }
             $0.capabilities = capabilities
             $0.agentInfo = Kernova_V1_AgentInfo.with {
@@ -1265,6 +1268,38 @@ struct VsockControlServiceTests {
         #expect(result.pushedBytes == UInt64(ClipboardPasteLimit.defaultBytes))
         #expect(result.guestSupportsPasteLimit == false)
         #expect(result.guestWillEnforce == ClipboardPasteLimit.defaultBytes)
+    }
+
+    // MARK: - Streamed-folder capability
+
+    /// Whether the service saw `clipboard.stream.directory.v1` in a guest Hello
+    /// advertising `directoryStreamCapable`.
+    private func observeDirectoryStreaming(directoryStreamCapable: Bool) async throws -> Bool {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let service = makeService(channel: host)
+        service.start()
+        defer { service.stop() }
+
+        _ = try await nextFrame(from: guest)  // host hello
+        try guest.send(
+            makeGuestHello(
+                agentVersion: "0.58.0", directoryStreamCapable: directoryStreamCapable))
+        try await waitForChange { service.agentVersion != nil }
+        return service.guestSupportsDirectoryStreaming
+    }
+
+    @Test("a guest advertising the streamed-folder capability is recorded as supporting it")
+    func directoryStreamingObservedFromHello() async throws {
+        #expect(try await observeDirectoryStreaming(directoryStreamCapable: true))
+    }
+
+    @Test("a guest without the streamed-folder capability is recorded as lacking it")
+    func directoryStreamingAbsentFromHello() async throws {
+        #expect(try await observeDirectoryStreaming(directoryStreamCapable: false) == false)
     }
 
     // MARK: - ObservedAgentInfo.boundedField

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -388,7 +388,7 @@ kernel resources until relaunch — hence one owner (`RuntimeFileAccess`) and on
 | **AppKit** | All UI |
 | **Observation** | `@Observable` models and view models |
 | **ServiceManagement** | `SMAppService.mainApp` — Open at Login |
-| **AppleArchive** | In-process `.aar` archiving for clipboard directory transfers |
+| **AppleArchive** | In-process archiving for clipboard folder transfers, encoded onto the wire |
 | **UniformTypeIdentifiers** | The `.kernova` bundle's `UTType` |
 | **AVFoundation** | Microphone permission status |
 | **ImageIO** | Thumbnail-only decoding for clipboard previews |


### PR DESCRIPTION
Closes #713.

## The argument

A copied folder round-tripped through a whole `.aar` on disk at **both** ends: the producer archived the tree into its own send-staging root and streamed the finished file, and the consumer staged that file and expanded it at paste time. Peak footprint on each side was the archive *plus* the tree it came from or went into — an intermediate that scales with the payload, which docs/CLIPBOARD.md §2 names as a defect ("serializing a tree must *itself* stream … with no full-size archive landing whole on disk at either end and no extracted tree left coexisting with its archive").

Now the producer walks and LZFSE-compresses the tree straight onto the wire, and the consumer feeds arriving chunks into an extract pipeline writing the destination tree. Memory is O(1) in archive size on both sides — a bounded pipe whose capacity is the credit window — and the only disk Kernova touches is the destination, which native pays too.

This is a consumption-time footprint change only. Lazy pull is untouched: the offer still carries the source folder's stat-walk estimate and retains the folder, and nothing is encoded until a real paste asks for the representation.

## Feasibility evidence

The issue required a prototype before committing, because the whole proposal rests on AppleArchive tolerating a purely sequential, non-seekable custom stream. It was run against production's exact pipeline — same `.lzfse`, same `TYP,PAT,LNK,DEV,DAT,UID,GID,MOD,FLG,MTM,CTM,SH2` key set, only `fileStream` swapped for `customStream` — and passed. What it established, and what the implementation is built around:

- **Both directions work sequentially.** `seek`, `pread` and `pwrite` were never invoked across encode, decode, a concurrent pipe, a slow reader, and a 5,080-entry wide tree. Round-trip fidelity was exact (path/type/mode/size/symlink-target/SHA-256) on a 282-entry, 117 MiB tree. The five unsupported `ArchiveByteStreamProtocol` requirements are implemented as `throw`.
- **A short write silently truncates the archive.** A sink capped at 16 KiB per `write` accepted 69 KiB of a 53 MiB archive, and `writeDirectoryContents` returned *no error* — AppleArchive never re-offers an unaccepted tail. The pipe's write is therefore all-or-nothing and the sink returns `buffer.count`.
- **Encode failures surface only from `close()`.** The 16 KiB truncation above was reported by `compressStream.close()` and nowhere else. Production's file-based `archive()` had the same latent hole (`defer { try? compressStream.close() }`), so an ENOSPC on the final flush yielded a silently truncated `.aar`; the new encode driver captures every close error and only then declares end of stream, so the reader's end of stream *means* "complete and flushed".
- **Callbacks may park indefinitely, are strictly serialized (max concurrency 1), and the first one plus `close()` run on the calling thread.** Both pipelines therefore run on their own queue, never the main actor, and the parking is what provides backpressure.
- **Buffer sizes vary 12 B – 1 MiB per callback, and decode issues exactly one 0-byte read at EOF.** Wire framing carries no meaning; a test feeds the extract one byte per write and gets the exact tree.
- **A truncated or failed decode always leaves a partial destination tree** (69.5 MiB across 2 entries after an 8 MiB truncation), and **a flipped byte is not detected by LZFSE/AppleArchive** — 8/8 single-byte flips extracted silently with corrupt payloads. So the transfer's SHA-256 stays the sole integrity gate, and cleanup on every abort path is mandatory rather than best-effort.

## What changed on the wire

`ClipboardStreamBegin.total_bytes` is `0` — unknown — for a streamed folder, because the compressed size is not knowable when the transfer starts. `ClipboardStreamEnd` carries the authoritative count and the SHA-256, and stays the commit gate. Directory-ness does **not** get a new proto field: the side that read the offer is the same side that sends the `ClipboardRequest`, so it primes its own receiver (`awaitTransfer(_:extractsDirectoryNamed:…)`) and the stream layer stays offer-agnostic.

Enforcement moves with it. The requester's `max_accept_byte_count` is checked cumulatively as bytes are produced rather than refused up front. The consumer's free-space pre-flight already gated on the offer's *uncompressed* stat-walk estimate, which is the more correct number now that it writes the uncompressed tree; mid-transfer, the per-window disk re-check becomes "is the 64 MiB margin still free", and the extract pipeline failing on a full volume is the backstop.

## Failure semantics

The issue flagged this: a streamed extract has already written part of the tree when verification fails. Every abort path — digest mismatch, size mismatch, a truncated or corrupt archive, transport failure, the stall watchdog, `cancel(generation:)`, `cancelAll()` — now tears the pipeline down and deletes the partial tree, and each has a test. `StagingSink` gained a `cancel()` so an abort wakes a write lane parked inside a sink rather than queueing behind the very write it is aborting.

## A flow-control bug found on the way

The credit loop asked for a whole chunk's worth of credit before reading. A source that produces bytes as it goes hands back short chunks, and its tail is shorter than a chunk — so the sender would park on credit for bytes it was never going to send, which only the next chunk could have unlocked. It survived the production window only because the ack quantum (window/4) is reached before the window fills; at a one-chunk window it deadlocks to `ack.timeout`. The loop now reads first and claims credit for exactly what came back, and fills each chunk so a dribbling source doesn't put one frame on the wire per dribble. A regression test pins it.

## Compatibility

Derived from the code, not assumed:

| Sender | Receiver | Outcome |
|---|---|---|
| new | new | streamed — works |
| old | new | the old peer declares the real archive size; a primed receiver ignores the declared total and extracts — **works unchanged** |
| **new** | **old** | `Begin.total_bytes = 0` trips the old receiver's overrun guard on chunk 1 → `size.overrun` abort → the paste serves nothing |

Only new-sender→old-receiver breaks, and the realistic case is a current host with a stale guest agent. docs/CLIPBOARD.md forbids a legacy fallback, so the gate is on what is advertised: a new `clipboard.stream.directory.v1` capability rides the control `Hello`, each side reads the peer's, and a folder representation is left out of the offer to a peer that lacks it — the same shape as the existing `clipboard.stream.v1` gate, with a `.notice` naming the capability. Every other representation is unaffected. The guest agent's `MARKETING_VERSION` bumps 0.57.0 → 0.58.0 (both configurations) so the host surfaces the update affordance. A test pins the old-sender case as still interoperating and another pins the unprimed case as a clean abort, never a truncated result.

## Rejected alternatives

- **A push-driven encode sink handing buffers to the chunk sender**, as the issue sketched. That inverts `ClipboardStreamSender`'s control flow and would mean reworking the credit window for a push source. The encode thread pushes into a bounded pipe and the sender *pulls* from it as an ordinary `ChunkReader` instead, so the flow-control loop is shared with every other payload and backpressure falls out of the pipe.
- **A new `is_directory` field on `ClipboardStreamBegin`.** The consumer already knows from the offer it acted on; putting it on the wire would be a second source of truth for a fact one side derived.
- **Keeping the file-to-file primitives as a fallback for an older peer.** That is exactly the legacy shim CLIPBOARD.md rules out. They have no callers now and are deleted, along with both send-staging roots and `ClipboardFileStaging.reserveURL`.
- **Enforcing free space only by letting the extract hit ENOSPC.** That would let a transfer fill the volume to the last byte, losing today's margin behavior; the per-window guard is re-keyed instead of dropped.

## Incidental fixes riding along

- The host re-extracted a fresh tree on **every** provider fire, so repeated pastes of one folder multiplied the on-disk cost. Paste-time extraction is gone entirely; a second paste re-serves the same tree, and a test asserts it.
- `ClipboardDirectoryArchive.archive` swallowed close errors, so an ENOSPC on the final flush produced a truncated `.aar` that passed every check. Discharged by deleting the function and building the new encode driver with close errors captured from the start.
- A disk-full abort for a payload with no declared size reported "0 bytes needed"; `ClipboardTransferIssue.diskFull` now carries an optional `needed`.

## Hardening the review turned up

- **The credit window was trusted, not enforced.** The receive lane never blocks — it hands each chunk to the write lane and returns — so the only thing bounding the backlog was the sender honoring the window. A declared payload was bounded by `total_bytes`; one that declares none had no bound at all, and a peer ignoring the window could queue chunks on a parked write lane until the host's heap ran out. CLIPBOARD.md §10 states the guest is untrusted, so this is in scope by the subsystem's own threat model. The backlog is now bounded uniformly at one credit window plus one maximum chunk — a figure no window-honoring sender can reach — and a peer past it is cut off with `flow.overrun`.
- **A folders-only copy to a peer without the capability filtered down to zero representations and still sent the offer.** The peer would drop its promise and be left with a pasteboard item nothing can serve. It now sends nothing, leaving the previous, still-working clipboard in place. The broader question — that *neither* side retires a peer's offer when a copy yields nothing offerable, which also predates this change for unreadable items — is filed as #779.
- **`extract.error` now raises its user-visible issue on the eager pull path too**, not only the blocking paste path.

One high-severity finding was raised and **dismissed as a false positive**: that the stacked `defer`s in the archive pipelines run after the result is computed, so a close failure would be discarded. They belong to the enclosing `do` block, not the function, and therefore run before the `return` expression is evaluated. Verified with a standalone probe of the exact shape. Both pipelines gained a line saying so, since the scoping fooled a careful reader.

## What a second, deeper review changed

The shape of the fix held, but three things it got wrong were all the same mistake — **a folder transfer was being measured in compressed bytes**, while everything that consumes those numbers is in the tree's unit:

- The mid-stream **disk guard** was paced by arriving wire bytes. At LZFSE's ~100:1 on text, each passing check admitted ~100 MB of tree writes, so the 64 MiB margin that exists to stop a transfer filling the volume never fired at all.
- **Nothing cross-checked the tree against the size the offer advertised.** The overrun guard was short-circuited for folders and Begin's gate passed zero, so one peer-supplied `byte_count` defeated both the user's paste ceiling and the free-space pre-flight, and gigabytes could land behind a figure of 1024.
- **Progress** climbed in compressed bytes against an uncompressed denominator — a 5:1 folder crawls to ~20 % over minutes and then snaps to 100 %, which reads as a hung paste and invites cancelling a healthy transfer.

All three are answered by one mechanism: a transparent `ClipboardArchiveCountingStream` interposed above the compressor (and below the decompressor), so both ends have the *uncompressed* count. `ArchiveByteStream` exposes instance `read`/`write`, so the stage forwards everything — including the random-access calls — and stays transparent rather than constraining the codec.

The ceiling policy: an extract may write **twice the advertised size, or 64 MiB, whichever is larger**. The archive container adds a header per entry to the file bytes the estimate sums, and a tree can grow a little between the copy-time walk and the paste-time encode, so equality is impossible; doubling covers header overhead for any tree whose file bytes dominate, and the floor covers a scaffold of empty directories whose estimate is legitimately zero.

Independently:

- **A park inside the archive source outlived every abort.** `stream()` parks in `reader.read(upTo:)` with no timeout, while abort, supersession and channel teardown all signal the transfer's own condition — a different object. A stalled encoder pinned the transfer forever, and since a transfer id is derivable the peer's retry was then dropped as a duplicate. This was a regression: before the change every chunk cycle passed through `awaitCredit`, which `markAborted` wakes and the no-ack deadline bounds. Retirement now reaches the source; the test hangs to the 60 s backstop with the hook removed.
- **The capability gate could strand a copy or ship junk.** On the host, latching the skipped buffer's digest stranded it for the session — and `VsockControlService.stop` clears the capability while the clipboard service lives on, so a brief control-channel blip was enough. On the guest, a folder-only copy fell through to the raw-snapshot path and offered Finder's leftover private flavors (`com.apple.finder.node`, `dyn.*`) as if they were the copy.
- **An ENOSPC from the extract reported as a corrupt archive**, sending the user to retry instead of to free space. Both failure sites re-check the volume now.
- `declaredTotalBytes: Int?` replaces re-deriving "unknown" from directory-ness, collapsing five of seven directory branches in the receiver — and closing the case where a `Begin` arriving after its pull was cancelled was re-classified as a plain file and the peer blamed for the first chunk.

One `high` finding was **dismissed with proof**: that the stacked `defer`s in the archive pipelines run after the result is computed, discarding close failures. They belong to the enclosing `do` block, not the function, so they run before the `return` expression is evaluated — confirmed with a standalone probe of the exact shape. Both pipelines carry a line saying so.

## Test plan

- [x] `make test` — full suite green
- [x] `make lint`
- [ ] Manual round trip on a real VM in both directions with a mixed tree (incompressible + compressible + symlinks + an `.app` bundle), watching that no `.aar` appears in either staging root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

