### PR TITLE
feat: Surface clipboard refusals on the status items when no window is watching

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -831,7 +831,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.58.0;
+				MARKETING_VERSION = 0.59.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
@@ -869,7 +869,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.58.0;
+				MARKETING_VERSION = 0.59.0;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -311,26 +311,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         statusItemController = HostAgentStatusItemController(
             viewModel: viewModel,
             preferences: preferences,
-            onOpen: { [weak self] vmID in
+            onOpen: { [weak self] vmID in self?.summonStatusItemTarget(for: vmID) },
+            onOpenClipboard: { [weak self] vmID in
                 guard let self else { return }
                 guard
-                    let instance = vmID.flatMap({ id in
-                        self.viewModel.instances.first(where: { $0.instanceID == id })
-                    })
+                    let instance = self.viewModel.instances.first(where: { $0.instanceID == vmID }),
+                    instance.canShowClipboard
                 else {
-                    self.summonUserInterface()
+                    // The window the notice pointed at can't open — the VM has
+                    // stopped, had sharing turned off, or is gone from the
+                    // library. Land on its usual surface rather than nowhere.
+                    self.summonStatusItemTarget(for: vmID)
                     return
                 }
-                self.viewModel.selectedID = instance.instanceID
-                switch Self.statusItemOpenTarget(
-                    displayPreference: instance.configuration.displayPreference,
-                    canUseExternalDisplay: instance.canUseExternalDisplay)
-                {
-                case .displayWindow:
-                    self.summonUserInterface(showing: .display(instance))
-                case .library:
-                    self.summonUserInterface()
-                }
+                self.viewModel.selectedID = vmID
+                self.summonUserInterface(showing: .clipboard(instance))
             },
             onQuit: { [weak self] in self?.requestFullQuit() }
         )
@@ -489,6 +484,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         /// One VM's dedicated display window (pop-out or fullscreen, per its
         /// `displayPreference`), and nothing else.
         case display(VMInstance)
+        /// One VM's clipboard window, and nothing else.
+        case clipboard(VMInstance)
+    }
+
+    /// Summons the surface the status item's per-VM commands land on: the VM's
+    /// own display window when it can present one, else the library.
+    ///
+    /// A `nil` or unknown id opens the library, which is where a VM that has left
+    /// the library is looked for.
+    private func summonStatusItemTarget(for vmID: UUID?) {
+        guard
+            let instance = vmID.flatMap({ id in
+                viewModel.instances.first(where: { $0.instanceID == id })
+            })
+        else {
+            summonUserInterface()
+            return
+        }
+        viewModel.selectedID = instance.instanceID
+        switch Self.statusItemOpenTarget(
+            displayPreference: instance.configuration.displayPreference,
+            canUseExternalDisplay: instance.canUseExternalDisplay)
+        {
+        case .displayWindow:
+            summonUserInterface(showing: .display(instance))
+        case .library:
+            summonUserInterface()
+        }
     }
 
     /// Where the status item's per-VM open command lands, as decided by
@@ -537,6 +560,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                 } else {
                     self.openDisplayWindow(for: instance)
                 }
+            case .clipboard(let instance):
+                self.showClipboardWindow(for: instance)
             }
             // Summoning from the status-item menu leaves the freshly-appeared menu
             // bar with its first menu highlighted: the status menu's dismissal
@@ -1124,6 +1149,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     @objc func showClipboard(_ sender: Any?) {
         guard let instance = activeInstance else { return }
+        showClipboardWindow(for: instance)
+    }
+
+    /// Shows or focuses the clipboard window for `instance`.
+    private func showClipboardWindow(for instance: VMInstance) {
         showAuxiliaryWindow(
             for: instance,
             isEligible: instance.canShowClipboard,

--- a/Kernova/App/ClipboardNoticeViewController.swift
+++ b/Kernova/App/ClipboardNoticeViewController.swift
@@ -1,0 +1,50 @@
+import AppKit
+
+/// Content for the transient popover the menu-bar status item shows when a
+/// clipboard transfer was refused and no clipboard window was open to say so.
+///
+/// The link only invokes `onOpenClipboardWindow`; the presenter
+/// (`HostAgentStatusItemController`) owns the dismissal and the window summons.
+@MainActor
+final class ClipboardNoticeViewController: NSViewController {
+    private let notice: ClipboardIssueCenter.Notice
+    private let onOpenClipboardWindow: () -> Void
+
+    init(
+        notice: ClipboardIssueCenter.Notice, onOpenClipboardWindow: @escaping () -> Void
+    ) {
+        self.notice = notice
+        self.onOpenClipboardWindow = onOpenClipboardWindow
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("ClipboardNoticeViewController does not support NSCoder")
+    }
+
+    override func loadView() {
+        var rows: [NSView] = [
+            makeCalloutHeadline(notice.issue.noticeHeadline(vmName: notice.vmName)),
+            makeCalloutBody(
+                notice.issue.displayMessage(pasteLimitBytes: notice.pasteLimitBytes)),
+        ]
+        if notice.issue.includesStaleClipboardContext {
+            rows.append(makeCalloutBody("The Mac clipboard still has its previous contents."))
+        }
+        rows.append(
+            makeLinkButton(
+                "Open Clipboard Window", target: self, action: #selector(openClipboardTapped)))
+
+        installCalloutStack(rows: rows)
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        syncCalloutContentSize()
+    }
+
+    @objc private func openClipboardTapped() {
+        onOpenClipboardWindow()
+    }
+}

--- a/Kernova/App/ClipboardWindowController.swift
+++ b/Kernova/App/ClipboardWindowController.swift
@@ -52,6 +52,9 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
     override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
         if statusObservation == nil { observeStatus() }
+        // On screen, the content controller renders this VM's transfer issues
+        // itself — the menu-bar notice stands down for as long as it is up.
+        ClipboardIssueCenter.shared.beginWatching(instanceID: instance.instanceID)
         Self.logger.debug("Clipboard window shown for VM '\(self.instance.name, privacy: .public)'")
     }
 
@@ -64,11 +67,26 @@ final class ClipboardWindowController: NSWindowController, NSWindowDelegate {
         }
         statusObservation?.cancel()
         statusObservation = nil
+        ClipboardIssueCenter.shared.endWatching(instanceID: instance.instanceID)
         Self.logger.debug("Clipboard window closing for VM '\(self.instance.name, privacy: .public)'")
     }
 
     func windowDidResignKey(_ notification: Notification) {
         clipboardContentVC.flushAndAnnounceEdit()
+    }
+
+    /// Hands the interruption back to the menu bar while the window is in the
+    /// Dock: its own transfer-issue banner is a few-second transient, so a
+    /// minimized window renders a refusal to nobody.
+    ///
+    /// Deliberately tracks miniaturization only, not occlusion: a window covered
+    /// by other windows is still the surface the user chose for this VM.
+    func windowDidMiniaturize(_ notification: Notification) {
+        ClipboardIssueCenter.shared.endWatching(instanceID: instance.instanceID)
+    }
+
+    func windowDidDeminiaturize(_ notification: Notification) {
+        ClipboardIssueCenter.shared.beginWatching(instanceID: instance.instanceID)
     }
 
     // MARK: - Status Observation

--- a/Kernova/App/HostAgentStatusItemController.swift
+++ b/Kernova/App/HostAgentStatusItemController.swift
@@ -25,8 +25,11 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
 
     private let viewModel: VMLibraryViewModel
     private let preferences: AppPreferences
+    private let issueCenter: ClipboardIssueCenter
     /// Summons the GUI — `nil` opens the library, a VM id opens just that VM.
     private let onOpen: (UUID?) -> Void
+    /// Opens the clipboard window of the VM a notice names.
+    private let onOpenClipboard: (UUID) -> Void
     private let onQuit: () -> Void
 
     /// Keeps the tooltip — and, while the dropdown is open, its VM rows — in
@@ -34,33 +37,50 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
     private var runningObservation: ObservationLoop?
     /// Keeps the paste readout in sync with the materializing transfer.
     private var pasteProgressObservation: ObservationLoop?
+    /// Fires when a clipboard refusal is queued for an interrupting surface.
+    private var clipboardNoticeObservation: ObservationLoop?
 
     /// The dropdown readout, its one-shot automatic open, and the shared menu
     /// wiring for a materializing paste.
     ///
-    /// Dismisses the soft-quit reminder before an automatic open, so the click
-    /// reaches the menu rather than the reminder's dismissal handler.
+    /// Dismisses any transient popover before an automatic open, so the click
+    /// reaches the reattached menu rather than the popover's dismissal handler.
     private lazy var pasteProgressPresenter = ClipboardProgressStatusItemPresenter(
         statusItem: statusItem, menu: menu,
-        willAutoOpen: { [weak self] in self?.dismissSoftQuitReminder() })
+        willAutoOpen: { [weak self] in self?.transientPopover.dismiss() })
 
-    /// Manages the transient "still running in the menu bar" soft-quit reminder
-    /// popover.
-    private let softQuitReminder = PopoverPresenter()
-    /// Auto-dismiss timer for the soft-quit reminder; cancelled if it closes
-    /// earlier (opt-out tap, opening the status menu, or a second soft quit).
-    private var softQuitReminderDismissTask: Task<Void, Never>?
+    /// The status item's one transient-popover slot, shared by the soft-quit
+    /// reminder and the clipboard notice.
+    private lazy var transientPopover = TransientStatusItemPopover(
+        statusItem: statusItem, menu: menu,
+        isDropdownOpen: { [weak self] in self?.isMenuOpen ?? false })
+
+    /// The notice currently shown, or the last one declined.
+    ///
+    /// One refusal is presented once. A repeat of the same kind is a new notice,
+    /// since the issue's `date` is its identity.
+    private var lastPresentedNotice: ClipboardIssueCenter.Notice?
+
+    /// How long a clipboard notice stays up unattended.
+    private static let clipboardNoticeDuration: Duration = .seconds(6)
+
+    /// How long the soft-quit reminder stays up unattended.
+    private static let softQuitReminderDuration: Duration = .seconds(4.5)
 
     init(
         viewModel: VMLibraryViewModel,
         preferences: AppPreferences = .shared,
+        issueCenter: ClipboardIssueCenter = .shared,
         onOpen: @escaping (UUID?) -> Void,
+        onOpenClipboard: @escaping (UUID) -> Void,
         onQuit: @escaping () -> Void
     ) {
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         self.viewModel = viewModel
         self.preferences = preferences
+        self.issueCenter = issueCenter
         self.onOpen = onOpen
+        self.onOpenClipboard = onOpenClipboard
         self.onQuit = onQuit
         super.init()
 
@@ -76,7 +96,7 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
                 // Evaluating the row model registers every property the rows
                 // (and the tooltip's running count) render, so the tracked set
                 // can't drift from the rendered set.
-                _ = StatusMenuVMSection.rows(for: self.viewModel.instances)
+                _ = self.currentRows()
             },
             apply: { [weak self] in
                 guard let self else { return }
@@ -89,6 +109,17 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
             track: { _ = ClipboardProgressCenter.shared.materializationProgress },
             apply: { [weak self] in self?.pasteProgressChanged() }
         )
+
+        clipboardNoticeObservation = observeRecurring(
+            track: { [weak self] in _ = self?.issueCenter.pendingNotice },
+            apply: { [weak self] in self?.pendingClipboardNoticeChanged() }
+        )
+    }
+
+    /// The dropdown's VM rows for the current library and clipboard issues.
+    private func currentRows() -> [StatusMenuVMRow] {
+        StatusMenuVMSection.rows(
+            for: viewModel.instances, issues: issueCenter.latestByInstance)
     }
 
     // MARK: - Paste progress
@@ -99,88 +130,50 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
         updateTooltip()
     }
 
+    // MARK: - Clipboard notice
+
+    /// Presents the clipboard refusal the issue center just queued, if the status
+    /// item can carry a popover right now.
+    ///
+    /// A notice that can't be shown is dropped rather than deferred: the
+    /// dropdown's own line is the fallback, and a refusal replayed later would
+    /// interrupt for something the user has moved past.
+    private func pendingClipboardNoticeChanged() {
+        guard let notice = issueCenter.pendingNotice, notice != lastPresentedNotice else { return }
+        lastPresentedNotice = notice
+        issueCenter.consumePendingNotice()
+
+        let content = ClipboardNoticeViewController(notice: notice) { [weak self] in
+            guard let self else { return }
+            self.transientPopover.dismiss()
+            self.onOpenClipboard(notice.instanceID)
+        }
+        guard
+            transientPopover.show(
+                content, for: Self.clipboardNoticeDuration, describedAs: "Clipboard notice")
+        else { return }
+        Self.logger.notice(
+            "Showing a clipboard notice for '\(notice.vmName, privacy: .public)'")
+    }
+
     // MARK: - Soft-quit reminder
 
     /// Shows a transient reminder popover anchored to the status item after a soft
     /// quit — unless the user has silenced it.
