### PR TITLE
fix: Release the peer's clipboard when a copy leaves nothing to offer

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -831,7 +831,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.59.0;
+				MARKETING_VERSION = 0.60.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
@@ -869,7 +869,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.59.0;
+				MARKETING_VERSION = 0.60.0;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;

--- a/Kernova/Services/ClipboardTransferIssue.swift
+++ b/Kernova/Services/ClipboardTransferIssue.swift
@@ -70,15 +70,19 @@ extension ClipboardTransferIssue {
             date: Date())
     }
 
-    /// Raised when a newer guest offer (or a release) supersedes a Copy to Mac
-    /// still on the host pasteboard: the stale promise is retracted rather than
-    /// left advertised but unservable.
-    static func staleCopyRetracted() -> ClipboardTransferIssue {
-        ClipboardTransferIssue(
+    /// Raised when a Copy to Mac still on the host pasteboard is superseded: the
+    /// stale promise is retracted rather than left advertised but unservable.
+    ///
+    /// `hasSuccessor` is whether a guest offer took the retracted one's place —
+    /// an offer the host could promise does, a release or an offer whose reps all
+    /// filtered out does not. Only the first leaves Copy to Mac a next step.
+    static func staleCopyRetracted(hasSuccessor: Bool) -> ClipboardTransferIssue {
+        let removal =
+            "The guest clipboard changed, so the earlier copy was removed from the Mac clipboard"
+        return ClipboardTransferIssue(
             kind: .staleCopyRetracted(
-                message:
-                    "The guest clipboard changed, so the earlier copy was removed from the Mac clipboard — use Copy to Mac to bring over the new copy."
-            ),
+                message: hasSuccessor
+                    ? "\(removal) — use Copy to Mac to bring over the new copy." : "\(removal)."),
             date: Date())
     }
 

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -544,11 +544,11 @@ final class VsockClipboardService: ClipboardServicing {
             )
         }
         let content = capped.content
