### PR TITLE
test: Park lazy-pull test pulls on the shared wait backstop

### DIFF
--- a/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/LazyPullCoordinatorTests.swift
@@ -55,13 +55,21 @@ struct LazyPullCoordinatorTests {
     /// self-reinforces (each test's deliver/abort/failAll, which would free a
     /// worker, is gated behind the very `waitUntil` that's timing out) and
     /// survives the automatic retry (#578).
+    ///
+    /// That semaphore is a raw backstop the stopwatch helpers never see, so
+    /// this arms the test session's OS activity itself. `timeout` is a
+    /// *competing* clock rather than a stuck-condition one: `pull` latches
+    /// `.timedOut` and deregisters the slot under the same lock its outcome is
+    /// read through, so a runner stall that outlasts the window turns a sound
+    /// expectation into a failure.
     private func runPull(
         _ coordinator: LazyPullCoordinator,
         transferID: UInt64,
-        timeout: TimeInterval,
+        timeout: TimeInterval = testWaitBackstop,
         send: @escaping @Sendable () -> Void = {}
     ) async -> LazyPullOutcome {
-        await withCheckedContinuation { (cont: CheckedContinuation<LazyPullOutcome, Never>) in
+        armTestSessionActivity()
+        return await withCheckedContinuation { (cont: CheckedContinuation<LazyPullOutcome, Never>) in
             let thread = Thread {
                 cont.resume(
                     returning: coordinator.pull(
@@ -85,7 +93,7 @@ struct LazyPullCoordinatorTests {
     @Test("pull blocks until deliver wakes it with the representation")
     func deliverWakesPull() async throws {
         let coordinator = LazyPullCoordinator()
-        async let outcome = runPull(coordinator, transferID: 7, timeout: 5)
+        async let outcome = runPull(coordinator, transferID: 7)
         try await waitUntil { coordinator.pendingSlotCountForTesting == 1 }
         coordinator.deliver(7, inlineRep("hello"))
 
@@ -100,7 +108,7 @@ struct LazyPullCoordinatorTests {
     @Test("pull surfaces an abort delivered while it waits")
     func abortWakesPull() async throws {
         let coordinator = LazyPullCoordinator()
-        async let outcome = runPull(coordinator, transferID: 3, timeout: 5)
+        async let outcome = runPull(coordinator, transferID: 3)
         try await waitUntil { coordinator.pendingSlotCountForTesting == 1 }
         coordinator.abort(
             3,
@@ -161,10 +169,7 @@ struct LazyPullCoordinatorTests {
                 releaseWindow2.wait()
             }
         }
-        // The window value itself is moot here — `windowWaitForTesting`
-        // controls boundary timing directly — but 300 ms documents the real
-        // production window this test stands in for.
-        async let outcome = runPull(coordinator, transferID: 11, timeout: 0.3)
+        async let outcome = runPull(coordinator, transferID: 11)
         try await window1Entered.wait { sawFirstWindow.value }
         coordinator.heartbeat(11)
         releaseWindow1.signal()
@@ -187,7 +192,7 @@ struct LazyPullCoordinatorTests {
     func heartbeatNoOpWhenAbsent() async throws {
         let coordinator = LazyPullCoordinator()
         coordinator.heartbeat(404)  // nobody waiting
-        async let outcome = runPull(coordinator, transferID: 12, timeout: 5)
+        async let outcome = runPull(coordinator, transferID: 12)
         try await waitUntil { coordinator.pendingSlotCountForTesting == 1 }
         coordinator.deliver(12, inlineRep("done"))
         // A late heartbeat after the slot resolves must not crash or hang.
@@ -201,8 +206,8 @@ struct LazyPullCoordinatorTests {
     @Test("failAll unblocks every waiting pull with .cancelled")
     func failAllCancels() async throws {
         let coordinator = LazyPullCoordinator()
-        async let a = runPull(coordinator, transferID: 1, timeout: 5)
-        async let b = runPull(coordinator, transferID: 2, timeout: 5)
+        async let a = runPull(coordinator, transferID: 1)
+        async let b = runPull(coordinator, transferID: 2)
         try await waitUntil { coordinator.pendingSlotCountForTesting == 2 }
         coordinator.failAll()
 
@@ -219,8 +224,8 @@ struct LazyPullCoordinatorTests {
     @Test("interleaved transfers resolve to their own outcomes")
     func interleavedDemux() async throws {
         let coordinator = LazyPullCoordinator()
-        async let first = runPull(coordinator, transferID: 100, timeout: 5)
-        async let second = runPull(coordinator, transferID: 200, timeout: 5)
+        async let first = runPull(coordinator, transferID: 100)
+        async let second = runPull(coordinator, transferID: 200)
         try await waitUntil { coordinator.pendingSlotCountForTesting == 2 }
 
         coordinator.deliver(100, inlineRep("first"))
@@ -245,7 +250,7 @@ struct LazyPullCoordinatorTests {
     @Test("a duplicate delivery after the slot resolves is a no-op")
     func idempotentDelivery() async throws {
         let coordinator = LazyPullCoordinator()
-        async let outcome = runPull(coordinator, transferID: 9, timeout: 5)
+        async let outcome = runPull(coordinator, transferID: 9)
         try await waitUntil { coordinator.pendingSlotCountForTesting == 1 }
         coordinator.deliver(9, inlineRep("once"))
         // Second delivery and a late abort must not crash or change the result.
@@ -276,10 +281,10 @@ struct LazyPullCoordinatorTests {
     )
     func pullSupersedesInFlightPullForSameID() async throws {
         let coordinator = LazyPullCoordinator()
-        async let first = runPull(coordinator, transferID: 7, timeout: 5)
+        async let first = runPull(coordinator, transferID: 7)
         try await waitUntil { coordinator.pendingSlotCountForTesting == 1 }
 
-        async let second = runPull(coordinator, transferID: 7, timeout: 5)
+        async let second = runPull(coordinator, transferID: 7)
         // The registration itself resolves the displaced pull — no need to
         // wait for a timeout window (CLIPBOARD.md §9: wake immediately).
         guard case .superseded = await first else {
@@ -307,16 +312,16 @@ struct LazyPullCoordinatorTests {
         // key — including a later successor's — leaving `deliver` unable to
         // reach anyone.
         let coordinator = LazyPullCoordinator()
-        async let first = runPull(coordinator, transferID: 7, timeout: 5)
+        async let first = runPull(coordinator, transferID: 7)
         try await waitUntil { coordinator.pendingSlotCountForTesting == 1 }
 
-        async let second = runPull(coordinator, transferID: 7, timeout: 5)
+        async let second = runPull(coordinator, transferID: 7)
         guard case .superseded = await first else {
             Issue.record("Expected .superseded for the first pull")
             return
         }
 
-        async let third = runPull(coordinator, transferID: 7, timeout: 5)
+        async let third = runPull(coordinator, transferID: 7)
         guard case .superseded = await second else {
             Issue.record("Expected .superseded for the second pull")
             return
@@ -396,11 +401,11 @@ struct LazyPullCoordinatorTests {
             onComplete: { rep in coordinator.deliver(transferID, rep) },
             onAbort: { info in coordinator.abort(transferID, info) })
 
-        async let firstAttempt = runPull(coordinator, transferID: transferID, timeout: 5)
+        async let firstAttempt = runPull(coordinator, transferID: transferID)
         try await waitUntil { coordinator.pendingSlotCountForTesting == 1 }
 
         // The retry: a second concurrent pull for the identical id.
-        async let secondAttempt = runPull(coordinator, transferID: transferID, timeout: 5)
+        async let secondAttempt = runPull(coordinator, transferID: transferID)
         guard case .superseded = await firstAttempt else {
             Issue.record("Expected .superseded for the displaced first attempt")
             return


### PR DESCRIPTION
Closes #795.

## The failure

The three `(#500)` supersession tests each start a pull, wait for its slot to register, then start a second pull for the same id and assert the first observes `.superseded`. Every one of them injected `timeout: 5` as the pull's inactivity window.

That window is a **competing clock**, not a stuck-condition backstop. `pull` latches `.timedOut` *and* deregisters its slot in a single lock hold:

```swift
slot.resolved = true
slot.outcome = .timedOut
if slots[transferID] === slot { slots[transferID] = nil }
```

so the two racers serialize cleanly on the coordinator's lock, with two orderings:

- **Retry registers first** — it finds the prior slot, displaces it, and the displaced pull returns `.superseded`. What the tests assert.
- **The 5 s window elapses first** — the slot is already gone by the time the retry registers, so there is nothing to displace and the first pull returns `.timedOut`.

The vulnerable gap is "first slot registered → retry's slot registered", which for these three tests spans a cooperative-task hop *plus* a fresh `Thread` spawn. That is why the trio fails together while their siblings (whose `deliver` is one hop after `waitUntil` resolves) usually survive the same stall.

**No production bug.** `LazyPullCoordinator` is race-free here — both paths take the lock, and the identity check already protects a successor's registration. The defect is entirely the injected test timeout, which docs/TESTING.md already rules out: *"Success-path waits must not pass a smaller explicit timeout; explicit values are for behavior-under-test deadlines only."*

## The fix

`runPull` defaults `timeout` to `testWaitBackstop` (60 s) and every success-path call site drops its explicit `5`. `pullTimesOut` keeps its short window — there the deadline *is* the assertion.

Two things found in contact:

- `pull` parks on a raw `DispatchSemaphore`, which the shared stopwatch helpers never see, so `runPull` now calls `armTestSessionActivity()` itself — the documented contract for a raw-semaphore backstop, and headless CI runners are exactly the display-off case it guards.
- A comment claimed `0.3` "documents the real production window this test stands in for". The production lazy-pull window is `ClipboardStreamTuning.lazyPullTimeout` (120 s), and the value is never read at all once `windowWaitForTesting` is installed. Deleted.

## Rejected alternative

Making the window unreachable via `windowWaitForTesting` (an untimed `semaphore.wait()`) would be fully deterministic, but converts any future regression from a failing assertion into a bundle hang. Parking on `testWaitBackstop` is the same guarantee with a diagnosable ceiling, and matches how the rest of the repo sizes these.

## Verification

The diagnosis is confirmed, not inferred: a temporary test that injects a 3 s stall between the displaced pull's registration and the retry's reproduced the reported failure text verbatim —

```
Issue recorded: Expected .superseded for the displaced first pull
```

— and the same stall passes once the window is the backstop. That scaffold was removed before committing.

## Test plan

- [x] `make test-suite SUITE=KernovaKitTests/LazyPullCoordinatorTests` — 19/19 pass
- [x] `make test` — 2577 passed, 0 failed
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183EN8qbC5soRhvmEfpXZHH