-    ///
-    /// Skipped when the status item isn't on screen: macOS hides status items it
-    /// can't fit in a crowded menu bar, and a popover anchored to a hidden button
-    /// would point at nothing.
     func showSoftQuitReminder() {
         guard !preferences.menuBarQuitReminderDismissed else { return }
-        guard let button = statusItem.button, statusItem.isVisible, button.window != nil else {
-            Self.logger.info(
-                "Soft-quit reminder skipped — the status item is not currently on screen")
-            return
-        }
-
-        // Re-arm cleanly if a prior reminder is still up.
-        softQuitReminderDismissTask?.cancel()
-
-        // RATIONALE: detach the dropdown while the reminder popover is anchored.
-        // With `statusItem.menu` assigned, `NSPopover.show(relativeTo:)` against
-        // the status-item button pops the assigned menu open by itself (macOS 26,
-        // observed on every soft quit with the cursor nowhere near the item), and
-        // that open dismisses the reminder via `menuNeedsUpdate` within a frame.
-        // Every dismissal path restores the menu.
-        statusItem.menu = nil
-        button.target = self
-        button.action = #selector(statusItemTappedDuringReminder)
 
         let content = MenuBarQuitReminderViewController(onStopReminding: { [weak self] in
             guard let self else { return }
             self.preferences.menuBarQuitReminderDismissed = true
             Self.logger.info("Soft-quit menu-bar reminder silenced by the user")
-            self.dismissSoftQuitReminder()
+            self.transientPopover.dismiss()
         })
-        // RATIONALE: `.applicationDefined`, not the default `.transient` — a soft
-        // quit deactivates the app moments after this shows, and a `.transient`
-        // popover auto-closes on app deactivation (see `PopoverPresenter`'s
-        // `onClose` doc), so the reminder would vanish before it could be read.
-        // Lifetime is bounded instead by the auto-dismiss timer below, the
-        // opt-out tap, and a click on the status item.
-        softQuitReminder.show(
-            content: content, from: button, preferredEdge: .minY, behavior: .applicationDefined)
+        guard
+            transientPopover.show(
+                content, for: Self.softQuitReminderDuration, describedAs: "Soft-quit reminder")
+        else { return }
         Self.logger.debug("Showing soft-quit menu-bar reminder")
-
-        softQuitReminderDismissTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(4.5))
-            guard !Task.isCancelled else { return }
-            self?.dismissSoftQuitReminder()
-        }
-    }
-
-    /// Closes the soft-quit reminder, cancels its auto-dismiss timer, and
-    /// reattaches the dropdown the reminder had detached.
-    ///
-    /// Idempotent.
-    private func dismissSoftQuitReminder() {
-        softQuitReminderDismissTask?.cancel()
-        softQuitReminderDismissTask = nil
-        softQuitReminder.close()
-        reattachStatusItemMenu()
-    }
-
-    /// Restores the dropdown after the soft-quit reminder detached it, clearing
-    /// the temporary button action.
-    private func reattachStatusItemMenu() {
-        guard statusItem.menu == nil else { return }
-        statusItem.button?.target = nil
-        statusItem.button?.action = nil
-        statusItem.menu = menu
-    }
-
-    /// Handles a click on the status item while the soft-quit reminder is up and
-    /// the dropdown is therefore detached.
-    @objc private func statusItemTappedDuringReminder() {
-        dismissSoftQuitReminder()
-        // Deferred a tick: the menu is reattached above, but popping it from
-        // inside the button-action callback the same click is still delivering
-        // re-enters menu tracking mid-event.
-        performOnMainRunLoop { [weak self] in
-            self?.statusItem.button?.performClick(nil)
-        }
     }
 
     // MARK: - Icon / tooltip
