### PR TITLE
fix: Tell the guest's own menu when a copy carries nothing

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -831,7 +831,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.61.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
@@ -869,7 +869,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.61.0;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -831,7 +831,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.61.0;
+				MARKETING_VERSION = 0.61.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
@@ -869,7 +869,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.61.0;
+				MARKETING_VERSION = 0.61.1;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;

--- a/KernovaMacOSAgent/AgentMenuText.swift
+++ b/KernovaMacOSAgent/AgentMenuText.swift
@@ -37,6 +37,7 @@ enum AgentMenuText {
             return offeringAnything
                 ? "Clipboard: shared without folders — Kernova on the Mac needs updating"
                 : "Clipboard: folders not shared — Kernova on the Mac needs updating"
+        case .copyCarriedNothing: return "Clipboard: nothing in that copy could be shared"
         case .disabled: return "Clipboard: disabled"
         }
     }

--- a/KernovaMacOSAgent/AgentUIState.swift
+++ b/KernovaMacOSAgent/AgentUIState.swift
@@ -16,10 +16,12 @@ enum HostConnectionState: Equatable, Sendable {
 ///
 /// `enabled` / `disabled` are the host-policy feature state; every other case
 /// records the most recent flow event, each set at the moment it starts rather
-/// than on completion. A flow event overwrites `enabled`; only host policy sets
-/// `disabled`.
+/// than on completion. A flow event overwrites `enabled`, and withdrawing the
+/// offer one left standing returns to it; only host policy sets `disabled`.
 enum ClipboardActivity: Equatable, Sendable {
-    /// Sharing is on by host policy and nothing has crossed yet this session.
+    /// Sharing is on by host policy and no copy of this guest's stands on the
+    /// host clipboard: nothing has crossed yet this session, or the guest
+    /// clipboard was emptied and the offer it had crossed under withdrawn.
     case enabled
     /// The guest's local clipboard was offered to the host (a local copy).
     case offeredToHost
@@ -48,6 +50,10 @@ enum ClipboardActivity: Equatable, Sendable {
     ///
     /// The copy was made in this guest, so the shortfall is reported here.
     case copyShortened(offeringAnything: Bool)
+    /// A copy left nothing that could be offered to the host at all.
+    ///
+    /// The copy was made in this guest, so the outcome is reported here.
+    case copyCarriedNothing
     /// Host policy turned clipboard sharing off.
     case disabled
 
@@ -55,10 +61,11 @@ enum ClipboardActivity: Equatable, Sendable {
     /// leaving it for the next time the user opens the dropdown.
     ///
     /// True for the outcomes of a gesture made in this guest that produces no
-    /// other signal — a paste that yields nothing, a copy that crosses short.
+    /// other signal — a paste that yields nothing, a copy that crosses short or
+    /// not at all.
     var isNotice: Bool {
         switch self {
-        case .pasteRefused, .copyShortened:
+        case .pasteRefused, .copyShortened, .copyCarriedNothing:
             return true
         case .enabled, .offeredToHost, .offeredFromHost, .sentToHost, .receivedFromHost, .disabled:
             return false

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -153,7 +153,17 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
 
     /// Last `NSPasteboard.changeCount` we observed; set after every poll and
     /// every host write so we don't echo our own content.
+    ///
+    /// `Self.unobservedChangeCount` until a poll on this connection has seen the
+    /// pasteboard, so whatever is standing is re-evaluated for the new host.
     private var lastPasteboardChangeCount: Int
+
+    /// `lastPasteboardChangeCount` before this connection has observed anything.
+    ///
+    /// No real `changeCount` is negative, so the first poll of a connection
+    /// always re-evaluates the standing snapshot — and knows it is looking at
+    /// one it never watched arrive.
+    private static let unobservedChangeCount = -1
 
     /// Digest of the most recent content we offered the host; suppresses
     /// redundant outbound offers on an unchanged clipboard.
@@ -447,7 +457,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             self.inboundPromise = nil
             // A brand-new host has no record of prior offers; re-announce.
             self.lastSeenDigest = nil
-            self.lastPasteboardChangeCount = -1
+            self.lastPasteboardChangeCount = Self.unobservedChangeCount
             self.folderSkippedChangeCount = nil
         }
         Self.logger.notice(
@@ -582,8 +592,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                             uti: candidate.type.identifier, fileURL: candidate.url,
                             byteCount: candidate.byteCount, filename: candidate.filename)
                     }, isConcealed: isConcealed)
-                sendOfferIfNeeded(
-                    content, channel: channel, changeCount: currentCount, pasteboardWasEmpty: false)
+                sendOfferIfNeeded(content, channel: channel, changeCount: currentCount)
             }
             return
         }
@@ -609,9 +618,12 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         // `evaluate` builds non-concealed content; re-stamp the flag when the
         // marker called for it.
         let content = outcome.content.withConcealed(isConcealed)
-        sendOfferIfNeeded(
-            content, channel: channel, changeCount: currentCount,
-            pasteboardWasEmpty: firstItemTypes.isEmpty)
+        guard !content.isEmpty else {
+            noteSnapshotOfferedNothing(
+                pasteboardHeldSomething: !firstItemTypes.isEmpty, changeCount: currentCount)
+            return
+        }
+        sendOfferIfNeeded(content, channel: channel, changeCount: currentCount)
     }
 
     /// Records, once per snapshot, that `count` copied folders were left out