-        // Filtering can empty the list. Send nothing rather than an offer with no
-        // representations: the peer would drop its promise and be left with a
-        // pasteboard item nothing can serve, where leaving the previous offer
-        // standing keeps a working clipboard.
+        // Filtering can empty the list. The buffer still moved on, so the guest's
+        // previous offer is retired rather than left serving content the user has
+        // already replaced.
         guard !content.representations.isEmpty else {
+            releaseOutboundOffer("nothing in the buffer can be offered to this guest")
             // Deliberately *not* latched into `lastGrabbedDigest`: the capability
             // is re-read from every `Hello`, and a control-channel blip alone
             // clears it, so latching would strand this buffer for the rest of the
@@ -613,6 +613,39 @@ final class VsockClipboardService: ClipboardServicing {
         return (
             ClipboardContent(representations: kept, isConcealed: clipboardContent.isConcealed),
             dropped
+        )
+    }
+
+    /// Retires the offer the guest still holds, because the buffer moved on to
+    /// content with nothing left to offer it.
+    ///
+    /// `ClipboardRelease` rather than an empty offer: an offer with no
+    /// representations drops the guest's promise but leaves the pasteboard item
+    /// behind it advertising flavors nothing can serve, where a release clears
+    /// that write too. Idempotent — the released offer is forgotten, so the later
+    /// calls a still-unofferable buffer draws send nothing.
+    private func releaseOutboundOffer(_ reason: String) {
+        guard let previous = pendingOutbound else { return }
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.clipboardRelease = Kernova_V1_ClipboardRelease.with {
+            $0.generation = previous.generation
+        }
+        do {
+            try channel.send(frame)
+        } catch {
+            Self.logger.error(
+                "Failed to release clipboard offer gen=\(previous.generation, privacy: .public) for '\(self.label, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+            return
+        }
+        sender?.cancel(generation: previous.generation)
+        pendingOutbound = nil
+        currentOutboundGeneration.set(0)
+        // The released offer was a reader of whatever drop it streamed from.
+        retireUnreferencedDropDirectories()
+        Self.logger.notice(
+            "Released clipboard offer gen=\(previous.generation, privacy: .public) to '\(self.label, privacy: .public)' (conn=\(self.connectionTag, privacy: .public)) — \(reason, privacy: .public)"
         )
     }
 
@@ -833,10 +866,11 @@ final class VsockClipboardService: ClipboardServicing {
         // The host pasteboard may still hold this VM's own promised write for
         // the superseded offer, which the guest can no longer serve
         // (`request.stale`) — retract it rather than leave a paste that
-        // silently serves nothing, and tell the user how to get the new copy.
+        // silently serves nothing. The notice is raised at each exit below rather
+        // than here: whether it may point at Copy to Mac depends on whether this
+        // offer leaves anything to copy.
         let retracted = retractStaleHostWrite?() ?? false
         if retracted {
-            raiseIssue(.staleCopyRetracted())
             // With the write retracted, no earlier session's staging can be
             // backing a live pasteboard item any more.
             staging.reclaimSiblingRoots()
@@ -846,6 +880,7 @@ final class VsockClipboardService: ClipboardServicing {
         }
 
         guard !offer.repInfo.isEmpty else {
+            if retracted { raiseIssue(.staleCopyRetracted(hasSuccessor: false)) }
             dropInboundPromise()
             return
         }
@@ -874,6 +909,7 @@ final class VsockClipboardService: ClipboardServicing {
             Self.logger.warning(
                 "Dropped the guest clipboard offer for '\(self.label, privacy: .public)' (gen=\(offer.generation, privacy: .public), conn=\(self.connectionTag, privacy: .public)): none of its \(bounded.reps.count, privacy: .public) representation(s) survived receive-side filtering"
             )
+            if retracted { raiseIssue(.staleCopyRetracted(hasSuccessor: false)) }
             dropInboundPromise()
             return
         }
@@ -885,8 +921,13 @@ final class VsockClipboardService: ClipboardServicing {
             ClipboardContent(representations: placeholders, isConcealed: promise.isConcealed))
         inboundPromise = promise
         previewMaterializationStarted = 0
-        // A retraction's issue is the new offer's own explainer — keep it.
-        if !retracted { clearIssue() }
+        // A retraction's issue is the new offer's own explainer, so it replaces
+        // whatever stood here rather than being cleared with it.
+        if retracted {
+            raiseIssue(.staleCopyRetracted(hasSuccessor: true))
+        } else {
+            clearIssue()
+        }
         // Bumped after the promise is live, so the passthrough coordinator's
         // `materializeForCopy` sees it.
         inboundOfferSeq &+= 1
@@ -1582,7 +1623,7 @@ final class VsockClipboardService: ClipboardServicing {
         // files ride the grace window rather than being swept (docs/CLIPBOARD.md
         // §3), so a paste mid-copy survives.
         if retractStaleHostWrite?() == true {
-            raiseIssue(.staleCopyRetracted())
+            raiseIssue(.staleCopyRetracted(hasSuccessor: false))
             staging.reclaimSiblingRoots()
             Self.logger.notice(
                 "Retracted the stale host-pasteboard promise for '\(self.label, privacy: .public)' (conn=\(self.connectionTag, privacy: .public)) after the guest released gen=\(release.generation, privacy: .public)"

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -642,6 +642,11 @@ final class VsockClipboardService: ClipboardServicing {
         sender?.cancel(generation: previous.generation)
         pendingOutbound = nil
         currentOutboundGeneration.set(0)
+        // The send-dedup latch means "the guest already has this", which the
+        // release just made false — so re-copying the released content is a new
+        // copy to a guest whose clipboard this emptied, not a redundant offer.
+        // `clearBuffer` drops it for the same reason.
+        lastGrabbedDigest = nil
         // The released offer was a reader of whatever drop it streamed from.
         retireUnreferencedDropDirectories()
         Self.logger.notice(

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -561,6 +561,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             // The change count is deliberately *not* advanced: the capability is
             // re-read from every `Hello`, so this copy becomes offerable the
             // moment the host advertises it.
+            releaseOutboundOffer("every copied item is a folder this host can't take")
             return
         }
         if !fileCandidates.isEmpty {
@@ -640,6 +641,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         _ content: ClipboardContent, channel: VsockChannel, changeCount: Int
     ) {
         guard !content.isEmpty else {
+            // The pasteboard still moved on, so the host's previous offer is
+            // retired rather than left serving a copy the user has replaced.
+            releaseOutboundOffer("the copy left nothing that can cross")
             lastPasteboardChangeCount = changeCount
             return
         }
@@ -683,6 +687,40 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                 "Failed to send clipboard offer: \(error.localizedDescription, privacy: .public)"
             )
         }
+    }
+
+    /// Retires the offer the host still holds, because this snapshot left nothing
+    /// to replace it with.
+    ///
+    /// `ClipboardRelease` rather than an empty offer: an offer with no
+    /// representations drops the host's promise but leaves the pasteboard item
+    /// behind it advertising flavors nothing can serve, where a release clears
+    /// that write too. Idempotent — the released offer is forgotten, so the later
+    /// calls a still-unofferable snapshot draws send nothing. A snapshot an
+    /// `org.nspasteboard.*` marker suppressed never reaches here: by that
+    /// marker's convention it is not a copy, and the clipboard before it still
+    /// stands.
+    private func releaseOutboundOffer(_ reason: String) {
+        guard let channel = liveChannel, let previous = pendingOutbound else { return }
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.clipboardRelease = Kernova_V1_ClipboardRelease.with {
+            $0.generation = previous.generation
+        }
+        do {
+            try channel.send(frame)
+        } catch {
+            Self.logger.warning(
+                "Failed to release clipboard offer gen=\(previous.generation, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            return
+        }
+        sender?.cancel(generation: previous.generation)
+        pendingOutbound = nil
+        currentOutboundGeneration.set(0)
+        Self.logger.notice(
+            "Released clipboard offer gen=\(previous.generation, privacy: .public) (conn=\(self.connectionTag, privacy: .public)) — \(reason, privacy: .public)"
+        )
     }
 
     /// One on-disk pasteboard file or folder gathered for an outbound offer.

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -718,6 +718,11 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         sender?.cancel(generation: previous.generation)
         pendingOutbound = nil
         currentOutboundGeneration.set(0)
+        // The send-dedup latch means "the host already has this", which the
+        // release just made false — so re-copying the released content is a new
+        // copy to a host whose clipboard this emptied, not a redundant offer.
+        // A fresh connection clears it for the same reason.
+        lastSeenDigest = nil
         Self.logger.notice(
             "Released clipboard offer gen=\(previous.generation, privacy: .public) (conn=\(self.connectionTag, privacy: .public)) — \(reason, privacy: .public)"
         )

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -935,6 +935,15 @@ struct VsockGuestClipboardAgentTests {
 
         let release = try await awaitRelease(on: hostChannel)
         #expect(release.generation == offer.generation)
+
+        // The release emptied the Mac's clipboard, so re-copying what it was
+        // holding is a copy that has to reach it — the send-dedup latch that said
+        // the host already had it stopped being true at the release.
+        pasteboard.setString("carried", forType: .string)
+        await MainActor.run { agent.checkClipboardChange() }
+        let reoffer = try await awaitOffer(on: hostChannel)
+        #expect(reoffer.repInfo.map(\.uti) == [ClipboardContent.utf8TextUTI])
+        #expect(reoffer.generation > offer.generation)
     }
 
     @Test("outbound suppressed: a transient snapshot is not a copy, so it releases nothing")

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -873,6 +873,102 @@ struct VsockGuestClipboardAgentTests {
                 == .copyShortened(offeringAnything: false))
     }
 
+    @Test("outbound: a folder-only copy releases the offer an older host is still holding, once")
+    func outboundFolderOnlyCopyReleasesThePreviousOffer() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(
+            pasteboard: pasteboard, agentFd: agentFd, hostStreamsDirectories: false)
+        defer { agent.stop() }
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        pasteboard.setString("carried", forType: .string)
+        await MainActor.run { agent.checkClipboardChange() }
+        let offer = try await awaitOffer(on: hostChannel)
+
+        let folder = try writeTempFolder(name: "Project", files: [("f.txt", Data("x".utf8))])
+        defer { try? FileManager.default.removeItem(at: folder.deletingLastPathComponent()) }
+        pasteboard.setItems([[(type: .fileURL, data: Data(folder.absoluteString.utf8))]])
+        await MainActor.run { agent.checkClipboardChange() }
+
+        // Nothing about this copy can cross, but the pasteboard still moved on:
+        // leaving the offer standing would keep a paste on the Mac serving
+        // "carried", which the user has already replaced.
+        let release = try await awaitRelease(on: hostChannel)
+        #expect(release.generation == offer.generation)
+
+        // This branch is re-entered on every poll tick (its change count is
+        // deliberately not advanced, so the copy can still be offered once the
+        // host advertises the capability); the release must not repeat with it.
+        await MainActor.run { agent.checkClipboardChange() }
+        let extra = try await maybeNextFrame(from: hostChannel, skippingAcks: true)
+        #expect(extra == nil)
+    }
+
+    @Test("outbound: a copy nothing survives releases the host's previous offer")
+    func outboundUnreadableCopyReleasesThePreviousOffer() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        pasteboard.setString("carried", forType: .string)
+        await MainActor.run { agent.checkClipboardChange() }
+        let offer = try await awaitOffer(on: hostChannel)
+
+        // A copied item whose resource values can't be read yields no file
+        // candidate, and the raw file-url flavor it leaves behind is filtered
+        // before reading — so this copy has nothing to offer at all.
+        pasteboard.setItem([
+            (type: .fileURL, data: Data("file:///nonexistent/\(UUID().uuidString)".utf8))
+        ])
+        await MainActor.run { agent.checkClipboardChange() }
+
+        let release = try await awaitRelease(on: hostChannel)
+        #expect(release.generation == offer.generation)
+    }
+
+    @Test("outbound suppressed: a transient snapshot is not a copy, so it releases nothing")
+    func outboundSuppressedSnapshotLeavesTheOfferStanding() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let agent = makeAgent(pasteboard: pasteboard, agentFd: agentFd)
+        defer { agent.stop() }
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        pasteboard.setString("carried", forType: .string)
+        await MainActor.run { agent.checkClipboardChange() }
+        _ = try await awaitOffer(on: hostChannel)
+
+        // The source app restores the pasteboard within seconds and clipboard
+        // managers ignore the marker by convention, so the clipboard before it is
+        // the one that still stands — on the host as much as in the guest.
+        pasteboard.setItem([
+            (
+                type: NSPasteboard.PasteboardType("org.nspasteboard.TransientType"),
+                data: Data([1])
+            ),
+            (type: .string, data: Data("noise".utf8)),
+        ])
+        await MainActor.run { agent.checkClipboardChange() }
+
+        let extra = try await maybeNextFrame(from: hostChannel, skippingAcks: true)
+        #expect(extra == nil)
+    }
+
     /// Requests representation `repIndex` of `offer` and collects its stream.
     private func requestOutboundRep(
         offer: Kernova_V1_ClipboardOffer, repIndex: UInt64, from channel: VsockChannel
@@ -3312,6 +3408,24 @@ struct VsockGuestClipboardAgentTests {
             default:
                 throw TestFailure(
                     "Expected ClipboardOffer, got \(String(describing: frame.payload))")
+            }
+        }
+    }
+
+    /// Awaits the next `ClipboardRelease` on `channel`, skipping stream acks.
+    private func awaitRelease(on channel: VsockChannel) async throws
+        -> Kernova_V1_ClipboardRelease
+    {
+        while true {
+            let frame = try await nextFrame(from: channel)
+            switch frame.payload {
+            case .clipboardRelease(let release):
+                return release
+            case .clipboardStreamAck:
+                continue
+            default:
+                throw TestFailure(
+                    "Expected ClipboardRelease, got \(String(describing: frame.payload))")
             }
         }
     }

--- a/KernovaTests/ClipboardIssueCenterTests.swift
+++ b/KernovaTests/ClipboardIssueCenterTests.swift
@@ -130,13 +130,13 @@ struct ClipboardIssueCenterTests {
         let center = ClipboardIssueCenter()
         report(.pasteTimedOut(), to: center)
 
-        report(.staleCopyRetracted(), to: center)
+        report(.staleCopyRetracted(hasSuccessor: true), to: center)
 
         #expect(center.latestByInstance.count == 1)
         #expect(
             center.latestByInstance[vmID]?.issue.kind
-                == ClipboardTransferIssue.staleCopyRetracted().kind)
-        #expect(center.pendingNotice?.issue.kind == ClipboardTransferIssue.staleCopyRetracted().kind)
+                == ClipboardTransferIssue.staleCopyRetracted(hasSuccessor: true).kind)
+        #expect(center.pendingNotice?.issue.kind == ClipboardTransferIssue.staleCopyRetracted(hasSuccessor: true).kind)
     }
 
     @Test("Consuming the pending notice leaves the dropdown's record standing")