@@ -232,8 +225,8 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
 
     func menuNeedsUpdate(_ menu: NSMenu) {
         // Opening the dropdown means the user found the icon — the soft-quit
-        // reminder has done its job.
-        dismissSoftQuitReminder()
+        // reminder has done its job, and the notice's line is in the menu below.
+        transientPopover.dismiss()
 
         menu.removeAllItems()
 
@@ -245,7 +238,7 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
 
         menu.addItem(.separator())
 
-        vmSection.rebuild(rows: StatusMenuVMSection.rows(for: viewModel.instances))
+        vmSection.rebuild(rows: currentRows())
 
         menu.addItem(.separator())
 
@@ -268,7 +261,7 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
     /// rebuilt by `menuNeedsUpdate` when it next opens.
     private func syncMenuIfOpen() {
         guard isMenuOpen else { return }
-        vmSection.sync(to: StatusMenuVMSection.rows(for: viewModel.instances))
+        vmSection.sync(to: currentRows())
     }
 
     // MARK: - Actions

--- a/Kernova/App/MenuBarQuitReminderViewController.swift
+++ b/Kernova/App/MenuBarQuitReminderViewController.swift
@@ -21,39 +21,18 @@ final class MenuBarQuitReminderViewController: NSViewController {
     }
 
     override func loadView() {
-        let title = makeCalloutHeadline("Kernova is still running in the menu bar.")
-        let body = makeCalloutBody(
-            "Your virtual machines keep running. Quit Kernova fully from this menu-bar icon.")
-        let stopReminding = makeLinkButton(
-            "Stop Reminding Me", target: self, action: #selector(stopRemindingTapped))
-
-        let stack = NSStackView(views: [title, body, stopReminding])
-        stack.orientation = .vertical
-        stack.alignment = .leading
-        stack.spacing = CalloutStyle.verticalSpacing
-        stack.translatesAutoresizingMaskIntoConstraints = false
-
-        let container = NSView()
-        container.addSubview(stack)
-        let padding = CalloutStyle.padding
-        NSLayoutConstraint.activate([
-            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: padding),
-            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: padding),
-            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -padding),
-            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -padding),
-            container.widthAnchor.constraint(equalToConstant: CalloutStyle.width),
+        installCalloutStack(rows: [
+            makeCalloutHeadline("Kernova is still running in the menu bar."),
+            makeCalloutBody(
+                "Your virtual machines keep running. Quit Kernova fully from this menu-bar icon."),
+            makeLinkButton(
+                "Stop Reminding Me", target: self, action: #selector(stopRemindingTapped)),
         ])
-        view = container
     }
 
     override func viewDidLayout() {
         super.viewDidLayout()
-        // Re-pin so `NSPopover` resizes its frame to the measured stack height
-        // under the configured width.
-        let fittingSize = view.fittingSize
-        if preferredContentSize != fittingSize {
-            preferredContentSize = fittingSize
-        }
+        syncCalloutContentSize()
     }
 
     @objc private func stopRemindingTapped() {

--- a/Kernova/App/StatusMenuVMSection.swift
+++ b/Kernova/App/StatusMenuVMSection.swift
@@ -4,6 +4,15 @@ import AppKit
 struct StatusMenuVMRow: Equatable {
     let instanceID: UUID
     let title: String
+    /// The clipboard-issue line to show indented under the row, or `nil` when the
+    /// VM has no outstanding issue.
+    let noticeText: String?
+
+    init(instanceID: UUID, title: String, noticeText: String? = nil) {
+        self.instanceID = instanceID
+        self.title = title
+        self.noticeText = noticeText
+    }
 }
 
 /// Owns the VM section of the status-item dropdown: one row per VM keeping the
@@ -22,6 +31,9 @@ final class StatusMenuVMSection {
 
     /// Live row items in display order; each `representedObject` is the VM's id.
     private var rowItems: [NSMenuItem] = []
+    /// The notice line under a row, keyed by VM id — present exactly for the rows
+    /// whose model carries one.
+    private var noticeItems: [UUID: NSMenuItem] = [:]
     /// The disabled placeholder, present exactly when `rowItems` is empty.
     private var placeholderItem: NSMenuItem?
 
@@ -31,11 +43,18 @@ final class StatusMenuVMSection {
         self.rowAction = rowAction
     }
 
-    /// The rows the section should show for `instances`.
-    static func rows(for instances: [VMInstance]) -> [StatusMenuVMRow] {
+    /// The rows the section should show for `instances`, each carrying the
+    /// clipboard issue `issues` holds for it.
+    ///
+    /// Only VMs with rows can carry a notice, so a stopped VM's issue never
+    /// shows.
+    static func rows(
+        for instances: [VMInstance], issues: [UUID: ClipboardIssueCenter.Notice] = [:]
+    ) -> [StatusMenuVMRow] {
         instances.filter(\.isKeepingAppAlive).map {
             StatusMenuVMRow(
-                instanceID: $0.instanceID, title: "\($0.name) — \($0.statusDisplayName)")
+                instanceID: $0.instanceID, title: "\($0.name) — \($0.statusDisplayName)",
+                noticeText: issues[$0.instanceID]?.issue.menuLineText)
         }
     }
 
@@ -43,13 +62,20 @@ final class StatusMenuVMSection {
     /// previously tracked items.
     func rebuild(rows: [StatusMenuVMRow]) {
         placeholderItem = nil
+        noticeItems = [:]
         rowItems = rows.map(makeRowItem)
-        if rowItems.isEmpty {
+        guard !rowItems.isEmpty else {
             let placeholder = Self.makePlaceholderItem()
             menu.addItem(placeholder)
             placeholderItem = placeholder
-        } else {
-            for item in rowItems { menu.addItem(item) }
+            return
+        }
+        for (row, item) in zip(rows, rowItems) {
+            menu.addItem(item)
+            guard let noticeText = row.noticeText else { continue }
+            let notice = Self.makeNoticeItem(noticeText)
+            menu.addItem(notice)
+            noticeItems[row.instanceID] = notice
         }
     }
 
@@ -70,31 +96,55 @@ final class StatusMenuVMSection {
                 menu.removeItem(item)
             }
         }
+        for (id, item) in noticeItems where !rows.contains(where: { $0.instanceID == id }) {
+            menu.removeItem(item)
+            noticeItems[id] = nil
+        }
         if let placeholderItem, !rows.isEmpty {
             menu.removeItem(placeholderItem)
             self.placeholderItem = nil
         }
 
-        rowItems = rows.enumerated().map { offset, row in
-            let target = start + offset
-            guard let existing = surviving[row.instanceID] else {
-                let item = makeRowItem(row)
-                menu.insertItem(item, at: target)
-                return item
+        var nextRowItems: [NSMenuItem] = []
+        var target = start
+        for row in rows {
+            let item = surviving[row.instanceID] ?? makeRowItem(row)
+            if item.title != row.title { item.title = row.title }
+            place(item, at: target)
+            target += 1
+            nextRowItems.append(item)
+
+            guard let noticeText = row.noticeText else {
+                if let stale = noticeItems.removeValue(forKey: row.instanceID) {
+                    menu.removeItem(stale)
+                }
+                continue
             }
-            if existing.title != row.title { existing.title = row.title }
-            if menu.index(of: existing) != target {
-                menu.removeItem(existing)
-                menu.insertItem(existing, at: target)
-            }
-            return existing
+            let notice = noticeItems[row.instanceID] ?? Self.makeNoticeItem(noticeText)
+            if notice.title != noticeText { notice.title = noticeText }
+            noticeItems[row.instanceID] = notice
+            place(notice, at: target)
+            target += 1
         }
+        rowItems = nextRowItems
 
         if rowItems.isEmpty, placeholderItem == nil {
             let placeholder = Self.makePlaceholderItem()
             menu.insertItem(placeholder, at: start)
             placeholderItem = placeholder
         }
+    }
+
+    /// Puts `item` at `index`, inserting one the menu doesn't hold yet and moving
+    /// one it holds elsewhere.
+    ///
+    /// Safe to call in ascending `index` order only: everything before `index` is
+    /// already final, so the removal can only shift items the loop hasn't placed.
+    private func place(_ item: NSMenuItem, at index: Int) {
+        let current = menu.index(of: item)
+        guard current != index else { return }
+        if current >= 0 { menu.removeItem(item) }
+        menu.insertItem(item, at: index)
     }
 
     /// The index the section's first item occupies, or `nil` when none of its
@@ -114,6 +164,12 @@ final class StatusMenuVMSection {
 
     private static func makePlaceholderItem() -> NSMenuItem {
         .statusMenuInfo(title: "No virtual machines running")
+    }
+
+    private static func makeNoticeItem(_ title: String) -> NSMenuItem {
+        let item = NSMenuItem.statusMenuInfo(title: title)
+        item.indentationLevel = 1
+        return item
     }
 }
 

--- a/Kernova/App/TransientStatusItemPopover.swift
+++ b/Kernova/App/TransientStatusItemPopover.swift
@@ -1,0 +1,122 @@
+import AppKit
+import KernovaKit
+import os
+
+/// The menu-bar status item's one transient-popover slot: a callout anchored to
+/// the item's button, up for a bounded stretch unless something dismisses it
+/// first.
+///
+/// The soft-quit reminder and the clipboard notice share the anchor, so they
+/// share the slot — showing either replaces the other. The dropdown is detached
+/// for as long as a popover is up, and reattached on every dismissal path, so a
+/// click on the status item reaches the menu again immediately.
+@MainActor
+final class TransientStatusItemPopover: NSObject {
+    private static let logger = Logger(subsystem: "app.kernova", category: "TransientStatusItemPopover")
+
+    private let statusItem: NSStatusItem
+    /// The dropdown detached while a popover is up.
+    private let menu: NSMenu
+    /// Whether the dropdown is on screen, which `NSMenu` doesn't expose.
+    private let isDropdownOpen: () -> Bool
+
+    private let presenter = PopoverPresenter()
+    /// Auto-dismiss timer for the popover currently up; cancelled when it closes
+    /// earlier or a newer callout takes the slot.
+    private var dismissTask: Task<Void, Never>?
+
+    init(statusItem: NSStatusItem, menu: NSMenu, isDropdownOpen: @escaping () -> Bool) {
+        self.statusItem = statusItem
+        self.menu = menu
+        self.isDropdownOpen = isDropdownOpen
+        super.init()
+        // The backstop for a close this type didn't initiate; a close that a
+        // newer callout has already replaced leaves the detachment in place.
+        presenter.onClose = { [weak self] in
+            guard let self, !self.presenter.isShown else { return }
+            self.reattachMenu()
+        }
+    }
+
+    /// Shows `content` for `duration`, replacing whatever the slot held.
+    ///
+    /// `false` when the status item can't carry a popover — hidden by the app,
+    /// dropped from a crowded menu bar, or with its dropdown already open —
+    /// which the caller logs its own outcome for; `description` names the
+    /// callout in this type's own skip line.
+    @discardableResult
+    func show(_ content: NSViewController, for duration: Duration, describedAs description: String)
+        -> Bool
+    {
+        let visible = statusItem.isVisible
+        let onScreen = statusItem.isButtonOnScreen
+        let dropdownOpen = isDropdownOpen()
+        guard let button = statusItem.button, visible, onScreen, !dropdownOpen else {
+            Self.logger.info(
+                "\(description, privacy: .public) skipped — visible=\(visible, privacy: .public), onScreen=\(onScreen, privacy: .public), menuOpen=\(dropdownOpen, privacy: .public)"
+            )
+            return false
+        }
+
+        // Re-arm cleanly if a prior callout is still up.
+        dismissTask?.cancel()
+
+        // RATIONALE: detach the dropdown while a popover is anchored. With
+        // `statusItem.menu` assigned, `NSPopover.show(relativeTo:)` against the
+        // status-item button pops the assigned menu open by itself (macOS 26,
+        // observed on every soft quit with the cursor nowhere near the item), and
+        // that open dismisses the popover through the controller's
+        // `menuNeedsUpdate` within a frame. Every dismissal path restores it.
+        statusItem.menu = nil
+        button.target = self
+        button.action = #selector(statusItemTapped)
+
+        // RATIONALE: `.applicationDefined`, not the default `.transient` — both
+        // callouts have to outlive the app deactivating, and a `.transient`
+        // popover auto-closes on deactivation (see `PopoverPresenter`'s `onClose`
+        // doc): a soft quit deactivates the app moments after the reminder shows,
+        // and acting on a clipboard refusal means switching to another app to
+        // retry the paste. Lifetime is bounded instead by `duration`, a click on
+        // the status item, and the content's own link.
+        presenter.show(
+            content: content, from: button, preferredEdge: .minY, behavior: .applicationDefined)
+
+        dismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: duration)
+            guard !Task.isCancelled else { return }
+            self?.dismiss()
+        }
+        return true
+    }
+
+    /// Closes whatever the slot holds, cancels its auto-dismiss timer, and
+    /// reattaches the dropdown.
+    ///
+    /// Idempotent.
+    func dismiss() {
+        dismissTask?.cancel()
+        dismissTask = nil
+        presenter.close()
+        reattachMenu()
+    }
+
+    /// Restores the dropdown, clearing the temporary button action.
+    private func reattachMenu() {
+        guard statusItem.menu == nil else { return }
+        statusItem.button?.target = nil
+        statusItem.button?.action = nil
+        statusItem.menu = menu
+    }
+
+    /// Handles a click on the status item while a popover is up and the dropdown
+    /// is therefore detached.
+    @objc private func statusItemTapped() {
+        dismiss()
+        // Deferred a tick: the menu is reattached above, but popping it from
+        // inside the button-action callback the same click is still delivering
+        // re-enters menu tracking mid-event.
+        performOnMainRunLoop { [weak self] in
+            self?.statusItem.button?.performClick(nil)
+        }
+    }
+}

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -858,7 +858,7 @@ final class VMInstance {
             // Read through `self` at each budget check, so a Settings change
             // lands on the live session without restarting the service.
             let service = VsockClipboardService(
-                channel: channel, label: self.name,
+                channel: channel, label: self.name, instanceID: self.instanceID,
                 maxPasteBytes: { [weak self] in
                     self?.effectiveClipboardMaxPasteBytes ?? ClipboardPasteLimit.defaultBytes
                 },

--- a/Kernova/Services/ClipboardIssueCenter.swift
+++ b/Kernova/Services/ClipboardIssueCenter.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Observation
+import os
+
+/// App-level aggregate of every live clipboard service's outstanding transfer
+/// problem.
+///
+/// Clipboard services are per-VM and their window is optional, so a refusal
+/// raised while no window is open has nowhere to render. Each service reports
+/// here instead: ``latestByInstance`` feeds the menu-bar dropdown's per-VM lines,
+/// and ``pendingNotice`` carries the one refusal no open window is already
+/// showing, for a surface that can interrupt.
+@MainActor
+@Observable
+final class ClipboardIssueCenter {
+    /// The process-wide center every clipboard service reports to by default.
+    static let shared = ClipboardIssueCenter()
+
+    private static let logger = Logger(subsystem: "app.kernova", category: "ClipboardIssueCenter")
+
+    /// One VM's outstanding clipboard problem, with everything a surface needs to
+    /// render it without reaching back to the instance.
+    struct Notice: Equatable, Sendable {
+        let instanceID: UUID
+        let vmName: String
+        let issue: ClipboardTransferIssue
+        /// The paste ceiling in force when the issue was raised, so a ceiling
+        /// changed afterwards cannot rewrite the figure this message names.
+        let pasteLimitBytes: Int
+    }
+
+    /// The outstanding problem of each VM that has one.
+    private(set) var latestByInstance: [UUID: Notice] = [:]
+
+    /// The problem awaiting an interrupting surface, or `nil` when none is.
+    ///
+    /// Set only for a VM nobody is watching, and only for an issue whose gesture
+    /// was made on this Mac (`ClipboardTransferIssue.warrantsInterruptingNotice`):
+    /// a clipboard window on screen renders the issue itself, and a second
+    /// surface for the same news would be noise.
+    private(set) var pendingNotice: Notice?
+
+    /// VMs whose clipboard window is on screen and rendering issues itself.
+    @ObservationIgnored
+    private var watchedInstances: Set<UUID> = []
+
+    /// Records `issue` as the VM's outstanding problem, and offers it to the
+    /// interrupting surface unless the VM is being watched or the refusal is the
+    /// guest's own to report.
+    func report(
+        _ issue: ClipboardTransferIssue, instanceID: UUID, vmName: String, pasteLimitBytes: Int
+    ) {
+        let notice = Notice(
+            instanceID: instanceID, vmName: vmName, issue: issue, pasteLimitBytes: pasteLimitBytes)
+        latestByInstance[instanceID] = notice
+        guard issue.warrantsInterruptingNotice else {
+            Self.logger.debug(
+                "Clipboard issue recorded for '\(vmName, privacy: .public)' — the guest reports its own refusal"
+            )
+            return
+        }
+        guard !watchedInstances.contains(instanceID) else {
+            Self.logger.debug(
+                "Clipboard issue recorded for watched VM '\(vmName, privacy: .public)' — its window renders it"
+            )
+            return
+        }
+        pendingNotice = notice
+        Self.logger.notice(
+            "Clipboard issue pending a menu-bar notice for '\(vmName, privacy: .public)': \(issue.menuLineText, privacy: .public)"
+        )
+    }
+
+    /// Drops the VM's outstanding problem, and the pending notice when it was
+    /// that VM's.
+    func clear(instanceID: UUID) {
+        latestByInstance.removeValue(forKey: instanceID)
+        if pendingNotice?.instanceID == instanceID { pendingNotice = nil }
+    }
+
+    /// Takes the pending notice off the queue once a surface has presented it (or
+    /// declined to).
+    func consumePendingNotice() {
+        pendingNotice = nil
+    }
+
+    /// Marks the VM as rendering its own issues, retiring any notice queued for
+    /// it.
+    func beginWatching(instanceID: UUID) {
+        watchedInstances.insert(instanceID)
+        if pendingNotice?.instanceID == instanceID { pendingNotice = nil }
+    }
+
+    /// Marks the VM as no longer rendering its own issues.
+    ///
+    /// Issues raised while it was watched stay consumed — only a problem raised
+    /// after this queues a notice.
+    func endWatching(instanceID: UUID) {
+        watchedInstances.remove(instanceID)
+    }
+}

--- a/Kernova/Services/ClipboardTransferIssue.swift
+++ b/Kernova/Services/ClipboardTransferIssue.swift
@@ -160,3 +160,120 @@ extension ClipboardTransferIssue {
             date: Date())
     }
 }
+
+// MARK: - Display copy
+
+extension ClipboardTransferIssue {
+    /// The full sentence every surface renders for this issue — the clipboard
+    /// window's banner and the status-item notice alike.
+    ///
+    /// `pasteLimitBytes` is the ceiling in force now, which only a peer-reported
+    /// over-cap paste needs: every other message either carries its own figure or
+    /// names none.
+    func displayMessage(pasteLimitBytes: Int) -> String {
+        switch kind {
+        case .diskFull(let needed, let available):
+            let detail =
+                [
+                    needed.map { "\(DataFormatters.formatBytes(UInt64($0))) needed" },
+                    available.map { "\(DataFormatters.formatBytes(UInt64($0))) free" },
+                ]
+                .compactMap { $0 }
+                .joined(separator: ", ")
+            let base = "Not enough disk space to receive the clipboard payload"
+            return detail.isEmpty ? base : "\(base) (\(detail))"
+        case .peerReportedError(let code, _):
+            switch ClipboardErrorCode(rawValue: code) {
+            case .pasteDiskFull:
+                return "The guest ran out of disk space receiving the clipboard file"
+            case .pasteTooLarge:
+                return
+                    "Too large to paste into the guest — over the \(ClipboardPasteLimit.displayLimit(pasteLimitBytes)) clipboard transfer limit"
+            case .pasteTimeout:
+                return "The clipboard transfer to the guest timed out"
+            case .pasteFailed, .copyTooLarge, .pasteIncompleteSet, .forwardItemsSkipped,
+                .folderPeerOutdated, .none:
+                return "Clipboard transfer failed on the guest side"
+            }
+        case .localFailure(_, let message):
+            return message
+        case .staleCopyRetracted(let message):
+            return message
+        }
+    }
+
+    /// The status-item notice's bold first line, naming the VM and which
+    /// direction the clipboard failed to move in.
+    func noticeHeadline(vmName: String) -> String {
+        switch kind {
+        case .diskFull:
+            return "Clipboard not pasted from \(Self.quoted(vmName))."
+        case .peerReportedError:
+            return "Clipboard not pasted into \(Self.quoted(vmName))."
+        case .staleCopyRetracted:
+            return "Clipboard changed in \(Self.quoted(vmName))."
+        case .localFailure(let code, _):
+            switch ClipboardErrorCode(rawValue: code) {
+            case .copyTooLarge:
+                return "Clipboard not copied from \(Self.quoted(vmName))."
+            case .folderPeerOutdated, .forwardItemsSkipped:
+                return "Clipboard not copied to \(Self.quoted(vmName))."
+            case .pasteIncompleteSet, .pasteTimeout, .pasteFailed:
+                return "Clipboard not pasted from \(Self.quoted(vmName))."
+            case .pasteDiskFull, .pasteTooLarge, .none:
+                return "Clipboard issue with \(Self.quoted(vmName))."
+            }
+        }
+    }
+
+    /// Whether a surface may add that the Mac clipboard still holds what it held
+    /// before.
+    ///
+    /// True only for the over-cap copy refusal, the one outcome that refuses the
+    /// publish whole and so leaves the previous contents in place; after any
+    /// other issue the sentence would be a guess.
+    var includesStaleClipboardContext: Bool {
+        guard case .localFailure(let code, _) = kind else { return false }
+        return ClipboardErrorCode(rawValue: code) == .copyTooLarge
+    }
+
+    /// Whether a host surface that interrupts may present this issue.
+    ///
+    /// docs/CLIPBOARD.md §13 — report a refusal on the side that made the
+    /// gesture. Every kind but `.peerReportedError` refuses a gesture made on
+    /// this Mac, or has its consequence here; a `.peerReportedError` refuses the
+    /// guest user's own paste, which the guest agent's own dropdown reveals over
+    /// there, so the host records it for the menu line and interrupts nobody.
+    var warrantsInterruptingNotice: Bool {
+        switch kind {
+        case .diskFull, .localFailure, .staleCopyRetracted: return true
+        case .peerReportedError: return false
+        }
+    }
+
+    /// The compact fragment the status-item dropdown shows under the VM's row —
+    /// no trailing period, since it reads as a menu line rather than prose.
+    var menuLineText: String {
+        switch kind {
+        case .diskFull:
+            return "Clipboard: paste from the guest failed"
+        case .staleCopyRetracted:
+            return "Clipboard: earlier copy was removed"
+        case .peerReportedError(let code, _):
+            return ClipboardErrorCode(rawValue: code) == .pasteTooLarge
+                ? "Clipboard: too large to paste into the guest"
+                : "Clipboard: paste into the guest failed"
+        case .localFailure(let code, _):
+            switch ClipboardErrorCode(rawValue: code) {
+            case .copyTooLarge: return "Clipboard: too large to copy to your Mac"
+            case .pasteTimeout: return "Clipboard: paste from the guest timed out"
+            case .pasteIncompleteSet, .pasteFailed: return "Clipboard: paste from the guest failed"
+            case .folderPeerOutdated: return "Clipboard: folder copy needs a guest agent update"
+            case .forwardItemsSkipped: return "Clipboard: some items weren't forwarded"
+            case .pasteDiskFull, .pasteTooLarge, .none: return "Clipboard: transfer didn't complete"
+            }
+        }
+    }
+
+    private static func quoted(_ name: String) -> String { "\u{201C}\(name)\u{201D}" }
+}

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -68,6 +68,13 @@ final class VsockClipboardService: ClipboardServicing {
     /// shows one progress readout across every live VM.
     private let progressCenter: ClipboardProgressCenter
 
+    /// App-level aggregate this VM's transfer problems feed, so a refusal raised
+    /// with no clipboard window open still reaches a surface.
+    private let issueCenter: ClipboardIssueCenter
+
+    /// The VM this service belongs to, as the issue center keys its notices.
+    private let instanceID: UUID
+
     /// Backstop for a lazy pull the peer never answers while the channel stays
     /// open.
     private let lazyPullTimeout: TimeInterval
@@ -238,7 +245,7 @@ final class VsockClipboardService: ClipboardServicing {
     /// Tests pass `stagingTempRoot` to isolate the staging directory between
     /// parallel runs.
     init(
-        channel: VsockChannel, label: String,
+        channel: VsockChannel, label: String, instanceID: UUID,
         freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
         maxPasteBytes: @escaping @MainActor () -> Int = { ClipboardPasteLimit.defaultBytes },
         peerStreamsDirectories: @escaping @MainActor () -> Bool = { false },
@@ -246,7 +253,8 @@ final class VsockClipboardService: ClipboardServicing {
         progressRevealDelay: TimeInterval = ClipboardProgressTracker.defaultRevealDelay,
         progressIdleLinger: TimeInterval = ClipboardProgressTracker.defaultIdleLinger,
         stagingTempRoot: URL = FileManager.default.temporaryDirectory,
-        progressCenter: ClipboardProgressCenter = .shared
+        progressCenter: ClipboardProgressCenter = .shared,
+        issueCenter: ClipboardIssueCenter = .shared
     ) {
         self.channel = channel
         self.label = label
@@ -254,6 +262,8 @@ final class VsockClipboardService: ClipboardServicing {
         self.peerStreamsDirectories = peerStreamsDirectories
         self.lazyPullTimeout = lazyPullTimeout
         self.progressCenter = progressCenter
+        self.issueCenter = issueCenter
+        self.instanceID = instanceID
         self.staging = ClipboardFileStaging(
             label: "host-\(label)", tempRoot: stagingTempRoot,
             freeSpaceProvider: freeSpaceProvider)
@@ -277,6 +287,11 @@ final class VsockClipboardService: ClipboardServicing {
 
     func start() {
         guard consumeTask == nil else { return }
+        // A fresh connection retires whatever the last one left standing: that
+        // problem described a transfer of a session that is over, and this
+        // service's own `lastTransferIssue` starts empty, so leaving it up would
+        // put the two surfaces in disagreement.
+        clearIssue()
         // Earlier sessions' receive and drop roots may still be serving the
         // pasteboard's current write (a stopped session's materialized reps stay
         // servable, and a dropped file's URL is copied as-is), so they are
@@ -412,6 +427,26 @@ final class VsockClipboardService: ClipboardServicing {
         return token
     }
 
+    // MARK: - Transfer issues
+
+    /// Publishes a user-visible transfer problem to this service's own readout
+    /// and to the app-level center that drives the menu-bar surfaces.
+    ///
+    /// The single write path for `lastTransferIssue`: the clipboard window is
+    /// optional, so an issue that reached only the property would have no surface
+    /// on the passthrough flows that raise most of them.
+    private func raiseIssue(_ issue: ClipboardTransferIssue) {
+        lastTransferIssue = issue
+        issueCenter.report(
+            issue, instanceID: instanceID, vmName: label, pasteLimitBytes: maxPasteBytes())
+    }
+
+    /// Retires the current problem from both surfaces.
+    private func clearIssue() {
+        lastTransferIssue = nil
+        issueCenter.clear(instanceID: instanceID)
+    }
+
     // MARK: - Public API
 
     func clearBuffer() {
@@ -424,7 +459,7 @@ final class VsockClipboardService: ClipboardServicing {
     }
 
     func reportIssue(_ issue: ClipboardTransferIssue) {
-        lastTransferIssue = issue
+        raiseIssue(issue)
     }
 
     func reserveDropDestination() -> URL? {
@@ -541,7 +576,7 @@ final class VsockClipboardService: ClipboardServicing {
             pendingOutbound = (generation: generation, content: content)
             currentOutboundGeneration.set(generation)
             lastGrabbedDigest = clipboardContent.digest
-            lastTransferIssue = nil
+            clearIssue()
             if offerable.droppedFolders > 0 {
                 // Ordered after the clear above, which would otherwise wipe it.
                 noteFoldersSkipped(
@@ -590,7 +625,7 @@ final class VsockClipboardService: ClipboardServicing {
     private func noteFoldersSkipped(_ message: @autoclosure () -> String) {
         guard folderSkippedDigest != clipboardContent.digest else { return }
         folderSkippedDigest = clipboardContent.digest
-        lastTransferIssue = .folderSkippedForOutdatedGuest()
+        raiseIssue(.folderSkippedForOutdatedGuest())
         let text = message()
         Self.logger.notice("\(text, privacy: .public)")
     }
@@ -668,9 +703,10 @@ final class VsockClipboardService: ClipboardServicing {
                 "Guest clipboard error for '\(self.label, privacy: .public)': \(error.code, privacy: .public) — \(error.message, privacy: .public)"
             )
             if error.code.hasPrefix("clipboard.") {
-                lastTransferIssue = ClipboardTransferIssue(
-                    kind: .peerReportedError(code: error.code, message: error.message),
-                    date: Date())
+                raiseIssue(
+                    ClipboardTransferIssue(
+                        kind: .peerReportedError(code: error.code, message: error.message),
+                        date: Date()))
             }
         case .clipboardStreamAbort(let abort):
             // Only a sender-bound abort reaches here; see the routing in `consume`.
@@ -800,7 +836,7 @@ final class VsockClipboardService: ClipboardServicing {
         // silently serves nothing, and tell the user how to get the new copy.
         let retracted = retractStaleHostWrite?() ?? false
         if retracted {
-            lastTransferIssue = .staleCopyRetracted()
+            raiseIssue(.staleCopyRetracted())
             // With the write retracted, no earlier session's staging can be
             // backing a live pasteboard item any more.
             staging.reclaimSiblingRoots()
@@ -850,7 +886,7 @@ final class VsockClipboardService: ClipboardServicing {
         inboundPromise = promise
         previewMaterializationStarted = 0
         // A retraction's issue is the new offer's own explainer — keep it.
-        if !retracted { lastTransferIssue = nil }
+        if !retracted { clearIssue() }
         // Bumped after the promise is live, so the passthrough coordinator's
         // `materializeForCopy` sees it.
         inboundOfferSeq &+= 1
@@ -1028,7 +1064,7 @@ final class VsockClipboardService: ClipboardServicing {
             )
             // The click reports its own outcome, but an automatic passthrough
             // publish has no return path — the issue is the only surface it has.
-            lastTransferIssue = .overCopyBudget(limitBytes: limit)
+            raiseIssue(.overCopyBudget(limitBytes: limit))
         }
 
         var items: [CopyToMacItem] = []
@@ -1104,7 +1140,7 @@ final class VsockClipboardService: ClipboardServicing {
             Self.logger.warning(
                 "Clipboard paste fired for gen=\(generation, privacy: .public) of '\(self.label, privacy: .public)' (conn=\(self.connectionTag, privacy: .public)) after the service stopped with the file set partially materialized — \(ClipboardErrorCode.pasteIncompleteSet.rawValue, privacy: .public); serving nothing"
             )
-            lastTransferIssue = .partialFileSetUnservable()
+            raiseIssue(.partialFileSetUnservable())
         }
         return true
     }
@@ -1122,7 +1158,7 @@ final class VsockClipboardService: ClipboardServicing {
             Self.logger.warning(
                 "Paste refused: \(ClipboardErrorCode.copyTooLarge.rawValue, privacy: .public) — paste-bound reps total \(snapshot.pasteBoundTotal, privacy: .public) bytes, over the \(limit, privacy: .public)-byte cap"
             )
-            lastTransferIssue = .overCopyBudget(limitBytes: limit)
+            raiseIssue(.overCopyBudget(limitBytes: limit))
             return nil
         }
         return snapshot
@@ -1189,8 +1225,8 @@ final class VsockClipboardService: ClipboardServicing {
             Self.logger.warning(
                 "Not enough disk space to receive clipboard rep '\(info.uti, privacy: .public)' (\(info.byteCount, privacy: .public) bytes)"
             )
-            lastTransferIssue = .diskFull(
-                needed: info.byteCount, available: staging.availableCapacity())
+            raiseIssue(
+                .diskFull(needed: info.byteCount, available: staging.availableCapacity()))
             return nil
         }
         // The host is the receiver here, so it sets the direction bit. [H3]
@@ -1234,7 +1270,7 @@ final class VsockClipboardService: ClipboardServicing {
                         Task { @MainActor [weak self] in self?.recordPullDiskFull(info) }
                     } else if info.code == "extract.error" {
                         Task { @MainActor [weak self] in
-                            self?.lastTransferIssue = .pasteFolderUnpackFailed()
+                            self?.raiseIssue(.pasteFolderUnpackFailed())
                         }
                     }
                     pull.resume(nil)
@@ -1289,7 +1325,7 @@ final class VsockClipboardService: ClipboardServicing {
             // inline rep pulls fine).
             switch lastTransferIssue?.kind {
             case .diskFull, .localFailure: break
-            case .peerReportedError, .staleCopyRetracted, .none: lastTransferIssue = nil
+            case .peerReportedError, .staleCopyRetracted, .none: clearIssue()
             }
         }
         return rep
@@ -1298,7 +1334,7 @@ final class VsockClipboardService: ClipboardServicing {
     /// Records a disk-full transfer issue for a pull that aborted mid-stream
     /// because the staging volume filled (the up-front case is set in `pull`).
     private func recordPullDiskFull(_ info: ClipboardStreamAbortInfo) {
-        lastTransferIssue = .diskFull(from: info)
+        raiseIssue(.diskFull(from: info))
     }
 
     // MARK: - Synchronous blocking pull (paste-time provider)
@@ -1385,7 +1421,7 @@ final class VsockClipboardService: ClipboardServicing {
     /// clipboard window renders is the only host-side account of why a paste
     /// produced nothing.
     nonisolated private func recordPasteIssue(_ issue: ClipboardTransferIssue) {
-        onMain { self.lastTransferIssue = issue }
+        onMain { self.raiseIssue(issue) }
     }
 
     /// Synchronously pulls one file rep, blocking the calling thread until the
@@ -1546,7 +1582,7 @@ final class VsockClipboardService: ClipboardServicing {
         // files ride the grace window rather than being swept (docs/CLIPBOARD.md
         // §3), so a paste mid-copy survives.
         if retractStaleHostWrite?() == true {
-            lastTransferIssue = .staleCopyRetracted()
+            raiseIssue(.staleCopyRetracted())
             staging.reclaimSiblingRoots()
             Self.logger.notice(
                 "Retracted the stale host-pasteboard promise for '\(self.label, privacy: .public)' (conn=\(self.connectionTag, privacy: .public)) after the guest released gen=\(release.generation, privacy: .public)"

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -780,11 +780,8 @@ final class VMLibraryViewModel {
             cleanupSetupResumeData(for: instance, permanently: permanently)
             lifecycle.clearActiveOperation(for: instance.id)
             sleepPausedInstanceIDs.remove(instance.id)
-            instances.removeAll { $0.id == instance.id }
+            evict(instance)
             persistOrder()
-            if selectedID == instance.id {
-                selectedID = instances.first?.id
-            }
             if permanently {
                 Self.logger.notice("Permanently deleted VM '\(instance.name, privacy: .public)'")
             } else {
@@ -2240,10 +2237,7 @@ final class VMLibraryViewModel {
                 // Cancel any in-flight setup task before evicting — otherwise it keeps
                 // mutating an orphan instance the view model no longer knows about.
                 instance.setupTask?.cancel()
-                instances.removeAll { $0.id == instance.id }
-                if selectedID == instance.id {
-                    selectedID = instances.first?.id
-                }
+                evict(instance)
                 Self.logger.info("VM '\(instance.name, privacy: .public)' no longer on disk — removed from library")
                 didChange = true
             }
@@ -2306,13 +2300,23 @@ final class VMLibraryViewModel {
 
     /// Removes a phantom instance from the library, clears its preparing state, and trashes its partial bundle.
     private func cleanupPhantomInstance(_ phantom: VMInstance) {
-        instances.removeAll { $0.id == phantom.id }
+        evict(phantom)
         persistOrder()
-        if selectedID == phantom.id {
-            selectedID = instances.first?.id
-        }
         phantom.preparingState = nil
         Self.trashPartialBundle(at: phantom.bundleURL, fileSystem: fileSystem)
+    }
+
+    /// Drops `instance` from the library, moving the selection off it and
+    /// releasing the app-level state keyed on it.
+    ///
+    /// The single removal path: a clipboard problem left in the issue center
+    /// would otherwise keep drawing a menu line for a VM that no longer exists.
+    private func evict(_ instance: VMInstance) {
+        instances.removeAll { $0.id == instance.id }
+        if selectedID == instance.id {
+            selectedID = instances.first?.id
+        }
+        ClipboardIssueCenter.shared.clear(instanceID: instance.instanceID)
     }
 
     // MARK: - Reorder

--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -602,35 +602,7 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
     }
 
     private func message(for issue: ClipboardTransferIssue) -> String {
-        switch issue.kind {
-        case .diskFull(let needed, let available):
-            let detail =
-                [
-                    needed.map { "\(DataFormatters.formatBytes(UInt64($0))) needed" },
-                    available.map { "\(DataFormatters.formatBytes(UInt64($0))) free" },
-                ]
-                .compactMap { $0 }
-                .joined(separator: ", ")
-            let base = "Not enough disk space to receive the clipboard payload"
-            return detail.isEmpty ? base : "\(base) (\(detail))"
-        case .peerReportedError(let code, _):
-            switch ClipboardErrorCode(rawValue: code) {
-            case .pasteDiskFull:
-                return "The guest ran out of disk space receiving the clipboard file"
-            case .pasteTooLarge:
-                return
-                    "Too large to paste into the guest — over the \(ClipboardPasteLimit.displayLimit(instance.effectiveClipboardMaxPasteBytes)) clipboard transfer limit"
-            case .pasteTimeout:
-                return "The clipboard transfer to the guest timed out"
-            case .pasteFailed, .copyTooLarge, .pasteIncompleteSet, .forwardItemsSkipped,
-                .folderPeerOutdated, .none:
-                return "Clipboard transfer failed on the guest side"
-            }
-        case .localFailure(_, let message):
-            return message
-        case .staleCopyRetracted(let message):
-            return message
-        }
+        issue.displayMessage(pasteLimitBytes: instance.effectiveClipboardMaxPasteBytes)
     }
 
     /// The message shown when "Copy to Mac" placed nothing on the pasteboard.

--- a/Kernova/Views/Detail/CalloutStyle.swift
+++ b/Kernova/Views/Detail/CalloutStyle.swift
@@ -57,6 +57,43 @@ func makeCalloutBody(_ text: String, color: NSColor = CalloutStyle.bodyColor) ->
     return label
 }
 
+extension NSViewController {
+    /// Installs `rows` as this controller's view: a padded vertical stack inside
+    /// a container fixed to the callout width.
+    ///
+    /// Pair with ``syncCalloutContentSize()`` so the hosting popover tracks the
+    /// height the rows measure at that width.
+    func installCalloutStack(rows: [NSView]) {
+        let stack = NSStackView(views: rows)
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = CalloutStyle.verticalSpacing
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.addSubview(stack)
+        let padding = CalloutStyle.padding
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: padding),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -padding),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -padding),
+            container.widthAnchor.constraint(equalToConstant: CalloutStyle.width),
+        ])
+        view = container
+    }
+
+    /// Re-pins the content size so `NSPopover` resizes its frame to the measured
+    /// stack height under the configured width.
+    ///
+    /// Call from `viewDidLayout`.
+    func syncCalloutContentSize() {
+        let fittingSize = view.fittingSize
+        guard preferredContentSize != fittingSize else { return }
+        preferredContentSize = fittingSize
+    }
+}
+
 /// Builds a monospaced, selectable `NSTextField` for code snippets (shell
 /// commands, paths, identifiers the user is expected to copy).
 @MainActor

--- a/KernovaKit/Sources/KernovaKit/ClipboardProgressStatusItemPresenter.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardProgressStatusItemPresenter.swift
@@ -106,7 +106,7 @@ public final class ClipboardProgressStatusItemPresenter {
     /// open may already be gone.
     public func revealDropdown(while stillStaged: @escaping @MainActor () -> Bool) {
         let visible = statusItem.isVisible
-        let onScreen = isButtonOnScreen
+        let onScreen = statusItem.isButtonOnScreen
         guard
             Self.allowsAutomaticOpen(
                 isVisible: visible, isOnScreen: onScreen, menuIsOpen: menuIsOpen)
@@ -145,22 +145,10 @@ public final class ClipboardProgressStatusItemPresenter {
         }
     }
 
-    /// Whether the item's button is on a screen right now.
-    ///
-    /// The button's window outlives macOS dropping the item from a crowded menu
-    /// bar and a full-screen window covering the menu bar, so its existence
-    /// proves nothing: only a visible window landing on a display does. Paired
-    /// with `NSStatusItem.isVisible`, which reports the app's own preference
-    /// rather than anything about the screen.
-    private var isButtonOnScreen: Bool {
-        guard let window = statusItem.button?.window, window.isVisible else { return false }
-        return NSScreen.screens.contains { $0.frame.intersects(window.frame) }
-    }
-
     /// Runs the auto-opener's decision for the current readout.
     private func applyAutoOpen(_ readout: ClipboardProgressSnapshot?) {
         let visible = statusItem.isVisible
-        let onScreen = isButtonOnScreen
+        let onScreen = statusItem.isButtonOnScreen
         let canOpen = visible && onScreen
         let action = autoOpener.readoutChanged(readout, menuIsOpen: menuIsOpen, canOpen: canOpen)
         log(action, readout: readout, visible: visible, onScreen: onScreen)

--- a/KernovaKit/Sources/KernovaKit/NSStatusItem+OnScreen.swift
+++ b/KernovaKit/Sources/KernovaKit/NSStatusItem+OnScreen.swift
@@ -1,0 +1,15 @@
+import AppKit
+
+extension NSStatusItem {
+    /// Whether the item's button is on a screen right now.
+    ///
+    /// The button's window outlives macOS dropping the item from a crowded menu
+    /// bar and a full-screen window covering the menu bar, so its existence
+    /// proves nothing: only a visible window landing on a display does. Paired
+    /// with ``isVisible``, which reports the app's own preference rather than
+    /// anything about the screen.
+    public var isButtonOnScreen: Bool {
+        guard let window = button?.window, window.isVisible else { return false }
+        return NSScreen.screens.contains { $0.frame.intersects(window.frame) }
+    }
+}

--- a/KernovaMacOSAgent/AgentMenuText.swift
+++ b/KernovaMacOSAgent/AgentMenuText.swift
@@ -33,6 +33,10 @@ enum AgentMenuText {
         case .receivedFromHost: return "Clipboard: received from host"
         case .pasteRefused(let code, let pasteLimitBytes):
             return "Clipboard: \(pasteRefusalDetail(code, pasteLimitBytes: pasteLimitBytes))"
+        case .copyShortened(let offeringAnything):
+            return offeringAnything
+                ? "Clipboard: shared without folders — Kernova on the Mac needs updating"
+                : "Clipboard: folders not shared — Kernova on the Mac needs updating"
         case .disabled: return "Clipboard: disabled"
         }
     }

--- a/KernovaMacOSAgent/AgentStatusItemController.swift
+++ b/KernovaMacOSAgent/AgentStatusItemController.swift
@@ -71,17 +71,16 @@ final class AgentStatusItemController: NSObject, NSMenuDelegate {
 
     // MARK: - Clipboard notice
 
-    /// Opens the dropdown on the clipboard refusal the agent just recorded.
+    /// Opens the dropdown on the clipboard notice the agent just recorded.
     ///
-    /// The refusal ends a gesture the user made in this guest and produces no
-    /// other signal — the paste simply yields nothing — so the line is revealed
-    /// rather than left for whenever the menu is next opened. The agent records
-    /// the activity before raising this, so `menuNeedsUpdate` builds the refusal
-    /// line into the dropdown this opens.
+    /// The notice ends a gesture the user made in this guest and produces no
+    /// other signal — the paste simply yields nothing, the copy simply crosses
+    /// short — so the line is revealed rather than left for whenever the menu is
+    /// next opened. The agent records the activity before raising this, so
+    /// `menuNeedsUpdate` builds the line into the dropdown this opens.
     func clipboardNoticeRaised() {
         pasteProgressPresenter.revealDropdown(while: { [weak self] in
-            guard let self, case .pasteRefused = self.clipboardActivity() else { return false }
-            return true
+            self?.clipboardActivity().isNotice ?? false
         })
     }
 
@@ -131,9 +130,9 @@ final class AgentStatusItemController: NSObject, NSMenuDelegate {
         }
 
         let activity = clipboardActivity()
-        // A refusal is what the auto-open is revealing, so it reads at the top
+        // A notice is what the auto-open is revealing, so it reads at the top
         // level; every other activity is state the Status submenu holds.
-        if case .pasteRefused = activity {
+        if activity.isNotice {
             addInfoItem(AgentMenuText.clipboardLine(activity))
             menu.addItem(.separator())
         }

--- a/KernovaMacOSAgent/AgentUIState.swift
+++ b/KernovaMacOSAgent/AgentUIState.swift
@@ -14,8 +14,8 @@ enum HostConnectionState: Equatable, Sendable {
 
 /// Clipboard sharing state for display in the menu.
 ///
-/// `enabled` / `disabled` are the host-policy feature state; the other five
-/// record the most recent flow event, each set at the moment it starts rather
+/// `enabled` / `disabled` are the host-policy feature state; every other case
+/// records the most recent flow event, each set at the moment it starts rather
 /// than on completion. A flow event overwrites `enabled`; only host policy sets
 /// `disabled`.
 enum ClipboardActivity: Equatable, Sendable {
@@ -43,6 +43,25 @@ enum ClipboardActivity: Equatable, Sendable {
     /// open, so a ceiling raised after the refusal would otherwise rewrite the
     /// figure a past refusal names. `nil` for reasons no ceiling explains.
     case pasteRefused(ClipboardErrorCode, pasteLimitBytes: Int?)
+    /// Copied folders were left out of what the host was offered, because it
+    /// cannot receive one; `offeringAnything` is whether the rest still went.
+    ///
+    /// The copy was made in this guest, so the shortfall is reported here.
+    case copyShortened(offeringAnything: Bool)
     /// Host policy turned clipboard sharing off.
     case disabled
+
+    /// Whether the menu-bar surface reveals this activity by itself rather than
+    /// leaving it for the next time the user opens the dropdown.
+    ///
+    /// True for the outcomes of a gesture made in this guest that produces no
+    /// other signal — a paste that yields nothing, a copy that crosses short.
+    var isNotice: Bool {
+        switch self {
+        case .pasteRefused, .copyShortened:
+            return true
+        case .enabled, .offeredToHost, .offeredFromHost, .sentToHost, .receivedFromHost, .disabled:
+            return false
+        }
+    }
 }

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -623,6 +623,15 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                 "Offering nothing — all \(count, privacy: .public) copied item(s) are folders and the host lacks \(KernovaCapability.clipboardStreamDirectoryV1, privacy: .public)"
             )
         }
+        // Deferred a turn so the shortfall outlives the offer this same snapshot
+        // still sends, which records `.offeredToHost` synchronously after this
+        // returns. The activity is written before the notice, so the dropdown it
+        // pops is rebuilt with the line already in it.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.clipboardActivityStorage = .copyShortened(offeringAnything: offeringAnything)
+            self.onClipboardNotice()
+        }
     }
 
     /// Announces `content` to the host when it's non-empty and not an echo of

--- a/KernovaMacOSAgentTests/AgentMenuTextTests.swift
+++ b/KernovaMacOSAgentTests/AgentMenuTextTests.swift
@@ -96,6 +96,30 @@ struct AgentMenuTextTests {
                 == "Clipboard: too large to paste")
     }
 
+    @Test("a copy that crossed short names what was left out and what fixes it")
+    func clipboardCopyShortenedLines() {
+        #expect(
+            AgentMenuText.clipboardLine(.copyShortened(offeringAnything: true))
+                == "Clipboard: shared without folders — Kernova on the Mac needs updating")
+        #expect(
+            AgentMenuText.clipboardLine(.copyShortened(offeringAnything: false))
+                == "Clipboard: folders not shared — Kernova on the Mac needs updating")
+    }
+
+    // MARK: - isNotice
+
+    @Test("Only the outcomes of a gesture made in this guest reveal themselves")
+    func noticeActivities() {
+        #expect(ClipboardActivity.pasteRefused(.pasteFailed, pasteLimitBytes: nil).isNotice)
+        #expect(ClipboardActivity.copyShortened(offeringAnything: true).isNotice)
+        #expect(ClipboardActivity.copyShortened(offeringAnything: false).isNotice)
+        for activity: ClipboardActivity in [
+            .enabled, .offeredToHost, .offeredFromHost, .sentToHost, .receivedFromHost, .disabled,
+        ] {
+            #expect(!activity.isNotice, "\(activity) must not open the dropdown by itself")
+        }
+    }
+
     // MARK: - logForwardingLine / statusSubmenu
 
     @Test("logForwardingLine reflects the enabled flag")

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -792,7 +792,9 @@ struct VsockGuestClipboardAgentTests {
         defer { hostChannel.close() }
 
         let capable = Box(false)
-        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        let notices = AtomicInt()
+        let agent = makeAgent(
+            pasteboard: pasteboard, agentFd: agentFd, onClipboardNotice: { notices.increment() })
         agent.hostStreamsDirectories = { capable.value }
         defer { agent.stop() }
         try await startAgentAndWaitForLiveChannel(agent: agent)
@@ -811,15 +813,64 @@ struct VsockGuestClipboardAgentTests {
         #expect(offer.repInfo.map(\.filename) == ["note.txt"])
         #expect(offer.repInfo.allSatisfy { !$0.isDirectory })
 
+        // The copy was made in this guest, so its own menu says what was left
+        // out — and outranks the `.offeredToHost` the shortened offer records,
+        // which would otherwise read as a copy that fully crossed.
+        try await notices.changed.wait { notices.value == 1 }
+        #expect(
+            await MainActor.run { agent.clipboardActivity }
+                == .copyShortened(offeringAnything: true))
+
+        // A re-check of the same snapshot is not a second copy, so it is not
+        // owed a second interruption.
+        await MainActor.run { agent.checkClipboardChange() }
+        pasteboard.setItems([[(type: .string, data: Data("plain".utf8))]])
+        await MainActor.run { agent.checkClipboardChange() }
+        let plain = try await awaitOffer(on: hostChannel)
+        #expect(plain.repInfo.map(\.uti) == [ClipboardContent.utf8TextUTI])
+        #expect(notices.value == 1)
+
         // Both dedup keys describe what was offered — the change count and the
         // offered content's digest — so neither notices the host catching up.
         // The dropped folder has to be re-offered once it can be received.
+        pasteboard.setItems([
+            [(type: .fileURL, data: Data(folder.absoluteString.utf8))],
+            [(type: .fileURL, data: Data(file.absoluteString.utf8))],
+        ])
         capable.value = true
         await MainActor.run { agent.checkClipboardChange() }
         let second = try await awaitOffer(on: hostChannel)
         #expect(second.repInfo.map(\.filename) == ["Project", "note.txt"])
         #expect(second.repInfo.map(\.isDirectory) == [true, false])
         #expect(second.generation > offer.generation)
+    }
+
+    @Test("outbound: a folder-only copy tells the guest's own menu nothing crossed")
+    func outboundFolderOnlyCopyRaisesTheGuestNotice() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let notices = AtomicInt()
+        let agent = makeAgent(
+            pasteboard: pasteboard, agentFd: agentFd, hostStreamsDirectories: false,
+            onClipboardNotice: { notices.increment() })
+        defer { agent.stop() }
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        let folder = try writeTempFolder(name: "Project", files: [("f.txt", Data("x".utf8))])
+        defer { try? FileManager.default.removeItem(at: folder.deletingLastPathComponent()) }
+        pasteboard.setItems([[(type: .fileURL, data: Data(folder.absoluteString.utf8))]])
+        await MainActor.run { agent.checkClipboardChange() }
+
+        // Nothing goes to the host, so the guest's menu is the only account of a
+        // copy that produced no offer at all.
+        try await notices.changed.wait { notices.value == 1 }
+        #expect(
+            await MainActor.run { agent.clipboardActivity }
+                == .copyShortened(offeringAnything: false))
     }
 
     /// Requests representation `repIndex` of `offer` and collects its stream.

--- a/KernovaTests/ClipboardIssueCenterTests.swift
+++ b/KernovaTests/ClipboardIssueCenterTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import KernovaKit
+import Testing
+
+@testable import Kernova
+
+/// Unit tests for `ClipboardIssueCenter` — the app-level aggregate that lets a
+/// clipboard refusal reach a surface when no clipboard window is open.
+///
+/// The interesting behavior is the split between the per-VM record the dropdown
+/// renders and the one-shot notice the popover presents, and that a watched VM's
+/// window suppresses the second without losing the first.
+@Suite("Clipboard Issue Center Tests")
+@MainActor
+struct ClipboardIssueCenterTests {
+    private let vmID = UUID()
+
+    private func report(
+        _ issue: ClipboardTransferIssue, to center: ClipboardIssueCenter, id: UUID? = nil,
+        vmName: String = "Build VM"
+    ) {
+        center.report(
+            issue, instanceID: id ?? vmID, vmName: vmName,
+            pasteLimitBytes: ClipboardPasteLimit.defaultBytes)
+    }
+
+    @Test("A fresh center holds nothing")
+    func emptyCenter() {
+        let center = ClipboardIssueCenter()
+        #expect(center.latestByInstance.isEmpty)
+        #expect(center.pendingNotice == nil)
+    }
+
+    @Test("An unwatched VM's issue is both recorded and queued for the notice")
+    func reportRecordsAndQueues() {
+        let center = ClipboardIssueCenter()
+        let issue = ClipboardTransferIssue.overCopyBudget(limitBytes: ClipboardPasteLimit.defaultBytes)
+
+        report(issue, to: center)
+
+        #expect(center.latestByInstance[vmID]?.issue == issue)
+        #expect(center.latestByInstance[vmID]?.vmName == "Build VM")
+        #expect(center.latestByInstance[vmID]?.pasteLimitBytes == ClipboardPasteLimit.defaultBytes)
+        #expect(center.pendingNotice == center.latestByInstance[vmID])
+    }
+
+    @Test("A watched VM's issue is recorded but never queued — its window shows it")
+    func watchedVMSuppressesTheNotice() {
+        let center = ClipboardIssueCenter()
+        center.beginWatching(instanceID: vmID)
+
+        report(.pasteTimedOut(), to: center)
+
+        #expect(center.latestByInstance[vmID]?.issue.kind == ClipboardTransferIssue.pasteTimedOut().kind)
+        #expect(center.pendingNotice == nil)
+    }
+
+    @Test("A guest-side refusal is recorded but never interrupts here")
+    func peerReportedErrorIsRecordedWithoutQueueing() {
+        let center = ClipboardIssueCenter()
+        let peerIssue = ClipboardTransferIssue(
+            kind: .peerReportedError(
+                code: ClipboardErrorCode.pasteTooLarge.rawValue, message: "wire text"),
+            date: Date())
+
+        report(peerIssue, to: center)
+
+        // The dropdown still explains why the guest's clipboard is short —
+        // only the popover, which interrupts the wrong user, stands down.
+        #expect(center.latestByInstance[vmID]?.issue == peerIssue)
+        #expect(center.pendingNotice == nil)
+    }
+
+    @Test("A host-side refusal after a guest-side one still queues")
+    func hostSideIssueQueuesAfterAPeerReportedOne() {
+        let center = ClipboardIssueCenter()
+        report(
+            ClipboardTransferIssue(
+                kind: .peerReportedError(
+                    code: ClipboardErrorCode.pasteFailed.rawValue, message: "wire text"),
+                date: Date()), to: center)
+
+        report(.pasteTimedOut(), to: center)
+
+        #expect(center.pendingNotice?.issue.kind == ClipboardTransferIssue.pasteTimedOut().kind)
+    }
+
+    @Test("Opening the window retires a notice already queued for that VM")
+    func beginWatchingDropsThePendingNotice() {
+        let center = ClipboardIssueCenter()
+        report(.pasteTimedOut(), to: center)
+        #expect(center.pendingNotice != nil)
+
+        center.beginWatching(instanceID: vmID)
+
+        #expect(center.pendingNotice == nil)
+        // The dropdown line survives the window taking over the interruption.
+        #expect(center.latestByInstance[vmID] != nil)
+    }
+
+    @Test("Another VM's notice survives one VM starting to be watched")
+    func beginWatchingLeavesOtherVMsAlone() {
+        let center = ClipboardIssueCenter()
+        let other = UUID()
+        report(.pasteTimedOut(), to: center, id: other, vmName: "CI VM")
+
+        center.beginWatching(instanceID: vmID)
+
+        #expect(center.pendingNotice?.instanceID == other)
+    }
+
+    @Test("Closing the window replays nothing — only a later issue queues again")
+    func endWatchingRestoresNothing() {
+        let center = ClipboardIssueCenter()
+        center.beginWatching(instanceID: vmID)
+        report(.pasteTimedOut(), to: center)
+
+        center.endWatching(instanceID: vmID)
+
+        #expect(center.pendingNotice == nil)
+
+        report(.partialFileSetUnservable(), to: center)
+        #expect(
+            center.pendingNotice?.issue.kind
+                == ClipboardTransferIssue.partialFileSetUnservable().kind)
+    }
+
+    @Test("A newer issue supersedes the one the VM was carrying")
+    func newerReportSupersedes() {
+        let center = ClipboardIssueCenter()
+        report(.pasteTimedOut(), to: center)
+
+        report(.staleCopyRetracted(), to: center)
+
+        #expect(center.latestByInstance.count == 1)
+        #expect(
+            center.latestByInstance[vmID]?.issue.kind
+                == ClipboardTransferIssue.staleCopyRetracted().kind)
+        #expect(center.pendingNotice?.issue.kind == ClipboardTransferIssue.staleCopyRetracted().kind)
+    }
+
+    @Test("Consuming the pending notice leaves the dropdown's record standing")
+    func consumeKeepsTheRecord() {
+        let center = ClipboardIssueCenter()
+        report(.pasteTimedOut(), to: center)
+
+        center.consumePendingNotice()
+
+        #expect(center.pendingNotice == nil)
+        #expect(center.latestByInstance[vmID] != nil)
+    }
+
+    @Test("Clearing a VM removes both its record and its queued notice")
+    func clearRemovesBoth() {
+        let center = ClipboardIssueCenter()
+        report(.pasteTimedOut(), to: center)
+
+        center.clear(instanceID: vmID)
+
+        #expect(center.latestByInstance.isEmpty)
+        #expect(center.pendingNotice == nil)
+    }
+
+    @Test("Clearing one VM leaves another VM's queued notice alone")
+    func clearLeavesOtherVMsAlone() {
+        let center = ClipboardIssueCenter()
+        let other = UUID()
+        report(.pasteTimedOut(), to: center, id: other, vmName: "CI VM")
+
+        center.clear(instanceID: vmID)
+
+        #expect(center.pendingNotice?.instanceID == other)
+        #expect(center.latestByInstance[other] != nil)
+    }
+}

--- a/KernovaTests/ClipboardTransferIssueTests.swift
+++ b/KernovaTests/ClipboardTransferIssueTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import KernovaKit
+import Testing
+
+@testable import Kernova
+
+/// Unit tests for the display copy on `ClipboardTransferIssue`.
+///
+/// One source of wording for the clipboard window's banner, the status-item
+/// notice popover, and the dropdown's per-VM line.
+@Suite("Clipboard Transfer Issue Copy Tests")
+struct ClipboardTransferIssueTests {
+    private let limit = ClipboardPasteLimit.defaultBytes
+
+    private func peerError(_ code: ClipboardErrorCode) -> ClipboardTransferIssue {
+        ClipboardTransferIssue(
+            kind: .peerReportedError(code: code.rawValue, message: "wire text"), date: Date())
+    }
+
+    // MARK: - displayMessage
+
+    @Test("A guest-reported failure reads as its own explanation, not the wire text")
+    func peerReportedMessages() {
+        let expected: [(ClipboardErrorCode, String)] = [
+            (
+                .pasteTooLarge,
+                "Too large to paste into the guest — over the \(ClipboardPasteLimit.displayLimit(limit)) clipboard transfer limit"
+            ),
+            (.pasteDiskFull, "The guest ran out of disk space receiving the clipboard file"),
+            (.pasteTimeout, "The clipboard transfer to the guest timed out"),
+            (.pasteFailed, "Clipboard transfer failed on the guest side"),
+        ]
+        for (code, message) in expected {
+            #expect(peerError(code).displayMessage(pasteLimitBytes: limit) == message)
+        }
+    }
+
+    @Test("An over-cap guest paste names the ceiling passed in, not the default")
+    func peerReportedTooLargeNamesTheGivenCeiling() {
+        let lowered = 512 * 1024 * 1024
+        #expect(
+            peerError(.pasteTooLarge).displayMessage(pasteLimitBytes: lowered)
+                == "Too large to paste into the guest — over the \(ClipboardPasteLimit.displayLimit(lowered)) clipboard transfer limit"
+        )
+    }
+
+    @Test("A disk-full notice appends whichever figures the abort knew")
+    func diskFullDetail() {
+        #expect(
+            ClipboardTransferIssue(kind: .diskFull(needed: nil, available: nil), date: Date())
+                .displayMessage(pasteLimitBytes: limit)
+                == "Not enough disk space to receive the clipboard payload")
+        let sized = ClipboardTransferIssue(
+            kind: .diskFull(needed: 4096, available: 1024), date: Date())
+        #expect(
+            sized.displayMessage(pasteLimitBytes: limit)
+                == "Not enough disk space to receive the clipboard payload (\(DataFormatters.formatBytes(4096)) needed, \(DataFormatters.formatBytes(1024)) free)"
+        )
+    }
+
+    @Test("An outcome produced on this side shows the message it already carries")
+    func localAndRetractedCarryTheirOwnMessage() {
+        #expect(
+            ClipboardTransferIssue.overCopyBudget(limitBytes: limit)
+                .displayMessage(pasteLimitBytes: limit)
+                == ClipboardTransferIssue.overCopyBudgetMessage(limitBytes: limit))
+        let retracted = ClipboardTransferIssue.staleCopyRetracted()
+        guard case .staleCopyRetracted(let message) = retracted.kind else {
+            Issue.record("Expected a staleCopyRetracted issue, got \(retracted.kind)")
+            return
+        }
+        #expect(retracted.displayMessage(pasteLimitBytes: limit) == message)
+    }
+
+    // MARK: - noticeHeadline
+
+    @Test("The headline names the VM and the direction the clipboard didn't move")
+    func headlinesByKind() {
+        let vm = "Build VM"
+        #expect(
+            ClipboardTransferIssue.overCopyBudget(limitBytes: limit).noticeHeadline(vmName: vm)
+                == "Clipboard not copied from \u{201C}Build VM\u{201D}.")
+        #expect(
+            ClipboardTransferIssue.folderSkippedForOutdatedGuest().noticeHeadline(vmName: vm)
+                == "Clipboard not copied to \u{201C}Build VM\u{201D}.")
+        #expect(
+            ClipboardTransferIssue.forwardSkippedItems(note: "skipped").noticeHeadline(vmName: vm)
+                == "Clipboard not copied to \u{201C}Build VM\u{201D}.")
+        for issue in [
+            ClipboardTransferIssue.partialFileSetUnservable(),
+            .pasteTimedOut(),
+            .pasteTransferFailed(),
+            .pasteFolderUnpackFailed(),
+            .pasteFileStagingFailed(),
+            ClipboardTransferIssue(kind: .diskFull(needed: 1, available: 0), date: Date()),
+        ] {
+            #expect(
+                issue.noticeHeadline(vmName: vm) == "Clipboard not pasted from \u{201C}Build VM\u{201D}.")
+        }
+        #expect(
+            peerError(.pasteFailed).noticeHeadline(vmName: vm)
+                == "Clipboard not pasted into \u{201C}Build VM\u{201D}.")
+        #expect(
+            ClipboardTransferIssue.staleCopyRetracted().noticeHeadline(vmName: vm)
+                == "Clipboard changed in \u{201C}Build VM\u{201D}.")
+    }
+
+    @Test("A local failure carrying an unrecognized code falls back to a neutral headline")
+    func unknownLocalCodeHeadline() {
+        let issue = ClipboardTransferIssue(
+            kind: .localFailure(code: "clipboard.unheard.of", message: "…"), date: Date())
+        #expect(issue.noticeHeadline(vmName: "VM") == "Clipboard issue with \u{201C}VM\u{201D}.")
+    }
+
+    // MARK: - includesStaleClipboardContext
+
+    @Test("Only the over-cap copy refusal may say the Mac clipboard is unchanged")
+    func staleContextIsCopyRefusalOnly() {
+        #expect(
+            ClipboardTransferIssue.overCopyBudget(limitBytes: limit).includesStaleClipboardContext)
+        for issue in [
+            ClipboardTransferIssue.partialFileSetUnservable(),
+            .pasteTimedOut(),
+            .pasteTransferFailed(),
+            .folderSkippedForOutdatedGuest(),
+            .forwardSkippedItems(note: "skipped"),
+            .staleCopyRetracted(),
+            ClipboardTransferIssue(kind: .diskFull(needed: 1, available: 0), date: Date()),
+            peerError(.pasteTooLarge),
+        ] {
+            #expect(!issue.includesStaleClipboardContext, "\(issue.kind) must not claim it")
+        }
+    }
+
+    // MARK: - warrantsInterruptingNotice
+
+    @Test("Only a refusal of a gesture made on this Mac interrupts on this side")
+    func interruptingNoticeIsHostSideOnly() {
+        for issue in [
+            ClipboardTransferIssue.overCopyBudget(limitBytes: limit),
+            .partialFileSetUnservable(),
+            .pasteTimedOut(),
+            .pasteTransferFailed(),
+            .folderSkippedForOutdatedGuest(),
+            .forwardSkippedItems(note: "skipped"),
+            .staleCopyRetracted(),
+            ClipboardTransferIssue(kind: .diskFull(needed: 1, available: 0), date: Date()),
+        ] {
+            #expect(issue.warrantsInterruptingNotice, "\(issue.kind) must interrupt here")
+        }
+        for code in [
+            ClipboardErrorCode.pasteTooLarge, .pasteDiskFull, .pasteTimeout, .pasteFailed,
+        ] {
+            #expect(
+                !peerError(code).warrantsInterruptingNotice,
+                "\(code.rawValue) is the guest's own refusal to report")
+        }
+    }
+
+    // MARK: - menuLineText
+
+    @Test("The dropdown line is a compact fragment per outcome")
+    func menuLines() {
+        #expect(
+            ClipboardTransferIssue.overCopyBudget(limitBytes: limit).menuLineText
+                == "Clipboard: too large to copy to your Mac")
+        #expect(
+            ClipboardTransferIssue.pasteTimedOut().menuLineText
+                == "Clipboard: paste from the guest timed out")
+        #expect(
+            ClipboardTransferIssue.pasteTransferFailed().menuLineText
+                == "Clipboard: paste from the guest failed")
+        #expect(
+            ClipboardTransferIssue.partialFileSetUnservable().menuLineText
+                == "Clipboard: paste from the guest failed")
+        #expect(
+            ClipboardTransferIssue(kind: .diskFull(needed: 1, available: 0), date: Date())
+                .menuLineText == "Clipboard: paste from the guest failed")
+        #expect(peerError(.pasteFailed).menuLineText == "Clipboard: paste into the guest failed")
+        #expect(
+            peerError(.pasteTooLarge).menuLineText == "Clipboard: too large to paste into the guest")
+        #expect(
+            ClipboardTransferIssue.staleCopyRetracted().menuLineText
+                == "Clipboard: earlier copy was removed")
+        #expect(
+            ClipboardTransferIssue.folderSkippedForOutdatedGuest().menuLineText
+                == "Clipboard: folder copy needs a guest agent update")
+        #expect(
+            ClipboardTransferIssue.forwardSkippedItems(note: "skipped").menuLineText
+                == "Clipboard: some items weren't forwarded")
+    }
+
+    @Test("No dropdown line ends in a period — they read as menu rows, not prose")
+    func menuLinesAreFragments() {
+        for issue in [
+            ClipboardTransferIssue.overCopyBudget(limitBytes: limit),
+            .pasteTimedOut(),
+            .pasteTransferFailed(),
+            .staleCopyRetracted(),
+            .folderSkippedForOutdatedGuest(),
+            peerError(.pasteFailed),
+        ] {
+            #expect(!issue.menuLineText.hasSuffix("."))
+        }
+    }
+}

