### PR TITLE
fix: Wait out a settling pause or resume before the termination save

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -728,15 +728,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     /// and a save issued against a held VM comes back as
     /// ``VMLifecycleCoordinator/LifecycleError/operationInProgress``.
     ///
+    /// The signal is ``VMLifecycleCoordinator/hasUnsettledOperation(for:)``
+    /// rather than the claim: a Stop arriving mid-wait releases the claim while
+    /// the pause it interrupted is still inside VZ, and saving there would issue
+    /// a second VZ operation on a busy VM.
+    ///
     /// `hasLiveSession` is what bounds the wait: `.installing`, `.starting` and
     /// `.restoring` all fail it, so the operations that run for minutes are
     /// skipped rather than waited on and can never hold a quit.
     nonisolated static func terminationSaveStep(
         hasLiveSession: Bool,
-        hasActiveOperation: Bool
+        hasUnsettledOperation: Bool
     ) -> TerminationSaveStep {
         guard hasLiveSession else { return .skip }
-        return hasActiveOperation ? .waitForOperation : .save
+        return hasUnsettledOperation ? .waitForOperation : .save
     }
 
     /// Reconciles the resident app with its open windows: `.regular` (Dock icon)
@@ -965,11 +970,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                     "Termination waiting on a lifecycle operation for '\(instance.name, privacy: .public)' to settle"
                 )
                 // The liveness escape ends the wait when the operation leaves the
-                // VM unsaveable — a failed pause landing on `.error`, or a
-                // Force Stop that bypassed serialization and cleared the token it
-                // never took.
+                // VM unsaveable — a failed pause landing on `.error`, or a Force
+                // Stop whose `vm.stop()` tears the session down while the
+                // interrupted operation is still inside VZ.
                 await waitForObservedChange { [viewModel] in
-                    !viewModel.lifecycle.hasActiveOperation(for: instance.id)
+                    !viewModel.lifecycle.hasUnsettledOperation(for: instance.id)
                         || !instance.hasLiveSession
                 }
             }
@@ -1006,7 +1011,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     private func step(for instance: VMInstance) -> TerminationSaveStep {
         Self.terminationSaveStep(
             hasLiveSession: instance.hasLiveSession,
-            hasActiveOperation: viewModel.lifecycle.hasActiveOperation(for: instance.id)
+            hasUnsettledOperation: viewModel.lifecycle.hasUnsettledOperation(for: instance.id)
         )
     }
 

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -710,6 +710,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         return .terminateNow
     }
 
+    /// What the termination save pass does with one VM it has selected.
+    enum TerminationSaveStep: Equatable {
+        /// Hold until the lifecycle operation on this VM finishes, then re-decide.
+        case waitForOperation
+        /// Save-suspend it now.
+        case save
+        /// Leave it alone.
+        case skip
+    }
+
+    /// Decides the pass's next move for one VM.
+    ///
+    /// ``VMStatus`` cannot tell a settling pause or resume from a settled VM —
+    /// both hold `.running` / `.paused` for the whole `vm.pause()` /
+    /// `vm.resume()` await — so the operation's own lifetime is what decides,
+    /// and a save issued against a held VM comes back as
+    /// ``VMLifecycleCoordinator/LifecycleError/operationInProgress``.
+    ///
+    /// `hasLiveSession` is what bounds the wait: `.installing`, `.starting` and
+    /// `.restoring` all fail it, so the operations that run for minutes are
+    /// skipped rather than waited on and can never hold a quit.
+    nonisolated static func terminationSaveStep(
+        hasLiveSession: Bool,
+        hasActiveOperation: Bool
+    ) -> TerminationSaveStep {
+        guard hasLiveSession else { return .skip }
+        return hasActiveOperation ? .waitForOperation : .save
+    }
+
     /// Reconciles the resident app with its open windows: `.regular` (Dock icon)
     /// while any user window is on screen, and when none are, either `.accessory`
     /// (status-item only) or a quit — see `residencyOutcome`.
@@ -904,15 +933,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     /// Waits out every in-flight save, then save-suspends whatever is still live.
     ///
     /// One instance per iteration, tracked by id: a failed force-stop leaves the