--- a/KernovaTests/ClipboardTransferIssueTests.swift
+++ b/KernovaTests/ClipboardTransferIssueTests.swift
@@ -64,12 +64,25 @@ struct ClipboardTransferIssueTests {
             ClipboardTransferIssue.overCopyBudget(limitBytes: limit)
                 .displayMessage(pasteLimitBytes: limit)
                 == ClipboardTransferIssue.overCopyBudgetMessage(limitBytes: limit))
-        let retracted = ClipboardTransferIssue.staleCopyRetracted()
+        let retracted = ClipboardTransferIssue.staleCopyRetracted(hasSuccessor: true)
         guard case .staleCopyRetracted(let message) = retracted.kind else {
             Issue.record("Expected a staleCopyRetracted issue, got \(retracted.kind)")
             return
         }
         #expect(retracted.displayMessage(pasteLimitBytes: limit) == message)
+    }
+
+    @Test("A retraction points at Copy to Mac only when an offer replaced the one it removed")
+    func retractionNamesCopyToMacOnlyWithASuccessor() {
+        let replaced = ClipboardTransferIssue.staleCopyRetracted(hasSuccessor: true)
+            .displayMessage(pasteLimitBytes: limit)
+        let unreplaced = ClipboardTransferIssue.staleCopyRetracted(hasSuccessor: false)
+            .displayMessage(pasteLimitBytes: limit)
+        #expect(replaced.contains("use Copy to Mac"))
+        // Without a successor the click has nothing to fetch, so the sentence
+        // stops at what happened.
+        #expect(!unreplaced.contains("use Copy to Mac"))
+        #expect(unreplaced.hasSuffix("removed from the Mac clipboard."))
     }
 
     // MARK: - noticeHeadline
