### PR TITLE
docs: Reset a merged worktree branch so cleanup can reap it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,23 @@ guard refuses ad-hoc `git -C <primary-checkout>` commands. After confirming
 the merge landed (`gh pr view <N> --json state -q .state` → `"MERGED"`),
 fast-forward `main` in that checkout rather than from this worktree.
 
+Then, still inside this worktree, drop the branch's now-redundant commits:
+
+```bash
+git fetch origin main && git reset --hard origin/main
+```
+
+Squash merging rewrites the work into a new commit, so the branch keeps
+commits `main` never gains and every later check reads them as unmerged work —
+which is what strands the worktree when a session ends without
+`ExitWorktree(remove)`. The reset is safe once state is `"MERGED"`: the work is
+on `main` as the squash commit, and the reset leaves this worktree matching it.
+
+Left-behind worktrees are removable the same way: verify `gh pr list --head
+<remote-branch> --state all` reports `MERGED`, then `git worktree remove <path>`
+(add `--force` if Xcode left an `xcuserstate` behind) and `git branch -D
+<worktree-branch>`.
+
 ## Matching review effort to the diff
 
 `/code-review low` for trivial/mechanical diffs; `medium` (precision-biased —


### PR DESCRIPTION
## Summary

Three `bridge-cse_*` worktrees were left on disk after their PRs merged. Squash merging rewrites the branch's work into a new commit, so the branch keeps commits `main` never gains — every later check reads them as unmerged work, and a session that ends without `ExitWorktree(remove)` strands the worktree.

Rather than teach the cleanup path about squash merges, make the worktree honestly unchanged once the merge has landed: after `gh pr view <N>` reports `MERGED`, reset the branch onto `origin/main`. The work is already on `main` as the squash commit, so nothing is lost, and the worktree now matches it.

Also documents the recovery path for worktrees already stranded, since the `: gone` upstream is the only signal they are done.

## Changes

- `CLAUDE.md`: extend "Post-merge cleanup in an `EnterWorktree` session" with the reset step and the stale-worktree cleanup commands.

## Test plan

- [x] `Tools/check-docs.sh` passes