### PR TITLE
fix: Render clipboard refusals from the per-VM record, not the live service

### DIFF
--- a/Kernova/Services/ClipboardIssueCenter.swift
+++ b/Kernova/Services/ClipboardIssueCenter.swift
@@ -2,14 +2,14 @@ import Foundation
 import Observation
 import os
 
-/// App-level aggregate of every live clipboard service's outstanding transfer
-/// problem.
+/// App-level aggregate, keyed by VM, of each one's outstanding clipboard
+/// transfer problem.
 ///
 /// Clipboard services are per-VM and their window is optional, so a refusal
-/// raised while no window is open has nowhere to render. Each service reports
-/// here instead, and every surface renders this record rather than a service's
-/// own — a service superseded by a reconnect still raises the failures of the
-/// pasteboard promises it published, which no live service can account for.
+/// raised while no window is open has nowhere to render. Every service reports
+/// here instead, and this is the only record — a service superseded by a
+/// reconnect still raises the failures of the pasteboard promises it published,
+/// so a problem outlives the connection that raised it and cannot be kept on one.
 ///
 /// ``latestByInstance`` feeds the clipboard window's banner and the menu-bar
 /// dropdown's per-VM lines; ``pendingNotice`` carries the one refusal no open

--- a/Kernova/Services/ClipboardIssueCenter.swift
+++ b/Kernova/Services/ClipboardIssueCenter.swift
@@ -7,9 +7,13 @@ import os
 ///
 /// Clipboard services are per-VM and their window is optional, so a refusal
 /// raised while no window is open has nowhere to render. Each service reports
