### PR TITLE
test: Exempt test waits from idle throttling and self-diagnose late backstops

### DIFF
--- a/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import KernovaKit
 
@@ -11,6 +12,21 @@ import KernovaKit
 /// (docs/TESTING.md, "Async waits in tests").
 public let testWaitBackstop: TimeInterval = 60
 
+// MARK: - Test-session OS activity
+
+/// OS activity held from the first wait for the rest of the process's life,
+/// exempting the test host from App Nap and idle timer throttling.
+///
+/// On an idle, display-off machine the OS can hold a windowless process's
+/// timers past the 60 s backstop, then release every armed wait at one
+/// instant, mass-failing whatever cases are in flight (observed 2026-08-06,
+/// #759). Test runs are user-initiated work even when the display is off.
+// The token is write-once and never read — retention is its entire job.
+nonisolated(unsafe) private let testSessionActivity: NSObjectProtocol =
+    ProcessInfo.processInfo.beginActivity(
+        options: [.userInitiated, .latencyCritical],
+        reason: "Test waits measure real time and must not be throttled")
+
 // MARK: - TestFailure
 
 /// A test failure with a diagnostic message, thrown by the wait helpers below.
@@ -23,6 +39,33 @@ public struct TestFailure: Error, CustomStringConvertible {
 
     /// The failure's diagnostic message.
     public var description: String { message }
+}
+
+// MARK: - Backstop self-diagnosis
+
+/// Renders the parenthetical a fired backstop appends to its `TestFailure`
+/// message: how far past its deadline it fired (continuous time) and how much
+/// of that the process spent suspended (continuous minus uptime elapsed), with
+/// a machine-state warning once either exceeds honest-scheduling bounds.
+func backstopDiagnosis(
+    timeout: TimeInterval, continuousElapsed: TimeInterval, uptimeElapsed: TimeInterval
+) -> String {
+    let late = continuousElapsed - timeout
+    let suspended = max(0, continuousElapsed - uptimeElapsed)
+    var text = String(
+        format: " (backstop fired %.2f s past its deadline, %.2f s of it process-suspended",
+        late, suspended)
+    // Scheduler noise keeps an honest backstop within a few seconds of its
+    // deadline and never suspends the process; past these bounds the wait did
+    // not get its full timeout of normal scheduling, so the numbers name the
+    // machine, not the condition under test.
+    if late >= 10 || suspended >= 1 {
+        text +=
+            " — the OS throttled this process's timers or suspended it;"
+            + " suspect machine state (sleep, display-off idle throttling)"
+            + " rather than a stuck condition"
+    }
+    return text + ")"
 }
 
 // MARK: - ResumeOnce