@@ -643,36 +655,47 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         }
     }
 
+    /// Retires the host's offer for a snapshot that yielded nothing offerable,
+    /// and tells the guest's own menu when a copy is what came up empty.
+    ///
+    /// `pasteboardHeldSomething` separates a copy whose every flavor was
+    /// filtered out from a pasteboard emptied outright, which are not the same
+    /// news. Only a snapshot a poll on this connection watched arrive is a copy
+    /// at all: the first poll re-evaluates whatever was already standing —
+    /// including a promise this agent wrote, whose providers stop serving the
+    /// moment the promise behind them is dropped — so it re-announces silently
+    /// rather than reporting a gesture nobody just made.
+    private func noteSnapshotOfferedNothing(pasteboardHeldSomething: Bool, changeCount: Int) {
+        // The pasteboard still moved on, so the host's previous offer is retired
+        // rather than left serving a copy the user has replaced.
+        let released = releaseOutboundOffer("the copy left nothing that can cross")
+        let watchedItArrive = lastPasteboardChangeCount != Self.unobservedChangeCount
+        lastPasteboardChangeCount = changeCount
+        guard pasteboardHeldSomething, watchedItArrive else {
+            // Nobody's copy came up short here, so the only line that can be
+            // left wrong is one claiming the offer this just withdrew.
+            if released { clipboardActivityStorage = .enabled }
+            return
+        }
+        // A copy was made in this guest and none of it could cross. Its own menu
+        // is the only account of that (docs/CLIPBOARD.md §13), and without one
+        // the line still reads as the copy before it, which did.
+        Self.logger.notice(
+            "Copy left nothing that can be offered to the host (conn=\(self.connectionTag, privacy: .public))"
+        )
+        clipboardActivityStorage = .copyCarriedNothing
+        onClipboardNotice()
+    }
+
     /// Announces `content` to the host when it's non-empty and not an echo of
     /// what we last wrote/sent, advancing the dedup + change-count bookkeeping.
-    ///
-    /// `pasteboardWasEmpty` separates the two ways `content` arrives empty — the
-    /// pasteboard holding nothing, and a copy whose every flavor was filtered
-    /// out — which owe the guest's menu different accounts.
     private func sendOfferIfNeeded(
-        _ content: ClipboardContent, channel: VsockChannel, changeCount: Int,
-        pasteboardWasEmpty: Bool
+        _ content: ClipboardContent, channel: VsockChannel, changeCount: Int
     ) {
         guard !content.isEmpty else {
-            // The pasteboard still moved on, so the host's previous offer is
-            // retired rather than left serving a copy the user has replaced.
-            let released = releaseOutboundOffer("the copy left nothing that can cross")
-            lastPasteboardChangeCount = changeCount
-            guard !pasteboardWasEmpty else {
-                // Nothing was copied — the clipboard was emptied — so the only
-                // line the user can be left holding is one claiming the offer
-                // this just withdrew.
-                if released { clipboardActivityStorage = .enabled }
-                return
-            }
-            // A copy was made in this guest and none of it could cross. Its own
-            // menu is the only account of that (docs/CLIPBOARD.md §13), and
-            // without one the line still reads as the copy before it, which did.
-            Self.logger.notice(
-                "Copy left nothing that can be offered to the host (conn=\(self.connectionTag, privacy: .public))"
-            )
-            clipboardActivityStorage = .copyCarriedNothing
-            onClipboardNotice()
+            // A caller that can observe an empty snapshot classifies it itself;
+            // one that hasn't can't claim a copy came up short.
+            noteSnapshotOfferedNothing(pasteboardHeldSomething: false, changeCount: changeCount)
             return
         }
         // Dedup on the buffer's own (uncapped) digest — the poll rebuilds the
@@ -867,7 +890,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                 guard self.pasteboard.changeCount == changeCount, !reps.isEmpty else { return }
                 self.sendOfferIfNeeded(
                     ClipboardContent(representations: reps), channel: channel,
-                    changeCount: changeCount, pasteboardWasEmpty: false)
+                    changeCount: changeCount)
             }
         }
     }

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -526,13 +526,18 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             }
         }
 