-/// here instead: ``latestByInstance`` feeds the menu-bar dropdown's per-VM lines,
-/// and ``pendingNotice`` carries the one refusal no open window is already
-/// showing, for a surface that can interrupt.
+/// here instead, and every surface renders this record rather than a service's
+/// own — a service superseded by a reconnect still raises the failures of the
+/// pasteboard promises it published, which no live service can account for.
+///
+/// ``latestByInstance`` feeds the clipboard window's banner and the menu-bar
+/// dropdown's per-VM lines; ``pendingNotice`` carries the one refusal no open
+/// window is already showing, for a surface that can interrupt.
 @MainActor
 @Observable
 final class ClipboardIssueCenter {
@@ -40,7 +44,8 @@ final class ClipboardIssueCenter {
     /// surface for the same news would be noise.
     private(set) var pendingNotice: Notice?
 
-    /// VMs whose clipboard window is on screen and rendering issues itself.
+    /// VMs whose clipboard window is on screen and rendering
+    /// ``latestByInstance`` itself.
     @ObservationIgnored
     private var watchedInstances: Set<UUID> = []
 

--- a/Kernova/Services/ClipboardServicing.swift
+++ b/Kernova/Services/ClipboardServicing.swift
@@ -26,14 +26,8 @@ protocol ClipboardServicing: AnyObject {
     /// that would silently never send.
     var supportsBinaryRepresentations: Bool { get }
 
-    /// Most recent user-visible transfer problem, or `nil` when healthy.
-    ///
-    /// Set when an outbound payload exceeds the transport limit or the peer
-    /// reports a clipboard error; cleared by the next successful transfer.
-    var lastTransferIssue: ClipboardTransferIssue? { get }
-
-    /// Records a problem an *automatic* path produced, for `lastTransferIssue`
-    /// to carry.
+    /// Records a problem an *automatic* path produced, for the transport to
+    /// publish to `ClipboardIssueCenter` — the one record every surface renders.
     ///
     /// A window gesture reports its own outcome inline; a passthrough forward has
     /// no return path, so the issue is the only account it can give. Default

--- a/Kernova/Services/SpiceClipboardService.swift
+++ b/Kernova/Services/SpiceClipboardService.swift
@@ -23,9 +23,6 @@ final class SpiceClipboardService: ClipboardServicing {
     /// `true` once the guest agent has completed the capabilities handshake.
     private(set) var isConnected: Bool = false
 
-    /// Always `nil` — the SPICE path keeps its log-only error handling.
-    var lastTransferIssue: ClipboardTransferIssue? { nil }
-
     var supportsBinaryRepresentations: Bool { false }
 
     /// Bumped once per inbound guest clipboard text.

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -22,8 +22,13 @@ final class VsockClipboardService: ClipboardServicing {
     /// `true` once `start()` has been called.
     private(set) var isConnected: Bool = false
 
-    /// Most recent user-visible transfer problem; cleared by the next
-    /// successful transfer in either direction.
+    /// Most recent user-visible transfer problem *this connection* raised;
+    /// cleared by the next successful transfer in either direction.
+    ///
+    /// This service's own record, driving which kinds a healthy pull retires —
+    /// not a rendering source. A promise this connection published outlives it,
+    /// so the surfaces render `ClipboardIssueCenter`'s per-VM record, which a
+    /// superseded service can still write to.
     private(set) var lastTransferIssue: ClipboardTransferIssue?
 
     /// The clipboard operation currently being shown (most-significant in-flight

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -22,14 +22,16 @@ final class VsockClipboardService: ClipboardServicing {
     /// `true` once `start()` has been called.
     private(set) var isConnected: Bool = false
 
-    /// Most recent user-visible transfer problem *this connection* raised;
-    /// cleared by the next successful transfer in either direction.
+    /// This VM's outstanding user-visible transfer problem, cleared by the next
+    /// successful transfer in either direction.
     ///
-    /// This service's own record, driving which kinds a healthy pull retires —
-    /// not a rendering source. A promise this connection published outlives it,
-    /// so the surfaces render `ClipboardIssueCenter`'s per-VM record, which a
-    /// superseded service can still write to.
-    private(set) var lastTransferIssue: ClipboardTransferIssue?
+    /// Reads through to `ClipboardIssueCenter` rather than storing a copy: a
+    /// promise this connection published outlives it, so a superseded service
+    /// still raises problems for this VM, and a per-connection record would
+    /// disagree with the one every surface renders.
+    var lastTransferIssue: ClipboardTransferIssue? {
+        issueCenter.latestByInstance[instanceID]?.issue
+    }
 
     /// The clipboard operation currently being shown (most-significant in-flight
     /// session past the reveal delay), or `nil`.
@@ -434,21 +436,18 @@ final class VsockClipboardService: ClipboardServicing {
 
     // MARK: - Transfer issues
 
-    /// Publishes a user-visible transfer problem to this service's own readout
-    /// and to the app-level center that drives the menu-bar surfaces.
+    /// Publishes a user-visible transfer problem for this VM.
     ///
-    /// The single write path for `lastTransferIssue`: the clipboard window is
-    /// optional, so an issue that reached only the property would have no surface
-    /// on the passthrough flows that raise most of them.
+    /// The single write path behind `lastTransferIssue`: the clipboard window is
+    /// optional, so an issue kept on this service would have no surface at all on
+    /// the passthrough flows that raise most of them.
     private func raiseIssue(_ issue: ClipboardTransferIssue) {
-        lastTransferIssue = issue
         issueCenter.report(
             issue, instanceID: instanceID, vmName: label, pasteLimitBytes: maxPasteBytes())
     }
 
-    /// Retires the current problem from both surfaces.
+    /// Retires this VM's current problem from every surface.
     private func clearIssue() {
-        lastTransferIssue = nil
         issueCenter.clear(instanceID: instanceID)
     }
 

--- a/Kernova/Views/Clipboard/ClipboardContentViewController.swift
+++ b/Kernova/Views/Clipboard/ClipboardContentViewController.swift
@@ -80,6 +80,15 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
     /// Quiet period before a keystroke burst commits off-actor.
     private let editDebounceInterval: Duration
 
+    /// This VM's outstanding transfer problem, whichever of its clipboard
+    /// services raised it — including one superseded by a reconnect, which still
+    /// raises the failures of the pasteboard promises it published.
+    ///
+    /// Not `clipboardService`'s own record: the center's notice stands down for
+    /// as long as this window is up, so a report this window skipped would reach
+    /// no surface at all.
+    private let issueCenter: ClipboardIssueCenter
+
     /// Last transfer issue already shown as a transient, so re-observation
     /// doesn't re-show it.
     private var lastShownIssue: ClipboardTransferIssue?
@@ -120,11 +129,13 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
         readPasteboard: NSPasteboard = .general,
         providerRegistry: LazyClipboardProviderRegistry = .shared,
         publisher: HostClipboardPublisher? = nil,
+        issueCenter: ClipboardIssueCenter = .shared,
         editDebounceInterval: Duration = .milliseconds(200)
     ) {
         self.instance = instance
         self.viewModel = viewModel
         self.readPasteboard = readPasteboard
+        self.issueCenter = issueCenter
         self.publisher =
             publisher
             ?? HostClipboardPublisher(
@@ -418,7 +429,7 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
                 let clipService = self.instance.clipboardService
                 _ = clipService?.clipboardContent
                 _ = clipService?.isConnected
-                _ = clipService?.lastTransferIssue
+                _ = self.issueCenter.latestByInstance[self.instance.instanceID]
                 _ = self.instance.vsockControlService?.agentStatus
                 _ = self.instance.agentStatus
                 _ = self.instance.configuration.clipboardPassthroughEnabled
@@ -487,10 +498,13 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
                 apply(content: content)
                 indicatorView.setText(ClipboardContentDescriber.indicatorText(for: content))
             }
-            if let issue = service.lastTransferIssue, issue != lastShownIssue {
-                lastShownIssue = issue
-                indicatorView.showTransientMessage(message(for: issue), style: .error)
-            }
+        }
+
+        if let notice = issueCenter.latestByInstance[instance.instanceID],
+            notice.issue != lastShownIssue
+        {
+            lastShownIssue = notice.issue
+            indicatorView.showTransientMessage(message(for: notice), style: .error)
         }
 
         applyStatus(status, canInstallKernovaAgent: canInstallKernovaAgent)
@@ -601,8 +615,8 @@ final class ClipboardContentViewController: NSViewController, NSTextViewDelegate
         }
     }
 
-    private func message(for issue: ClipboardTransferIssue) -> String {
-        issue.displayMessage(pasteLimitBytes: instance.effectiveClipboardMaxPasteBytes)
+    private func message(for notice: ClipboardIssueCenter.Notice) -> String {
+        notice.issue.displayMessage(pasteLimitBytes: notice.pasteLimitBytes)
     }
 
     /// The message shown when "Copy to Mac" placed nothing on the pasteboard.

--- a/KernovaTests/ClipboardContentViewControllerTests.swift
+++ b/KernovaTests/ClipboardContentViewControllerTests.swift
@@ -632,13 +632,24 @@ struct ClipboardContentViewControllerCopyOutcomeTests {
         #expect(try await copyMessage(failWrite: true) == "Couldn't write to the Mac clipboard")
     }
 
+    /// Publishes `issue` for `instance` the way a clipboard service does.
+    private func report(
+        _ issue: ClipboardTransferIssue, to center: ClipboardIssueCenter, for instance: VMInstance
+    ) {
+        center.report(
+            issue, instanceID: instance.instanceID, vmName: instance.name,
+            pasteLimitBytes: instance.effectiveClipboardMaxPasteBytes)
+    }
+
     @Test("every error code the guest sends renders its own message")
     func peerReportedCodesRenderTheirOwnMessage() {
+        let center = ClipboardIssueCenter()
         let service = FakeClipboardService(content: ClipboardContent(text: "buffer bytes"))
         let instance = makeClipboardInstance()
         instance.clipboardService = service
         let vc = ClipboardContentViewController(
-            instance: instance, viewModel: makeClipboardViewModel(preferences: preferences))
+            instance: instance, viewModel: makeClipboardViewModel(preferences: preferences),
+            issueCenter: center)
 
         let expected: [(ClipboardErrorCode, String)] = [
             (
@@ -651,8 +662,10 @@ struct ClipboardContentViewControllerCopyOutcomeTests {
         ]
         for (code, message) in expected {
             // A fresh `date` is what re-fires the transient for a repeat issue.
-            service.lastTransferIssue = ClipboardTransferIssue(
-                kind: .peerReportedError(code: code.rawValue, message: "wire text"), date: Date())
+            report(
+                ClipboardTransferIssue(
+                    kind: .peerReportedError(code: code.rawValue, message: "wire text"),
+                    date: Date()), to: center, for: instance)
             vc.simulateObservationForTesting()
             #expect(vc.indicatorTextForTesting == message)
         }
@@ -660,17 +673,45 @@ struct ClipboardContentViewControllerCopyOutcomeTests {
 
     @Test("an outcome produced on this side shows the message it carries")
     func localFailureShowsItsOwnMessage() {
+        let center = ClipboardIssueCenter()
         let service = FakeClipboardService(content: ClipboardContent(text: "buffer bytes"))
         let instance = makeClipboardInstance()
         instance.clipboardService = service
         let vc = ClipboardContentViewController(
-            instance: instance, viewModel: makeClipboardViewModel(preferences: preferences))
+            instance: instance, viewModel: makeClipboardViewModel(preferences: preferences),
+            issueCenter: center)
 
-        service.lastTransferIssue = .overCopyBudget(limitBytes: ClipboardPasteLimit.defaultBytes)
+        report(
+            .overCopyBudget(limitBytes: ClipboardPasteLimit.defaultBytes), to: center,
+            for: instance)
         vc.simulateObservationForTesting()
         #expect(
             vc.indicatorTextForTesting
                 == ClipboardTransferIssue.overCopyBudgetMessage(limitBytes: ClipboardPasteLimit.defaultBytes))
+    }
+
+    @Test("a refusal from the superseded service the reconnect replaced still renders")
+    func supersededServiceRefusalStillRenders() {
+        let center = ClipboardIssueCenter()
+        let instance = makeClipboardInstance()
+        let superseded = FakeClipboardService(content: ClipboardContent(text: "buffer bytes"))
+        superseded.issueReporter = { [self] in report($0, to: center, for: instance) }
+        instance.clipboardService = superseded
+        let vc = ClipboardContentViewController(
+            instance: instance, viewModel: makeClipboardViewModel(preferences: preferences),
+            issueCenter: center)
+        // The clipboard channel reconnects: the window now shows a service that
+        // knows nothing of the promise the old one left on the pasteboard.
+        instance.clipboardService = FakeClipboardService(content: .empty)
+
+        // That promise fires on a paste and fails against the dead channel.
+        superseded.reportIssue(.pasteTimedOut())
+        vc.simulateObservationForTesting()
+
+        #expect(
+            vc.indicatorTextForTesting
+                == ClipboardTransferIssue.pasteTimedOut().displayMessage(
+                    pasteLimitBytes: instance.effectiveClipboardMaxPasteBytes))
     }
 }
 
@@ -690,7 +731,11 @@ private final class FakeClipboardService: ClipboardServicing {
 
     var isConnected: Bool = true
     var supportsBinaryRepresentations: Bool = true
-    var lastTransferIssue: ClipboardTransferIssue?
+
+    /// Where `reportIssue` publishes, as a real transport publishes to
+    /// `ClipboardIssueCenter` — so a test can raise an issue from a service the
+    /// window is no longer showing.
+    var issueReporter: ((ClipboardTransferIssue) -> Void)?
 
     /// What `materializeForCopy` hands the publisher, or `nil` to resolve the
     /// buffer's own representations the way the protocol default does.
@@ -723,6 +768,7 @@ private final class FakeClipboardService: ClipboardServicing {
         announcedCount += 1
     }
     func clearBuffer() { clipboardContent = .empty }
+    func reportIssue(_ issue: ClipboardTransferIssue) { issueReporter?(issue) }
     // materializeForPreview uses the protocol-extension default (no-op).
 
     func materializeForCopy() -> [CopyToMacItem] {

--- a/KernovaTests/ClipboardPassthroughCoordinatorTests.swift
+++ b/KernovaTests/ClipboardPassthroughCoordinatorTests.swift
@@ -526,7 +526,6 @@ struct ClipboardPassthroughCoordinatorTests {
         var clipboardContent: ClipboardContent = .empty
         var isConnected = true
         var supportsBinaryRepresentations = true
-        var lastTransferIssue: ClipboardTransferIssue?
         private(set) var inboundOfferSeq: UInt64 = 0
         /// What the next `materializeForCopy` promises.
         var promises: [CopyToMacPromise] = []

--- a/KernovaTests/VMToolbarManagerTests.swift
+++ b/KernovaTests/VMToolbarManagerTests.swift
@@ -189,7 +189,6 @@ struct VMToolbarManagerTests {
         var clipboardContent: ClipboardContent = .empty
         var isConnected = true
         var supportsBinaryRepresentations = true
-        var lastTransferIssue: ClipboardTransferIssue?
         var transferProgress: ClipboardProgressSnapshot?
 
         /// Builds a snapshot carrying just the fraction the bar renders.

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -2715,6 +2715,56 @@ struct VsockClipboardServiceTests {
         #expect(service.lastTransferIssue == refusal)
     }
 
+    @Test("a healthy pull leaves standing the refusal a superseded connection raised")
+    func supersededRefusalSurvivesAHealthyPull() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let vmID = UUID()
+        let issues = ClipboardIssueCenter()
+        let service = VsockClipboardService(
+            channel: host, label: "Build VM", instanceID: vmID, issueCenter: issues)
+        service.start()
+        defer { service.stop() }
+
+        let noteBytes = Data("note".utf8)
+        let responder = FakeGuestResponder(guest: guest)
+        defer { responder.cancel() }
+        responder.register(
+            generation: 21, repIndex: 0, uti: ClipboardContent.utf8TextUTI, bytes: noteBytes,
+            isInline: true)
+        responder.start()
+
+        try guest.send(
+            makeOffer(
+                generation: 21,
+                reps: [
+                    (
+                        uti: ClipboardContent.utf8TextUTI, byteCount: noteBytes.count, filename: "",
+                        isInline: true
+                    )
+                ]))
+        try await waitForChange { service.clipboardContent.representations.count == 1 }
+
+        // The connection this one replaced: its pasteboard promise fires on a
+        // paste and fails against the dead channel, well after the reconnect.
+        // Reported under this VM, never seen by the live service.
+        let refusal = ClipboardTransferIssue.pasteTimedOut()
+        issues.report(
+            refusal, instanceID: vmID, vmName: "Build VM",
+            pasteLimitBytes: ClipboardPasteLimit.defaultBytes)
+
+        // This service's own pull succeeding says nothing about that paste, so
+        // the refusal stays up — the gate reads the record it would retire, not
+        // this connection's view of it.
+        await service.materializeForPreview()
+        #expect(service.clipboardContent.text == "note")
+        #expect(issues.latestByInstance[vmID]?.issue == refusal)
+        #expect(service.lastTransferIssue == refusal)
+    }
+
     @Test("each promised file rep pastes through its own blocking pull")
     func copyPromisedFilesPasteViaBlockingPull() async throws {
         let (guest, host) = try makePair()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -172,10 +172,11 @@ Clipboard (principles and trade-off rules: [CLIPBOARD.md](CLIPBOARD.md)):
   the menu-bar status item renders one readout, so each service pushes its snapshot here and the
   center republishes the most significant.
 - `ClipboardIssueCenter` — the same shape for refusals, since a clipboard window is optional:
-  `VsockClipboardService` reports every `lastTransferIssue` write here,
-  `ClipboardWindowController` registers as a watcher for as long as its window is up, and
-  `HostAgentStatusItemController` renders what is left — a popover for the notice no window
-  claimed, and a line under each VM's dropdown row.
+  `VsockClipboardService` reports every user-visible transfer problem here, and every surface
+  reads the per-VM record back — `ClipboardContentViewController`'s banner (which is also why
+  `ClipboardWindowController` registers as a watcher for as long as its window is up) and
+  `HostAgentStatusItemController`'s popover for the notice no window claimed plus the line under
+  each VM's dropdown row.
 - `AgentStatus` — the enum driving install/update/reinstall affordances, sourced from
   `VsockControlService` (macOS) or `SpiceClipboardService` (Linux) and read through
   `VMInstance.agentStatus`.

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -232,7 +232,9 @@ complexity that does not move a real metric is just complexity, and is rejected.
 completion, error, abort — must clear the indicator; never leave a stuck bar. Progress UI is
 necessary but not sufficient: the OS paste deadline cannot be signaled into (§2), so a bar never
 substitutes for the cap that keeps a paste inside it. **Report a refusal on the side that made the
-gesture**, since the user owed the message is the one who acted.
+gesture**, since the user owed the message is the one who acted. **A refusal belongs to the VM, not
+to the connection that raised it** — a promise outlives the service that published it (§3), so every
+surface renders the per-VM record rather than a live service's own property.
 
 **Progress is aggregate per operation, never per file.** A session is one user-visible operation —
 a paste, a Copy to Mac, a preview fetch, one side serving a peer's pulls — and its bar climbs


### PR DESCRIPTION
Closes #781

## Summary

`ClipboardIssueCenter` stands its interrupting notice down for a VM whose clipboard window is on screen, on the premise that the window renders that VM's refusals itself. The window rendered only `instance.clipboardService`'s `lastTransferIssue` — the *live* service's.

A clipboard-channel reconnect replaces that service, but the pasteboard promises the superseded one published stay on the pasteboard: `stop()` deliberately leaves them servable, and only supersession retracts the write. When one of those fires on a later paste and fails against the dead channel, the stopped service raises the issue and reports it under the same instance ID. The watched check suppressed the notice, and the window — showing the replacement service, which knows nothing of that promise — showed nothing. The paste failed with no explanation anywhere. With the window closed the notice fired normally; only the window-open overlap lost the message.

## The fix

The window renders the center's per-VM record instead. `latestByInstance[instanceID]` is keyed by the VM, so it carries a report from any of that VM's services, and the watched suppression becomes truthful: the window really does render every refusal reported for the VM it is showing.

Rather than leaving the per-service property as a second thing a surface could read — which is how this bug arose — `lastTransferIssue` leaves `ClipboardServicing`. `SpiceClipboardService`'s always-`nil` stub goes with it. `VsockClipboardService` keeps the property internally: it is that connection's own record of what it raised, and it drives which issue kinds a healthy pull retires (a disk-full or locally-produced outcome survives a succeeding sibling; a peer-reported one does not).

The window also now names the ceiling `Notice` pinned at report time rather than reading the live one, which is what that field exists for.

## Alternative considered

Keying watches and reports by the *reporting service* rather than the instance ID — the other shape the review suggested. It surfaces the refusal, but in the menu bar, while the window the user has open for that VM still shows nothing; and it keeps the two records that can disagree. Rejected for that reason.

## Test plan

- [x] `make test` — full suite green
- [x] New `supersededServiceRefusalStillRenders`: a service the reconnect replaced reports a paste failure; the window renders it while showing the replacement
- [x] `peerReportedCodesRenderTheirOwnMessage` / `localFailureShowsItsOwnMessage` reworked to publish through an injected center, the way a transport does
- [x] `make lint`

Pre-existing local flake, unrelated: a handful of vsock and file-monitor tests stall ~65s on the first attempt and pass on the test plan's retry. Reproduced on unmodified `main` (7 tests, same set, same signature).