--- a/KernovaTests/StatusMenuVMSectionTests.swift
+++ b/KernovaTests/StatusMenuVMSectionTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import KernovaKit
 import Testing
 
 @testable import Kernova
@@ -23,8 +24,14 @@ struct StatusMenuVMSectionTests {
         return VMInstance(configuration: config, bundleURL: bundleURL, status: status)
     }
 
-    private func row(_ id: UUID, _ title: String) -> StatusMenuVMRow {
-        StatusMenuVMRow(instanceID: id, title: title)
+    private func row(_ id: UUID, _ title: String, notice: String? = nil) -> StatusMenuVMRow {
+        StatusMenuVMRow(instanceID: id, title: title, noticeText: notice)
+    }
+
+    private func notice(for id: UUID, _ issue: ClipboardTransferIssue) -> ClipboardIssueCenter.Notice {
+        ClipboardIssueCenter.Notice(
+            instanceID: id, vmName: "VM", issue: issue,
+            pasteLimitBytes: ClipboardPasteLimit.defaultBytes)
     }
 
     /// Builds a menu shaped like the real dropdown — items above and below the
@@ -59,6 +66,29 @@ struct StatusMenuVMSectionTests {
                 StatusMenuVMRow(instanceID: running.instanceID, title: "Build VM — Running"),
                 StatusMenuVMRow(instanceID: starting.instanceID, title: "CI VM — Starting"),
             ])