-    /// VM live, so re-selecting on state alone would loop forever. The wait at the
-    /// top of each iteration also covers a save the user starts while the pass
-    /// runs — reaching a `.saving` VM through `trySave` comes back as
-    /// `operationInProgress`, and the failure path below would force-stop it
-    /// mid-write.
+    /// VM live, so re-selecting on state alone would loop forever, and marking a
+    /// VM handled *before* its wait keeps that guarantee when a user-initiated
+    /// operation keeps re-taking the lock.
+    ///
+    /// The wait at the top of each iteration covers a save the user starts on
+    /// another VM while the pass runs — a `.saving` VM is never selected here
+    /// (`.saving` fails `hasLiveSession`), so nothing else would stop the loop
+    /// from breaking out and letting the process exit mid-write. The per-VM wait
+    /// below covers the selected VM's own settling operation, per
+    /// ``terminationSaveStep(hasLiveSession:hasActiveOperation:)``.
     private func runTerminationSavePass() async {
         var handled: Set<UUID> = []
         var savedCount = 0
         var failedCount = 0
+        var skippedCount = 0
         while true {
             if viewModel.hasSaveInFlight {
                 Self.logger.notice("Termination waiting on an in-flight save to settle")
@@ -924,25 +959,66 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
                 })
             else { break }
             handled.insert(instance.id)
-            if await saveForTermination(instance) {
-                savedCount += 1
-            } else {
-                failedCount += 1
+
+            if step(for: instance) == .waitForOperation {
+                Self.logger.notice(
+                    "Termination waiting on a lifecycle operation for '\(instance.name, privacy: .public)' to settle"
+                )
+                // The liveness escape ends the wait when the operation leaves the
+                // VM unsaveable — a failed pause landing on `.error`, or a
+                // Force Stop that bypassed serialization and cleared the token it
+                // never took.
+                await waitForObservedChange { [viewModel] in
+                    !viewModel.lifecycle.hasActiveOperation(for: instance.id)
+                        || !instance.hasLiveSession
+                }
+            }
+
+            // Re-decided after the wait: a VM that is no longer live must not
+            // reach `trySave`, whose generic failure path force-stops.
+            switch step(for: instance) {
+            case .save:
+                if await saveForTermination(instance) {
+                    savedCount += 1
+                } else {
+                    failedCount += 1
+                }
+            case .skip:
+                Self.logger.notice(
+                    "Termination skipping '\(instance.name, privacy: .public)': it is no longer a live session this pass can save"
+                )
+                skippedCount += 1
+            case .waitForOperation:
+                // A second operation took the lock while the first was being
+                // waited out. One attempt per VM, so this one is not re-waited.
+                Self.logger.warning(
+                    "Termination skipping '\(instance.name, privacy: .public)': another lifecycle operation took it"
+                )
+                skippedCount += 1
             }
         }
         Self.logger.notice(
-            "Termination save complete: \(savedCount, privacy: .public) saved, \(failedCount, privacy: .public) failed of \(handled.count, privacy: .public) total"
+            "Termination save complete: \(savedCount, privacy: .public) saved, \(failedCount, privacy: .public) failed, \(skippedCount, privacy: .public) skipped"
+        )
+    }
+
+    /// The pass's move for `instance`, read from live state.
+    private func step(for instance: VMInstance) -> TerminationSaveStep {
+        Self.terminationSaveStep(
+            hasLiveSession: instance.hasLiveSession,
+            hasActiveOperation: viewModel.lifecycle.hasActiveOperation(for: instance.id)
         )
     }
 
     /// Save-suspends one VM for termination, force-stopping it when the save
     /// fails so a half-live VM can't outlive the process.
     ///