@@ -79,11 +122,19 @@ public final class AsyncGate: @unchecked Sendable {
         isolation: isolated (any Actor)? = #isolation,
         until predicate: () -> Bool
     ) async throws {
+        _ = testSessionActivity
         let clock = MonotonicEngineClock()
         let start = clock.now
+        let uptimeStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
         while !predicate() {
-            if clock.seconds(since: start) >= timeout {
-                throw TestFailure("Condition not met within \(timeout) s")
+            let elapsed = clock.seconds(since: start)
+            if elapsed >= timeout {
+                let uptimeElapsed =
+                    Double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - uptimeStart) / 1_000_000_000
+                throw TestFailure(
+                    "Condition not met within \(timeout) s"
+                        + backstopDiagnosis(
+                            timeout: timeout, continuousElapsed: elapsed, uptimeElapsed: uptimeElapsed))
             }
             await armOnce(
                 clock: clock, start: start, timeout: timeout,
@@ -149,13 +200,22 @@ public func waitUntil(
     isolation: isolated (any Actor)? = #isolation,
     _ predicate: () -> Bool
 ) async throws {
+    _ = testSessionActivity
     let clock = MonotonicEngineClock()
     let start = clock.now
+    let uptimeStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
     while !predicate() && clock.seconds(since: start) < timeout {
         try await Task.sleep(nanoseconds: 50_000_000)
     }
     guard predicate() else {
-        throw TestFailure("Predicate did not become true within \(timeout) s")
+        let uptimeElapsed =
+            Double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - uptimeStart) / 1_000_000_000
+        throw TestFailure(
+            "Predicate did not become true within \(timeout) s"
+                + backstopDiagnosis(
+                    timeout: timeout,
+                    continuousElapsed: clock.seconds(since: start),
+                    uptimeElapsed: uptimeElapsed))
     }
 }
 

--- a/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
@@ -14,17 +14,18 @@ public let testWaitBackstop: TimeInterval = 60
 
 // MARK: - Test-session OS activity
 
-/// OS activity held from the first wait for the rest of the process's life,
-/// exempting the test host from App Nap and idle timer throttling.
+/// OS activity exempting the test host from App Nap and idle timer throttling,
+/// begun on the first `BackstopStopwatch` creation — whose init reads this
+/// token precisely to run the lazy initializer — and held for the rest of the
+/// process's life.
 ///
 /// On an idle, display-off machine the OS can hold a windowless process's
 /// timers past the 60 s backstop, then release every armed wait at one
 /// instant, mass-failing whatever cases are in flight (observed 2026-08-06,
 /// #759). Test runs are user-initiated work even when the display is off.
-// The token is write-once and never read — retention is its entire job.
 nonisolated(unsafe) private let testSessionActivity: NSObjectProtocol =
     ProcessInfo.processInfo.beginActivity(
-        options: [.userInitiated, .latencyCritical],
+        options: .userInitiated,
         reason: "Test waits measure real time and must not be throttled")
 
 // MARK: - TestFailure
@@ -41,29 +42,71 @@ public struct TestFailure: Error, CustomStringConvertible {
     public var description: String { message }
 }
 
-// MARK: - Backstop self-diagnosis
+// MARK: - BackstopStopwatch
 
-/// Renders the parenthetical a fired backstop appends to its `TestFailure`
-/// message: how far past its deadline it fired (continuous time) and how much
-/// of that the process spent suspended (continuous minus uptime elapsed), with
-/// a machine-state warning once either exceeds honest-scheduling bounds.
+/// Captures both timelines at wait start so a fired backstop can self-diagnose.
+///
+/// Creating one also begins the test session's OS activity. Every wait seam —
+/// `AsyncGate.wait`, `waitUntil`, and the app test targets' helpers — starts
+/// one and appends `diagnosis(timeout:)` to its backstop `TestFailure`.
+public struct BackstopStopwatch: Sendable {
+    private let clock = MonotonicEngineClock()
+    private let start: EngineInstant
+    private let uptimeStartNanoseconds: UInt64
+
+    /// Reads both clocks, arming the session activity as a side effect.
+    public init() {
+        _ = testSessionActivity
+        start = clock.now
+        uptimeStartNanoseconds = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+    }
+
+    /// Seconds of continuous time since creation.
+    public var elapsed: TimeInterval { clock.seconds(since: start) }
+
+    /// The parenthetical a fired backstop appends to its failure message, from
+    /// readings taken at the call — empty when `elapsed` never reached
+    /// `timeout` (a predicate that flapped, not a fired backstop).
+    public func diagnosis(timeout: TimeInterval) -> String {
+        let uptimeElapsed =
+            Double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - uptimeStartNanoseconds)
+            / 1_000_000_000
+        return backstopDiagnosis(
+            timeout: timeout, continuousElapsed: elapsed, uptimeElapsed: uptimeElapsed)
+    }
+
+    /// `diagnosis(timeout:)` for the `Duration`-based wait helpers.
+    @available(macOS 13.0, *)
+    public func diagnosis(timeout: Duration) -> String {
+        let seconds =
+            Double(timeout.components.seconds) + Double(timeout.components.attoseconds) * 1e-18
+        return diagnosis(timeout: seconds)
+    }
+}
+
+/// Renders `BackstopStopwatch.diagnosis(timeout:)`: how far past its deadline
+/// the backstop fired (continuous time) and how much of the wait the system
+/// spent asleep (continuous minus uptime elapsed), with a machine-state
+/// warning once either exceeds honest-scheduling bounds.
 func backstopDiagnosis(
     timeout: TimeInterval, continuousElapsed: TimeInterval, uptimeElapsed: TimeInterval
 ) -> String {
+    guard continuousElapsed >= timeout else { return "" }
     let late = continuousElapsed - timeout
-    let suspended = max(0, continuousElapsed - uptimeElapsed)
+    let slept = max(0, continuousElapsed - uptimeElapsed)
     var text = String(
-        format: " (backstop fired %.2f s past its deadline, %.2f s of it process-suspended",
-        late, suspended)
-    // Scheduler noise keeps an honest backstop within a few seconds of its
-    // deadline and never suspends the process; past these bounds the wait did
-    // not get its full timeout of normal scheduling, so the numbers name the
-    // machine, not the condition under test.
-    if late >= 10 || suspended >= 1 {
+        format: " (backstop fired %.2f s past its deadline; the system slept %.2f s of the wait",
+        late, slept)
+    // System sleep is the only state this clock pair separates — App Nap-class
+    // throttling and per-process suspension advance both clocks and surface as
+    // lateness alone. Scheduler noise keeps an honest backstop within a few
+    // seconds of its deadline; past these bounds the wait did not get its full
+    // timeout of normal scheduling, so the numbers name the machine, not the
+    // condition under test.
+    if late >= 10 || slept >= 1 {
         text +=
-            " — the OS throttled this process's timers or suspended it;"
-            + " suspect machine state (sleep, display-off idle throttling)"
-            + " rather than a stuck condition"
+            " — suspect machine state (system sleep, display-off idle throttling,"
+            + " process suspension) rather than a stuck condition"
     }
     return text + ")"
 }
@@ -122,35 +165,28 @@ public final class AsyncGate: @unchecked Sendable {
         isolation: isolated (any Actor)? = #isolation,
         until predicate: () -> Bool
     ) async throws {
-        _ = testSessionActivity
-        let clock = MonotonicEngineClock()
-        let start = clock.now
-        let uptimeStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+        let stopwatch = BackstopStopwatch()
         while !predicate() {
-            let elapsed = clock.seconds(since: start)
-            if elapsed >= timeout {
-                let uptimeElapsed =
-                    Double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - uptimeStart) / 1_000_000_000
+            if stopwatch.elapsed >= timeout {
                 throw TestFailure(
                     "Condition not met within \(timeout) s"
-                        + backstopDiagnosis(
-                            timeout: timeout, continuousElapsed: elapsed, uptimeElapsed: uptimeElapsed))
+                        + stopwatch.diagnosis(timeout: timeout))
             }
             await armOnce(
-                clock: clock, start: start, timeout: timeout,
+                stopwatch: stopwatch, timeout: timeout,
                 isolation: isolation, predicate: predicate)
         }
     }
 
     /// Suspends until the next `notify()`, an immediate hit (the predicate
     /// already holds at arm time, closing the arm-vs-notify race), or the