+    }
+
+    @Test("A VM with an outstanding clipboard issue carries its dropdown line")
+    func rowModelCarriesTheClipboardLine() {
+        let running = makeInstance(name: "Build VM", status: .running)
+        let quiet = makeInstance(name: "CI VM", status: .running)
+        let issue = ClipboardTransferIssue.overCopyBudget(limitBytes: ClipboardPasteLimit.defaultBytes)
+
+        let rows = StatusMenuVMSection.rows(
+            for: [running, quiet], issues: [running.instanceID: notice(for: running.instanceID, issue)])
+
+        #expect(rows.map(\.noticeText) == [issue.menuLineText, nil])
+    }
+
+    @Test("A stopped VM's issue never reaches the dropdown — it has no row to sit under")
+    func rowModelSkipsIssuesOfVMsWithoutRows() {
+        let stopped = makeInstance(name: "Idle VM", status: .stopped)
+        let issue = ClipboardTransferIssue.pasteTimedOut()
+
+        let rows = StatusMenuVMSection.rows(
+            for: [stopped], issues: [stopped.instanceID: notice(for: stopped.instanceID, issue)])
+
+        #expect(rows.isEmpty)
     }
 
     @Test("A preparing phantom's row shows its operation, not raw status")
@@ -103,6 +133,25 @@ struct StatusMenuVMSectionTests {
         #expect(menu.items[3].representedObject as? UUID == second)
         #expect(menu.items[2].target === target)
         #expect(menu.items[2].action == #selector(RowTarget.rowTapped(_:)))
+    }
+
+    @Test("Rebuild puts an indented, disabled notice line under the row it belongs to")
+    func rebuildInsertsNoticeLines() {
+        let first = UUID()
+        let second = UUID()
+        let (menu, _, _) = makeSection(rows: [
+            row(first, "One — Running", notice: "Clipboard: too large to copy to your Mac"),
+            row(second, "Two — Running"),
+        ])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Open Kernova", "", "One — Running", "Clipboard: too large to copy to your Mac",
+                "Two — Running", "", "Quit Kernova",
+            ])
+        #expect(menu.items[3].isEnabled == false)
+        #expect(menu.items[3].indentationLevel == 1)
+        #expect(menu.items[3].representedObject == nil)
     }
 
     // MARK: - Sync
