### PR TITLE
fix: Rename the General settings lifecycle toggles

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -85,7 +85,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     /// Whether a pending quit should actually terminate the resident app.
     ///
-    /// While *Keep Running in Menu Bar* is on (the default), GUI-origin quits (⌘Q,
+    /// While *Continue running in Status Bar* is on (the default), GUI-origin quits (⌘Q,
     /// "Close All Windows", the Dock's Quit) only close the GUI and leave the app
     /// resident with its VMs running headless. Only consulted for the resident
     /// app, not the test host.

--- a/Kernova/Services/LoginItemService.swift
+++ b/Kernova/Services/LoginItemService.swift
@@ -28,8 +28,8 @@ struct LoginAgentRegistration: LoginItemRegistration {
     func unregister() throws { try service.unregister() }
 }
 
-/// "Open at Login" wrapper over `SMAppService`, driving the General settings
-/// toggle.
+/// "Launch into Background at Login" wrapper over `SMAppService`, driving the
+/// General settings toggle.
 ///
 /// `.status` is the source of truth and is **never persisted locally** — the
 /// toggle reads it live, so a change made in System Settings is always

--- a/Kernova/Views/Settings/GeneralSettingsViewController.swift
+++ b/Kernova/Views/Settings/GeneralSettingsViewController.swift
@@ -4,18 +4,18 @@ import ServiceManagement
 /// The "General" pane of the Settings window.
 ///
 /// Hosts two app-lifecycle toggles:
-/// - *Open at Login*, backed by the embedded LaunchAgent through
+/// - *Launch into Background at Login*, backed by the embedded LaunchAgent through
 ///   `LoginItemService`. `.status` is the source of truth (never persisted): the
 ///   switch is synced from it on appear and whenever the app regains focus, so a
 ///   change made in System Settings → Login Items is reflected without a restart.
