### PR TITLE
refactor: Load the VM library after launch, off the main actor

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -16,7 +16,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private let preferences: AppPreferences
     private var mainWindowController: MainWindowController?
     private let viewModel: VMLibraryViewModel
-    /// The library's first read from disk, started once launch is complete.
+    /// The library's first read from disk, started in
+    /// `applicationWillFinishLaunching`.
     ///
     /// Retained so `application(_:open:)` can wait for it: a Finder open that
     /// launched the app is delivered while the read is still in flight.
@@ -295,6 +296,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     // MARK: - NSApplicationDelegate
 
+    /// Starts the library read.
+    ///
+    /// Deliberately here and not in `applicationDidFinishLaunching`: AppKit
+    /// delivers a launch document's `application(_:open:)` *between* the two, and
+    /// that path waits on `libraryLoad` — left unset, the wait would silently
+    /// pass through and re-import a bundle already in the library. Starting the
+    /// read costs nothing here; the task body only runs once the main actor
+    /// yields, and its file I/O is off the main actor either way.
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        libraryLoad = Task { @MainActor [viewModel] in await viewModel.startLibrary() }
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         setupMainMenu()
 
@@ -324,12 +337,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         } else {
             startResidentApp()
         }
-
-        // Last, and asynchronously: the library read is disk-bound, and every
-        // step above — the cold-launch resolution most of all — has to reach the
-        // run loop without waiting on it. The window is already on screen and
-        // fills in when the read lands.
-        libraryLoad = Task { @MainActor [viewModel] in await viewModel.startLibrary() }
     }
 
     // MARK: - Resident App
@@ -1024,12 +1031,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     /// readable.
     ///
     /// The wait is what makes a Finder open of a bundle *already in the library*
-    /// still resolve to "select the existing VM": this callback is delivered
-    /// right after `applicationDidFinishLaunching`, while the first read is in
-    /// flight, and `importVMs(fromDroppedURLs:)` dedups by UUID against
-    /// `instances` — against an empty library it would copy the bundle a second
-    /// time instead. Awaiting a finished load resumes on the next tick, so an
-    /// open arriving later is unaffected.
+    /// still resolve to "select the existing VM": a launch document arrives
+    /// while the first read is in flight, and `importVMs(fromDroppedURLs:)`
+    /// dedups by UUID against `instances` — against an empty library it would
+    /// copy the bundle a second time instead. Awaiting a finished load resumes
+    /// on the next tick, so an open arriving later is unaffected.
     ///
     /// `importVMs(fromDroppedURLs:)` then reserves every destination in the batch
     /// without suspending and runs the copies concurrently, so two overlapping

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -16,6 +16,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private let preferences: AppPreferences
     private var mainWindowController: MainWindowController?
     private let viewModel: VMLibraryViewModel
+    /// The library's first read from disk, started once launch is complete.
+    ///
+    /// Retained so `application(_:open:)` can wait for it: a Finder open that
+    /// launched the app is delivered while the read is still in flight.
+    private var libraryLoad: Task<Void, Never>?
     private var clipboardWindows: [UUID: ClipboardWindowController] = [:]
     private var clipboardObservers: [UUID: Any] = [:]
     private var displayWindows: [UUID: VMDisplayWindowController] = [:]
@@ -319,6 +324,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         } else {
             startResidentApp()
         }
+
+        // Last, and asynchronously: the library read is disk-bound, and every
+        // step above — the cold-launch resolution most of all — has to reach the
+        // run loop without waiting on it. The window is already on screen and
+        // fills in when the read lands.
+        libraryLoad = Task { @MainActor [viewModel] in await viewModel.startLibrary() }
     }
 
     // MARK: - Resident App
@@ -1009,13 +1020,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         }
     }
 
-    /// Filters to `.kernova` bundles and imports the batch.
+    /// Filters to `.kernova` bundles and imports the batch, once the library is
+    /// readable.
     ///
-    /// `VMLibraryViewModel.importVMs(fromDroppedURLs:)` reserves each bundle's
-    /// destination synchronously and runs the copies concurrently, so this
-    /// synchronous delegate callback isn't blocked and the whole batch imports.
+    /// The wait is what makes a Finder open of a bundle *already in the library*
+    /// still resolve to "select the existing VM": this callback is delivered
+    /// right after `applicationDidFinishLaunching`, while the first read is in
+    /// flight, and `importVMs(fromDroppedURLs:)` dedups by UUID against
+    /// `instances` — against an empty library it would copy the bundle a second
+    /// time instead. Awaiting a finished load resumes on the next tick, so an
+    /// open arriving later is unaffected.
+    ///
+    /// `importVMs(fromDroppedURLs:)` then reserves every destination in the batch
+    /// without suspending and runs the copies concurrently, so two overlapping
+    /// triggers still see each other's phantoms.
     private func importVMs(from urls: [URL]) {
-        viewModel.importVMs(fromDroppedURLs: urls)
+        Task { @MainActor in
+            await self.libraryLoad?.value
+            self.viewModel.importVMs(fromDroppedURLs: urls)
+        }
     }
 
     // MARK: - Menu Actions