@@ -200,6 +249,98 @@ struct StatusMenuVMSectionTests {
 
         #expect(menu.items[2] === secondItem)
         #expect(menu.items[3] === firstItem)
+    }
+
+    @Test("An issue arriving while the menu is open inserts its line under the row")
+    func syncInsertsNoticeLine() {
+        let id = UUID()
+        let other = UUID()
+        let (menu, section, _) = makeSection(
+            rows: [row(id, "One — Running"), row(other, "Two — Running")])
+        let rowItem = menu.items[2]
+
+        section.sync(to: [
+            row(id, "One — Running", notice: "Clipboard: paste from the guest timed out"),
+            row(other, "Two — Running"),
+        ])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Open Kernova", "", "One — Running", "Clipboard: paste from the guest timed out",
+                "Two — Running", "", "Quit Kernova",
+            ])
+        #expect(menu.items[2] === rowItem)
+        #expect(menu.items[3].indentationLevel == 1)
+    }
+
+    @Test("A cleared issue drops its line without disturbing the rows")
+    func syncRemovesNoticeLine() {
+        let id = UUID()
+        let (menu, section, _) = makeSection(rows: [
+            row(id, "VM — Running", notice: "Clipboard: paste from the guest timed out")
+        ])
+        let rowItem = menu.items[2]
+
+        section.sync(to: [row(id, "VM — Running")])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Open Kernova", "", "VM — Running", "", "Quit Kernova",
+            ])
+        #expect(menu.items[2] === rowItem)
+    }
+
+    @Test("A superseding issue retitles the existing line in place")
+    func syncRetitlesNoticeLine() {
+        let id = UUID()
+        let (menu, section, _) = makeSection(rows: [
+            row(id, "VM — Running", notice: "Clipboard: paste from the guest timed out")
+        ])
+        let noticeItem = menu.items[3]
+
+        section.sync(to: [row(id, "VM — Running", notice: "Clipboard: earlier copy was removed")])
+
+        #expect(menu.items[3] === noticeItem)
+        #expect(noticeItem.title == "Clipboard: earlier copy was removed")
+        #expect(menu.items.count == 6)
+    }
+
+    @Test("A VM stopping takes its notice line with its row")
+    func syncRemovesNoticeLineWithTheRow() {
+        let stopping = UUID()
+        let surviving = UUID()
+        let (menu, section, _) = makeSection(rows: [
+            row(stopping, "One — Running", notice: "Clipboard: earlier copy was removed"),
+            row(surviving, "Two — Running"),
+        ])
+
+        section.sync(to: [row(surviving, "Two — Running")])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Open Kernova", "", "Two — Running", "", "Quit Kernova",
+            ])
+    }
+
+    @Test("Reordering rows carries each notice line under its own row")
+    func syncReordersNoticeLinesWithRows() {
+        let first = UUID()
+        let second = UUID()
+        let (menu, section, _) = makeSection(rows: [
+            row(first, "One — Running", notice: "Clipboard: earlier copy was removed"),
+            row(second, "Two — Running", notice: "Clipboard: some items weren't forwarded"),
+        ])
+
+        section.sync(to: [
+            row(second, "Two — Running", notice: "Clipboard: some items weren't forwarded"),
+            row(first, "One — Running", notice: "Clipboard: earlier copy was removed"),
+        ])
+
+        #expect(
+            menu.items.map(\.title) == [
+                "Open Kernova", "", "Two — Running", "Clipboard: some items weren't forwarded",
+                "One — Running", "Clipboard: earlier copy was removed", "", "Quit Kernova",
+            ])
     }
 
     @Test("Rows stay anchored when items are inserted above the section")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -250,6 +250,24 @@ struct VMLibraryViewModelTests {
         #expect(storage.deleteVMBundleCallCount == 1)
     }
 