+        // Read once: the marker disposition, the flavors worth reading, and the
+        // account an empty result owes the menu all have to describe the same
+        // snapshot.
+        let firstItemTypes = pasteboard.firstItemTypes
+
         // `org.nspasteboard.*` marker handling, from the unfiltered first-item
         // type list: a transient/auto-generated snapshot is never offered; a
         // concealed one (a password) is offered but flagged so the host window
         // hides it. Folders are never concealed secrets, so the estimate path
         // below ignores the flag.
         let disposition = ClipboardSnapshotPolicy.disposition(
-            forTypes: pasteboard.firstItemTypes.map(\.rawValue))
+            forTypes: firstItemTypes.map(\.rawValue))
         if case .suppress(let reason) = disposition {
             Self.logger.notice(
                 "Clipboard snapshot suppressed by \(String(describing: reason), privacy: .public) marker"
@@ -577,13 +582,14 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                             uti: candidate.type.identifier, fileURL: candidate.url,
                             byteCount: candidate.byteCount, filename: candidate.filename)
                     }, isConcealed: isConcealed)
-                sendOfferIfNeeded(content, channel: channel, changeCount: currentCount)
+                sendOfferIfNeeded(
+                    content, channel: channel, changeCount: currentCount, pasteboardWasEmpty: false)
             }
             return
         }
 
         // Non-file snapshot. NSPasteboard reads run on the main queue.