-/// - *Keep Running in Menu Bar* (#624), backed by `AppPreferences`. Governs
+/// - *Continue running in Status Bar*, backed by `AppPreferences`. Governs
 ///   whether a GUI-origin quit (⌘Q) closes Kernova's windows but leaves it
 ///   resident in the menu bar, or quits the app outright.
 @MainActor
 final class GeneralSettingsViewController: NSViewController {
     private let loginItem: LoginItemService
     private let preferences: AppPreferences
-    private let openAtLoginSwitch = NSSwitch()
+    private let launchAtLoginSwitch = NSSwitch()
     private let keepInMenuBarSwitch = NSSwitch()
     private var focusObserver: (any NSObjectProtocol)?
 
@@ -32,20 +32,19 @@ final class GeneralSettingsViewController: NSViewController {
     }
 
     override func loadView() {
-        openAtLoginSwitch.controlSize = .small
-        openAtLoginSwitch.target = self
-        openAtLoginSwitch.action = #selector(openAtLoginToggled)
+        launchAtLoginSwitch.controlSize = .small
+        launchAtLoginSwitch.target = self
+        launchAtLoginSwitch.action = #selector(launchAtLoginToggled)
 
         keepInMenuBarSwitch.controlSize = .small
         keepInMenuBarSwitch.target = self
         keepInMenuBarSwitch.action = #selector(keepInMenuBarToggled)
 
         let loginCard = makeGroupedFormCard(rows: [
-            makeGroupedFormCardRow("Open at Login", control: openAtLoginSwitch)
+            makeGroupedFormCardRow("Launch into Background at Login", control: launchAtLoginSwitch)
         ])
         let loginCaption = makeGroupedFormCaption(
-            "Start Kernova automatically when you log in, so its virtual machines and clipboard "
-                + "sharing are ready without opening a window.")
+            "Start Kernova automatically when you log in.")
         let openLoginItemsButton = NSButton(
             title: "Open Login Items Settings…", target: self,
             action: #selector(openLoginItemsSettings))
@@ -54,12 +53,12 @@ final class GeneralSettingsViewController: NSViewController {
         openLoginItemsButton.setContentHuggingPriority(.required, for: .horizontal)
 
         let menuBarCard = makeGroupedFormCard(rows: [
-            makeGroupedFormCardRow("Keep Running in Menu Bar", control: keepInMenuBarSwitch)
+            makeGroupedFormCardRow("Continue running in Status Bar", control: keepInMenuBarSwitch)
         ])
         let menuBarCaption = makeGroupedFormCaption(
-            "Quitting (⌘Q) closes Kernova's windows but keeps it running in the menu bar, so your "
-                + "virtual machines keep running. Quit fully from the menu bar icon, or with Quit "
-                + "Kernova (⌥⌘Q).")
+            "Quitting (⌘Q) or closing all windows will keep Kernova running in the Status Bar. To "
+                + "fully quit, either Quit directly from the Status Icon or with Quit Kernova "
+                + "(⌥⌘Q).")
 
         let section = NSStackView(views: [
             makeGroupedFormSectionHeader("General"),
@@ -131,11 +130,11 @@ final class GeneralSettingsViewController: NSViewController {
 
     /// Mirrors the switch to the live `SMAppService` status (the source of truth).
     private func refreshFromStatus() {
-        openAtLoginSwitch.state = loginItem.isEnabled ? .on : .off
+        launchAtLoginSwitch.state = loginItem.isEnabled ? .on : .off
     }
 
-    @objc private func openAtLoginToggled() {
-        let enable = openAtLoginSwitch.state == .on
+    @objc private func launchAtLoginToggled() {
+        let enable = launchAtLoginSwitch.state == .on
         let status = loginItem.setEnabled(enable)
         // `.requiresApproval` means the user must flip Kernova on in System
         // Settings; deep-link there. `refreshFromStatus` then reflects the true

--- a/Kernova/Views/Settings/SettingsTabViewController.swift
+++ b/Kernova/Views/Settings/SettingsTabViewController.swift
@@ -27,7 +27,7 @@ enum SettingsPaneMetrics {
 
 /// The toolbar-style tab container for the Settings window.
 ///
-/// Holds a **General** tab (Open at Login), a **Reminders** tab (turning
+/// Holds a **General** tab (app-lifecycle toggles), a **Reminders** tab (turning
 /// suppressed reminders back on), a **Clipboard** tab (the maximum paste size),
 /// and an **Advanced** tab; the toolbar style is used so further panes can be
 /// added later as additional `NSTabViewItem`s.

--- a/KernovaTests/LoginItemServiceTests.swift
+++ b/KernovaTests/LoginItemServiceTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Kernova
 
-/// Unit tests for `LoginItemService` — the "Open at Login" wrapper (#460).
+/// Unit tests for `LoginItemService` — the login-item wrapper.
 ///
 /// Uses an injectable `LoginItemRegistration` fake so register/unregister and
 /// status mapping are exercised without touching the real login-item database

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Requires macOS 26 (Tahoe) or later on Apple Silicon to run the app. macOS guests
 - **macOS and Linux guests** — a step-by-step creation wizard, including IPSW download for macOS; EFI/UEFI or direct kernel boot for Linux
 - **Full lifecycle** — start, stop, pause, resume, suspend, and restore, plus Force Stop for a hung VM and a one-shot Start in Recovery Mode for macOS guests
 - **Cloning and import** — clone a VM with freshly regenerated identifiers; import `.kernova` bundles by double-click or drag-and-drop, which is also how you bring existing VMs into the sandboxed library (on the same volume it's an APFS clone: near-instant, no double disk usage)
-- **Keeps running in the background** — a resident menu-bar app with an opt-in Open at Login toggle, so closing the window leaves VMs running headless. Quitting save-suspends them; system sleep auto-pauses and wake resumes
+- **Keeps running in the background** — a resident menu-bar app with an opt-in Launch into Background at Login toggle, so closing the window leaves VMs running headless. Quitting save-suspends them; system sleep auto-pauses and wake resumes
 
 <p align="center">
   <picture>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -184,7 +184,7 @@ Clipboard (principles and trade-off rules: [CLIPBOARD.md](CLIPBOARD.md)):
   version comes from a build-phase-written sidecar so it cannot drift from the shipped binary
   ([BUILD.md](BUILD.md)).
 
-Also here: `LoginItemService` (the `SMAppService.agent` wrapper behind the Open at Login toggle),
+Also here: `LoginItemService` (the `SMAppService.agent` wrapper behind the login-item toggle),
 `AttachmentFileMonitor` (existence watching for the settings attachment rows), `RuntimeFileAccess`
 (per-boot security-scoped access, released once in `tearDownSession`), and `SerialSocketRelay`
 (below).
@@ -393,7 +393,7 @@ kernel resources until relaunch — hence one owner (`RuntimeFileAccess`) and on
 | **Virtualization** | VM lifecycle |
 | **AppKit** | All UI |
 | **Observation** | `@Observable` models and view models |
-| **ServiceManagement** | `SMAppService.agent` — the embedded login LaunchAgent behind Open at Login |
+| **ServiceManagement** | `SMAppService.agent` — the embedded login LaunchAgent behind Launch into Background at Login |
 | **AppleArchive** | In-process archiving for clipboard folder transfers, encoded onto the wire |
 | **UniformTypeIdentifiers** | The `.kernova` bundle's `UTType` |
 | **AVFoundation** | Microphone permission status |

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -28,4 +28,4 @@ The only executable the app spawns is its own bundled `KernovaRelaunchHelper`, s
 
 ## Launch model
 
-Kernova is a resident menu-bar app, with no Mach service anywhere in the design. "Open at Login" is an opt-in General-settings toggle that registers a per-user LaunchAgent embedded at `Contents/Library/LaunchAgents` through `SMAppService.agent` (`LoginItemService`), which is MAS- and sandbox-compatible. The agent re-execs the app itself with `LaunchPosture.loginLaunchFlag`, so the sandbox rule that a sandboxed app's agent must itself be sandboxed is satisfied by the app's own entitlements — the agent needs none of its own.
+Kernova is a resident menu-bar app, with no Mach service anywhere in the design. "Launch into Background at Login" is an opt-in General-settings toggle that registers a per-user LaunchAgent embedded at `Contents/Library/LaunchAgents` through `SMAppService.agent` (`LoginItemService`), which is MAS- and sandbox-compatible. The agent re-execs the app itself with `LaunchPosture.loginLaunchFlag`, so the sandbox rule that a sandboxed app's agent must itself be sandboxed is satisfied by the app's own entitlements — the agent needs none of its own.


### PR DESCRIPTION
## Summary

The two General-pane toggles were named for their mechanism rather than their effect. They now say what they do, with captions rewritten to match:

| | Before | After |
|---|---|---|
| Label | Open at Login | **Launch into Background at Login** |
| Caption | Start Kernova automatically when you log in, so its virtual machines and clipboard sharing are ready without opening a window. | Start Kernova automatically when you log in. |
| Label | Keep Running in Menu Bar | **Continue running in Status Bar** |
| Caption | Quitting (⌘Q) closes Kernova's windows but keeps it running in the menu bar, so your virtual machines keep running. Quit fully from the menu bar icon, or with Quit Kernova (⌥⌘Q). | Quitting (⌘Q) or closing all windows will keep Kernova running in the Status Bar. To fully quit, either Quit directly from the Status Icon or with Quit Kernova (⌥⌘Q). |

The second caption's "or closing all windows" is checked against the code, not assumed: with this toggle on, `AppDelegate.appMenuQuitItems` retitles the ⌘Q item to "Close All Windows" and adds ⌥⌘Q as the true quit, so the caption names the commands the menu actually presents.

## Changes

- `GeneralSettingsViewController` — both row labels and captions; the `openAtLogin*` switch and action renamed to `launchAtLogin*` so the symbols track the label. `keepInMenuBarSwitch` keeps its name, which tracks the `AppPreferences.keepInMenuBarOnQuit` key it drives — renaming that would mean touching a persisted `UserDefaults` key for a copy change.
- Doc comments that named either toggle by its UI label: `AppDelegate`, `LoginItemService`, `SettingsTabViewController`, `LoginItemServiceTests`. Where a reference was about the mechanism rather than the label (the tab list, the `LoginItemService` architecture entry), it moved to a neutral phrase so it needs no upkeep on the next copy change.
- `README.md`, `docs/SANDBOX.md`, `docs/ARCHITECTURE.md` — the same label references.

No behavior change: no control flow, no persisted key, and no `SMAppService` call site moved.

## Test plan

- [x] `make build` and `make lint` (including the docs line-cap and link check) pass
- [x] `make test` — 2581 tests, 0 failures, verified from the xcresult rather than the rendered log
- [x] No test asserts either string, so none needed updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcznTrG2nKSmuWBrTNbvFD
