### PR TITLE
fix: Isolate isButtonOnScreen to the main actor

### DIFF
--- a/KernovaKit/Sources/KernovaKit/NSStatusItem+OnScreen.swift
+++ b/KernovaKit/Sources/KernovaKit/NSStatusItem+OnScreen.swift
@@ -8,7 +8,7 @@ extension NSStatusItem {
     /// proves nothing: only a visible window landing on a display does. Paired
     /// with ``isVisible``, which reports the app's own preference rather than
     /// anything about the screen.
-    public var isButtonOnScreen: Bool {
+    @MainActor public var isButtonOnScreen: Bool {
         guard let window = button?.window, window.isVisible else { return false }
         return NSScreen.screens.contains { $0.frame.intersects(window.frame) }
     }


### PR DESCRIPTION
## Summary
- Mark `NSStatusItem.isButtonOnScreen` as `@MainActor`. The SDK does not isolate `NSStatusItem`, so the extension property defaulted to nonisolated while its body reads main actor-isolated `NSWindow` state (`window`, `isVisible`, `frame`), producing three "main actor-isolated property can not be referenced from a nonisolated context" warnings in each target that compiles the file. Isolation is also semantically right: the property answers a question about live window/screen state.
- The alternative — `MainActor.assumeIsolated` in the body — would only fit if a nonisolated caller existed; all three call sites (`ClipboardProgressStatusItemPresenter`, `TransientStatusItemPopover`) are `@MainActor` types, so none does and no caller changes are needed.

## Changes
- `KernovaKit/Sources/KernovaKit/NSStatusItem+OnScreen.swift`

## Test plan
- [x] `make build` — clean, no concurrency warnings referencing the file
- [x] `make test` — 2577/2577 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HifRvk2tzYeEopJj51EawK