-        let raw: [(uti: String, data: Data)] = pasteboard.firstItemTypes.compactMap { type in
+        let raw: [(uti: String, data: Data)] = firstItemTypes.compactMap { type in
             guard !ClipboardSnapshotPolicy.shouldSkipBeforeReading(uti: type.rawValue) else {
                 return nil
             }
@@ -603,7 +609,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         // `evaluate` builds non-concealed content; re-stamp the flag when the
         // marker called for it.
         let content = outcome.content.withConcealed(isConcealed)
-        sendOfferIfNeeded(content, channel: channel, changeCount: currentCount)
+        sendOfferIfNeeded(
+            content, channel: channel, changeCount: currentCount,
+            pasteboardWasEmpty: firstItemTypes.isEmpty)
     }
 
     /// Records, once per snapshot, that `count` copied folders were left out
@@ -637,14 +645,34 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
 
     /// Announces `content` to the host when it's non-empty and not an echo of
     /// what we last wrote/sent, advancing the dedup + change-count bookkeeping.
+    ///
+    /// `pasteboardWasEmpty` separates the two ways `content` arrives empty — the
+    /// pasteboard holding nothing, and a copy whose every flavor was filtered
+    /// out — which owe the guest's menu different accounts.
     private func sendOfferIfNeeded(
-        _ content: ClipboardContent, channel: VsockChannel, changeCount: Int
+        _ content: ClipboardContent, channel: VsockChannel, changeCount: Int,
+        pasteboardWasEmpty: Bool
     ) {
         guard !content.isEmpty else {
             // The pasteboard still moved on, so the host's previous offer is
             // retired rather than left serving a copy the user has replaced.
-            releaseOutboundOffer("the copy left nothing that can cross")
+            let released = releaseOutboundOffer("the copy left nothing that can cross")
             lastPasteboardChangeCount = changeCount
+            guard !pasteboardWasEmpty else {
+                // Nothing was copied — the clipboard was emptied — so the only
+                // line the user can be left holding is one claiming the offer
+                // this just withdrew.
+                if released { clipboardActivityStorage = .enabled }
+                return
+            }
+            // A copy was made in this guest and none of it could cross. Its own
+            // menu is the only account of that (docs/CLIPBOARD.md §13), and
+            // without one the line still reads as the copy before it, which did.
+            Self.logger.notice(
+                "Copy left nothing that can be offered to the host (conn=\(self.connectionTag, privacy: .public))"
+            )
+            clipboardActivityStorage = .copyCarriedNothing
+            onClipboardNotice()
             return
         }
         // Dedup on the buffer's own (uncapped) digest — the poll rebuilds the
@@ -690,7 +718,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     }
 
     /// Retires the offer the host still holds, because this snapshot left nothing
-    /// to replace it with.
+    /// to replace it with, reporting whether one was actually withdrawn.
     ///
     /// `ClipboardRelease` rather than an empty offer: an offer with no
     /// representations drops the host's promise but leaves the pasteboard item
@@ -700,8 +728,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// `org.nspasteboard.*` marker suppressed never reaches here: by that
     /// marker's convention it is not a copy, and the clipboard before it still
     /// stands.
-    private func releaseOutboundOffer(_ reason: String) {
-        guard let channel = liveChannel, let previous = pendingOutbound else { return }
+    @discardableResult
+    private func releaseOutboundOffer(_ reason: String) -> Bool {
+        guard let channel = liveChannel, let previous = pendingOutbound else { return false }
         var frame = Frame()
         frame.protocolVersion = 1
         frame.clipboardRelease = Kernova_V1_ClipboardRelease.with {
@@ -713,7 +742,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             Self.logger.warning(
                 "Failed to release clipboard offer gen=\(previous.generation, privacy: .public): \(error.localizedDescription, privacy: .public)"
             )
-            return
+            return false
         }
         sender?.cancel(generation: previous.generation)
         pendingOutbound = nil
@@ -726,6 +755,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         Self.logger.notice(
             "Released clipboard offer gen=\(previous.generation, privacy: .public) (conn=\(self.connectionTag, privacy: .public)) — \(reason, privacy: .public)"
         )
+        return true
     }
 
     /// One on-disk pasteboard file or folder gathered for an outbound offer.
@@ -837,7 +867,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
                 guard self.pasteboard.changeCount == changeCount, !reps.isEmpty else { return }
                 self.sendOfferIfNeeded(
                     ClipboardContent(representations: reps), channel: channel,
-                    changeCount: changeCount)
+                    changeCount: changeCount, pasteboardWasEmpty: false)
             }
         }
     }

--- a/KernovaMacOSAgentTests/AgentMenuTextTests.swift
+++ b/KernovaMacOSAgentTests/AgentMenuTextTests.swift
@@ -106,6 +106,16 @@ struct AgentMenuTextTests {
                 == "Clipboard: folders not shared — Kernova on the Mac needs updating")
     }
 
+    @Test("a copy that carried nothing says so rather than naming a cause it can't know")
+    func clipboardCopyCarriedNothingLine() {
+        // Unreadable items, an all-filtered flavor set and a pasteboard whose
+        // every item is already staged all reach this line, so it names the
+        // outcome the user can see and no reason it would have to guess at.
+        #expect(
+            AgentMenuText.clipboardLine(.copyCarriedNothing)
+                == "Clipboard: nothing in that copy could be shared")
+    }
+
     // MARK: - isNotice
 
     @Test("Only the outcomes of a gesture made in this guest reveal themselves")