@@ -101,7 +114,7 @@ struct ClipboardTransferIssueTests {
             peerError(.pasteFailed).noticeHeadline(vmName: vm)
                 == "Clipboard not pasted into \u{201C}Build VM\u{201D}.")
         #expect(
-            ClipboardTransferIssue.staleCopyRetracted().noticeHeadline(vmName: vm)
+            ClipboardTransferIssue.staleCopyRetracted(hasSuccessor: true).noticeHeadline(vmName: vm)
                 == "Clipboard changed in \u{201C}Build VM\u{201D}.")
     }
 
@@ -124,7 +137,7 @@ struct ClipboardTransferIssueTests {
             .pasteTransferFailed(),
             .folderSkippedForOutdatedGuest(),
             .forwardSkippedItems(note: "skipped"),
-            .staleCopyRetracted(),
+            .staleCopyRetracted(hasSuccessor: true),
             ClipboardTransferIssue(kind: .diskFull(needed: 1, available: 0), date: Date()),
             peerError(.pasteTooLarge),
         ] {
@@ -143,7 +156,7 @@ struct ClipboardTransferIssueTests {
             .pasteTransferFailed(),
             .folderSkippedForOutdatedGuest(),
             .forwardSkippedItems(note: "skipped"),
-            .staleCopyRetracted(),
+            .staleCopyRetracted(hasSuccessor: true),
             ClipboardTransferIssue(kind: .diskFull(needed: 1, available: 0), date: Date()),
         ] {
             #expect(issue.warrantsInterruptingNotice, "\(issue.kind) must interrupt here")
@@ -180,7 +193,7 @@ struct ClipboardTransferIssueTests {
         #expect(
             peerError(.pasteTooLarge).menuLineText == "Clipboard: too large to paste into the guest")
         #expect(
-            ClipboardTransferIssue.staleCopyRetracted().menuLineText
+            ClipboardTransferIssue.staleCopyRetracted(hasSuccessor: true).menuLineText
                 == "Clipboard: earlier copy was removed")
         #expect(
             ClipboardTransferIssue.folderSkippedForOutdatedGuest().menuLineText
@@ -196,7 +209,7 @@ struct ClipboardTransferIssueTests {
             ClipboardTransferIssue.overCopyBudget(limitBytes: limit),
             .pasteTimedOut(),
             .pasteTransferFailed(),
-            .staleCopyRetracted(),
+            .staleCopyRetracted(hasSuccessor: true),
             .folderSkippedForOutdatedGuest(),
             peerError(.pasteFailed),
         ] {

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -1780,6 +1780,28 @@ struct VsockClipboardServiceTests {
         let snapshot = recorder.frames.count
         service.grabIfChanged()
         try await expectNoNewFrames(on: recorder, sinceCount: snapshot)
+
+        // The release emptied the guest's clipboard, so re-copying the content it
+        // was holding is a copy that has to reach it — the send-dedup latch that
+        // said the guest already had it stopped being true at the release.
+        service.clipboardContent = ClipboardContent(text: "carried")
+        service.grabIfChanged()
+        try await waitForFrames(recorder) {
+            recorder.frames.dropFirst(snapshot).contains {
+                if case .clipboardOffer = $0.payload { return true }
+                return false
+            }
+        }
+        let reofferFrame = try #require(
+            recorder.frames.dropFirst(snapshot).first {
+                if case .clipboardOffer = $0.payload { return true }
+                return false
+            })
+        guard case .clipboardOffer(let reoffer) = reofferFrame.payload else {
+            Issue.record("Expected clipboardOffer, got \(String(describing: reofferFrame.payload))")
+            return
+        }
+        #expect(reoffer.generation > offer.generation)
     }
 
     @Test("a folder is left out of the offer for a guest that can't receive one")

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -1670,9 +1670,9 @@ struct VsockClipboardServiceTests {
         let snapshot = recorder.frames.count
         service.grabIfChanged()
 
-        // An offer with no representations would retire whatever the guest is
-        // holding and leave it a pasteboard item nothing can serve; sending
-        // nothing leaves the previous, still-working clipboard in place.
+        // An offer with no representations would leave the guest a pasteboard
+        // item nothing can serve, and there is no earlier offer to release, so
+        // this copy has nothing to say on the wire at all.
         try await expectNoNewFrames(on: recorder, sinceCount: snapshot)
         // The window is the only surface that can explain why the copy did
         // nothing, so the skip has to reach it.
@@ -1706,6 +1706,80 @@ struct VsockClipboardServiceTests {
         #expect(service.lastTransferIssue == nil)
         #expect(issues.latestByInstance[vmID] == nil)
         #expect(issues.pendingNotice == nil)
+    }
+
+    @Test("a folders-only copy releases the offer the guest is still holding, once")
+    func foldersOnlyCopyReleasesThePreviousOffer() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let service = VsockClipboardService(
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(),
+            peerStreamsDirectories: { false })
+        service.start()
+        defer { service.stop() }
+
+        let recorder = FrameRecorder(channel: guest)
+        defer { recorder.cancel() }
+
+        service.clipboardContent = ClipboardContent(text: "carried")
+        service.grabIfChanged()
+        try await waitForFrames(recorder) {
+            recorder.first {
+                if case .clipboardOffer = $0.payload { return true }
+                return false
+            } != nil
+        }
+        let offerFrame = try #require(
+            recorder.first {
+                if case .clipboardOffer = $0.payload { return true }
+                return false
+            })
+        guard case .clipboardOffer(let offer) = offerFrame.payload else {
+            Issue.record("Expected clipboardOffer, got \(String(describing: offerFrame.payload))")
+            return
+        }
+
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let folder = parent.appendingPathComponent("OnlyFolder", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+
+        // The buffer moved on to a copy with nothing this guest can take. Leaving
+        // the offer standing would keep a paste in the guest serving "carried",
+        // which the user has already replaced.
+        service.clipboardContent = ClipboardContent(representations: [
+            ClipboardContent.Representation(
+                directorySourceURL: folder, estimatedByteCount: 0, filename: "OnlyFolder",
+                uti: "public.folder")
+        ])
+        service.grabIfChanged()
+        try await waitForFrames(recorder) {
+            recorder.first {
+                if case .clipboardRelease = $0.payload { return true }
+                return false
+            } != nil
+        }
+        let releaseFrame = try #require(
+            recorder.first {
+                if case .clipboardRelease = $0.payload { return true }
+                return false
+            })
+        guard case .clipboardRelease(let release) = releaseFrame.payload else {
+            Issue.record("Expected clipboardRelease, got \(String(describing: releaseFrame.payload))")
+            return
+        }
+        #expect(release.generation == offer.generation)
+
+        // This branch is re-entered rather than latched (so the copy can still be
+        // offered once the guest advertises the capability); the release must not
+        // repeat with it.
+        let snapshot = recorder.frames.count
+        service.grabIfChanged()
+        try await expectNoNewFrames(on: recorder, sinceCount: snapshot)
     }
 
     @Test("a folder is left out of the offer for a guest that can't receive one")

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -140,6 +140,12 @@ Preserve **every** representation the source offered and choose which to hand ov
 the destination asks. Dropping one — losing an inline image when syncing rich text — is a fidelity
 defect; round-trip equality with a native copy/paste is the bar.
 