+    @Test("deleteConfirmed retires the VM's clipboard issue from the app-level center")
+    func deleteConfirmedClearsClipboardIssue() {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        viewModel.instances.append(instance)
+        storage.bundles[instance.bundleURL] = instance.configuration
+        // The process-wide center is what the production seam clears; the entry
+        // is keyed on this test's own VM id, so no other test can see it.
+        ClipboardIssueCenter.shared.report(
+            .pasteTimedOut(), instanceID: instance.instanceID, vmName: instance.name,
+            pasteLimitBytes: 1024)
+
+        viewModel.deleteConfirmed(instance)
+
+        #expect(ClipboardIssueCenter.shared.latestByInstance[instance.instanceID] == nil)
+        #expect(ClipboardIssueCenter.shared.pendingNotice == nil)
+    }
+
     @Test("deleteConfirmed selects first remaining instance when deleting selected")
     func deleteConfirmedUpdatesSelection() {
         let (viewModel, storage, _, _, _) = makeViewModel()

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -300,7 +300,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -321,7 +321,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -331,6 +331,34 @@ struct VsockClipboardServiceTests {
         #expect(service.isConnected)
     }
 
+    @Test("A new connection retires the issue the last session left standing")
+    func startClearsThePreviousSessionsIssue() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let issues = ClipboardIssueCenter()
+        let vmID = UUID()
+        // What the previous session left on the dropdown before the VM restarted
+        // or the agent reconnected.
+        issues.report(
+            .pasteTimedOut(), instanceID: vmID, vmName: "Build VM",
+            pasteLimitBytes: ClipboardPasteLimit.defaultBytes)
+        #expect(issues.latestByInstance[vmID] != nil)
+
+        let service = VsockClipboardService(
+            channel: host, label: "Build VM", instanceID: vmID, issueCenter: issues)
+        service.start()
+        defer { service.stop() }
+
+        // Both surfaces start empty together — the service's own readout has
+        // nothing to show for a transfer that belonged to a finished session.
+        #expect(service.lastTransferIssue == nil)
+        #expect(issues.latestByInstance[vmID] == nil)
+        #expect(issues.pendingNotice == nil)
+    }
+
     @Test("A control-plane payload on the clipboard channel closes it")
     func wrongPortPayloadClosesChannel() async throws {
         let (guest, host) = try makePair()
@@ -338,7 +366,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -360,7 +388,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -383,7 +411,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -411,7 +439,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -440,7 +468,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -521,7 +549,7 @@ struct VsockClipboardServiceTests {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: stagingRoot) }
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)",
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(),
             peerStreamsDirectories: { true }, stagingTempRoot: stagingRoot)
         service.start()
         defer { service.stop() }
@@ -622,7 +650,7 @@ struct VsockClipboardServiceTests {
         defer { guest.close() }
 
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", peerStreamsDirectories: { true })
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), peerStreamsDirectories: { true })
         service.start()
         defer { service.stop() }
 
@@ -716,7 +744,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -764,7 +792,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -811,7 +839,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -881,7 +909,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -935,7 +963,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1003,7 +1031,7 @@ struct VsockClipboardServiceTests {
         var noSigpipe: Int32 = 1
         _ = setsockopt(hostFd, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size))
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1180,7 +1208,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1221,7 +1249,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1253,7 +1281,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1293,7 +1321,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1331,7 +1359,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1384,7 +1412,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1416,7 +1444,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1456,7 +1484,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1487,7 +1515,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1548,7 +1576,7 @@ struct VsockClipboardServiceTests {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: stagingRoot) }
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", stagingTempRoot: stagingRoot)
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), stagingTempRoot: stagingRoot)
         service.start()
         defer { service.stop() }
 
@@ -1617,9 +1645,11 @@ struct VsockClipboardServiceTests {
         defer { guest.close() }
 
         let capable = Box(false)
+        let issues = ClipboardIssueCenter()
+        let vmID = UUID()
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)",
-            peerStreamsDirectories: { capable.value })
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: vmID,
+            peerStreamsDirectories: { capable.value }, issueCenter: issues)
         service.start()
         defer { service.stop() }
 
@@ -1671,6 +1701,11 @@ struct VsockClipboardServiceTests {
             return
         }
         #expect(offer.repInfo.map(\.filename) == ["OnlyFolder"])
+        // The copy now crossed whole, so the menu-bar surfaces must stop naming
+        // a shortfall that no longer exists.
+        #expect(service.lastTransferIssue == nil)
+        #expect(issues.latestByInstance[vmID] == nil)
+        #expect(issues.pendingNotice == nil)
     }
 
     @Test("a folder is left out of the offer for a guest that can't receive one")
@@ -1681,9 +1716,11 @@ struct VsockClipboardServiceTests {
         defer { guest.close() }
 
         let capable = Box(false)
+        let issues = ClipboardIssueCenter()
+        let vmID = UUID()
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)",
-            peerStreamsDirectories: { capable.value })
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: vmID,
+            peerStreamsDirectories: { capable.value }, issueCenter: issues)
         service.start()
         defer { service.stop() }
 
@@ -1717,6 +1754,10 @@ struct VsockClipboardServiceTests {
         #expect(
             service.lastTransferIssue?.kind
                 == ClipboardTransferIssue.folderSkippedForOutdatedGuest().kind)
+        // The menu-bar surfaces are the ones a passthrough user sees, so the
+        // shortfall has to reach the center too.
+        #expect(issues.latestByInstance[vmID]?.issue == service.lastTransferIssue)
+        #expect(issues.pendingNotice?.instanceID == vmID)
 
         // The surviving rep keeps the index the offer gave it, so the request's
         // low 16 bits still address it.
@@ -1787,7 +1828,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1833,7 +1874,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1904,7 +1945,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -1975,7 +2016,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         // The test calls stop() itself mid-flow (that is the action under test);
         // this defer is an idempotent safety net for the early-throw path.
@@ -2032,7 +2073,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2102,7 +2143,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2158,7 +2199,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2214,7 +2255,7 @@ struct VsockClipboardServiceTests {
         defer { try? FileManager.default.removeItem(at: tempRoot) }
         let label = "vm-\(UUID().uuidString)"
         let service = VsockClipboardService(
-            channel: host, label: label, stagingTempRoot: tempRoot)
+            channel: host, label: label, instanceID: UUID(), stagingTempRoot: tempRoot)
 
         // An earlier session's receive root, still backing the pasteboard's
         // write at start — the retraction below is what frees it.
@@ -2259,7 +2300,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         // Nothing to retract at the offer; the release finds the stale write.
         var retractionResults: [Bool] = [false, true]
         var retractionCalls = 0