--- a/Kernova/App/DetailContainerViewController.swift
+++ b/Kernova/App/DetailContainerViewController.swift
@@ -30,6 +30,9 @@ final class DetailContainerViewController: NSViewController {
     private lazy var emptyStateView = DetailEmptyStateView { [weak self] in
         self?.presentCreationWizard()
     }
+    /// Shown until the library's first read lands — a bare pane, because at that
+    /// point the app knows of no VM to show and cannot yet say there is none.
+    private let unloadedLibraryView = NSView()
     private var routerVC: VMDetailRouterViewController?
     private var currentContentView: NSView?
     private var displayedInstanceID: UUID?
@@ -102,6 +105,14 @@ final class DetailContainerViewController: NSViewController {
     // MARK: - Detail content (empty state ⇆ router)
 
     private func updateContent() {
+        // "No Virtual Machine Selected", with its New Virtual Machine button, is
+        // a claim about the library — wrong, and actionable, while the library is
+        // still being read.
+        guard viewModel.hasLoadedLibrary else {
+            displayedInstanceID = nil
+            showContentView(unloadedLibraryView)
+            return
+        }
         if let selected = viewModel.selectedInstance {
             let router: VMDetailRouterViewController
             if let existing = routerVC {
@@ -187,6 +198,10 @@ final class DetailContainerViewController: NSViewController {
         stateObservation = observeRecurring(
             track: { [weak self] in
                 guard let self else { return }
+                // Load completion is its own signal: a library that reads back
+                // empty changes nothing else, so without this the pane would
+                // never leave `unloadedLibraryView`.
+                _ = self.viewModel.hasLoadedLibrary
                 _ = self.viewModel.selectedInstance
                 _ = self.viewModel.selectedInstance?.status
                 _ = self.viewModel.selectedInstance?.displayMode

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -159,7 +159,7 @@ final class VMLibraryViewModel {
     /// Fills the library from disk, then starts watching the VMs directory for
     /// changes made outside the app.
     ///
-    /// Called once, from `applicationDidFinishLaunching`. Deliberately not part
+    /// Called once, from `applicationWillFinishLaunching`. Deliberately not part
     /// of `init`: everything the initializer does runs before `NSApplication.run()`,
     /// so a library read there sits between process start and the first window.
     /// The watcher starts only after the read applies — its callback re-reads

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -21,6 +21,15 @@ final class VMLibraryViewModel {
     // MARK: - State
 
     var instances: [VMInstance] = []
+
+    /// Whether the library's first read from disk has finished.
+    ///
+    /// `false` until then, so UI can tell "no VMs" from "not read yet" — an empty
+    /// `instances` means nothing before the first `loadVMs()` applies. Stays
+    /// `true` across later reloads, and is set even when the read fails: the
+    /// answer is then known to be empty.
+    private(set) var hasLoadedLibrary = false
+
     var selectedID: UUID? {
         didSet {
             guard selectedID != oldValue else { return }
@@ -47,8 +56,9 @@ final class VMLibraryViewModel {
 
     /// Presentation delegate for alerts, sheets, and the creation wizard.
     ///
-    /// Errors raised before a presenter is attached (e.g. the initial `loadVMs()`
-    /// in `init`) are buffered and flushed when one is set.
+    /// Errors raised before a presenter is attached (e.g. a login launch, where
+    /// the library loads with no window on screen) are buffered and flushed when
+    /// one is set.
     @ObservationIgnored weak var presenter: (any VMLibraryPresenting)? {
         didSet {
             guard presenter != nil, !bufferedErrors.isEmpty else { return }
@@ -143,9 +153,20 @@ final class VMLibraryViewModel {
             downloadsDirectory: downloadsDirectory
         )
 
-        loadVMs()
-        startDirectoryWatcher()
         startSleepWatcher()
+    }
+
+    /// Fills the library from disk, then starts watching the VMs directory for
+    /// changes made outside the app.
+    ///
+    /// Called once, from `applicationDidFinishLaunching`. Deliberately not part
+    /// of `init`: everything the initializer does runs before `NSApplication.run()`,
+    /// so a library read there sits between process start and the first window.
+    /// The watcher starts only after the read applies — its callback re-reads
+    /// every bundle on the main actor, which must not race the initial load.
+    func startLibrary() async {
+        await loadVMs()
+        startDirectoryWatcher()
     }
 
     // MARK: - Initial Status
@@ -155,7 +176,7 @@ final class VMLibraryViewModel {
     /// A surviving install context — either guest's — is the canonical signal
     /// that the VM has never completed its initial boot, so it outranks
     /// `.paused`/`.stopped`.
-    static func initialStatus(for config: VMConfiguration, layout: VMBundleLayout) -> VMStatus {
+    nonisolated static func initialStatus(for config: VMConfiguration, layout: VMBundleLayout) -> VMStatus {
         if config.installContext != nil || config.linuxInstallContext != nil {
             return .initialBoot
         }
@@ -164,58 +185,104 @@ final class VMLibraryViewModel {
 
     // MARK: - Load
 
-    func loadVMs() {
+    /// One VM bundle as read from disk, before it becomes a `VMInstance`.
+    ///
+    /// `VMInstance` is `@MainActor`, so the read and the model construction have
+    /// to be separable: this is what crosses back from the reading task.
+    private struct ScannedBundle: Sendable {
+        let configuration: VMConfiguration
+        let bundleURL: URL
+        let status: VMStatus
+    }
+
+    /// The whole library as read from disk in one pass.
+    private struct LibraryScan: Sendable {
+        var bundles: [ScannedBundle] = []
+        /// Bundle names whose configuration could not be read.
+        var failedBundleNames: [String] = []
+    }
+
+    /// Reads every bundle under the VMs directory.
+    ///
+    /// Nonisolated so the disk work can run off the main actor; it touches no
+    /// view-model state and reports failures through the returned scan.
+    private nonisolated static func scanLibrary(using storage: any VMStorageProviding) throws -> LibraryScan {
+        var scan = LibraryScan()
+        for bundleURL in try storage.listVMBundles() {
+            do {
+                let config = try storage.loadConfiguration(from: bundleURL)
+                scan.bundles.append(
+                    ScannedBundle(
+                        configuration: config,
+                        bundleURL: bundleURL,
+                        status: initialStatus(for: config, layout: VMBundleLayout(bundleURL: bundleURL))))
+            } catch {
+                logger.error(
+                    "Failed to load VM from \(bundleURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+                scan.failedBundleNames.append(bundleURL.deletingPathExtension().lastPathComponent)
+            }
+        }
+        return scan
+    }
+
+    /// Replaces the library with what is on disk.
+    ///
+    /// The read runs off the main actor — a library of any size is bound by
+    /// per-bundle file reads, and blocking the main actor for them stalls
+    /// whatever window is already on screen.
+    func loadVMs() async {
         reportedFailedBundles.removeAll()
+        let storage = storageService
+        // Whatever the read returns, it is over: a listing that failed answers
+        // "no VMs" too, and UI must not go on waiting for a load that finished.
+        defer { hasLoadedLibrary = true }
         do {
-            let bundles = try storageService.listVMBundles()
-            var failedBundles: [String] = []
-            instances = bundles.compactMap { bundleURL in
-                do {
-                    let config = try storageService.loadConfiguration(from: bundleURL)
-                    let layout = VMBundleLayout(bundleURL: bundleURL)
-                    let initialStatus = Self.initialStatus(for: config, layout: layout)
-                    let instance = VMInstance(
-                        configuration: config, bundleURL: bundleURL, status: initialStatus,
-                        preferences: preferences)
-                    wirePersistence(for: instance)
-                    return instance
-                } catch {
-                    Self.logger.error(
-                        "Failed to load VM from \(bundleURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)"
-                    )
-                    failedBundles.append(bundleURL.deletingPathExtension().lastPathComponent)
-                    return nil
-                }
-            }
-            if !failedBundles.isEmpty {
-                reportedFailedBundles.formUnion(failedBundles)
-                presentError(LoadError.bundleLoadFailed(names: failedBundles))
-            }
-
-            if let savedOrder = preferences.vmOrder {
-                customOrder = savedOrder
-                Self.logger.debug("Loaded custom VM order: \(self.customOrder.count, privacy: .public) UUID(s)")
-            } else {
-                Self.logger.debug("No custom VM order found — using default createdAt sort")
-            }
-            sortInstances()
-            customOrder = instances.map(\.id)
-
-            if selectedID == nil || !instances.contains(where: { $0.id == selectedID }) {
-                if let savedID = preferences.lastSelectedVMID,
-                    instances.contains(where: { $0.id == savedID })
-                {
-                    selectedID = savedID
-                    Self.logger.debug("Restored last-selected VM from UserDefaults: \(savedID.uuidString)")
-                } else {
-                    selectedID = instances.first?.id
-                }
-            }
-            Self.logger.notice("Loaded \(self.instances.count, privacy: .public) VMs")
+            let scan = try await Task.detached(priority: .userInitiated) {
+                try Self.scanLibrary(using: storage)
+            }.value
+            apply(scan)
         } catch {
             Self.logger.error("Failed to load VM library: \(error.localizedDescription, privacy: .public)")
             presentError(error)
         }
+    }
+
+    /// Turns a scan into the live library: instances, order, and selection.
+    private func apply(_ scan: LibraryScan) {
+        instances = scan.bundles.map { scanned in
+            let instance = VMInstance(
+                configuration: scanned.configuration, bundleURL: scanned.bundleURL,
+                status: scanned.status, preferences: preferences)
+            wirePersistence(for: instance)
+            return instance
+        }
+
+        if !scan.failedBundleNames.isEmpty {
+            reportedFailedBundles.formUnion(scan.failedBundleNames)
+            presentError(LoadError.bundleLoadFailed(names: scan.failedBundleNames))
+        }
+
+        if let savedOrder = preferences.vmOrder {
+            customOrder = savedOrder
+            Self.logger.debug("Loaded custom VM order: \(self.customOrder.count, privacy: .public) UUID(s)")
+        } else {
+            Self.logger.debug("No custom VM order found — using default createdAt sort")
+        }
+        sortInstances()
+        customOrder = instances.map(\.id)
+
+        if selectedID == nil || !instances.contains(where: { $0.id == selectedID }) {
+            if let savedID = preferences.lastSelectedVMID,
+                instances.contains(where: { $0.id == savedID })
+            {
+                selectedID = savedID
+                Self.logger.debug("Restored last-selected VM from UserDefaults: \(savedID.uuidString)")
+            } else {
+                selectedID = instances.first?.id
+            }
+        }
+        Self.logger.notice("Loaded \(self.instances.count, privacy: .public) VMs")
     }
 
     // MARK: - Create
@@ -2408,7 +2475,7 @@ final class VMLibraryViewModel {
     }
 
     /// Routes an error message to the presenter, buffering it if none is
-    /// attached yet (e.g. during the initial `loadVMs()` in `init`).
+    /// attached yet.
     private func surfaceError(_ message: String, title: String = "Error") {
         if let presenter {
             presenter.presentError(message, title: title)

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -234,6 +234,10 @@ final class VMLibraryViewModel {
     func loadVMs() async {
         reportedFailedBundles.removeAll()
         let storage = storageService
+        // The read is asynchronous, so the library can be mutated while it runs.
+        // Anything appearing in `instances` after this line is newer than
+        // whatever the read returns, and the result must not delete it.
+        let knownBeforeRead = Set(instances.map(\.id))
         // Whatever the read returns, it is over: a listing that failed answers
         // "no VMs" too, and UI must not go on waiting for a load that finished.
         defer { hasLoadedLibrary = true }
@@ -241,7 +245,7 @@ final class VMLibraryViewModel {
             let scan = try await Task.detached(priority: .userInitiated) {
                 try Self.scanLibrary(using: storage)
             }.value
-            apply(scan)
+            apply(scan, keepingInstancesAddedSince: knownBeforeRead)
         } catch {
             Self.logger.error("Failed to load VM library: \(error.localizedDescription, privacy: .public)")
             presentError(error)
@@ -249,14 +253,26 @@ final class VMLibraryViewModel {
     }
 
     /// Turns a scan into the live library: instances, order, and selection.
-    private func apply(_ scan: LibraryScan) {
-        instances = scan.bundles.map { scanned in
-            let instance = VMInstance(
-                configuration: scanned.configuration, bundleURL: scanned.bundleURL,
-                status: scanned.status, preferences: preferences)
-            wirePersistence(for: instance)
-            return instance
-        }
+    ///
+    /// Instances registered since the read began outlive it, and outrank the
+    /// read's view of the same VM. A preparing phantom is the case that matters:
+    /// its copy is uninterruptible, so dropping the row would leave the copy
+    /// running against a bundle the library has forgotten — with no row to
+    /// cancel from, and `hasPreparing` back to `false`, which is exactly the gap
+    /// `reconcileWithDisk` refuses to open.
+    private func apply(_ scan: LibraryScan, keepingInstancesAddedSince knownBeforeRead: Set<UUID>) {
+        let addedDuringRead = instances.filter { !knownBeforeRead.contains($0.id) }
+        let addedDuringReadIDs = Set(addedDuringRead.map(\.id))
+        instances =
+            scan.bundles
+            .filter { !addedDuringReadIDs.contains($0.configuration.id) }
+            .map { scanned in
+                let instance = VMInstance(
+                    configuration: scanned.configuration, bundleURL: scanned.bundleURL,
+                    status: scanned.status, preferences: preferences)
+                wirePersistence(for: instance)
+                return instance
+            } + addedDuringRead
 
         if !scan.failedBundleNames.isEmpty {
             reportedFailedBundles.formUnion(scan.failedBundleNames)

--- a/KernovaTests/DetailContainerLibraryLoadTests.swift
+++ b/KernovaTests/DetailContainerLibraryLoadTests.swift
@@ -1,0 +1,113 @@
+import AppKit
+import Testing
+import Foundation
+@testable import Kernova
+
+/// The detail pane across the library's empty-until-read interval. The app now
+/// presents its window before the library has been read, so the pane has to
+/// distinguish "no VMs" from "no VMs *yet*".
+@Suite("DetailContainer library-load state", .serialized)
+@MainActor
+struct DetailContainerLibraryLoadTests {
+    private let preferences = makeEphemeralPreferences(suiteName: "test.kernova.detail-load")
+
+    private func makeViewModel(storageService: MockVMStorageService = MockVMStorageService())
+        -> VMLibraryViewModel
+    {
+        VMLibraryViewModel(
+            storageService: storageService,
+            diskImageService: MockDiskImageService(),
+            virtualizationService: MockVirtualizationService(),
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService(),
+            usbDeviceService: MockUSBDeviceService(),
+            preferences: preferences
+        )
+    }
+
+    /// Hosts the container in a window and runs the appearance pass that builds
+    /// its content and arms its observation, as the split view controller does.
+    private func present(_ controller: DetailContainerViewController) -> NSWindow {
+        controller.loadViewIfNeeded()
+        let window = showInTestWindow(controller.view, size: NSSize(width: 900, height: 600))
+        controller.viewDidAppear()
+        return window
+    }
+
+    /// Runs after every main-actor task already queued, so an `ObservationLoop`
+    /// wake-up enqueued by the mutation under test has been applied.
+    ///
+    /// `ObservationLoop` applies through `Task { @MainActor … }` enqueued
+    /// synchronously from the mutation, so a task enqueued afterwards lands
+    /// behind it — a deterministic hand-off, not a poll or a settle delay.
+    private func drainMainActor() async {
+        await Task { @MainActor in }.value
+    }
+
+    private func hasEmptyState(_ controller: DetailContainerViewController) -> Bool {
+        func search(_ view: NSView) -> Bool {
+            if view is DetailEmptyStateView { return true }
+            return view.subviews.contains(where: search)
+        }
+        return search(controller.view)
+    }
+
+    private func storageHoldingOneVM() -> (MockVMStorageService, VMConfiguration) {
+        let storage = MockVMStorageService()
+        let config = VMConfiguration(name: "Library VM", guestOS: .linux, bootMode: .efi)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+        storage.bundles[url] = config
+        return (storage, config)
+    }
+
+    @Test("The no-VM empty state is withheld until the library has been read")
+    func emptyStateWithheldBeforeLoad() {
+        let (storage, _) = storageHoldingOneVM()
+        let viewModel = makeViewModel(storageService: storage)
+        let controller = DetailContainerViewController(viewModel: viewModel)
+        let window = present(controller)
+        defer { window.close() }
+
+        // The library holds a VM that simply hasn't been read yet, so "No Virtual
+        // Machine Selected" — and its New Virtual Machine button — would be a
+        // false claim the user can act on.
+        #expect(viewModel.hasLoadedLibrary == false)
+        #expect(hasEmptyState(controller) == false)
+    }
+
+    @Test("A library that reads back empty reaches the no-VM empty state")
+    func emptyStateShownAfterEmptyLoad() async {
+        let viewModel = makeViewModel()
+        let controller = DetailContainerViewController(viewModel: viewModel)
+        let window = present(controller)
+        defer { window.close() }
+        #expect(hasEmptyState(controller) == false)
+
+        await viewModel.loadVMs()
+        await drainMainActor()
+
+        // Load completion is the only change here — an empty library leaves
+        // `instances` and `selectedID` exactly as they were — so this pins the
+        // pane's observation of it. Tracking only the instance list would strand
+        // the pane blank for the whole session.
+        #expect(viewModel.hasLoadedLibrary == true)
+        #expect(hasEmptyState(controller) == true)
+    }
+
+    @Test("A loaded VM replaces the withheld state with its detail content")
+    func detailShownAfterPopulatedLoad() async {
+        let (storage, config) = storageHoldingOneVM()
+        let viewModel = makeViewModel(storageService: storage)
+        let controller = DetailContainerViewController(viewModel: viewModel)
+        let window = present(controller)
+        defer { window.close() }
+
+        await viewModel.loadVMs()
+        await drainMainActor()
+
+        #expect(viewModel.selectedID == config.id)
+        #expect(viewModel.instances.map(\.name) == ["Library VM"])
+        #expect(hasEmptyState(controller) == false)
+    }
+}

--- a/KernovaTests/Mocks/MockVMStorageService.swift
+++ b/KernovaTests/Mocks/MockVMStorageService.swift
@@ -9,8 +9,8 @@ import Foundation
 /// parallel/`.serialized` tests copying real bundles into it can't collide or leak state into
 /// each other.
 ///
-/// Because `vmsDirectory`/`cloneVMBundle` are real, on-disk paths, and every `VMLibraryViewModel`
-/// starts a real `VMDirectoryWatcher` against `vmsDirectory` in `init`, a test driving an async
+/// Because `vmsDirectory`/`cloneVMBundle` are real, on-disk paths, and `VMLibraryViewModel.startLibrary()`
+/// starts a real `VMDirectoryWatcher` against `vmsDirectory`, a test that calls it and drives an async
 /// clone/import to completion should register every other in-memory instance's `bundleURL` in
 /// `bundles` too (as the existing clone tests do) — otherwise a watcher-triggered
 /// `reconcileWithDisk()` racing the test could mistake an unregistered resting-state instance for a
@@ -31,6 +31,7 @@ final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
 
     // MARK: - Call Tracking
 
+    var listVMBundlesCallCount = 0
     var saveConfigurationCallCount = 0
     var deleteVMBundleCallCount = 0
     var permanentlyDeleteVMBundleCallCount = 0
@@ -70,6 +71,7 @@ final class MockVMStorageService: VMStorageProviding, @unchecked Sendable {
     }
 
     func listVMBundles() throws -> [URL] {
+        listVMBundlesCallCount += 1
         if let error = listVMBundlesError { throw error }
         return Array(bundles.keys)
     }

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -65,8 +65,9 @@ struct VMLibraryViewModelTests {
     // MARK: - Initial State
 
     @Test("ViewModel starts with empty instances when storage is empty")
-    func initialStateEmpty() {
+    func initialStateEmpty() async {
         let (viewModel, _, _, _, _) = makeViewModel()
+        await viewModel.loadVMs()
         #expect(viewModel.instances.isEmpty)
         #expect(viewModel.selectedID == nil)
         #expect(presenter.showCreationWizard == false)
@@ -75,8 +76,50 @@ struct VMLibraryViewModelTests {
 
     // MARK: - Load
 
+    @Test("init reads nothing — the library is loaded after launch, not during construction")
+    func initDoesNotReadStorage() {
+        let storage = MockVMStorageService()
+        let config = VMConfiguration(name: "First VM", guestOS: .linux, bootMode: .efi)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+        storage.bundles[url] = config
+
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+
+        #expect(storage.listVMBundlesCallCount == 0)
+        #expect(viewModel.instances.isEmpty)
+        #expect(viewModel.hasLoadedLibrary == false)
+    }
+
+    @Test("hasLoadedLibrary flips once the read applies, even for an empty library")
+    func hasLoadedLibraryFlipsOnEmptyLibrary() async {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        #expect(viewModel.hasLoadedLibrary == false)
+
+        await viewModel.loadVMs()
+
+        #expect(viewModel.hasLoadedLibrary == true)
+        #expect(viewModel.instances.isEmpty)
+    }
+
+    @Test("hasLoadedLibrary flips even when the bundle listing fails")
+    func hasLoadedLibraryFlipsWhenListingFails() async {
+        let storage = MockVMStorageService()
+        storage.listVMBundlesError = VMStorageError.bundleNotFound(
+            FileManager.default.temporaryDirectory)
+
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+        await viewModel.loadVMs()
+
+        // The read is over and the answer is "no VMs" — the UI must not wait
+        // forever on a load that already failed.
+        #expect(viewModel.hasLoadedLibrary == true)
+        #expect(viewModel.instances.isEmpty)
+        #expect(presenter.showError == true)
+    }
+
     @Test("loadVMs auto-selects the first VM")
-    func loadVMsAutoSelectsFirst() {
+    func loadVMsAutoSelectsFirst() async {
         let storage = MockVMStorageService()
         let config1 = VMConfiguration(name: "First VM", guestOS: .linux, bootMode: .efi)
         let config2 = VMConfiguration(name: "Second VM", guestOS: .linux, bootMode: .efi)
@@ -88,13 +131,14 @@ struct VMLibraryViewModelTests {
         storage.bundles[url2] = config2
 
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+        await viewModel.loadVMs()
 
         #expect(viewModel.instances.count == 2)
         #expect(viewModel.selectedID == viewModel.instances.first?.id)
     }
 
     @Test("loadVMs preserves valid selection on reload")
-    func loadVMsPreservesSelection() {
+    func loadVMsPreservesSelection() async {
         let storage = MockVMStorageService()
         let config1 = VMConfiguration(name: "First VM", guestOS: .linux, bootMode: .efi)
         let config2 = VMConfiguration(name: "Second VM", guestOS: .linux, bootMode: .efi)
@@ -106,10 +150,11 @@ struct VMLibraryViewModelTests {
         storage.bundles[url2] = config2
 
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+        await viewModel.loadVMs()
         let secondID = viewModel.instances.last?.id
         viewModel.selectedID = secondID
 
-        viewModel.loadVMs()
+        await viewModel.loadVMs()
 
         #expect(viewModel.selectedID == secondID)
     }
@@ -140,7 +185,7 @@ struct VMLibraryViewModelTests {
     }
 
     @Test("loadVMs restores selection from UserDefaults when VM still exists")
-    func loadVMsRestoresFromUserDefaults() {
+    func loadVMsRestoresFromUserDefaults() async {
         let storage = MockVMStorageService()
         let config1 = VMConfiguration(name: "First VM", guestOS: .linux, bootMode: .efi)
         let config2 = VMConfiguration(name: "Second VM", guestOS: .linux, bootMode: .efi)
@@ -151,7 +196,7 @@ struct VMLibraryViewModelTests {
         storage.bundles[url1] = config1
         storage.bundles[url2] = config2
 
-        // Seed preferences before ViewModel init triggers loadVMs()
+        // Seed preferences before the load, which is what consults them
         preferences.lastSelectedVMID = config2.id
 
         let viewModel = VMLibraryViewModel(
@@ -163,12 +208,13 @@ struct VMLibraryViewModelTests {
             preferences: preferences
         )
         viewModel.presenter = presenter
+        await viewModel.loadVMs()
 
         #expect(viewModel.selectedID == config2.id)
     }
 
     @Test("loadVMs surfaces error when individual bundles fail to load")
-    func loadVMsSurfacesErrorForFailedBundles() {
+    func loadVMsSurfacesErrorForFailedBundles() async {
         let storage = MockVMStorageService()
         // Add a good bundle and a bad bundle
         let goodConfig = VMConfiguration(name: "Good VM", guestOS: .linux, bootMode: .efi)
@@ -183,6 +229,7 @@ struct VMLibraryViewModelTests {
         storage.loadConfigurationFailURLs = [badURL]
 
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+        await viewModel.loadVMs()
 
         // Good VM loaded, bad VM skipped
         #expect(viewModel.instances.count == 1)
@@ -193,7 +240,7 @@ struct VMLibraryViewModelTests {
     }
 
     @Test("loadVMs falls back to first VM when stored ID is invalid")
-    func loadVMsFallsBackWhenStoredIDInvalid() {
+    func loadVMsFallsBackWhenStoredIDInvalid() async {
         let storage = MockVMStorageService()
         let config = VMConfiguration(name: "Only VM", guestOS: .linux, bootMode: .efi)
         let url = FileManager.default.temporaryDirectory
@@ -212,6 +259,7 @@ struct VMLibraryViewModelTests {
             preferences: preferences
         )
         viewModel.presenter = presenter
+        await viewModel.loadVMs()
 
         #expect(viewModel.selectedID == config.id)
     }
@@ -2387,25 +2435,26 @@ struct VMLibraryViewModelTests {
     }
 
     @Test("reconcileWithDisk suppression is maintained after full reload")
-    func reconcileSuppressionMaintainedAfterReload() {
+    func reconcileSuppressionMaintainedAfterReload() async {
         let storage = MockVMStorageService()
         let badURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("broken-vm.kernova", isDirectory: true)
         storage.bundles[badURL] = VMConfiguration(name: "Bad VM", guestOS: .linux, bootMode: .efi)
         storage.loadConfigurationFailURLs.insert(badURL)
 
-        // loadVMs() in init reports the error and seeds reportedFailedBundles
+        // The initial load reports the error and seeds reportedFailedBundles
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+        await viewModel.loadVMs()
         #expect(presenter.showError == true)
         #expect(presenter.errorMessage?.contains("broken-vm") == true)
 
-        // First reconcile after init is suppressed
+        // First reconcile after the load is suppressed
         presenter.reset()
         viewModel.reconcileWithDisk()
         #expect(presenter.showError == false)
 
         // Full reload resets suppression, then re-seeds from its own failures
-        viewModel.loadVMs()
+        await viewModel.loadVMs()
         #expect(presenter.showError == true)
         #expect(presenter.errorMessage?.contains("broken-vm") == true)
 
@@ -2416,15 +2465,16 @@ struct VMLibraryViewModelTests {
     }
 
     @Test("reconcileWithDisk does not re-present errors already reported by loadVMs")
-    func reconcileDoesNotDuplicateLoadVMsErrors() {
+    func reconcileDoesNotDuplicateLoadVMsErrors() async {
         let storage = MockVMStorageService()
         let badURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("broken-vm.kernova", isDirectory: true)
         storage.bundles[badURL] = VMConfiguration(name: "Bad VM", guestOS: .linux, bootMode: .efi)
         storage.loadConfigurationFailURLs.insert(badURL)
 
-        // loadVMs() runs in init and should report the error
+        // The initial load should report the error
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+        await viewModel.loadVMs()
         #expect(presenter.showError == true)
         #expect(presenter.errorMessage?.contains("broken-vm") == true)
 
@@ -2477,7 +2527,7 @@ struct VMLibraryViewModelTests {
     // MARK: - Initial Boot status assignment
 
     @Test("loadVMs assigns .initialBoot when config has installContext")
-    func loadVMsAssignsInitialBoot() {
+    func loadVMsAssignsInitialBoot() async {
         let storage = MockVMStorageService()
         var config = VMConfiguration(name: "Pending VM", guestOS: .macOS, bootMode: .macOS)
         config.installContext = MacOSInstallContext(
@@ -2489,14 +2539,14 @@ struct VMLibraryViewModelTests {
         storage.bundles[url] = config
 
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
-        viewModel.loadVMs()
+        await viewModel.loadVMs()
 
         #expect(viewModel.instances.count == 1)
         #expect(viewModel.instances[0].status == .initialBoot)
     }
 
     @Test("loadVMs assigns .stopped when no installContext")
-    func loadVMsAssignsStoppedWithoutInstallContext() {
+    func loadVMsAssignsStoppedWithoutInstallContext() async {
         let storage = MockVMStorageService()
         let config = VMConfiguration(name: "Installed VM", guestOS: .linux, bootMode: .efi)
         let url = FileManager.default.temporaryDirectory
@@ -2504,7 +2554,7 @@ struct VMLibraryViewModelTests {
         storage.bundles[url] = config
 
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
-        viewModel.loadVMs()
+        await viewModel.loadVMs()
 
         #expect(viewModel.instances.count == 1)
         #expect(viewModel.instances[0].status == .stopped)
@@ -4081,7 +4131,7 @@ struct VMLibraryViewModelTests {
     }
 
     @Test("loadVMs applies custom order from UserDefaults")
-    func loadVMsAppliesCustomOrder() {
+    func loadVMsAppliesCustomOrder() async {
         let storage = MockVMStorageService()
         let config1 = VMConfiguration(
             name: "First", guestOS: .linux, bootMode: .efi, createdAt: Date(timeIntervalSince1970: 100))
@@ -4111,12 +4161,13 @@ struct VMLibraryViewModelTests {
             preferences: preferences
         )
         viewModel.presenter = presenter
+        await viewModel.loadVMs()
 
         #expect(viewModel.instances.map(\.name) == ["Third", "First", "Second"])
     }
 
     @Test("loadVMs falls back to createdAt when no custom order exists")
-    func loadVMsFallsBackToCreatedAt() {
+    func loadVMsFallsBackToCreatedAt() async {
         let storage = MockVMStorageService()
         let config1 = VMConfiguration(
             name: "Older", guestOS: .linux, bootMode: .efi, createdAt: Date(timeIntervalSince1970: 100))
@@ -4130,12 +4181,13 @@ struct VMLibraryViewModelTests {
         storage.bundles[url2] = config2
 
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+        await viewModel.loadVMs()
 
         #expect(viewModel.instances.map(\.name) == ["Older", "Newer"])
     }
 
     @Test("reconcileWithDisk appends new VMs after custom-ordered ones")
-    func reconcileAppendsNewVMs() {
+    func reconcileAppendsNewVMs() async {
         let storage = MockVMStorageService()
         let config1 = VMConfiguration(
             name: "Existing", guestOS: .linux, bootMode: .efi, createdAt: Date(timeIntervalSince1970: 200))
@@ -4144,6 +4196,7 @@ struct VMLibraryViewModelTests {
         storage.bundles[url1] = config1
 
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+        await viewModel.loadVMs()
         #expect(viewModel.instances.count == 1)
 
         // Simulate a new VM appearing on disk
@@ -4176,7 +4229,7 @@ struct VMLibraryViewModelTests {
     }
 
     @Test("custom order ignores stale UUIDs not present in loaded VMs")
-    func customOrderIgnoresStaleUUIDs() {
+    func customOrderIgnoresStaleUUIDs() async {
         let storage = MockVMStorageService()
         let config = VMConfiguration(name: "Only VM", guestOS: .linux, bootMode: .efi)
         let url = FileManager.default.temporaryDirectory
@@ -4196,6 +4249,7 @@ struct VMLibraryViewModelTests {
             preferences: preferences
         )
         viewModel.presenter = presenter
+        await viewModel.loadVMs()
 
         #expect(viewModel.instances.count == 1)
         #expect(viewModel.instances.first?.name == "Only VM")
@@ -4371,7 +4425,7 @@ struct VMLibraryViewModelTests {
     }
 
     @Test("onAgentBecameCurrent (wired by loadVMs) auto-ejects the installer disk")
-    func onAgentBecameCurrentAutoEjectsInstaller() throws {
+    func onAgentBecameCurrentAutoEjectsInstaller() async throws {
         let installerURL = try #require(KernovaMacOSAgentInfo.installerDiskImageURL)
         let storage = MockVMStorageService()
         var config = VMConfiguration(name: "Wired VM", guestOS: .linux, bootMode: .efi)
@@ -4382,6 +4436,7 @@ struct VMLibraryViewModelTests {
             .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
         storage.bundles[url] = config
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+        await viewModel.loadVMs()
         let instance = try #require(viewModel.instances.first)
 
         #expect(viewModel.isGuestAgentInstallerMounted(on: instance))

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -118,6 +118,35 @@ struct VMLibraryViewModelTests {
         #expect(presenter.showError == true)
     }
 
+    @Test("A VM registered while the read is in flight survives the load")
+    func loadVMsKeepsInstancesAddedDuringTheRead() async {
+        let storage = MockVMStorageService()
+        let onDisk = VMConfiguration(name: "On Disk", guestOS: .linux, bootMode: .efi)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(onDisk.id.uuidString).kernova", isDirectory: true)
+        storage.bundles[url] = onDisk
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+
+        let load = Task { @MainActor in await viewModel.loadVMs() }
+        // Runs behind `load`, so `loadVMs` has captured the pre-read instance
+        // list and suspended on the detached scan. The append below then lands
+        // in the read window, with no `await` before it for `apply` to slip in.
+        await Task { @MainActor in }.value
+
+        // Stands in for an import phantom or a wizard-created VM: registered
+        // after the scan started, so the scan cannot know about it.
+        let arrival = makeInstance(name: "Arrived Mid-Read")
+        viewModel.instances.append(arrival)
+
+        await load.value
+
+        // The scan's result must not delete it — its bundle copy may still be
+        // running, and nothing else would put the row back.
+        #expect(viewModel.instances.contains { $0.id == arrival.id })
+        #expect(viewModel.instances.contains { $0.id == onDisk.id })
+        #expect(viewModel.instances.count == 2)
+    }
+
     @Test("loadVMs auto-selects the first VM")
     func loadVMsAutoSelectsFirst() async {
         let storage = MockVMStorageService()
@@ -2300,10 +2329,9 @@ struct VMLibraryViewModelTests {
             .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
         storage.bundles[bundleURL] = config
 
+        // The library is never loaded here, so the bundle is on disk and absent
+        // from memory — exactly what reconciliation is for.
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
-        // loadVMs already ran during init, so the instance should be loaded
-        // But let's clear and reconcile manually to test the specific method
-        viewModel.instances.removeAll()
 
         viewModel.reconcileWithDisk()
 
@@ -2380,7 +2408,7 @@ struct VMLibraryViewModelTests {
         // Create viewModel first (no bad bundles yet)
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
 
-        // Introduce the bad bundle after init so it's new to reconcileWithDisk
+        // Introduce the bad bundle after construction so it is new to reconcileWithDisk
         let badURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("broken-vm.kernova", isDirectory: true)
         storage.bundles[badURL] = VMConfiguration(name: "Bad VM", guestOS: .linux, bootMode: .efi)
@@ -2415,7 +2443,7 @@ struct VMLibraryViewModelTests {
         let storage = MockVMStorageService()
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
 
-        // Introduce the bad bundle after init so it's new to reconcileWithDisk
+        // Introduce the bad bundle after construction so it is new to reconcileWithDisk
         let badURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("broken-vm.kernova", isDirectory: true)
         storage.bundles[badURL] = VMConfiguration(name: "Bad VM", guestOS: .linux, bootMode: .efi)
@@ -2492,7 +2520,7 @@ struct VMLibraryViewModelTests {
         let storage = MockVMStorageService()
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
 
-        // Introduce the bad bundle after init so it's new to reconcileWithDisk
+        // Introduce the bad bundle after construction so it is new to reconcileWithDisk
         let bundleURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("recoverable.kernova", isDirectory: true)
         let config = VMConfiguration(name: "Recoverable VM", guestOS: .linux, bootMode: .efi)


### PR DESCRIPTION
Closes #792

## Summary

The VM library was read inside `VMLibraryViewModel.init`, which `AppDelegate.init` runs *before* `NSApplication.run()`. Every launch paid the whole read — a directory listing plus a JSON decode and a stat per bundle — on the main thread, before the app could finish launching or put a window on screen.

The read now starts from `applicationWillFinishLaunching` and does its file I/O off the main actor. Nothing on the launch path touches disk any more; the window is presented and the library fills in behind it.

## Changes

**`VMLibraryViewModel`**
- `init` no longer loads, and no longer starts the directory watcher — only the sleep watcher, which registers notification observers and does no I/O.
- New `startLibrary()` loads and *then* starts the directory watcher. The order is load-bearing: the watcher's `reconcileWithDisk()` re-reads every bundle synchronously on the main actor, so starting it first would let it both race the initial load and reintroduce the stall this change removes.
- `loadVMs()` is now `async`, split along the isolation boundary it always implicitly had:
  - `scanLibrary(using:)` — `nonisolated`, runs in a detached task, touches no view-model state, returns a `Sendable` `LibraryScan`.
  - `apply(_:)` — `@MainActor`, builds the `VMInstance`s (which are `@MainActor`) and applies order and selection.
- `hasLoadedLibrary` records that the first read finished, including when it failed: a failed listing answers "no VMs" too, and UI must not wait on a load that is over.

**`AppDelegate`** — owns the load `Task`, started in `applicationWillFinishLaunching` — ahead of `application(_:open:)`, which waits on it. `resolveColdLaunch(from:)` is untouched and still runs while the launch Apple event is current.

**`DetailContainerViewController`** — shows a bare pane until the library has been read, and tracks `hasLoadedLibrary` in its observation.

## The empty-then-populated interval

The one place the transition is user-visible is the detail pane. Its empty state reads "No Virtual Machine Selected — Select a virtual machine from the sidebar or create a new one" and carries a **New Virtual Machine** button. Shown to someone with a full library while the read is in flight, that is both false and actionable, so the pane withholds it until the library is known. No spinner: SPEC.md asks for nothing here, and a blank pane for the duration of a local file read is the honest minimum.

The sidebar and the status item needed no changes — both are observation-driven, and the status menu is rebuilt on open.

## A correctness hazard this had to handle

`application(_:open:)` is delivered between `applicationWillFinishLaunching` and `applicationDidFinishLaunching`, while the read is still in flight, and `importVMs(fromDroppedURLs:)` dedups by UUID against `instances`. Against a not-yet-read library that dedup misses — so double-clicking a bundle that is *already in the library* (reachable via **Open VMs Folder**) would copy a multi-GB bundle a second time instead of selecting the existing VM. The open path now waits for the load.

The wait sits at that call site rather than inside `importVMs(fromDroppedURLs:)` because that method's reservation pass is deliberately suspension-free, so overlapping triggers see each other's phantoms — the property #487 fixed and its test pins.

## Deviation from the issue

The issue reports the load costing ~1.9 s of pre-window time. The unified log for that day does not support it: `Loaded N VMs` lands roughly 0.3-0.5 s after process start, and on the very launch the issue quotes, ~1.2 s sat *after* the load, inside `setupMainMenu()`'s first menu-bar/text-service materialization. The numbers in the issue line up with the `resident app ready` record, not the `Loaded N VMs` one.

The change is still worth making on its own terms — it takes all disk I/O out of the pre-`run()` path, which is a precondition for the launch-posture work discussed on #790, and it scales with library size rather than being fixed. But it is not a 1.9 s win, and anyone chasing the remaining launch latency should look at `setupMainMenu()` and status-item creation first.

## Test plan

- [x] `make build`, `make test`, `make lint` clean
- [x] New `VMLibraryViewModel` tests: `init` reads no storage; `hasLoadedLibrary` flips after an empty load and after a failed listing
- [x] New `DetailContainerLibraryLoadTests`: the empty state is withheld before the read, appears after a library that reads back empty (which pins the `hasLoadedLibrary` observation — nothing else changes in that case, so tracking only the instance list would strand the pane blank), and a loaded VM shows its detail content
- [x] Existing load/order/selection/reconcile tests updated to drive the load explicitly
- [ ] Behavioral launch verification by the maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