+- **Every copy replaces what the peer holds — including one that carries nothing.** A native
+  copy makes the previous pasteboard unreachable, so an offer filtering left empty — whatever
+  filtered it — *releases* the peer rather than leaving it advertising content the user has
+  already replaced. Only a release clears the peer's pasteboard write; an empty offer retires
+  the promise and leaves that write behind it unservable. A snapshot an `org.nspasteboard.*`
+  marker suppressed is not a copy and releases nothing.
 - **Directory fidelity rides the archive's field-key set.** A folder crosses as an archive of its
   tree, and what survives the round trip is exactly what `ClipboardDirectoryArchive`'s key set
   carries — entry kinds, permissions, ownership, flags, timestamps, link targets, per-entry


### PR DESCRIPTION
Closes #779

## Summary

When a copy produced no offerable representations, neither side told its peer that the previous clipboard was gone. The peer kept advertising the earlier offer, so a paste there served content the user had already replaced — silently stale rather than empty.

Both sides now send the `ClipboardRelease` the protocol already carries. It has existed since the first vsock clipboard commit and both sides already *handled* it; nothing ever sent one.

## The decision the issue asked for

The issue flagged that retiring the peer's clipboard on a copy the user *did* make is a different outcome from leaving it alone, and asked for it to be decided deliberately.