@@ -2293,7 +2334,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         var retractionCalls = 0
         service.retractStaleHostWrite = {
             retractionCalls += 1
@@ -2316,7 +2357,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         let pasteboard = NSPasteboard(name: NSPasteboard.Name("KernovaTest-\(UUID().uuidString)"))
         pasteboard.clearContents()
         let publisher = HostClipboardPublisher(
@@ -2369,7 +2410,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         let pasteboard = NSPasteboard(name: NSPasteboard.Name("KernovaTest-\(UUID().uuidString)"))
         pasteboard.clearContents()
         let publisher = HostClipboardPublisher(
@@ -2413,7 +2454,7 @@ struct VsockClipboardServiceTests {
         host1.start()
         defer { guest1.close() }
         let service1 = VsockClipboardService(
-            channel: host1, label: label, stagingTempRoot: tempRoot)
+            channel: host1, label: label, instanceID: UUID(), stagingTempRoot: tempRoot)
         service1.start()
         let fileBytes = Data((0..<(16 * 1024)).map { UInt8(truncatingIfNeeded: $0) })
         let responder = FakeGuestResponder(guest: guest1)
@@ -2439,7 +2480,7 @@ struct VsockClipboardServiceTests {
         host2.start()
         defer { guest2.close() }
         let service2 = VsockClipboardService(
-            channel: host2, label: label, stagingTempRoot: tempRoot)
+            channel: host2, label: label, instanceID: UUID(), stagingTempRoot: tempRoot)
         service2.hostPasteboardHoldsOurWrite = { true }
         service2.start()
         #expect(FileManager.default.fileExists(atPath: stagedURL.path))
@@ -2451,7 +2492,7 @@ struct VsockClipboardServiceTests {
         host3.start()
         defer { guest3.close() }
         let service3 = VsockClipboardService(
-            channel: host3, label: label, stagingTempRoot: tempRoot)
+            channel: host3, label: label, instanceID: UUID(), stagingTempRoot: tempRoot)
         service3.hostPasteboardHoldsOurWrite = { false }
         service3.start()
         defer { service3.stop() }
@@ -2465,7 +2506,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2498,7 +2539,13 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        // Its own center rather than the process-wide `.shared` default: the
+        // menu-bar surfaces render what lands *here*, so the assertions below
+        // cover the service→center hop a closed clipboard window depends on.
+        let issues = ClipboardIssueCenter()
+        let vmID = UUID()
+        let service = VsockClipboardService(
+            channel: host, label: "Build VM", instanceID: vmID, issueCenter: issues)
         service.start()
         defer { service.stop() }
 
@@ -2535,6 +2582,12 @@ struct VsockClipboardServiceTests {
                     code: ClipboardErrorCode.copyTooLarge.rawValue,
                     message: ClipboardTransferIssue.overCopyBudgetMessage(limitBytes: ClipboardPasteLimit.defaultBytes))
         )
+        // ...and reaches the app-level center, which is what surfaces it when no
+        // clipboard window is open to render the issue.
+        #expect(issues.latestByInstance[vmID]?.issue == service.lastTransferIssue)
+        #expect(issues.latestByInstance[vmID]?.vmName == "Build VM")
+        #expect(issues.latestByInstance[vmID]?.pasteLimitBytes == ClipboardPasteLimit.defaultBytes)
+        #expect(issues.pendingNotice == issues.latestByInstance[vmID])
     }
 
     @Test("a lowered ceiling refuses a file set the default would have served")
@@ -2546,7 +2599,7 @@ struct VsockClipboardServiceTests {
 
         let lowered = 512 * 1024 * 1024
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", maxPasteBytes: { lowered })
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), maxPasteBytes: { lowered })
         service.start()
         defer { service.stop() }
 
@@ -2585,7 +2638,7 @@ struct VsockClipboardServiceTests {
 
         let raised = 16 * 1024 * 1024 * 1024
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", maxPasteBytes: { raised })
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), maxPasteBytes: { raised })
         service.start()
         defer { service.stop() }
 
@@ -2617,7 +2670,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2669,7 +2722,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2714,7 +2767,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2747,7 +2800,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2787,7 +2840,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2850,7 +2903,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2883,7 +2936,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2925,7 +2978,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2952,7 +3005,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -2981,7 +3034,8 @@ struct VsockClipboardServiceTests {
         // Reveal instantly so the mid-flight transfer surfaces (the sanctioned
         // "drive the shown path" test value; see VsockClipboardService's doc).
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", progressRevealDelay: 0, progressIdleLinger: 0)
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), progressRevealDelay: 0,
+            progressIdleLinger: 0)
         service.start()
         defer { service.stop() }
 
@@ -3046,7 +3100,7 @@ struct VsockClipboardServiceTests {
         // regression the pull resolves to nothing when this fires, so the
         // test fails either way and the value's size never masks it.
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", lazyPullTimeout: 5)
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), lazyPullTimeout: 5)
         service.start()
         defer { service.stop() }
 
@@ -3145,7 +3199,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -3206,7 +3260,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -3275,7 +3329,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         // The test calls stop() itself mid-flow (that is the action under test);
         // this defer is an idempotent safety net for the early-throw path.
@@ -3338,7 +3392,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -3382,7 +3436,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -3418,7 +3472,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -3448,7 +3502,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -3531,7 +3585,7 @@ struct VsockClipboardServiceTests {
         // A tiny backstop so the parked pull resolves promptly instead of waiting
         // the production 120 s.
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)",
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(),
             lazyPullTimeout: 0.2)
         service.start()
         defer { service.stop() }
@@ -3570,7 +3624,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -3612,7 +3666,7 @@ struct VsockClipboardServiceTests {
         // failure-kind-agnostic — materializeForPreview skips the generation
         // latch on any nil pull result, timeout and abort alike.
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", lazyPullTimeout: 60)
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), lazyPullTimeout: 60)
         service.start()
         defer { service.stop() }
 
@@ -3658,7 +3712,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -3695,7 +3749,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -3756,7 +3810,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -3804,7 +3858,7 @@ struct VsockClipboardServiceTests {
         // A tiny backstop so the parked fire resolves promptly instead of waiting
         // the production window.
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)",
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(),
             lazyPullTimeout: 0.2)
         service.start()
         defer { service.stop() }
@@ -3865,9 +3919,11 @@ struct VsockClipboardServiceTests {
         defer { guest.close() }
 
         // 1 MiB free: the rep plus the free-space margin doesn't fit.
+        let issues = ClipboardIssueCenter()
+        let vmID = UUID()
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)",
-            freeSpaceProvider: { _ in 1024 * 1024 })
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: vmID,
+            freeSpaceProvider: { _ in 1024 * 1024 }, issueCenter: issues)
         service.start()
         defer { service.stop() }
 
@@ -3895,6 +3951,10 @@ struct VsockClipboardServiceTests {
         }
         #expect(needed == 4096)
         #expect(available == 1024 * 1024)
+        // A provider fire has no return path to the gesture, so the center is
+        // what carries the refusal to a surface outside the clipboard window.
+        #expect(issues.latestByInstance[vmID]?.issue == service.lastTransferIssue)
+        #expect(issues.pendingNotice?.instanceID == vmID)
     }
 
     @Test("a copied folder whose archive can't be unpacked reports the unpack failure")
@@ -3908,7 +3968,7 @@ struct VsockClipboardServiceTests {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: stagingRoot) }
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", stagingTempRoot: stagingRoot)
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), stagingTempRoot: stagingRoot)
         service.start()
         defer { service.stop() }
 
@@ -3965,7 +4025,7 @@ struct VsockClipboardServiceTests {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", stagingTempRoot: tempRoot)
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), stagingTempRoot: tempRoot)
         service.start()
         defer { service.stop() }
 
@@ -4001,7 +4061,7 @@ struct VsockClipboardServiceTests {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", stagingTempRoot: tempRoot)
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), stagingTempRoot: tempRoot)
         // A "Copy to Mac" of the dropped file put its own path on the pasteboard.
         service.hostPasteboardHoldsOurWrite = { true }
         service.start()
@@ -4036,7 +4096,7 @@ struct VsockClipboardServiceTests {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", stagingTempRoot: tempRoot)
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), stagingTempRoot: tempRoot)
         service.start()
         defer { service.stop() }
 
@@ -4065,7 +4125,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -4103,7 +4163,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -4132,7 +4192,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -4160,7 +4220,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -4207,7 +4267,7 @@ struct VsockClipboardServiceTests {
         host.start()
         defer { guest.close() }
 
-        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)")
+        let service = VsockClipboardService(channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID())
         service.start()
         defer { service.stop() }
 
@@ -4238,7 +4298,8 @@ struct VsockClipboardServiceTests {
 
         // `.zero` reveal delay → the transfer shows as soon as a chunk lands.
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", progressRevealDelay: 0, progressIdleLinger: 0)
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), progressRevealDelay: 0,
+            progressIdleLinger: 0)
         service.start()
         defer { service.stop() }
 
@@ -4284,7 +4345,7 @@ struct VsockClipboardServiceTests {
         // an idle terminal firing inside it would end the very session under test.
         // Nothing waits on the linger — `stop()` clears the readout at teardown.
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", progressRevealDelay: 0,
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), progressRevealDelay: 0,
             progressIdleLinger: 60)
         service.start()
         defer { service.stop() }
@@ -4375,7 +4436,7 @@ struct VsockClipboardServiceTests {
         // service→center hop the menu bar actually reads.
         let center = ClipboardProgressCenter()
         let service = VsockClipboardService(
-            channel: host, label: label, progressRevealDelay: 0, progressIdleLinger: 0,
+            channel: host, label: label, instanceID: UUID(), progressRevealDelay: 0, progressIdleLinger: 0,
             progressCenter: center)
         service.start()
         defer { service.stop() }
@@ -4444,7 +4505,8 @@ struct VsockClipboardServiceTests {
 
         // A reveal delay long enough that the fast transfer completes first.
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", progressRevealDelay: 3600, progressIdleLinger: 0)
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), progressRevealDelay: 3600,
+            progressIdleLinger: 0)
         service.start()
         defer { service.stop() }
 
@@ -4474,7 +4536,8 @@ struct VsockClipboardServiceTests {
         defer { guest.close() }
 
         let service = VsockClipboardService(
-            channel: host, label: "test-\(UUID().uuidString)", progressRevealDelay: 0, progressIdleLinger: 0)
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(), progressRevealDelay: 0,
+            progressIdleLinger: 0)
         service.start()
 
         let responder = FakeGuestResponder(guest: guest)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,6 +171,11 @@ Clipboard (principles and trade-off rules: [CLIPBOARD.md](CLIPBOARD.md)):
 - `ClipboardProgressCenter` — app-level singleton, not per VM: clipboard services are per-VM but
   the menu-bar status item renders one readout, so each service pushes its snapshot here and the
   center republishes the most significant.
+- `ClipboardIssueCenter` — the same shape for refusals, since a clipboard window is optional:
+  `VsockClipboardService` reports every `lastTransferIssue` write here,
+  `ClipboardWindowController` registers as a watcher for as long as its window is up, and
+  `HostAgentStatusItemController` renders what is left — a popover for the notice no window
+  claimed, and a line under each VM's dropdown row.
 - `AgentStatus` — the enum driving install/update/reinstall affordances, sourced from
   `VsockControlService` (macOS) or `SpiceClipboardService` (Linux) and read through
   `VMInstance.agentStatus`.


### PR DESCRIPTION
## Summary
- With Automatic Clipboard Passthrough on and the clipboard window closed — its normal state — a refused guest copy had no visible surface: the Mac clipboard silently kept its previous contents and the next ⌘V pasted stale data. Refusals now reach the always-present menu-bar status item: a transient notice popover for the refusal nobody is watching (headline naming the VM, the issue's own message, the stale-clipboard context line for the over-cap case, and an Open Clipboard Window link), plus a persistent line under the VM's dropdown row for as long as the issue stands — the surface that survives a fullscreen VM hiding the menu bar.
- The guest half (#717's comment): folders left out of a guest copy because the host predates `clipboard.stream.directory.v1` now record `ClipboardActivity.copyShortened` and auto-reveal the guest agent's dropdown, exactly the `.pasteRefused` pattern.
- Display copy is defined once, on `ClipboardTransferIssue`; the window banner, popover, and menu line all render that source. A new `ClipboardIssueCenter` mirrors `ClipboardProgressCenter`: services report, surfaces observe, and a clipboard window suppresses the popover for its VM only while genuinely on screen (miniaturizing hands back to the status item). Per CLIPBOARD.md §13 the popover interrupts only for host-side kinds — `.peerReportedError` is the guest user's own paste gesture, already auto-revealed in-guest, so it gets the passive menu line only.
- Route: implemented, then three review passes (built-in high review plus standard and adversarial Codex). All eight verified findings are absorbed — chiefly detaching the status-item menu around the popover (the macOS 26 behavior the soft-quit reminder's `RATIONALE:` records would otherwise dismiss the notice within a frame), one shared `TransientStatusItemPopover` lifecycle for both status-item popovers, routing the notice's link through the activation/summon path with a fallback when the clipboard window can't open, issue-center clearing at session start and VM removal, one shared `NSStatusItem.isButtonOnScreen` predicate, and a required `instanceID` on `VsockClipboardService`. The one narrow residual (a superseded service's report suppressed while a window watches) is #781. Rejected alternative: auto-opening the dropdown instead of a popover — §13 reserves self-opening menus for pastes.

## Changes
- Host: new `ClipboardIssueCenter`, `TransientStatusItemPopover`, `ClipboardNoticeViewController`; `ClipboardTransferIssue` owns the display copy + `warrantsInterruptingNotice`; `VsockClipboardService` funnels every issue write through `raiseIssue`/`clearIssue`; `HostAgentStatusItemController`, `StatusMenuVMSection` (per-VM notice lines), `ClipboardWindowController` (visibility-scoped watching), `AppDelegate` (`SummonTarget.clipboard`, `VMLibraryViewModel.evict`), `NSStatusItem.isButtonOnScreen` and `CalloutStyle` stack helpers in shared code.
- Guest: `ClipboardActivity.copyShortened(offeringAnything:)` with a shared `isNotice` reveal predicate; `noteFoldersSkipped` records and reveals; `AgentMenuText` renders both variants; `MARKETING_VERSION` 0.58.0 → 0.59.0.
- Docs: ARCHITECTURE.md gains the `ClipboardIssueCenter` entry.

## Test plan
- [x] `make build`; `make test` fully green — 2404 app/KernovaKit cases plus 152 guest-agent cases
- [x] New coverage: `ClipboardIssueCenterTests`, `ClipboardTransferIssueTests`, notice lines in `StatusMenuVMSectionTests`, center assertions in `VsockClipboardServiceTests`, guest folders-skipped notice tests
- [x] Live check on macOS 26: an over-cap passthrough copy with the window closed keeps the popover up its full 6 s (menu detached while shown); minimizing the clipboard window hands suppression back to the status item

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bgk7h1GZUsTuzAw19xhxid