-    /// deadline backstop (`start` + `timeout`) — whichever comes first.
+    /// deadline backstop (`timeout` after the stopwatch's start) — whichever
+    /// comes first.
     // `isolation` uses the Swift `isolated` keyword to pin this helper to the
     // caller's actor, so it is intentionally never referenced by name.
     // periphery:ignore:parameters isolation
     private func armOnce(
-        clock: MonotonicEngineClock,
-        start: EngineInstant,
+        stopwatch: BackstopStopwatch,
         timeout: TimeInterval,
         isolation: isolated (any Actor)?,
         predicate: () -> Bool
@@ -176,7 +212,7 @@ public final class AsyncGate: @unchecked Sendable {
             // Resume at the deadline even if no notify arrives, so a stuck
             // condition fails the wait instead of hanging.
             backstop = Task {
-                try? await clock.sleep(for: max(0, timeout - clock.seconds(since: start)))
+                try? await MonotonicEngineClock().sleep(for: max(0, timeout - stopwatch.elapsed))
                 self.lock.withLock { self.waiters[id] = nil }
                 once.fire { cont.resume() }
             }
@@ -200,22 +236,14 @@ public func waitUntil(
     isolation: isolated (any Actor)? = #isolation,
     _ predicate: () -> Bool
 ) async throws {
-    _ = testSessionActivity
-    let clock = MonotonicEngineClock()
-    let start = clock.now
-    let uptimeStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
-    while !predicate() && clock.seconds(since: start) < timeout {
+    let stopwatch = BackstopStopwatch()
+    while !predicate() && stopwatch.elapsed < timeout {
         try await Task.sleep(nanoseconds: 50_000_000)
     }
     guard predicate() else {
-        let uptimeElapsed =
-            Double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - uptimeStart) / 1_000_000_000
         throw TestFailure(
             "Predicate did not become true within \(timeout) s"
-                + backstopDiagnosis(
-                    timeout: timeout,
-                    continuousElapsed: clock.seconds(since: start),
-                    uptimeElapsed: uptimeElapsed))
+                + stopwatch.diagnosis(timeout: timeout))
     }
 }
 

--- a/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
+++ b/KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift
@@ -15,9 +15,10 @@ public let testWaitBackstop: TimeInterval = 60
 // MARK: - Test-session OS activity
 
 /// OS activity exempting the test host from App Nap and idle timer throttling,
-/// begun on the first `BackstopStopwatch` creation — whose init reads this
-/// token precisely to run the lazy initializer — and held for the rest of the
-/// process's life.
+/// begun by the first `armTestSessionActivity()` call — which reads this token
+/// precisely to run the lazy initializer — and held for the rest of the
+/// process's life. `.userInitiated` also deliberately keeps the machine from
+/// idle-sleeping mid-run: system sleep would blow every armed backstop.
 ///
 /// On an idle, display-off machine the OS can hold a windowless process's
 /// timers past the 60 s backstop, then release every armed wait at one
@@ -27,6 +28,15 @@ nonisolated(unsafe) private let testSessionActivity: NSObjectProtocol =
     ProcessInfo.processInfo.beginActivity(
         options: .userInitiated,
         reason: "Test waits measure real time and must not be throttled")
+
+/// Begins the test session's OS activity on first call; later calls no-op.
+///
+/// `BackstopStopwatch.init` calls this, covering every wait built on the
+/// shared helpers; a wait that bypasses them (a raw semaphore backstop) calls
+/// it directly before parking.
+public func armTestSessionActivity() {
+    _ = testSessionActivity
+}
 
 // MARK: - TestFailure
 
@@ -46,9 +56,8 @@ public struct TestFailure: Error, CustomStringConvertible {
 
 /// Captures both timelines at wait start so a fired backstop can self-diagnose.
 ///
-/// Creating one also begins the test session's OS activity. Every wait seam —
-/// `AsyncGate.wait`, `waitUntil`, and the app test targets' helpers — starts
-/// one and appends `diagnosis(timeout:)` to its backstop `TestFailure`.
+/// Creating one also arms the test session's OS activity. Every shared wait
+/// helper starts one and throws `TestFailure.backstop` at its deadline.
 public struct BackstopStopwatch: Sendable {
     private let clock = MonotonicEngineClock()
     private let start: EngineInstant
@@ -56,7 +65,7 @@ public struct BackstopStopwatch: Sendable {
 
     /// Reads both clocks, arming the session activity as a side effect.
     public init() {
-        _ = testSessionActivity
+        armTestSessionActivity()
         start = clock.now
         uptimeStartNanoseconds = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
     }
@@ -67,27 +76,41 @@ public struct BackstopStopwatch: Sendable {
     /// The parenthetical a fired backstop appends to its failure message, from
     /// readings taken at the call — empty when `elapsed` never reached
     /// `timeout` (a predicate that flapped, not a fired backstop).
-    public func diagnosis(timeout: TimeInterval) -> String {
+    func diagnosis(timeout: TimeInterval) -> String {
         let uptimeElapsed =
             Double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - uptimeStartNanoseconds)
             / 1_000_000_000
         return backstopDiagnosis(
             timeout: timeout, continuousElapsed: elapsed, uptimeElapsed: uptimeElapsed)
     }
+}
 
-    /// `diagnosis(timeout:)` for the `Duration`-based wait helpers.
+extension TestFailure {
+    /// A fired-backstop failure with the stopwatch's self-diagnosis appended.
+    ///
+    /// Every deadline throw goes through here so no wait seam ships a bare
+    /// timeout message without the timing numbers.
+    public static func backstop(
+        _ message: String, stopwatch: BackstopStopwatch, timeout: TimeInterval
+    ) -> TestFailure {
+        TestFailure(message + stopwatch.diagnosis(timeout: timeout))
+    }
+
+    /// `backstop(_:stopwatch:timeout:)` for the `Duration`-based wait helpers.
     @available(macOS 13.0, *)
-    public func diagnosis(timeout: Duration) -> String {
+    public static func backstop(
+        _ message: String, stopwatch: BackstopStopwatch, timeout: Duration
+    ) -> TestFailure {
         let seconds =
             Double(timeout.components.seconds) + Double(timeout.components.attoseconds) * 1e-18
-        return diagnosis(timeout: seconds)
+        return backstop(message, stopwatch: stopwatch, timeout: seconds)
     }
 }
 
 /// Renders `BackstopStopwatch.diagnosis(timeout:)`: how far past its deadline
 /// the backstop fired (continuous time) and how much of the wait the system
-/// spent asleep (continuous minus uptime elapsed), with a machine-state
-/// warning once either exceeds honest-scheduling bounds.
+/// spent asleep (continuous minus uptime elapsed), with a machine-state hint
+/// once either exceeds honest-scheduling bounds.
 func backstopDiagnosis(
     timeout: TimeInterval, continuousElapsed: TimeInterval, uptimeElapsed: TimeInterval
 ) -> String {
@@ -99,14 +122,13 @@ func backstopDiagnosis(
         late, slept)
     // System sleep is the only state this clock pair separates — App Nap-class
     // throttling and per-process suspension advance both clocks and surface as
-    // lateness alone. Scheduler noise keeps an honest backstop within a few
-    // seconds of its deadline; past these bounds the wait did not get its full
-    // timeout of normal scheduling, so the numbers name the machine, not the
-    // condition under test.
-    if late >= 10 || slept >= 1 {
+    // lateness alone. The lateness bound scales down with short explicit
+    // timeouts, and the hint stays a hint: a starved CI runner can fire an
+    // honest backstop seconds late, so the numbers outrank the wording.
+    if late >= min(5, timeout) || slept >= 1 {
         text +=
-            " — suspect machine state (system sleep, display-off idle throttling,"
-            + " process suspension) rather than a stuck condition"
+            " — consider machine state (system sleep, display-off idle"
+            + " throttling, process suspension) alongside a stuck condition"
     }
     return text + ")"
 }
@@ -168,9 +190,9 @@ public final class AsyncGate: @unchecked Sendable {
         let stopwatch = BackstopStopwatch()
         while !predicate() {
             if stopwatch.elapsed >= timeout {
-                throw TestFailure(
-                    "Condition not met within \(timeout) s"
-                        + stopwatch.diagnosis(timeout: timeout))
+                throw TestFailure.backstop(
+                    "Condition not met within \(timeout) s",
+                    stopwatch: stopwatch, timeout: timeout)
             }
             await armOnce(
                 stopwatch: stopwatch, timeout: timeout,
@@ -241,9 +263,9 @@ public func waitUntil(
         try await Task.sleep(nanoseconds: 50_000_000)
     }
     guard predicate() else {
-        throw TestFailure(
-            "Predicate did not become true within \(timeout) s"
-                + stopwatch.diagnosis(timeout: timeout))
+        throw TestFailure.backstop(
+            "Predicate did not become true within \(timeout) s",
+            stopwatch: stopwatch, timeout: timeout)
     }
 }
 

--- a/KernovaKit/Tests/KernovaKitTests/BackstopDiagnosisTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/BackstopDiagnosisTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 @Suite("Backstop self-diagnosis")
 struct BackstopDiagnosisTests {
-    @Test("an on-time backstop with no system sleep reports its numbers without a machine-state warning")
+    @Test("an on-time backstop with no system sleep reports its numbers without a machine-state hint")
     func onTimeBackstop() {
         let text = backstopDiagnosis(timeout: 60, continuousElapsed: 60.25, uptimeElapsed: 60.25)
         #expect(text.contains("0.25 s past its deadline"))
@@ -13,25 +13,39 @@ struct BackstopDiagnosisTests {
         #expect(!text.contains("machine state"))
     }
 
-    @Test("a backstop far past its deadline warns of machine state even without system sleep")
+    @Test("the #759 shape — several seconds late, no sleep — earns the machine-state hint")
+    func throttledBackstop() {
+        let text = backstopDiagnosis(timeout: 60, continuousElapsed: 66.5, uptimeElapsed: 66.5)
+        #expect(text.contains("6.50 s past its deadline"))
+        #expect(text.contains("machine state"))
+    }
+
+    @Test("a backstop far past its deadline hints at machine state even without system sleep")
     func lateUnsleptBackstop() {
         let text = backstopDiagnosis(timeout: 60, continuousElapsed: 126.70, uptimeElapsed: 126.70)
         #expect(text.contains("66.70 s past its deadline"))
-        #expect(text.contains("suspect machine state"))
+        #expect(text.contains("machine state"))
     }
 
-    @Test("continuous-vs-uptime divergence reports system sleep and warns even when barely late")
+    @Test("the lateness bound scales down to a short explicit timeout")
+    func shortTimeoutBackstop() {
+        let text = backstopDiagnosis(timeout: 2, continuousElapsed: 11, uptimeElapsed: 11)
+        #expect(text.contains("9.00 s past its deadline"))
+        #expect(text.contains("machine state"))
+    }
+
+    @Test("continuous-vs-uptime divergence reports system sleep and hints even when barely late")
     func systemSleepBackstop() {
         let text = backstopDiagnosis(timeout: 60, continuousElapsed: 61, uptimeElapsed: 2)
         #expect(text.contains("the system slept 59.00 s of the wait"))
-        #expect(text.contains("suspect machine state"))
+        #expect(text.contains("machine state"))
     }
 
     @Test("uptime elapsed exceeding continuous elapsed clamps the sleep figure to zero")
     func clockGranularityJitter() {
         let text = backstopDiagnosis(timeout: 60, continuousElapsed: 60.5, uptimeElapsed: 60.6)
         #expect(text.contains("the system slept 0.00 s"))
-        #expect(!text.contains("suspect machine state"))
+        #expect(!text.contains("machine state"))
     }
 
     @Test("elapsed short of the timeout renders nothing — the backstop never fired")

--- a/KernovaKit/Tests/KernovaKitTests/BackstopDiagnosisTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/BackstopDiagnosisTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import KernovaTestSupport
+
+@Suite("Backstop self-diagnosis")
+struct BackstopDiagnosisTests {
+    @Test("an on-time, unsuspended backstop reports its numbers without a machine-state warning")
+    func onTimeBackstop() {
+        let text = backstopDiagnosis(timeout: 60, continuousElapsed: 60.25, uptimeElapsed: 60.25)
+        #expect(text.contains("0.25 s past its deadline"))
+        #expect(text.contains("0.00 s of it process-suspended"))
+        #expect(!text.contains("machine state"))
+    }
+
+    @Test("a backstop far past its deadline warns of timer throttling even unsuspended")
+    func lateUnsuspendedBackstop() {
+        let text = backstopDiagnosis(timeout: 60, continuousElapsed: 126.70, uptimeElapsed: 126.70)
+        #expect(text.contains("66.70 s past its deadline"))
+        #expect(text.contains("suspect machine state"))
+    }
+
+    @Test("continuous-vs-uptime divergence reports suspension and warns even when barely late")
+    func suspendedBackstop() {
+        let text = backstopDiagnosis(timeout: 60, continuousElapsed: 61, uptimeElapsed: 2)
+        #expect(text.contains("59.00 s of it process-suspended"))
+        #expect(text.contains("suspect machine state"))
+    }
+
+    @Test("uptime elapsed exceeding continuous elapsed clamps suspension to zero")
+    func clockGranularityJitter() {
+        let text = backstopDiagnosis(timeout: 60, continuousElapsed: 60.5, uptimeElapsed: 60.6)
+        #expect(text.contains("0.00 s of it process-suspended"))
+        #expect(!text.contains("suspect machine state"))
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/BackstopDiagnosisTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/BackstopDiagnosisTests.swift
@@ -5,32 +5,38 @@ import Testing
 
 @Suite("Backstop self-diagnosis")
 struct BackstopDiagnosisTests {
-    @Test("an on-time, unsuspended backstop reports its numbers without a machine-state warning")
+    @Test("an on-time backstop with no system sleep reports its numbers without a machine-state warning")
     func onTimeBackstop() {
         let text = backstopDiagnosis(timeout: 60, continuousElapsed: 60.25, uptimeElapsed: 60.25)
         #expect(text.contains("0.25 s past its deadline"))
-        #expect(text.contains("0.00 s of it process-suspended"))
+        #expect(text.contains("the system slept 0.00 s"))
         #expect(!text.contains("machine state"))
     }
 
-    @Test("a backstop far past its deadline warns of timer throttling even unsuspended")
-    func lateUnsuspendedBackstop() {
+    @Test("a backstop far past its deadline warns of machine state even without system sleep")
+    func lateUnsleptBackstop() {
         let text = backstopDiagnosis(timeout: 60, continuousElapsed: 126.70, uptimeElapsed: 126.70)
         #expect(text.contains("66.70 s past its deadline"))
         #expect(text.contains("suspect machine state"))
     }
 
-    @Test("continuous-vs-uptime divergence reports suspension and warns even when barely late")
-    func suspendedBackstop() {
+    @Test("continuous-vs-uptime divergence reports system sleep and warns even when barely late")
+    func systemSleepBackstop() {
         let text = backstopDiagnosis(timeout: 60, continuousElapsed: 61, uptimeElapsed: 2)
-        #expect(text.contains("59.00 s of it process-suspended"))
+        #expect(text.contains("the system slept 59.00 s of the wait"))
         #expect(text.contains("suspect machine state"))
     }
 
-    @Test("uptime elapsed exceeding continuous elapsed clamps suspension to zero")
+    @Test("uptime elapsed exceeding continuous elapsed clamps the sleep figure to zero")
     func clockGranularityJitter() {
         let text = backstopDiagnosis(timeout: 60, continuousElapsed: 60.5, uptimeElapsed: 60.6)
-        #expect(text.contains("0.00 s of it process-suspended"))
+        #expect(text.contains("the system slept 0.00 s"))
         #expect(!text.contains("suspect machine state"))
+    }
+
+    @Test("elapsed short of the timeout renders nothing — the backstop never fired")
+    func flappedPredicate() {
+        let text = backstopDiagnosis(timeout: 60, continuousElapsed: 0.15, uptimeElapsed: 0.15)
+        #expect(text.isEmpty)
     }
 }

--- a/KernovaMacOSAgentTests/TestHelpers.swift
+++ b/KernovaMacOSAgentTests/TestHelpers.swift
@@ -43,6 +43,7 @@ func makeChannelPair() throws -> (VsockChannel, VsockChannel) {
 ///   producing a frame (EOF), so the two failure shapes are identifiable.
 func nextFrame(from channel: VsockChannel) async throws -> Frame {
     let timeout = testWaitBackstop
+    let stopwatch = BackstopStopwatch()
     let receiver = Task<Frame?, Error> {
         var iterator = channel.incoming.makeAsyncIterator()
         return try await iterator.next()
@@ -59,7 +60,9 @@ func nextFrame(from channel: VsockChannel) async throws -> Frame {
         }
         return frame
     } catch is CancellationError {
-        throw TestFailure("Timed out waiting for a frame after \(timeout) s")
+        throw TestFailure(
+            "Timed out waiting for a frame after \(timeout) s"
+                + stopwatch.diagnosis(timeout: timeout))
     }
 }
 
@@ -71,6 +74,7 @@ func nextFrame(from channel: VsockChannel) async throws -> Frame {
 /// - Throws: `TestFailure("Timed out…")` if no value arrives in time.
 func awaitFirst<T: Sendable>(_ stream: AsyncStream<T>) async throws -> T {
     let timeout = testWaitBackstop
+    let stopwatch = BackstopStopwatch()
     let task = Task<T?, Never> {
         var iterator = stream.makeAsyncIterator()
         return await iterator.next()
@@ -81,7 +85,9 @@ func awaitFirst<T: Sendable>(_ stream: AsyncStream<T>) async throws -> T {
     }
     defer { timeoutTask.cancel() }
     guard let value = await task.value else {
-        throw TestFailure("Timed out waiting for stream value after \(timeout) s")
+        throw TestFailure(
+            "Timed out waiting for stream value after \(timeout) s"
+                + stopwatch.diagnosis(timeout: timeout))
     }
     return value
 }

--- a/KernovaMacOSAgentTests/TestHelpers.swift
+++ b/KernovaMacOSAgentTests/TestHelpers.swift
@@ -56,13 +56,21 @@ func nextFrame(from channel: VsockChannel) async throws -> Frame {
 
     do {
         guard let frame = try await receiver.value else {
+            // Cancelling the task suspended in `AsyncThrowingStream.next()`
+            // makes it return nil rather than throw, so the timeout lands here
+            // too, distinguishable from a genuine EOF only by the clock.
+            if stopwatch.elapsed >= timeout {
+                throw TestFailure.backstop(
+                    "Timed out waiting for a frame after \(timeout) s",
+                    stopwatch: stopwatch, timeout: timeout)
+            }
             throw TestFailure("Channel finished without producing a frame (EOF)")
         }
         return frame
     } catch is CancellationError {
-        throw TestFailure(
-            "Timed out waiting for a frame after \(timeout) s"
-                + stopwatch.diagnosis(timeout: timeout))
+        throw TestFailure.backstop(
+            "Timed out waiting for a frame after \(timeout) s",
+            stopwatch: stopwatch, timeout: timeout)
     }
 }
 
@@ -72,6 +80,8 @@ func nextFrame(from channel: VsockChannel) async throws -> Frame {
 /// deadline.
 ///
 /// - Throws: `TestFailure("Timed out…")` if no value arrives in time.
+/// - Throws: `TestFailure("Stream finished…")` when the stream ends without
+///   ever producing a value, so the two failure shapes are identifiable.
 func awaitFirst<T: Sendable>(_ stream: AsyncStream<T>) async throws -> T {
     let timeout = testWaitBackstop
     let stopwatch = BackstopStopwatch()
@@ -85,9 +95,12 @@ func awaitFirst<T: Sendable>(_ stream: AsyncStream<T>) async throws -> T {
     }
     defer { timeoutTask.cancel() }
     guard let value = await task.value else {
-        throw TestFailure(
-            "Timed out waiting for stream value after \(timeout) s"
-                + stopwatch.diagnosis(timeout: timeout))
+        if stopwatch.elapsed >= timeout {
+            throw TestFailure.backstop(
+                "Timed out waiting for stream value after \(timeout) s",
+                stopwatch: stopwatch, timeout: timeout)
+        }
+        throw TestFailure("Stream finished without producing a value")
     }
     return value
 }

--- a/KernovaMacOSAgentTests/VsockGuestClientTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClientTests.swift
@@ -547,7 +547,9 @@ struct ClassifySocketErrnoTests {
         }
 
         // Blocking waits go to GCD so the cooperative pool keeps its threads
-        // (docs/TESTING.md, "Blocking bridge calls").
+        // (docs/TESTING.md, "Blocking bridge calls"). A raw semaphore wait
+        // bypasses the stopwatch helpers, so arm the session activity itself.
+        armTestSessionActivity()
         let entered = await offCooperativePool {
             firstAttemptEntered.wait(timeout: .now() + testWaitBackstop) == .success
         }

--- a/KernovaTests/RestoreImageProbeTests.swift
+++ b/KernovaTests/RestoreImageProbeTests.swift
@@ -280,6 +280,9 @@ final class ProbeStubURLProtocol: URLProtocol, @unchecked Sendable {
         // The primer belongs here rather than above because nothing handed to
         // the client reaches it until `startLoading` has returned.
         DispatchQueue.global().async { [self] in
+            // A raw semaphore wait bypasses the stopwatch helpers, so arm the
+            // session activity itself.
+            armTestSessionActivity()
             deliver(reply.body.prefix(Self.bodyPrimerBytes), finishing: false)
             let backstop =
                 DispatchTime.now() + .seconds(Int(testWaitBackstop))

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -86,6 +86,7 @@ func makeRawSocketPair() throws -> (Int32, Int32) {
 @MainActor
 func nextFrame(from channel: VsockChannel) async throws -> Frame {
     let timeout: Duration = .seconds(testWaitBackstop)
+    let stopwatch = BackstopStopwatch()
     let receiver = Task<Frame?, Error> {
         var iterator = channel.incoming.makeAsyncIterator()
         return try await iterator.next()
@@ -107,7 +108,9 @@ func nextFrame(from channel: VsockChannel) async throws -> Frame {
         }
         return frame
     } catch is CancellationError {
-        throw TestFailure("Timed out waiting for a frame after \(timeout)")
+        throw TestFailure(
+            "Timed out waiting for a frame after \(timeout)"
+                + stopwatch.diagnosis(timeout: timeout))
     }
 }
 
@@ -161,10 +164,13 @@ func waitForChange(
     timeout: Duration = .seconds(testWaitBackstop),
     until predicate: @escaping @MainActor () -> Bool
 ) async throws {
+    let stopwatch = BackstopStopwatch()
     let deadline = ContinuousClock.now.advanced(by: timeout)
     while !predicate() {
         if ContinuousClock.now >= deadline {
-            throw TestFailure("Observed condition not met within \(timeout)")
+            throw TestFailure(
+                "Observed condition not met within \(timeout)"
+                    + stopwatch.diagnosis(timeout: timeout))
         }
         await armObservationOnce(deadline: deadline, predicate: predicate)
     }

--- a/KernovaTests/TestHelpers.swift
+++ b/KernovaTests/TestHelpers.swift
@@ -91,11 +91,12 @@ func nextFrame(from channel: VsockChannel) async throws -> Frame {
         var iterator = channel.incoming.makeAsyncIterator()
         return try await iterator.next()
     }
-    // `receiver` is not cancelled in `defer` because every exit path
-    // already awaits `receiver.value` (success, EOF, or timeout-induced
-    // CancellationError). By the time the function returns, the receiver task
-    // has completed; a redundant cancel would be a no-op and obscures intent.
-    // Cancelling the timeoutTask is necessary on the success path.
+    // `receiver` is not cancelled in `defer` because every exit path already
+    // awaits `receiver.value` — success, EOF, or the timeout task's cancel,
+    // which surfaces as a nil from `next()`. By the time the function returns,
+    // the receiver task has completed; a redundant cancel would be a no-op and
+    // obscures intent. Cancelling the timeoutTask is necessary on the success
+    // path.
     let timeoutTask = Task<Void, Never> {
         try? await Task.sleep(for: timeout)
         receiver.cancel()
@@ -104,13 +105,21 @@ func nextFrame(from channel: VsockChannel) async throws -> Frame {
 
     do {
         guard let frame = try await receiver.value else {
+            // Cancelling the task suspended in `AsyncThrowingStream.next()`
+            // makes it return nil rather than throw, so the timeout lands here
+            // too, distinguishable from a genuine EOF only by the clock.
+            if stopwatch.elapsed >= testWaitBackstop {
+                throw TestFailure.backstop(
+                    "Timed out waiting for a frame after \(timeout)",
+                    stopwatch: stopwatch, timeout: timeout)
+            }
             throw TestFailure("Channel finished without producing a frame (EOF)")
         }
         return frame
     } catch is CancellationError {
-        throw TestFailure(
-            "Timed out waiting for a frame after \(timeout)"
-                + stopwatch.diagnosis(timeout: timeout))
+        throw TestFailure.backstop(
+            "Timed out waiting for a frame after \(timeout)",
+            stopwatch: stopwatch, timeout: timeout)
     }
 }
 
@@ -168,9 +177,9 @@ func waitForChange(
     let deadline = ContinuousClock.now.advanced(by: timeout)
     while !predicate() {
         if ContinuousClock.now >= deadline {
-            throw TestFailure(
-                "Observed condition not met within \(timeout)"
-                    + stopwatch.diagnosis(timeout: timeout))
+            throw TestFailure.backstop(
+                "Observed condition not met within \(timeout)",
+                stopwatch: stopwatch, timeout: timeout)
         }
         await armObservationOnce(deadline: deadline, predicate: predicate)
     }


### PR DESCRIPTION
## Summary

Follow-up to the #759 watchlist entry. A post-hoc timeline analysis (posted on the issue) pinned the failing window to a display-off, unattended machine with no system sleep involved: the OS held the windowless test host's timers past the 60 s backstop, then released every armed wait at one instant, mass-failing whatever unrelated cases were in flight — all recovered on xcodebuild's retry.

`KernovaTestSupport` gains one mechanism with two halves, and every wait seam in all three test targets funnels through it (`AsyncGate.wait`, `waitUntil`, `waitForChange`, both `nextFrame`s, `awaitFirst`, plus the two raw semaphore backstops):

- **Prevention** — `armTestSessionActivity()` begins a `.userInitiated` `ProcessInfo` activity held for the rest of the process's life, exempting the test session from App Nap and idle timer throttling (and deliberately keeping the machine from idle-sleeping mid-run — system sleep would blow every armed backstop). `BackstopStopwatch.init` calls it, so helper-based waits are covered automatically; the raw semaphore waits call it directly.
- **Self-diagnosis** — every deadline throw goes through `TestFailure.backstop`, which appends how far past its deadline the backstop fired and how much of the wait the system spent asleep (continuous minus uptime elapsed), with a machine-state hint once lateness exceeds `min(5 s, timeout)` or sleep exceeds 1 s. System sleep is the only state the clock pair separates — App Nap-class throttling advances both clocks and surfaces as lateness alone — and the hint stays a hint, since a starved CI runner can fire an honest backstop late. Nothing renders when the timeout never elapsed. Any recurrence of #759 then diagnoses itself from the xcresult.

Two review rounds are absorbed. The first drove the seam-coverage consolidation, the system-sleep relabel, and dropping `.latencyCritical`. The second found (and empirically verified) a pre-existing bug the diff sat on: cancelling the task suspended in `AsyncThrowingStream.next()` returns nil rather than throwing, so both `nextFrame`s reported every timeout as EOF — letting `expectEOF` pass on a hung channel and making the diagnosis unreachable on those seams. The nil branch now splits timeout from EOF by the stopwatch clock, and `awaitFirst` likewise separates a stream that finished early from a timeout.

## Changes

- `KernovaKit/Sources/KernovaTestSupport/AsyncWaits.swift` — `armTestSessionActivity()`, `BackstopStopwatch`, `TestFailure.backstop(_:stopwatch:timeout:)` (TimeInterval + Duration), the `backstopDiagnosis` formatter; `AsyncGate.wait`, `armOnce`, and `waitUntil` rewired
- `KernovaTests/TestHelpers.swift` — `nextFrame` (nil-branch timeout split), `waitForChange`
- `KernovaMacOSAgentTests/TestHelpers.swift` — `nextFrame` (same split), `awaitFirst` (early-finish split)
- `KernovaMacOSAgentTests/VsockGuestClientTests.swift`, `KernovaTests/RestoreImageProbeTests.swift` — arm the activity at the raw semaphore waits
- `KernovaKit/Tests/KernovaKitTests/BackstopDiagnosisTests.swift` — on-time, #759-shape, far-late, short-timeout, system-sleep, clock-jitter clamp, and flapped-predicate cases

## Test plan

- [x] `make test-package` — 348 tests, new suite included
- [x] `make lint`
- [x] `make test` — full suite green (app + agent targets), no retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pyRNZgXpQqLa45oDWMxnb