### PR TITLE
refactor: Clear the dead-code scan findings

### DIFF
--- a/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift
@@ -3,7 +3,7 @@ import Foundation
 import System
 
 /// Why an extract was stopped by the consumer rather than by the archive.
-public enum ClipboardArchiveOutputRefusal: Equatable, Sendable {
+enum ClipboardArchiveOutputRefusal: Equatable, Sendable {
     /// The staging volume no longer has room for the tree being written.
     case diskFull
     /// The tree outgrew the size the offer advertised for it.
@@ -11,7 +11,7 @@ public enum ClipboardArchiveOutputRefusal: Equatable, Sendable {
 }
 
 /// Why a streamed directory archive stopped.
-public enum ClipboardArchiveStreamError: Error, Equatable {
+enum ClipboardArchiveStreamError: Error, Equatable {
     /// A seek or random-access operation on a purely sequential stream.
     ///
     /// AppleArchive drives both pipelines here with sequential reads and writes

--- a/KernovaKit/Sources/KernovaKit/KernovaLogger.swift
+++ b/KernovaKit/Sources/KernovaKit/KernovaLogger.swift
@@ -67,6 +67,8 @@ public struct KernovaLogger: Sendable {
         forward(level: .warning, message: message.wireRendered)
     }
 
+    // periphery:ignore - the level ladder mirrors `os.Logger`, and the wire enum
+    // carries `.error` through to `VsockGuestLogService`, which re-logs it.
     /// Logs at `.error` and forwards the wire form.
     public func error(_ message: KernovaLogMessage) {
         osLogger.error("\(message.localRendered, privacy: .public)")

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryTransferTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryTransferTests.swift
@@ -24,20 +24,6 @@ struct ClipboardDirectoryTransferTests {
             directorySource: directorySource)
     }
 
-    /// A tree whose archive is far smaller than the tree it unpacks to — the
-    /// shape every compressed-vs-decompressed accounting bug hides in.
-    private func makeCompressibleTree(uncompressedBytes: Int = 512 * 1024) throws -> (
-        scratch: URL, source: URL
-    ) {
-        let fm = FileManager.default
-        let scratch = makeScratch()
-        let source = scratch.appendingPathComponent("Logs", isDirectory: true)
-        try fm.createDirectory(at: source, withIntermediateDirectories: true)
-        try Data(repeating: 0x20, count: uncompressedBytes)
-            .write(to: source.appendingPathComponent("big.log"))
-        return (scratch, source)
-    }
-
     private func makeScratch() -> URL {
         FileManager.default.temporaryDirectory.appendingPathComponent(
             "dirtransfer-\(UUID().uuidString)", isDirectory: true)

--- a/KernovaKit/Tests/KernovaKitTests/LazyClipboardDataProviderTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/LazyClipboardDataProviderTests.swift
@@ -1,7 +1,6 @@
 import AppKit
 import Foundation
 import Testing
-import KernovaTestSupport
 
 @testable import KernovaKit
 

--- a/KernovaTests/ClipboardPasteLimitPolicyPushTests.swift
+++ b/KernovaTests/ClipboardPasteLimitPolicyPushTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import KernovaKit
-import KernovaTestSupport
 import Testing
 
 @testable import Kernova

--- a/KernovaTests/VMInstanceAgentReconnectTests.swift
+++ b/KernovaTests/VMInstanceAgentReconnectTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import KernovaKit
-import KernovaTestSupport
 import Testing
 
 @testable import Kernova

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -2,7 +2,6 @@ import Testing
 import Foundation
 import AppKit
 import KernovaKit
-import KernovaTestSupport
 @testable import Kernova
 
 @Suite("VMInstance Tests")

--- a/KernovaTests/VMInstanceVsockAdmissionTests.swift
+++ b/KernovaTests/VMInstanceVsockAdmissionTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import KernovaKit
-import KernovaTestSupport
 import Testing
 
 @testable import Kernova

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -914,7 +914,7 @@ struct VMLifecycleCoordinatorTests {
         let digest: String
     }
 
-    private func makeLinuxFixture(name: String = #function) throws -> LinuxFixture {
+    private func makeLinuxFixture() throws -> LinuxFixture {
         let downloads = FileManager.default.temporaryDirectory
             .appendingPathComponent("linuxImage-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: downloads, withIntermediateDirectories: true)

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -97,7 +97,9 @@ Annotate freely here, unlike a `RATIONALE:` — the scan re-raises the symbol de
 - **Fix** when the finding is real — delete the symbol, or demote `public` to `internal` if only the access level is redundant.
 - **Dismiss** never applies: every annotation carries a reason, since silently retained symbols become a maintenance hazard.
 
-**Format** — put the directive **between** the doc comment and the declaration so DocC still associates the doc with the symbol, and keep the reason in the same comment block, with no blank line after the directive. `periphery:ignore:parameters <names>` scopes it to those parameters instead of the whole declaration:
+**Format** — keep the directive and its reason in one comment block, with no blank line after the directive. The block goes directly above the declaration, after the doc comment; on a `public` declaration it goes **above** the doc comment instead, since swift-format's `AllPublicDeclarationsHaveDocumentation` only credits a `///` that touches the declaration and `make lint` is a required check.
+
+`periphery:ignore:parameters <names>` scopes the directive to those parameters instead of the whole declaration:
 
 ```swift
 /// Suspends until the next `notify()`, an immediate hit, or the `deadline`


### PR DESCRIPTION
Closes #787

## Summary

All nine Periphery findings. Eight are genuinely dead and are removed; one is retained behind a `// periphery:ignore`, disclosed below.

**Redundant public accessibility (1 finding).** `ClipboardArchiveStreamError` is thrown, caught, and pattern-matched only inside `KernovaKit` — `ClipboardDirectoryStream` and `ClipboardStreamReceiver` in production, and `ClipboardDirectoryStreamTests` through `@testable import`. Nothing in `Kernova`, `KernovaMacOSAgent`, or `KernovaRelaunchHelper` names it. It narrows to internal.

**Its payload narrows too, though the scan did not flag it.** `ClipboardArchiveOutputRefusal` has the same in-module-only reference set, but Periphery suppresses the redundant-public warning while an enclosing public declaration forces the accessibility — here, `case outputRefused(ClipboardArchiveOutputRefusal)`. Narrowing only the parent would have removed that suppression and surfaced the payload as a brand-new finding on the next Monday scan, so both move in this diff. The local scan below confirms neither reappears.

**Unused function, retained (1 finding).** `KernovaLogger.error(_:)` has no caller, and Periphery is right about that — but [docs/REVIEW.md](docs/REVIEW.md#periphery-directives) already rules on this exact shape, with this exact example: **Annotate** when "the surface is intentionally complete (all `os.Logger` levels exposed even if one isn't called today)."

The supporting facts line up with that rule. The type's own doc comment states the contract ("Construction and call-site syntax match `os.Logger`, privacy attributes included"); `Kernova_V1_LogRecord.Level` carries `.error` on the wire; and `VsockGuestLogService.swift:151` already re-logs `.error` records on the host. The gap is structural rather than accidental: the agent's busiest error paths live in `VsockGuestClient`, which [deliberately uses raw `os.Logger`, never `KernovaLogger`](https://github.com/nicholas-lonsinger/kernova/blob/main/KernovaMacOSAgent/VsockGuestClient.swift#L137-L139), because the sink it would forward through is that very transport. So no current `KernovaLogger` user has hit an error path, and deleting the level would leave the emitter unable to produce a level the rest of the pipeline fully supports.

**The annotation-placement rule was wrong, and this annotation is what found it.** [docs/REVIEW.md](docs/REVIEW.md) instructed putting the directive *between* the doc comment and the declaration. On a `public` declaration that fails `make lint` — a required check — because swift-format's `AllPublicDeclarationsHaveDocumentation` only credits a `///` that touches the declaration. The rule's worked example is a `private func`, where either placement passes, so nothing had exercised the case that breaks.

Verified rather than assumed, by linting a probe carrying all three shapes against the repo's own `.swift-format`: between-placement on a public declaration is flagged; above-placement on a public declaration is not; and on a private declaration neither is. The paragraph now states the public-declaration exception. Its old stated reason — "so DocC still associates the doc with the symbol" — argued for the very adjacency that between-placement destroys, so it is dropped rather than reworded.

A second full scan confirms the `- <reason>` form that [docs/REVIEW.md](docs/REVIEW.md) and AGENTS.md prescribe is one Periphery actually honours, so the code here uses it. That was worth establishing: had it not parsed, every annotation written to spec would silently fail to suppress its finding.

**Unused test declarations and imports (7 findings).** `ClipboardDirectoryTransferTests.makeCompressibleTree` is an unused near-duplicate of the live helper of the same name in `ClipboardDirectoryAccountingTests`, which has ten call sites; deleting the dead copy removes the duplication rather than leaving two. `makeLinuxFixture` drops a `name: String = #function` parameter its body never read and none of its 20 callers ever passed. Five test files drop a `KernovaTestSupport` import they use nothing from — the same shape as the `RemindersSettingsViewControllerTests` import cleared in #705.

## Changes

- `KernovaKit/Sources/KernovaKit/ClipboardDirectoryStream.swift`
- `KernovaKit/Sources/KernovaKit/KernovaLogger.swift`
- `KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryTransferTests.swift`
- `KernovaKit/Tests/KernovaKitTests/LazyClipboardDataProviderTests.swift`
- `KernovaTests/ClipboardPasteLimitPolicyPushTests.swift`
- `KernovaTests/VMInstanceAgentReconnectTests.swift`
- `KernovaTests/VMInstanceTests.swift`
- `KernovaTests/VMInstanceVsockAdmissionTests.swift`
- `KernovaTests/VMLifecycleCoordinatorTests.swift`
- `docs/REVIEW.md` — the "Periphery directives" format paragraph

No behavior changes: two access-level narrowings on types no other target could see, one comment, and test-local deletions. No component boundary moved, so no ARCHITECTURE.md edit.

## Test plan

- [x] `make test` — 2511 tests pass across all three targets, `** TEST SUCCEEDED **`
- [x] `make lint`
- [x] `periphery scan` (3.7.4, repo `.periphery.yml`) locally — reproduced all nine findings verbatim before the change, and *No unused code detected* after. This is what verifies the two things a reviewer cannot check by reading: that the `// periphery:ignore` actually parses, and that narrowing `ClipboardArchiveOutputRefusal` alongside its parent leaves nothing newly exposed.
- [x] `periphery scan` a second time with the directive in `- <reason>` form — also clean, establishing that the prescribed format suppresses the finding.
- [x] `swift-format lint --strict` against a probe carrying between/above placement on public and private declarations, to pin down which combination `AllPublicDeclarationsHaveDocumentation` rejects.

## Notes

- One `// periphery:ignore` added, on `KernovaLogger.error(_:)` in `KernovaKit/Sources/KernovaKit/KernovaLogger.swift`. Evidence cited in the comment: the level ladder's `os.Logger` parity (stated in the type's own doc comment) and the `.error` re-log in `Kernova/Services/VsockGuestLogService.swift`.
- The docs/REVIEW.md edit is a correction, not an addition — the paragraph gave instructions that fail a required check. `AsyncWaits.swift` already carries both orderings (public `waitUntil` above the doc comment, private `armOnce` between), so the codebase was consistent with the corrected rule while the doc was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsALxm3NKdiK24YwF977nq
