### PR TITLE
fix: Hold an explicit quit until an in-flight VM save settles

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -36,6 +36,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     /// Latched once the termination gate has replied `.terminateLater`, so a
     /// second quit can't start a second save pass: its `trySave` would come back
     /// as `operationInProgress` and the catch would force-stop a VM mid-save.
+    ///
+    /// Never reset, matching the quit flags below: every later quit defers to the
+    /// pass, which always replies and terminates the app.
     private var isRunningTerminationSavePass = false
     private let clipboardMenuItem: NSMenuItem
     private var settingsWindowController: SettingsWindowController?
@@ -673,8 +676,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     enum TerminationOutcome: Equatable {
         /// Downgrade the quit to a GUI close; the app stays resident.
         case closeGUI
-        /// A quit is already in flight with its reply outstanding — drop this one.
-        case duplicate
+        /// Wait on the save pass already running, without starting a second one.
+        case deferToSavePass
         /// Nothing to save and nothing to wait out.
         case terminateNow
         /// Reply later: wait out every in-flight save, then save-suspend whatever
@@ -691,14 +694,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     /// `hasUninterruptibleWork` — it may defer a quit nobody asked for
     /// indefinitely, where an explicit quit may only wait out what termination
     /// would corrupt.
+    ///
+    /// A running save pass outranks the soft-quit downgrade: the app is already
+    /// on its way out, so closing the GUI and telling the user it stays resident
+    /// would be false.
     nonisolated static func terminationOutcome(
         shouldTerminateAgent: Bool,
         isSavePassRunning: Bool,
         hasSaveInFlight: Bool,
         hasInstancesToSave: Bool
     ) -> TerminationOutcome {
+        if isSavePassRunning { return .deferToSavePass }
         guard shouldTerminateAgent else { return .closeGUI }
-        if isSavePassRunning { return .duplicate }
         if hasSaveInFlight || hasInstancesToSave { return .saveThenTerminate }
         return .terminateNow
     }
@@ -857,14 +864,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             }
             return .terminateCancel
 
-        case .duplicate:
-            // The first request's pass still replies, so the app terminates either
-            // way; cancelling here keeps a second save pass from racing it.
+        case .deferToSavePass:
+            // Deferred, never cancelled: a `.terminateCancel` here would report a
+            // veto to whoever asked, and loginwindow reads that as the app
+            // refusing a logout, restart, or shut down. `.terminateLater` runs a
+            // nested wait instead, which the pass's single
+            // `reply(toApplicationShouldTerminate:)` resolves.
             if terminationIsTCCRevocation {
                 relaunchAfterTermination = true
             }
             Self.logger.notice("Quit requested while the termination save pass is running — deferring to it")
-            return .terminateCancel
+            return .terminateLater
 
         case .terminateNow:
             cancelAndCleanupPreparingInstances()
@@ -928,12 +938,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     /// Save-suspends one VM for termination, force-stopping it when the save
     /// fails so a half-live VM can't outlive the process.
     ///