@@ -113,6 +123,7 @@ struct AgentMenuTextTests {
         #expect(ClipboardActivity.pasteRefused(.pasteFailed, pasteLimitBytes: nil).isNotice)
         #expect(ClipboardActivity.copyShortened(offeringAnything: true).isNotice)
         #expect(ClipboardActivity.copyShortened(offeringAnything: false).isNotice)
+        #expect(ClipboardActivity.copyCarriedNothing.isNotice)
         for activity: ClipboardActivity in [
             .enabled, .offeredToHost, .offeredFromHost, .sentToHost, .receivedFromHost, .disabled,
         ] {

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -946,6 +946,72 @@ struct VsockGuestClipboardAgentTests {
         #expect(reoffer.generation > offer.generation)
     }
 
+    @Test("outbound: a copy nothing survives tells the guest's own menu it didn't cross, once")
+    func outboundUnreadableCopyRaisesTheGuestNotice() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let notices = AtomicInt()
+        let agent = makeAgent(
+            pasteboard: pasteboard, agentFd: agentFd, onClipboardNotice: { notices.increment() })
+        defer { agent.stop() }
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        pasteboard.setString("carried", forType: .string)
+        await MainActor.run { agent.checkClipboardChange() }
+        _ = try await awaitOffer(on: hostChannel)
+        #expect(await MainActor.run { agent.clipboardActivity } == .offeredToHost)
+
+        pasteboard.setItem([
+            (type: .fileURL, data: Data("file:///nonexistent/\(UUID().uuidString)".utf8))
+        ])
+        await MainActor.run { agent.checkClipboardChange() }
+
+        // The release emptied the Mac's clipboard, so leaving the line at the
+        // copy that crossed before it would read as the copy that just didn't.
+        try await notices.changed.wait { notices.value == 1 }
+        #expect(await MainActor.run { agent.clipboardActivity } == .copyCarriedNothing)
+
+        // A re-check of the same snapshot is not a second copy, so it is not
+        // owed a second interruption.
+        await MainActor.run { agent.checkClipboardChange() }
+        #expect(notices.value == 1)
+    }
+
+    @Test("outbound: an emptied clipboard withdraws the offer without reading as a failed copy")
+    func outboundEmptiedPasteboardReturnsTheMenuToEnabled() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let notices = AtomicInt()
+        let agent = makeAgent(
+            pasteboard: pasteboard, agentFd: agentFd, onClipboardNotice: { notices.increment() })
+        defer { agent.stop() }
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+
+        pasteboard.setString("carried", forType: .string)
+        await MainActor.run { agent.checkClipboardChange() }
+        let offer = try await awaitOffer(on: hostChannel)
+
+        pasteboard.clearContents()
+        await MainActor.run { agent.checkClipboardChange() }
+
+        let release = try await awaitRelease(on: hostChannel)
+        #expect(release.generation == offer.generation)
+
+        // Emptying the clipboard is nobody's failed gesture: the offer it had
+        // crossed under is gone, which is all the line may still claim, and
+        // there is no outcome worth opening the dropdown over.
+        #expect(await MainActor.run { agent.clipboardActivity } == .enabled)
+        #expect(notices.value == 0)
+    }
+
     @Test("outbound suppressed: a transient snapshot is not a copy, so it releases nothing")
     func outboundSuppressedSnapshotLeavesTheOfferStanding() async throws {
         let pasteboard = FakePasteboard()

--- a/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestClipboardAgentTests.swift
@@ -981,6 +981,45 @@ struct VsockGuestClipboardAgentTests {
         #expect(notices.value == 1)
     }
 
+    @Test("outbound: the first poll of a connection re-reads a snapshot without blaming a copy")
+    func outboundFirstPollAfterConnectingReportsNoCopy() async throws {
+        let pasteboard = FakePasteboard()
+        let (agentFd, remoteFd) = try makeRawSocketPair()
+        let hostChannel = VsockChannel(fileDescriptor: remoteFd)
+        hostChannel.start()
+        defer { hostChannel.close() }
+
+        let notices = AtomicInt()
+        let agent = makeAgent(
+            pasteboard: pasteboard, agentFd: agentFd, onClipboardNotice: { notices.increment() })
+        defer { agent.stop() }
+
+        // A snapshot already standing when the channel comes up, whose flavors
+        // read as nothing. The promise this agent wrote for a host offer is the
+        // one that matters: reconnecting drops the promise behind it, so its
+        // providers stop serving and every type comes back empty — for a copy
+        // the guest user never made.
+        pasteboard.setItem([
+            (type: .fileURL, data: Data("file:///nonexistent/\(UUID().uuidString)".utf8))
+        ])
+        try await startAgentAndWaitForLiveChannel(agent: agent)
+        await MainActor.run { agent.checkClipboardChange() }
+
+        // Re-announcing to a host that has no record of prior offers is not a
+        // gesture anyone just made, so it interrupts nobody and leaves the line
+        // where policy set it.
+        #expect(notices.value == 0)
+        #expect(await MainActor.run { agent.clipboardActivity } == .enabled)
+
+        // The copy after it is watched arriving, so that one is reported.
+        pasteboard.setItem([
+            (type: .fileURL, data: Data("file:///nonexistent/\(UUID().uuidString)".utf8))
+        ])
+        await MainActor.run { agent.checkClipboardChange() }
+        try await notices.changed.wait { notices.value == 1 }
+        #expect(await MainActor.run { agent.clipboardActivity } == .copyCarriedNothing)
+    }
+
     @Test("outbound: an emptied clipboard withdraws the offer without reading as a failed copy")
     func outboundEmptiedPasteboardReturnsTheMenuToEnabled() async throws {
         let pasteboard = FakePasteboard()


### PR DESCRIPTION
## Summary

`VsockGuestClipboardAgent`'s empty-content branch releases the host's clipboard and wrote nothing to `clipboardActivity`, so the agent's menu-bar line kept whatever the *previous* copy set — typically `.offeredToHost`. The dropdown read as a copy that crossed while the Mac's clipboard had in fact just been emptied by the release the same path sent. The folders-only branch never had this: `noteFoldersSkipped` records `.copyShortened(offeringAnything: false)` and raises the notice.

Three outcomes reach that branch and they are not the same news:

- **A copy nothing survives** — unreadable items, all-skipped flavors, every item already inside our staging root. A gesture was made in this guest and none of it could cross, so it gets a new `.copyCarriedNothing` and interrupts, exactly as `.copyShortened(offeringAnything: false)` does for the identical user-visible outcome (docs/CLIPBOARD.md §13 — report on the side that made the gesture).
- **An emptied pasteboard** — nobody's failed gesture. It returns the line to `.enabled` and interrupts nobody.
- **A snapshot no poll on this connection watched arrive** — `serve` drops `inboundPromise` and resets the change count to its sentinel, so the first poll re-reads whatever was already standing. When that is the promise this agent wrote for the host's last offer, its providers no longer serve and every type comes back empty — a copy the guest user never made. It re-announces silently.

The first two are told apart by the first item's type list, which `checkClipboardChange` now reads once and shares with the marker disposition and the flavor read, so the two decisions cannot describe different snapshots. The third is told apart by the change count having advanced from a real observation rather than from the post-connect sentinel, now named `unobservedChangeCount`.

The whole policy lives in `noteSnapshotOfferedNothing`, off the offer path: `sendOfferIfNeeded` keeps its original signature and routes its own empty guard through the helper, so the two callers that cannot observe an empty snapshot carry no classification they are unable to make.

The `.enabled` reset is conditioned on the release having actually withdrawn something (`releaseOutboundOffer` now reports it). With no offer standing, nothing about the line had become false, so an unrelated clipboard clear can't wipe a refusal notice it isn't replacing.

`.enabled`'s meaning widens from "nothing has crossed yet this session" to "no copy of this guest's stands on the host clipboard" — true of both the session start and a withdrawn offer.

The guest agent's `MARKETING_VERSION` moves 0.60.0 → 0.61.1: the fix lives entirely in the agent binary, so a running guest needs the reinstall the version mismatch surfaces.

Closes #785

## Changes

- `KernovaMacOSAgent/AgentUIState.swift` — new `.copyCarriedNothing` case, included in `isNotice`; `.enabled` redocumented
- `KernovaMacOSAgent/AgentMenuText.swift` — "Clipboard: nothing in that copy could be shared"; names the outcome and no cause, since the branch cannot tell which of the three produced it
- `KernovaMacOSAgent/VsockGuestClipboardAgent.swift` — `noteSnapshotOfferedNothing(pasteboardHeldSomething:changeCount:)`; `releaseOutboundOffer` returns whether it withdrew an offer; `unobservedChangeCount`; single read of `firstItemTypes`
- `Kernova.xcodeproj/project.pbxproj` — agent `MARKETING_VERSION` in both configurations
- Tests — the menu line and its notice status; the copy that carries nothing reports once and is not owed a second interruption on re-check; the first poll of a connection re-reads a standing unreadable snapshot without a notice while the copy after it still reports; the emptied clipboard withdraws the offer, returns to `.enabled` and raises no notice

## Test plan

- [x] `make test` — 2568 passed, 0 failed
- [x] `make lint`
- [x] The reconnect regression test fails on all three assertions with its gate removed

## Notes

No `RATIONALE:` comments added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)