**Retire it.** The yardstick in docs/CLIPBOARD.md is round-trip equality with a native copy/paste: on one Mac a copy makes the previous pasteboard unreachable. Between "the peer serves the previous, unrelated copy" and "the peer's clipboard is empty", only the second matches. Serving superseded content is silent and wrong; an empty clipboard is visible and correct.

## Why a release and not an empty offer

The previous answer — send nothing — was chosen because an empty offer is *worse* than doing nothing, and that reasoning holds: an empty offer makes the peer drop its promise while leaving the pasteboard item it already wrote in place, advertising flavors nothing can serve. A release is the message that also clears that write (the guest clears its pasteboard if the user hasn't replaced it; the host retracts its promised write and surfaces the retraction).

## Rejected alternatives

- **Leave it standing, report only on the copying side.** The copying side already reports the folder case; the *other* side is the one left holding a wrong clipboard, and it gets no signal at all. Status quo, and the bug.
- **Clear the host window's placeholder content on release too.** Out of scope — that is existing release-handling behavior with its own test, and the retraction notice already explains the state.
- **Gate on a new capability.** Unnecessary: `handleRelease` shipped in the first vsock clipboard commit on both sides, so every agent that speaks this protocol handles it.

## Scope

Uniform across both ways a copy can come back empty, per the issue's "so the two don't diverge":

| Reason | Side | Path |
|---|---|---|
| Every copied item is a folder, peer lacks `clipboard.stream.directory.v1` | both | host `grabIfChanged` after `offerableContent()`; guest `checkClipboardChange`'s folders-only branch |
| Nothing survives filtering (unreadable items, all-skipped flavors, an emptied pasteboard) | guest | `sendOfferIfNeeded`'s empty-content branch |

A snapshot suppressed by an `org.nspasteboard.*` marker deliberately releases nothing: by that marker's own convention it is not a copy — the source app restores the pasteboard within seconds and clipboard managers ignore it — so the clipboard before it still stands.

The issue's first bullet described the unreadable case as returning from `estimateAndOffer`'s `guard !reps.isEmpty`. That guard is unreachable (`estimateAndOffer` is only called with a non-empty candidate list); the state it named is real and reaches the wire through `sendOfferIfNeeded`'s empty-content branch, which is where the fix sits.

## Message honesty

Making the release path live exposed a dead end in the retraction notice, which ended "— use Copy to Mac to bring over the new copy." After a release there is no successor to bring over, and following that instruction produces an error. `staleCopyRetracted` now takes `hasSuccessor`, and `handleOffer` raises the notice at each of its exits once that is known — which also fixes the pre-existing case of an offer whose representations all filter out on the receive side.

## Changes

- `VsockClipboardService.releaseOutboundOffer` / `VsockGuestClipboardAgent.releaseOutboundOffer` — send the release, cancel that generation's in-flight transfers, forget the offer. Idempotent, so the branches that re-enter on every poll tick send one release.
- `ClipboardTransferIssue.staleCopyRetracted(hasSuccessor:)`, and `handleOffer` restructured to raise it per exit.
- `docs/CLIPBOARD.md` §6 — every copy replaces what the peer holds, including one that carries nothing.
- Guest agent `MARKETING_VERSION` 0.59.0 → 0.60.0; the guest half of this needs a reinstall.

## Test plan

- [x] `make test` — full suite green
- [x] New host test: a folders-only buffer releases the offer the guest holds, and only once
- [x] New guest tests: a folders-only copy and a copy nothing survives each release the host's offer; a transient snapshot releases nothing
- [x] Verified the new tests fail (60 s frame-wait backstop) with the release call sites disabled, so they are not vacuous
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)