+    /// A save rejected because the VM already holds a lifecycle operation (a
+    /// pause or resume still settling) is left alone: force-stopping there would
+    /// abort an operation that is about to finish and discard the very guest
+    /// state the pass exists to save, where letting the process exit costs the
+    /// same RAM and nothing more.
+    ///
     /// - Returns: `true` when the state was saved.
     private func saveForTermination(_ instance: VMInstance) async -> Bool {
         do {
             try await viewModel.trySave(instance)
             viewModel.saveConfiguration(for: instance)
             return true
+        } catch VMLifecycleCoordinator.LifecycleError.operationInProgress {
+            Self.logger.warning(
+                "Skipped saving '\(instance.name, privacy: .public)' during termination: another lifecycle operation holds it"
+            )
+            return false
         } catch {
             Self.logger.error(
                 "Failed to save '\(instance.name, privacy: .public)' during termination: \(error.localizedDescription, privacy: .public)"

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -33,6 +33,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     /// Latched once the reconcile has asked to terminate, so a window closing
     /// during the async save can't request a second termination.
     private var isQuittingOnLastWindowClose = false
+    /// Latched once the termination gate has replied `.terminateLater`, so a
+    /// second quit can't start a second save pass: its `trySave` would come back
+    /// as `operationInProgress` and the catch would force-stop a VM mid-save.
+    private var isRunningTerminationSavePass = false
     private let clipboardMenuItem: NSMenuItem
     private var settingsWindowController: SettingsWindowController?
 
@@ -665,6 +669,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         return .quit
     }
 
+    /// What the termination gate does with a quit request.
+    enum TerminationOutcome: Equatable {
+        /// Downgrade the quit to a GUI close; the app stays resident.
+        case closeGUI
+        /// A quit is already in flight with its reply outstanding — drop this one.
+        case duplicate
+        /// Nothing to save and nothing to wait out.
+        case terminateNow
+        /// Reply later: wait out every in-flight save, then save-suspend whatever
+        /// is still live.
+        case saveThenTerminate
+    }
+
+    /// Decides the termination gate's reply.
+    ///
+    /// A save already in flight forces the deferred reply even when the gate has
+    /// nothing of its own to save: `VZVirtualMachine.saveMachineStateTo` writes
+    /// the save file in place, so exiting through it truncates the file. The
+    /// window reconcile answers a different question with
+    /// `hasUninterruptibleWork` — it may defer a quit nobody asked for
+    /// indefinitely, where an explicit quit may only wait out what termination
+    /// would corrupt.
+    nonisolated static func terminationOutcome(
+        shouldTerminateAgent: Bool,
+        isSavePassRunning: Bool,
+        hasSaveInFlight: Bool,
+        hasInstancesToSave: Bool
+    ) -> TerminationOutcome {
+        guard shouldTerminateAgent else { return .closeGUI }
+        if isSavePassRunning { return .duplicate }
+        if hasSaveInFlight || hasInstancesToSave { return .saveThenTerminate }
+        return .terminateNow
+    }
+
     /// Reconciles the resident app with its open windows: `.regular` (Dock icon)
     /// while any user window is on screen, and when none are, either `.accessory`
     /// (status-item only) or a quit — see `residencyOutcome`.
@@ -797,7 +835,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         // Every quit path funnels through `terminate:` and thus this method, so
         // this single gate covers them all — see `quitShouldTerminateAgent`.
-        if !isTestHost && !quitShouldTerminateAgent {
+        switch Self.terminationOutcome(
+            shouldTerminateAgent: isTestHost || quitShouldTerminateAgent,
+            isSavePassRunning: isRunningTerminationSavePass,
+            hasSaveInFlight: viewModel.hasSaveInFlight,
+            hasInstancesToSave: viewModel.instances.contains(where: \.hasLiveSession)
+        ) {
+        case .closeGUI:
             Self.logger.notice("GUI-origin quit — closing the GUI; app stays resident")
             // Defer so the close runs after this termination request is fully cancelled.
             Task { @MainActor in
@@ -812,59 +856,97 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                 self.statusItemController?.showSoftQuitReminder()
             }
             return .terminateCancel
-        }
 
-        cancelAndCleanupPreparingInstances()
-
-        // Save VMs that have a live virtual machine; cold-paused VMs already have state on disk
-        let runningInstances = viewModel.instances.filter {
-            ($0.status == .running || $0.status == .paused) && $0.virtualMachine != nil
-        }
-
-        guard !runningInstances.isEmpty else {
-            return .terminateNow
-        }
-
-        // macOS quits and relaunches the app when a TCC permission is revoked, and
-        // its built-in relaunch times out while VMs are saving. Mark for relaunch
-        // so `applicationWillTerminate` launches the helper after saves complete.
-        if terminationIsTCCRevocation {
-            relaunchAfterTermination = true
-        }
-
-        Task { @MainActor in
-            var savedCount = 0
-            var failedCount = 0
-            for instance in runningInstances {
-                do {
-                    try await viewModel.trySave(instance)
-                    viewModel.saveConfiguration(for: instance)
-                    savedCount += 1
-                } catch {
-                    Self.logger.error(
-                        "Failed to save '\(instance.name, privacy: .public)' during termination: \(error.localizedDescription, privacy: .public)"
-                    )
-                    failedCount += 1
-                    do {
-                        try await viewModel.tryForceStop(instance)
-                    } catch {
-                        Self.logger.error(
-                            "Failed to force-stop '\(instance.name, privacy: .public)' during termination: \(error.localizedDescription, privacy: .public)"
-                        )
-                    }
-                }
+        case .duplicate:
+            // The first request's pass still replies, so the app terminates either
+            // way; cancelling here keeps a second save pass from racing it.
+            if terminationIsTCCRevocation {
+                relaunchAfterTermination = true
             }
-            Self.logger.notice(
-                "Termination save complete: \(savedCount, privacy: .public) saved, \(failedCount, privacy: .public) failed of \(runningInstances.count, privacy: .public) total"
-            )
-            // A drop/odoc delivered during the async save window above can register
-            // a fresh phantom, so sweep again right before the deferred reply or
-            // that bundle is orphaned on disk.
-            self.cancelAndCleanupPreparingInstances()
-            NSApplication.shared.reply(toApplicationShouldTerminate: true)
-        }
+            Self.logger.notice("Quit requested while the termination save pass is running — deferring to it")
+            return .terminateCancel
 
-        return .terminateLater
+        case .terminateNow:
+            cancelAndCleanupPreparingInstances()
+            return .terminateNow
+
+        case .saveThenTerminate:
+            cancelAndCleanupPreparingInstances()
+            // macOS quits and relaunches the app when a TCC permission is revoked, and
+            // its built-in relaunch times out while VMs are saving. Mark for relaunch
+            // so `applicationWillTerminate` launches the helper after saves complete.
+            if terminationIsTCCRevocation {
+                relaunchAfterTermination = true
+            }
+            isRunningTerminationSavePass = true
+            Task { @MainActor in
+                await self.runTerminationSavePass()
+                // A drop/odoc delivered during the async save window above can register
+                // a fresh phantom, so sweep again right before the deferred reply or
+                // that bundle is orphaned on disk.
+                self.cancelAndCleanupPreparingInstances()
+                NSApplication.shared.reply(toApplicationShouldTerminate: true)
+            }
+            return .terminateLater
+        }
+    }
+
+    /// Waits out every in-flight save, then save-suspends whatever is still live.
+    ///
+    /// One instance per iteration, tracked by id: a failed force-stop leaves the
+    /// VM live, so re-selecting on state alone would loop forever. The wait at the
+    /// top of each iteration also covers a save the user starts while the pass
+    /// runs — reaching a `.saving` VM through `trySave` comes back as
+    /// `operationInProgress`, and the failure path below would force-stop it
+    /// mid-write.
+    private func runTerminationSavePass() async {
+        var handled: Set<UUID> = []
+        var savedCount = 0
+        var failedCount = 0
+        while true {
+            if viewModel.hasSaveInFlight {
+                Self.logger.notice("Termination waiting on an in-flight save to settle")
+                await waitForObservedChange { [viewModel] in !viewModel.hasSaveInFlight }
+            }
+            guard
+                let instance = viewModel.instances.first(where: {
+                    $0.hasLiveSession && !handled.contains($0.id)
+                })
+            else { break }
+            handled.insert(instance.id)
+            if await saveForTermination(instance) {
+                savedCount += 1
+            } else {
+                failedCount += 1
+            }
+        }
+        Self.logger.notice(
+            "Termination save complete: \(savedCount, privacy: .public) saved, \(failedCount, privacy: .public) failed of \(handled.count, privacy: .public) total"
+        )
+    }
+
+    /// Save-suspends one VM for termination, force-stopping it when the save
+    /// fails so a half-live VM can't outlive the process.
+    ///
+    /// - Returns: `true` when the state was saved.
+    private func saveForTermination(_ instance: VMInstance) async -> Bool {
+        do {
+            try await viewModel.trySave(instance)
+            viewModel.saveConfiguration(for: instance)
+            return true
+        } catch {
+            Self.logger.error(
+                "Failed to save '\(instance.name, privacy: .public)' during termination: \(error.localizedDescription, privacy: .public)"
+            )
+            do {
+                try await viewModel.tryForceStop(instance)
+            } catch {
+                Self.logger.error(
+                    "Failed to force-stop '\(instance.name, privacy: .public)' during termination: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+            return false
+        }
     }
 
     /// Cancels every preparing instance's task and trashes its partial bundle.

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -331,8 +331,18 @@ final class VMInstance {
         return virtualMachine != nil
     }
 
+    /// Whether a live `VZVirtualMachine` is attached and settled at a state VZ
+    /// can act on — the VMs a termination save-suspends, and the ones a device
+    /// can be attached to.
+    ///
+    /// A cold-paused VM is excluded: its state is already on disk, with nothing
+    /// live to act on.
+    var hasLiveSession: Bool {
+        status.canSave && hasLiveVirtualMachine
+    }
+
     var canAttachUSBDevices: Bool {
-        (status == .running || status == .paused) && hasLiveVirtualMachine
+        hasLiveSession
     }
 
     /// `true` when the bundled guest-agent installer disk can be attached to or

--- a/Kernova/Models/VMStatus.swift
+++ b/Kernova/Models/VMStatus.swift
@@ -43,6 +43,25 @@ enum VMStatus: Sendable {
         }
     }
 
+    /// Whether terminating during this state would leave a half-written file
+    /// where a complete one belongs, so a quit must wait the operation out
+    /// instead of exiting through it.
+    ///
+    /// The subset of ``isTransitioning`` an *explicit* quit is obliged to honor:
+    /// `VZVirtualMachine.saveMachineStateTo` writes the save file in place, so an
+    /// exit mid-write truncates the file a later restore reads. A restore keeps
+    /// that file until its resume succeeds, and a start or install writes nothing
+    /// a relaunch cannot redo. Exhaustive rather than `default`, so a new state
+    /// has to choose a side.
+    var terminationMustWaitOut: Bool {
+        switch self {
+        case .saving:
+            true
+        case .starting, .restoring, .installing, .running, .paused, .stopped, .error, .initialBoot:
+            false
+        }
+    }
+
     /// Overlay label for save/restore transitions, or `nil` for all other states.
     var transitionLabel: String? {
         switch self {

--- a/Kernova/Utilities/ObservationLoop.swift
+++ b/Kernova/Utilities/ObservationLoop.swift
@@ -57,3 +57,36 @@ func observeRecurring(
 ) -> ObservationLoop {
     ObservationLoop(track: track, apply: apply)
 }
+
+/// Holds the loop so the `apply` closure can cancel the very loop it belongs to.
+@MainActor
+private final class ObservationLoopBox {
+    var loop: ObservationLoop?
+}
+
+/// Suspends until `predicate` holds, waking on each change to an `@Observable`
+/// property the predicate reads.
+///
+/// Resumes only when `predicate` holds — including for a cancelled caller — so
+/// use it to wait out an operation that completes or fails on its own.
+/// `predicate` must be side-effect-free and must read every value it inspects
+/// through an `@Observable` getter, or nothing wakes the wait.
+@MainActor
+func waitForObservedChange(until predicate: @escaping @MainActor () -> Bool) async {
+    guard !predicate() else { return }
+    let box = ObservationLoopBox()
+    // The pre-arm check above and `observeRecurring` both run without suspending,
+    // so no change can slip between them, and cancelling inside `apply` stops any
+    // further fire — the continuation resumes exactly once.
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        box.loop = observeRecurring(
+            track: { _ = predicate() },
+            apply: {
+                guard predicate() else { return }
+                box.loop?.cancel()
+                box.loop = nil
+                continuation.resume()
+            }
+        )
+    }
+}

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -117,6 +117,15 @@ final class VMLibraryViewModel {
         instances.contains { $0.isPreparing || $0.status.isTransitioning }
     }
 
+    /// Whether any VM is mid-save — the one operation an explicit quit has to
+    /// wait out rather than terminate through.
+    ///
+    /// Narrower than ``hasUninterruptibleWork``, which the window reconcile uses
+    /// to hold back a quit nobody asked for.
+    var hasSaveInFlight: Bool {
+        instances.contains { $0.status.terminationMustWaitOut }
+    }
+
     private var customOrder: [UUID] = []
 
     /// Bundle names whose load failures have already been reported to the user.

--- a/KernovaTests/AppDelegateTerminationOutcomeTests.swift
+++ b/KernovaTests/AppDelegateTerminationOutcomeTests.swift
@@ -26,6 +26,13 @@ struct AppDelegateTerminationOutcomeTests {
         #expect(outcome(shouldTerminateAgent: false, hasInstancesToSave: true) == .closeGUI)
     }
 
+    @Test("a system quit during the save pass is deferred, never vetoed")
+    func systemQuitDuringSavePassIsNotVetoed() {
+        // `.deferToSavePass` replies `.terminateLater`; a `.terminateCancel` would
+        // reach loginwindow as Kernova refusing the logout or shut down.
+        #expect(outcome(isSavePassRunning: true) == .deferToSavePass)
+    }
+
     @Test("an idle library terminates immediately")
     func idleLibraryTerminatesNow() {
         #expect(outcome() == .terminateNow)
@@ -56,16 +63,18 @@ struct AppDelegateTerminationOutcomeTests {
     @Test(
         "a quit arriving during the save pass defers to it",
         arguments: [true, false])
-    func quitDuringSavePassIsDropped(hasInstancesToSave: Bool) {
-        // The first request's `.terminateLater` reply still terminates the app. A
-        // second pass would hit `operationInProgress` on the VM already saving and
-        // force-stop it mid-write.
+    func quitDuringSavePassDefersToIt(hasInstancesToSave: Bool) {
+        // A second pass would hit `operationInProgress` on the VM already saving
+        // and force-stop it mid-write.
         #expect(
-            outcome(isSavePassRunning: true, hasInstancesToSave: hasInstancesToSave) == .duplicate)
+            outcome(isSavePassRunning: true, hasInstancesToSave: hasInstancesToSave)
+                == .deferToSavePass)
     }
 
-    @Test("a soft quit during the save pass still just closes the GUI")
-    func softQuitDuringSavePassClosesTheGUI() {
-        #expect(outcome(shouldTerminateAgent: false, isSavePassRunning: true) == .closeGUI)
+    @Test("a soft quit during the save pass defers to it rather than closing the GUI")
+    func softQuitDuringSavePassDefersToIt() {
+        // Closing the windows would pop the "still running in the menu bar"
+        // reminder seconds before the pass's reply exits the process.
+        #expect(outcome(shouldTerminateAgent: false, isSavePassRunning: true) == .deferToSavePass)
     }
 }

--- a/KernovaTests/AppDelegateTerminationOutcomeTests.swift
+++ b/KernovaTests/AppDelegateTerminationOutcomeTests.swift
@@ -1,0 +1,71 @@
+import Testing
+
+@testable import Kernova
+
+/// Unit tests for `AppDelegate.terminationOutcome` — what the termination gate
+/// replies to a quit request (#805).
+@Suite("AppDelegate termination outcome")
+struct AppDelegateTerminationOutcomeTests {
+    private func outcome(
+        shouldTerminateAgent: Bool = true,
+        isSavePassRunning: Bool = false,
+        hasSaveInFlight: Bool = false,
+        hasInstancesToSave: Bool = false
+    ) -> AppDelegate.TerminationOutcome {
+        AppDelegate.terminationOutcome(
+            shouldTerminateAgent: shouldTerminateAgent,
+            isSavePassRunning: isSavePassRunning,
+            hasSaveInFlight: hasSaveInFlight,
+            hasInstancesToSave: hasInstancesToSave)
+    }
+
+    @Test("a soft quit closes the GUI whatever the VMs are doing")
+    func softQuitClosesTheGUI() {
+        #expect(outcome(shouldTerminateAgent: false) == .closeGUI)
+        #expect(outcome(shouldTerminateAgent: false, hasSaveInFlight: true) == .closeGUI)
+        #expect(outcome(shouldTerminateAgent: false, hasInstancesToSave: true) == .closeGUI)
+    }
+
+    @Test("an idle library terminates immediately")
+    func idleLibraryTerminatesNow() {
+        #expect(outcome() == .terminateNow)
+    }
+
+    @Test("live VMs are save-suspended before termination")
+    func liveVMsAreSaved() {
+        #expect(outcome(hasInstancesToSave: true) == .saveThenTerminate)
+    }
+
+    // MARK: - In-flight save
+
+    @Test("a save already in flight defers the reply with nothing else to save")
+    func saveInFlightAloneDefersTermination() {
+        // The regression: a VM mid-save is neither `.running` nor `.paused`, so the
+        // gate used to see an empty save set and terminate through the write,
+        // truncating the save file `saveMachineStateTo` writes in place.
+        #expect(outcome(hasSaveInFlight: true) == .saveThenTerminate)
+    }
+
+    @Test("a save in flight alongside a live VM defers the reply")
+    func saveInFlightWithOtherLiveVMs() {
+        #expect(outcome(hasSaveInFlight: true, hasInstancesToSave: true) == .saveThenTerminate)
+    }
+
+    // MARK: - Re-entrancy
+
+    @Test(
+        "a quit arriving during the save pass defers to it",
+        arguments: [true, false])
+    func quitDuringSavePassIsDropped(hasInstancesToSave: Bool) {
+        // The first request's `.terminateLater` reply still terminates the app. A
+        // second pass would hit `operationInProgress` on the VM already saving and
+        // force-stop it mid-write.
+        #expect(
+            outcome(isSavePassRunning: true, hasInstancesToSave: hasInstancesToSave) == .duplicate)
+    }
+
+    @Test("a soft quit during the save pass still just closes the GUI")
+    func softQuitDuringSavePassClosesTheGUI() {
+        #expect(outcome(shouldTerminateAgent: false, isSavePassRunning: true) == .closeGUI)
+    }
+}

--- a/KernovaTests/ObservationLoopTests.swift
+++ b/KernovaTests/ObservationLoopTests.swift
@@ -147,6 +147,71 @@ struct ObservationLoopTests {
         #expect(counter.count == 0)
     }
 
+    // MARK: - waitForObservedChange
+
+    @Test("waitForObservedChange returns without suspending when the predicate already holds")
+    func waitReturnsImmediatelyWhenSatisfied() async {
+        let subject = Subject()
+        subject.value = 7
+
+        await waitForObservedChange { subject.value == 7 }
+    }
+
+    @Test("waitForObservedChange resumes on the change that satisfies the predicate")
+    func waitResumesOnSatisfyingChange() async {
+        let subject = Subject()
+        let task = Task { @MainActor in await waitForObservedChange { subject.value == 2 } }
+        await drain()
+
+        subject.value = 2
+
+        // Awaiting the task *is* the wait — it returns only once the production
+        // helper has resumed.
+        await task.value
+    }
+
+    @Test("waitForObservedChange stays suspended through a change that does not satisfy it")
+    func waitIgnoresUnsatisfyingChange() async {
+        let subject = Subject()
+        let counter = Counter()
+        let task = Task { @MainActor in
+            await waitForObservedChange { subject.value == 2 }
+            counter.increment()
+        }
+        await drain()
+
+        subject.value = 1
+        await drain()
+        #expect(counter.count == 0)
+
+        subject.value = 2
+        await task.value
+        #expect(counter.count == 1)
+    }
+
+    @Test("waitForObservedChange stops observing once it resumes")
+    func waitStopsObservingAfterResuming() async {
+        let subject = Subject()
+        let evaluations = Counter()
+        let task = Task { @MainActor in
+            await waitForObservedChange {
+                evaluations.increment()
+                return subject.value == 1
+            }
+        }
+        await drain()
+        subject.value = 1
+        await task.value
+
+        let afterResume = evaluations.count
+        subject.value = 2
+        await drain()
+
+        // A loop left armed would re-evaluate the predicate — and could resume a
+        // continuation that has already fired.
+        #expect(evaluations.count == afterResume)
+    }
+
     @Test("multiple independent loops can observe the same subject")
     func independentLoops() async {
         let subject = Subject()

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -160,6 +160,36 @@ struct VMInstanceTests {
         #expect(instance.isColdPaused == false)
     }
 
+    // MARK: - hasLiveSession
+
+    @Test(
+        "hasLiveSession is true for a running or live-paused VM",
+        arguments: [VMStatus.running, .paused])
+    func hasLiveSessionWithLiveVM(status: VMStatus) {
+        let instance = makeInstance(status: status)
+        instance.hasLiveVirtualMachineOverrideForTesting = true
+        #expect(instance.hasLiveSession == true)
+    }
+
+    @Test(
+        "hasLiveSession is false without a live virtual machine",
+        arguments: [VMStatus.running, .paused, .stopped, .error])
+    func hasLiveSessionWithoutLiveVM(status: VMStatus) {
+        let instance = makeInstance(status: status)
+        #expect(instance.hasLiveSession == false)
+    }
+
+    @Test(
+        "hasLiveSession is false mid-transition even with a live virtual machine",
+        arguments: [VMStatus.saving, .restoring, .starting, .installing, .initialBoot])
+    func hasLiveSessionIsFalseWhileTransitioning(status: VMStatus) {
+        // A VM that has not settled at `.running`/`.paused` is not something the
+        // termination pass can snapshot.
+        let instance = makeInstance(status: status)
+        instance.hasLiveVirtualMachineOverrideForTesting = true
+        #expect(instance.hasLiveSession == false)
+    }
+
     // MARK: - effectiveMachineIdentifierData
 
     @Test("effectiveMachineIdentifierData prefers the configuration field")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -3078,6 +3078,39 @@ struct VMLibraryViewModelTests {
         #expect(!viewModel.hasUninterruptibleWork)
     }
 
+    @Test("hasSaveInFlight covers a saving VM alone")
+    func hasSaveInFlightCoversSavingOnly() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        viewModel.instances = [instance]
+
+        instance.status = .saving
+        #expect(viewModel.hasSaveInFlight)
+        // Every other transition is one an explicit quit may terminate through.
+        for status in [VMStatus.starting, .restoring, .installing, .running, .paused, .stopped] {
+            instance.status = status
+            #expect(!viewModel.hasSaveInFlight)
+        }
+    }
+
+    @Test("hasSaveInFlight finds a saving VM among settled ones")
+    func hasSaveInFlightFindsAnyInstance() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let running = makeInstance()
+        running.status = .running
+        let saving = makeInstance()
+        saving.status = .saving
+        viewModel.instances = [running, saving]
+
+        #expect(viewModel.hasSaveInFlight)
+    }
+
+    @Test("hasSaveInFlight is false for an empty library")
+    func hasSaveInFlightIsFalseWhenEmpty() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        #expect(!viewModel.hasSaveInFlight)
+    }
+
     @Test("keepInMenuBarOnQuit defaults on and persists in both directions")
     func keepInMenuBarOnQuitPersistsBothDirections() {
         let (viewModel, _, _, _, _) = makeViewModel()

--- a/KernovaTests/VMStatusTests.swift
+++ b/KernovaTests/VMStatusTests.swift
@@ -154,6 +154,33 @@ struct VMStatusTests {
         #expect(VMStatus.error.isTransitioning == false)
     }
 
+    @Test("terminationMustWaitOut covers saving alone")
+    func terminationMustWaitOut() {
+        #expect(VMStatus.saving.terminationMustWaitOut == true)
+        // A restore keeps the save file until its resume succeeds, and a start or
+        // install writes nothing a relaunch cannot redo, so an explicit quit is
+        // free to terminate through them.
+        #expect(VMStatus.starting.terminationMustWaitOut == false)
+        #expect(VMStatus.restoring.terminationMustWaitOut == false)
+        #expect(VMStatus.installing.terminationMustWaitOut == false)
+        #expect(VMStatus.running.terminationMustWaitOut == false)
+        #expect(VMStatus.paused.terminationMustWaitOut == false)
+        #expect(VMStatus.stopped.terminationMustWaitOut == false)
+        #expect(VMStatus.initialBoot.terminationMustWaitOut == false)
+        #expect(VMStatus.error.terminationMustWaitOut == false)
+    }
+
+    @Test(
+        "terminationMustWaitOut stays a subset of isTransitioning",
+        arguments: [
+            VMStatus.stopped, .starting, .running, .paused, .saving, .restoring, .installing, .initialBoot, .error,
+        ])
+    func terminationWaitIsSubsetOfTransitioning(status: VMStatus) {
+        // The window reconcile holds a quit for anything transitioning; the
+        // explicit gate waits out a strict subset of that.
+        #expect(!status.terminationMustWaitOut || status.isTransitioning)
+    }
+
     // MARK: - Transition Label
 
     @Test("transitionLabel returns label for saving and restoring, nil otherwise")


### PR DESCRIPTION
Closes #805

## The defect

`applicationShouldTerminate` built its save set from `(status == .running || status == .paused) && virtualMachine != nil`. A VM mid-save is `.saving`, so it was excluded: with no other live VM the gate replied `.terminateNow` and the process exited while `VZVirtualMachine.saveMachineStateTo` was still writing. That write goes straight to `instance.saveFileURL` with no temp-and-rename, so the exit left a truncated file exactly where a restore looks for valid saved state. With another VM live the gate did reply `.terminateLater`, but the reply fired when *its own* pass finished, unrelated to the foreign save's progress.

Two adjacent instances of the same defect turned up while implementing, both fixed here because this change widens the `.terminateLater` window and leaving them would make it a net regression:

- **Re-entrant quit.** The gate had no guard against being re-entered while its own deferred reply was outstanding. A second ⌥⌘Q ran a second pass, `VMLifecycleCoordinator.serialized` rejected the duplicate `trySave` with `operationInProgress`, and the gate's `catch` read that as a save failure and called `tryForceStop` — force-killing the VM mid-save.
- **A save started during the pass.** Menus stay live during `.terminateLater`, so a user-initiated Suspend on a not-yet-reached VM landed in that same `operationInProgress` → force-stop path.

## The design

The gate now decides through a `nonisolated static func terminationOutcome(...)` sitting beside `residencyOutcome`, over four plain `Bool`s, so the full matrix is unit-testable (`applicationShouldTerminate` itself is not):

| | outcome | reply |
|---|---|---|
| pass already running | `.deferToSavePass` | `.terminateLater` |
| soft quit (keep-in-menu-bar) | `.closeGUI` — unchanged | `.terminateCancel` |
| save in flight, or a live VM to save | `.saveThenTerminate` | `.terminateLater` |
| neither | `.terminateNow` | `.terminateNow` |

A running pass is checked *before* the soft-quit downgrade: the app is already on its way out, so closing the GUI and popping the "still running in the menu bar" reminder would be false. And it defers rather than cancels — a `.terminateCancel` reaches loginwindow as Kernova refusing a logout, restart, or shut down, which is exactly what `systemQuitSenderBundleIDs` exists to prevent. `.terminateLater` runs a nested wait that the pass's single `reply(toApplicationShouldTerminate:)` resolves.

`runTerminationSavePass` then waits out any in-flight save before selecting each instance, one per iteration tracked by id (a failed force-stop leaves the VM live, so re-selecting on state alone would spin). The wait is `waitForObservedChange(until:)`, a new awaitable wrapper over the existing `ObservationLoop` — no second observation mechanism, and directly unit-testable.

## Deviations from the issue

**The issue proposed sharing #804's hold predicate, `hasUninterruptibleWork`, verbatim. That is the wrong predicate for this route.** It also covers `isPreparing` and `.installing`/`.starting`/`.restoring`, so on the termination gate it would (a) make a quit wait for an import that the very next line trashes (`cancelAndCleanupPreparingInstances`) and (b) hold a quit for the tens of minutes a macOS install runs — including a `loginwindow` logout quit that must not stall the session.

The two routes ask genuinely different questions of the same state: a window close is not an instruction to quit, so it may defer indefinitely; an explicit quit is, so it may only wait out what termination would *corrupt*. Of the transitioning states only `.saving` qualifies — a restore keeps the save file until its resume succeeds, and a start or install writes nothing a relaunch cannot redo.

So the consolidation lands one layer deeper than the issue suggested, on `VMStatus`, which already owns per-state termination semantics through the exhaustive `isTransitioning` switch. `terminationMustWaitOut` is its sibling; each route composes the question it actually asks, and a test pins the subset relationship so the two can't drift apart. Likewise `VMInstance.hasLiveSession` replaces the gate's inline liveness filter — a parallel path around the documented single liveness read — and absorbs `canAttachUSBDevices`, which spelled the identical expression by hand.

Rejected alternatives: a bounded timeout on the wait (a truncating force-exit is the outcome it would produce, and the existing pass already awaits `trySave` unboundedly); making the gate cancel the in-flight save (there is no cancellation seam, and cancelling a `saveMachineStateTo` mid-write *is* the truncation).

Explicit non-goals, all pre-existing: a VM killed mid-`.starting`/`.restoring`/`.installing` by an explicit quit, and the deliberate cancel-and-trash of in-flight imports.

## Review round

`/code-review high` plus two Codex reviews. Fixed in the second commit: the loginwindow veto, the false soft-quit reminder, and a force-stop that fired when a save was rejected because a pause or resume still held the VM's lifecycle lock — a hard kill that discarded the guest RAM the pass exists to save.

Deferred as #807: actually *saving* that VM. The pass detects an in-flight operation from `VMStatus`, and only `.saving` encodes one — a settling pause holds `.running` and a settling resume holds `.paused`. The complete fix waits on the operation's own lifetime, which needs `VMLifecycleCoordinator.activeOperations` to be observable; it is a plain `@MainActor final class` today, so a wait on it would never wake and would hang the quit.

Dismissed: the adversarial review argued `hasSaveInFlight` can go false while `saveMachineStateTo` still has an outstanding continuation, because `forceStop` moves the VM to `.stopped` without joining the save. Reachable only by force-stopping a VM mid-save and then quitting inside that window — and Force Stop is the discard-this-state command, whose whole point is that the save file is forfeit. Same root cause as #807 either way.

## Test plan

- [x] `make lint`, `make test` (full suite green)
- [x] `AppDelegateTerminationOutcomeTests` — 9 cases; the regression assertion is "a save in flight with nothing else to save defers the reply", which the old gate answered `.terminateNow`
- [x] `ObservationLoopTests` — `waitForObservedChange` returns without suspending when already satisfied, resumes on the satisfying change, stays suspended through a non-satisfying one, and stops observing after it resumes
- [x] `VMStatusTests` / `VMInstanceTests` / `VMLibraryViewModelTests` — the three new predicates, including the subset invariant
- [ ] Manual (not unit-testable): start a VM, click Suspend, press ⌥⌘Q while "Suspending…" is up — the app stays alive until the save completes, logging `Termination waiting on an in-flight save to settle` then `Termination save complete: …`, and the VM restores on relaunch. Repeat with a second ⌥⌘Q during the pass for `deferring to it` plus a single clean exit, and once more with Apple menu → Log Out during the pass to confirm the logout is not vetoed.

## Notes

No `RATIONALE:` comments added. No component boundary changed, so no `docs/ARCHITECTURE.md` edit; no AGENTS.md rule changed; the guest agent is untouched, so no `MARKETING_VERSION` bump.