-    /// A save rejected because the VM already holds a lifecycle operation (a
-    /// pause or resume still settling) is left alone: force-stopping there would
-    /// abort an operation that is about to finish and discard the very guest
-    /// state the pass exists to save, where letting the process exit costs the
-    /// same RAM and nothing more.
+    /// The pass waits an in-flight lifecycle operation out before calling this,
+    /// so a rejection here is the residual race where a user-initiated operation
+    /// takes the lock in between. It is left alone rather than force-stopped:
+    /// force-stopping would abort an operation that is about to finish and
+    /// discard the very guest state the pass exists to save, where letting the
+    /// process exit costs the same RAM and nothing more.
     ///
     /// - Returns: `true` when the state was saved.
     private func saveForTermination(_ instance: VMInstance) async -> Bool {

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -12,8 +12,10 @@ import os
 /// ``LifecycleError/operationInProgress``. `stop` and `forceStop` bypass that
 /// serialization entirely, so a hung operation can always be interrupted.
 @MainActor
+@Observable
 final class VMLifecycleCoordinator {
-    private static let logger = Logger(subsystem: "app.kernova", category: "VMLifecycleCoordinator")
+    nonisolated private static let logger = Logger(
+        subsystem: "app.kernova", category: "VMLifecycleCoordinator")
 
     let virtualizationService: any VirtualizationProviding
     let installService: any MacOSInstallProviding
@@ -73,6 +75,12 @@ final class VMLifecycleCoordinator {
 
     // MARK: - Operation Serialization
 
+    /// Whether a serialized operation currently holds this VM.
+    ///
+    /// Observable, so a `withObservationTracking` wait on it wakes when the
+    /// operation ends — which is what lets a caller hold for an operation whose
+    /// ``VMStatus`` never changes (a pause settles at `.running`, a resume at
+    /// `.paused`).
     func hasActiveOperation(for instanceID: UUID) -> Bool {
         activeOperations[instanceID] != nil
     }

--- a/Kernova/ViewModels/VMLifecycleCoordinator.swift
+++ b/Kernova/ViewModels/VMLifecycleCoordinator.swift
@@ -14,8 +14,7 @@ import os
 @MainActor
 @Observable
 final class VMLifecycleCoordinator {
-    nonisolated private static let logger = Logger(
-        subsystem: "app.kernova", category: "VMLifecycleCoordinator")
+    private static let logger = Logger(subsystem: "app.kernova", category: "VMLifecycleCoordinator")
 
     let virtualizationService: any VirtualizationProviding
     let installService: any MacOSInstallProviding
@@ -37,6 +36,13 @@ final class VMLifecycleCoordinator {
     ///
     /// The token allows `defer` blocks to avoid clobbering entries inserted by a later operation.
     private var activeOperations: [UUID: UUID] = [:]
+
+    /// Maps VM ID → the number of ``serialized`` bodies still executing for it.
+    ///
+    /// Counted rather than flagged: `stop` and `forceStop` clear a claim without
+    /// stopping the body that held it, so a second operation can acquire the
+    /// claim and run alongside the first. Each body clears its own entry.
+    private var unsettledOperations: [UUID: Int] = [:]
 
     init(
         virtualizationService: any VirtualizationProviding,
@@ -75,14 +81,27 @@ final class VMLifecycleCoordinator {
 
     // MARK: - Operation Serialization
 
-    /// Whether a serialized operation currently holds this VM.
+    /// Whether a serialized operation currently *claims* this VM — the read that
+    /// decides whether a new request is rejected.
+    func hasActiveOperation(for instanceID: UUID) -> Bool {
+        activeOperations[instanceID] != nil
+    }
+
+    /// Whether any serialized operation for this VM is still running its body,
+    /// and so may still have a VZ call in flight.
+    ///
+    /// Distinct from ``hasActiveOperation(for:)``, which tracks the claim:
+    /// `stop` and `forceStop` release another operation's claim so a user can
+    /// always interrupt, but the interrupted body keeps running. A caller
+    /// deciding whether it may issue its *own* VZ operation therefore asks this,
+    /// not the claim, or it acts while VZ is still busy.
     ///
     /// Observable, so a `withObservationTracking` wait on it wakes when the
     /// operation ends — which is what lets a caller hold for an operation whose
     /// ``VMStatus`` never changes (a pause settles at `.running`, a resume at
     /// `.paused`).
-    func hasActiveOperation(for instanceID: UUID) -> Bool {
-        activeOperations[instanceID] != nil
+    func hasUnsettledOperation(for instanceID: UUID) -> Bool {
+        unsettledOperations[instanceID] != nil
     }
 
     /// Removes any active-operation tracking for the given VM.
@@ -94,9 +113,10 @@ final class VMLifecycleCoordinator {
 
     /// Executes `body` only if no other operation is already in flight for this VM.
     ///
-    /// The `defer` removes the entry only if its token still matches, so a stale
+    /// The `defer` removes the claim only if its token still matches, so a stale
     /// removal cannot clobber a token written by `stop`/`forceStop` or by a
-    /// subsequent operation.
+    /// subsequent operation. The unsettled count is dropped unconditionally,
+    /// because it tracks *this* body and nothing else can end it.
     private func serialized<T>(
         _ instance: VMInstance,
         action: String,
@@ -111,10 +131,13 @@ final class VMLifecycleCoordinator {
 
         let token = UUID()
         activeOperations[instance.id] = token
+        unsettledOperations[instance.id, default: 0] += 1
         defer {
             if activeOperations[instance.id] == token {
                 activeOperations.removeValue(forKey: instance.id)
             }
+            let remaining = (unsettledOperations[instance.id] ?? 1) - 1
+            unsettledOperations[instance.id] = remaining > 0 ? remaining : nil
         }
 
         Self.logger.debug(

--- a/KernovaTests/AppDelegateTerminationOutcomeTests.swift
+++ b/KernovaTests/AppDelegateTerminationOutcomeTests.swift
@@ -85,11 +85,11 @@ struct AppDelegateTerminationOutcomeTests {
 struct AppDelegateTerminationSaveStepTests {
     private func step(
         hasLiveSession: Bool = true,
-        hasActiveOperation: Bool = false
+        hasUnsettledOperation: Bool = false
     ) -> AppDelegate.TerminationSaveStep {
         AppDelegate.terminationSaveStep(
             hasLiveSession: hasLiveSession,
-            hasActiveOperation: hasActiveOperation)
+            hasUnsettledOperation: hasUnsettledOperation)
     }
 
     @Test("a settled live VM is saved")
@@ -103,7 +103,7 @@ struct AppDelegateTerminationSaveStepTests {
         // for the whole VZ await, so the pass reached `trySave` on a VM the
         // coordinator had locked, took `operationInProgress`, and exited with the
         // guest live — an unclean power loss instead of a suspend.
-        #expect(step(hasActiveOperation: true) == .waitForOperation)
+        #expect(step(hasUnsettledOperation: true) == .waitForOperation)
     }
 
     @Test("a VM with no live session is skipped whatever it is doing")
@@ -111,6 +111,6 @@ struct AppDelegateTerminationSaveStepTests {
         // `.installing`, `.starting` and `.restoring` all fail `hasLiveSession`,
         // which is what keeps an install — tens of minutes — from holding a quit.
         #expect(step(hasLiveSession: false) == .skip)
-        #expect(step(hasLiveSession: false, hasActiveOperation: true) == .skip)
+        #expect(step(hasLiveSession: false, hasUnsettledOperation: true) == .skip)
     }
 }

--- a/KernovaTests/AppDelegateTerminationOutcomeTests.swift
+++ b/KernovaTests/AppDelegateTerminationOutcomeTests.swift
@@ -78,3 +78,39 @@ struct AppDelegateTerminationOutcomeTests {
         #expect(outcome(shouldTerminateAgent: false, isSavePassRunning: true) == .deferToSavePass)
     }
 }
+
+/// Unit tests for `AppDelegate.terminationSaveStep` — what the termination save
+/// pass does with one VM it has selected (#807).
+@Suite("AppDelegate termination save step")
+struct AppDelegateTerminationSaveStepTests {
+    private func step(
+        hasLiveSession: Bool = true,
+        hasActiveOperation: Bool = false
+    ) -> AppDelegate.TerminationSaveStep {
+        AppDelegate.terminationSaveStep(
+            hasLiveSession: hasLiveSession,
+            hasActiveOperation: hasActiveOperation)
+    }
+
+    @Test("a settled live VM is saved")
+    func settledLiveVMIsSaved() {
+        #expect(step() == .save)
+    }
+
+    @Test("a live VM holding a lifecycle operation is waited out, not skipped")
+    func settlingLiveVMIsWaitedOut() {
+        // The regression: a pause holds `.running` and a resume holds `.paused`
+        // for the whole VZ await, so the pass reached `trySave` on a VM the
+        // coordinator had locked, took `operationInProgress`, and exited with the
+        // guest live — an unclean power loss instead of a suspend.
+        #expect(step(hasActiveOperation: true) == .waitForOperation)
+    }
+
+    @Test("a VM with no live session is skipped whatever it is doing")
+    func nonLiveVMIsSkipped() {
+        // `.installing`, `.starting` and `.restoring` all fail `hasLiveSession`,
+        // which is what keeps an install — tens of minutes — from holding a quit.
+        #expect(step(hasLiveSession: false) == .skip)
+        #expect(step(hasLiveSession: false, hasActiveOperation: true) == .skip)
+    }
+}

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -194,8 +194,8 @@ struct VMLifecycleCoordinatorTests {
         try await task.value
     }
 
-    @Test("an observed wait on hasActiveOperation wakes when the operation ends")
-    func hasActiveOperationWakesAnObservedWait() async throws {
+    @Test("an observed wait on hasUnsettledOperation wakes when the operation ends")
+    func hasUnsettledOperationWakesAnObservedWait() async throws {
         // What the termination save pass holds a quit on: a pause or resume
         // settles without changing `VMStatus`, so the pass waits on this read
         // through `withObservationTracking`. Were it not observable the wait
@@ -208,26 +208,51 @@ struct VMLifecycleCoordinatorTests {
             try await coordinator.start(instance)
         }
         await suspendingService.waitUntilSuspended()
-        #expect(coordinator.hasActiveOperation(for: instanceID))
+        #expect(coordinator.hasUnsettledOperation(for: instanceID))
 
+        // The wait is on the *fire*, not on the read it guards: a coordinator
+        // publishing no change would let the read settle anyway, so only the
+        // fire separates a wait that woke from one that outlived its backstop.
         let gate = AsyncGate()
         let fired = ObservationFireRecorder()
         withObservationTracking {
-            _ = coordinator.hasActiveOperation(for: instanceID)
+            _ = coordinator.hasUnsettledOperation(for: instanceID)
         } onChange: {
             fired.record()
             gate.notify()
         }
 
-        // Runs once the wait below suspends, so tracking is armed before the
-        // operation releases the lock. The wait is on the *fire*, not on the
-        // read it guards: a coordinator publishing no change would let the read
-        // settle anyway, and only the fire distinguishes a wait that woke from
-        // one that merely outlived its backstop.
+        // Deferred so the operation ends after tracking is armed, which is the
+        // ordering the pass sees.
         Task { @MainActor in suspendingService.resumeSuspended() }
         try await gate.wait { fired.didFire }
-        #expect(!coordinator.hasActiveOperation(for: instanceID))
+        #expect(!coordinator.hasUnsettledOperation(for: instanceID))
         try await task.value
+    }
+
+    @Test("a stop taking the claim mid-operation leaves the operation unsettled")
+    func stopDoesNotSettleTheOperationItInterrupts() async throws {
+        // The pass waits before saving. `stop` and `forceStop` release the claim
+        // so a user can always break in, but the operation they interrupt is
+        // still inside VZ — resolving the wait there would issue the save as a
+        // second concurrent VZ operation.
+        let (coordinator, suspendingService) = makeSuspendingCoordinator()
+        let instance = makeInstance()
+        instance.status = .running
+
+        let task = Task { @MainActor in
+            try await coordinator.start(instance)
+        }
+        await suspendingService.waitUntilSuspended()
+
+        try coordinator.stop(instance)
+
+        #expect(!coordinator.hasActiveOperation(for: instance.id))
+        #expect(coordinator.hasUnsettledOperation(for: instance.id))
+
+        suspendingService.resumeSuspended()
+        try await task.value
+        #expect(!coordinator.hasUnsettledOperation(for: instance.id))
     }
 
     @Test("concurrent operation on the same VM throws operationInProgress")

--- a/KernovaTests/VMLifecycleCoordinatorTests.swift
+++ b/KernovaTests/VMLifecycleCoordinatorTests.swift
@@ -1,5 +1,7 @@
 import CryptoKit
 import Foundation
+import KernovaTestSupport
+import Observation
 import Testing
 
 @testable import Kernova
@@ -189,6 +191,42 @@ struct VMLifecycleCoordinatorTests {
 
         // Let the operation complete
         suspendingService.resumeSuspended()
+        try await task.value
+    }
+
+    @Test("an observed wait on hasActiveOperation wakes when the operation ends")
+    func hasActiveOperationWakesAnObservedWait() async throws {
+        // What the termination save pass holds a quit on: a pause or resume
+        // settles without changing `VMStatus`, so the pass waits on this read
+        // through `withObservationTracking`. Were it not observable the wait
+        // would have nothing to wake on and the quit would hang.
+        let (coordinator, suspendingService) = makeSuspendingCoordinator()
+        let instance = makeInstance()
+        let instanceID = instance.id
+
+        let task = Task { @MainActor in
+            try await coordinator.start(instance)
+        }
+        await suspendingService.waitUntilSuspended()
+        #expect(coordinator.hasActiveOperation(for: instanceID))
+
+        let gate = AsyncGate()
+        let fired = ObservationFireRecorder()
+        withObservationTracking {
+            _ = coordinator.hasActiveOperation(for: instanceID)
+        } onChange: {
+            fired.record()
+            gate.notify()
+        }
+
+        // Runs once the wait below suspends, so tracking is armed before the
+        // operation releases the lock. The wait is on the *fire*, not on the
+        // read it guards: a coordinator publishing no change would let the read
+        // settle anyway, and only the fire distinguishes a wait that woke from
+        // one that merely outlived its backstop.
+        Task { @MainActor in suspendingService.resumeSuspended() }
+        try await gate.wait { fired.didFire }
+        #expect(!coordinator.hasActiveOperation(for: instanceID))
         try await task.value
     }
 
@@ -1647,4 +1685,16 @@ struct VMLifecycleCoordinatorTests {
         guard path.count > 1, path.hasSuffix("/") else { return path }
         return String(path.dropLast())
     }
+}
+
+/// Records that a `withObservationTracking` `onChange` fired, from the
+/// `@Sendable` closure the API hands it — which no actor-isolated state can be
+/// written from.
+private final class ObservationFireRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    var didFire: Bool { lock.withLock { value } }
+
+    func record() { lock.withLock { value = true } }
 }


### PR DESCRIPTION
Closes #807

## Summary

`runTerminationSavePass` derived "an operation is in flight" from `VMStatus`, and only `.saving` encodes one. `VirtualizationService.pause` holds `status == .running` for the whole `vm.pause()` await and `resume` holds `.paused` for the whole `vm.resume()` await, both with a live `VZVirtualMachine` and an active serialization token. So a VM the user paused or resumed a moment before quitting satisfied `hasLiveSession`, was selected by the pass, and had its `trySave` rejected with `LifecycleError.operationInProgress` before the service was reached. #806 stopped that rejection from force-stopping the VM, but the VM was still never suspended — the process exited with it live, so the guest took an unclean power loss instead of being restored on next launch.

The pass now waits on the operation's own lifetime rather than on a status that cannot express it.

## Changes

- **`VMLifecycleCoordinator` is `@Observable`.** That is what gives the coordinator's operation tracking something a `withObservationTracking` wait can wake on. Without it the wait would have hung the quit.
- **Claim vs. body.** `hasActiveOperation` keeps its original meaning — the *claim*, which decides whether a new request is rejected. A new `hasUnsettledOperation(for:)`, backed by a per-VM count of executing `serialized` bodies, answers the different question the pass actually has: *is a VZ call still in flight?* The two diverge because `stop` and `forceStop` deliberately release another operation's claim so a user can always interrupt, without stopping the body that held it. Counted rather than flagged, since once a claim is released a second operation can acquire it and run alongside the first.
- **`AppDelegate.terminationSaveStep(hasLiveSession:hasUnsettledOperation:)`** — a `nonisolated static` decision function in the idiom #806 established (`residencyOutcome`, `terminationOutcome`), returning `.waitForOperation` / `.save` / `.skip`. It is the only part of the pass that is unit-testable, since `runTerminationSavePass` itself is not.
- **`runTerminationSavePass`** holds on `.waitForOperation` via `waitForObservedChange`, then **re-reads the step** before saving. The re-read matters: a VM the wait left unsaveable (a failed pause landing on `.error`, a Force Stop that tore the session down) must not reach `trySave`, whose generic failure path force-stops. `handled.insert` stays *before* the wait, so one attempt per VM keeps the loop guaranteed to terminate. Skips are now counted alongside saves and failures.
- The wait also escapes on `!instance.hasLiveSession`, which is what ends it when the operation leaves the VM unsaveable rather than settled.

### Boundedness

The wait is bounded **in kind** rather than by a clock. `hasLiveSession` is `status.canSave && hasLiveVirtualMachine`, so `.installing`, `.starting` and `.restoring` all fail it and are never selected — an install cannot hold a quit. Only a pause, a resume or a save can be in flight on a VM this pass selects. (All six `serialized` call sites were checked against this.)

## Deviations from what the issue proposed

- **`hasSaveInFlight` stays status-based.** The issue suggested it "compose from an operation-lifetime signal instead of a status". It must not: `hasSaveInFlight` feeds both the gate's `terminationOutcome` and the pass's *global* top-of-loop wait, so widening it to "any active operation" would let an install defer a quit and then hold the pass indefinitely — the outcome #806 explicitly ruled out. The operation-lifetime signal is applied **per instance**, only after `hasLiveSession` has already excluded the long-running states.
- **No new `VMLibraryViewModel` wrapper.** The pass reads `viewModel.lifecycle` directly; `lifecycle` is already an internal `let`, and a pass-through predicate would be a second name for one fact.
- **Considered and rejected: moving the pass into `VMLibraryViewModel` or a new `TerminationSavePass` type** to make the whole loop testable end to end. It is a clean move, but `AppDelegate.swift` is ~2,000 lines and `VMLibraryViewModel.swift` ~2,540, so it either grows the larger file or adds a type for a ~55-line loop. #806 accepted the pass itself as manually verified; the step function plus the coordinator tests cover the new logic without that churn.

## Review

Three reviews (built-in at `high`, plus Codex standard and adversarial).

**Fixed:** the wait originally keyed on the claim, so a Stop arriving mid-wait ended it while the interrupted pause was still inside VZ — the pass would then issue a save as a second concurrent VZ operation. Two of the three reviewers flagged this; it is what `hasUnsettledOperation` addresses. Also reverted an incidental `nonisolated` on the coordinator's logger that no caller needed, and corrected a test comment that claimed an ordering the code does not depend on.

**Filed:** #809 — the pass's waits (the `hasSaveInFlight` wait, the new per-VM wait, and the `trySave` await) have no deadline, so a wedged VZ callback leaves the deferred termination reply unsent and blocks logout. Unbounded on `main` too; bounding it requires choosing a fallback between two shipped bugs (#805, #807), which is a policy decision rather than a local fix.

**Dismissed:** a save racing a user's Force Stop is still possible, because `forceStop` bypasses serialization by design — it can already race a pass save on `main` with no operation in flight, so it is pre-existing rather than introduced here. Likewise a user starting a fresh lifecycle operation *after* pressing ⌘Q (the `.waitForOperation` arm after the re-read): the VM is skipped with a warning, and it needs clicking that no normal quit flow produces.

## Test plan

- [x] `make build`
- [x] `make lint`
- [x] `make test` (full suite)
- [x] The observability test waits on the observation **fire**, not on the read it guards — verified by removing `@Observable` and confirming the test *fails*. Its first form only ran 60 s slower and still passed, which is why it was rewritten.
- [x] A coordinator test pins that a Stop taking the claim mid-operation leaves the operation unsettled.
- [ ] Manual: start a VM, Pause, quit immediately — the log shows `Termination waiting on a lifecycle operation for '<name>' to settle` then `1 saved`, and the VM restores on next launch. Repeat with Resume from a live-paused VM.

## Notes

No `RATIONALE:` comments added. No component boundary changed (no new service or protocol, no changed data flow or actor isolation), so no `docs/ARCHITECTURE.md` edit; no AGENTS.md rule changed; the guest agent is untouched, so no `MARKETING_VERSION` bump.