### PR TITLE
fix: Spin the sidebar row while a lifecycle operation settles

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -126,6 +126,17 @@ final class VMLibraryViewModel {
         instances.contains { $0.status.terminationMustWaitOut }
     }
 
+    /// Whether `instance` has work in flight that its sidebar row renders as busy.
+    ///
+    /// The lifecycle term is the one a pause or resume shows up in: both hold a
+    /// status that reads as resting — `.running` for a pause, `.paused` for a
+    /// resume — for the whole VZ await, so ``VMStatus`` alone renders nothing
+    /// while one is settling.
+    func isBusy(_ instance: VMInstance) -> Bool {
+        instance.isPreparing || instance.status.isTransitioning
+            || lifecycle.hasUnsettledOperation(for: instance.id)
+    }
+
     private var customOrder: [UUID] = []
 
     /// Bundle names whose load failures have already been reported to the user.

--- a/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
+++ b/Kernova/Views/Sidebar/SidebarVMRowCellView.swift
@@ -33,6 +33,10 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
     /// which decides whether the controller restores sidebar focus.
     private var onCommitRename: ((String, Bool) -> Void)?
     private var onCancelRename: (() -> Void)?
+    /// Reads this row's busy state, live: the cell's own observation loop calls
+    /// it, so every observable read inside it wakes the row — including the
+    /// lifecycle operation no ``VMStatus`` case represents.
+    private var isBusy: (() -> Bool)?
 
     /// `true` while the name field is in its editable rename state.
     private(set) var isRenaming = false
@@ -151,6 +155,7 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
         instance: VMInstance,
         isRenaming: Bool,
         installPromptDisabled: Bool,
+        isBusy: @escaping () -> Bool,
         onCommitRename: @escaping (String, Bool) -> Void,
         onCancelRename: @escaping () -> Void,
         onMountAgent: @escaping () -> Void,
@@ -159,6 +164,7 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
         let isRebindToDifferentVM = self.instance !== instance
         self.instance = instance
         self.installPromptDisabled = installPromptDisabled
+        self.isBusy = isBusy
         self.onCommitRename = onCommitRename
         self.onCancelRename = onCancelRename
 
@@ -179,6 +185,10 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
                 _ = instance.configuration.guestOS
                 _ = instance.status
                 _ = instance.isPreparing
+                // Keeps the two reads above as well: `isBusy` short-circuits, so
+                // it registers the lifecycle term only while the others are
+                // false, and the tooltip and icon color need `status` anyway.
+                _ = self.isBusy?()
                 _ = instance.virtualMachine
                 _ = instance.statusToolTip
                 _ = instance.statusDisplayNSColor
@@ -201,7 +211,7 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
             nameField.stringValue = instance.name
         }
 
-        let busy = instance.isPreparing || instance.status.isTransitioning
+        let busy = isBusy?() ?? false
         if busy {
             iconView.isHidden = true
             spinner.isHidden = false
@@ -377,6 +387,7 @@ final class SidebarVMRowCellView: NSTableCellView, NSTextFieldDelegate {
         instance = nil
         onCommitRename = nil
         onCancelRename = nil
+        isBusy = nil
         spinner.stopAnimation(nil)
         // Close any popover, stop the agent spinner, and drop the closures —
         // they capture the bound VMInstance and would otherwise keep it alive.

--- a/Kernova/Views/Sidebar/SidebarViewController.swift
+++ b/Kernova/Views/Sidebar/SidebarViewController.swift
@@ -572,6 +572,10 @@ extension SidebarViewController: NSOutlineViewDelegate {
             // Capture `instance` weakly: the cell stores these closures, so a
             // strong capture would keep a deleted VM alive until the cell is
             // recycled.
+            isBusy: { [weak self, weak instance] in
+                guard let self, let instance else { return false }
+                return self.viewModel.isBusy(instance)
+            },
             onCommitRename: { [weak self, weak instance] newName, endedByReturn in
                 guard let self, let instance else { return }
                 self.viewModel.commitRename(for: instance, newName: newName, from: .sidebar)

--- a/KernovaTests/SidebarViewControllerTests.swift
+++ b/KernovaTests/SidebarViewControllerTests.swift
@@ -198,10 +198,13 @@ struct SidebarViewControllerTests {
 
     // MARK: - Row busy state
 
-    private func makeBusyStateRow(isBusy: Bool) -> SidebarVMRowCellView {
+    /// The cell holds its instance weakly, so the caller keeps `instance` alive:
+    /// binding a temporary would leave the row on a deallocated VM, and its
+    /// observation loop registering nothing.
+    private func makeBusyStateRow(instance: VMInstance, isBusy: Bool) -> SidebarVMRowCellView {
         let cell = SidebarVMRowCellView()
         cell.configure(
-            instance: makeInstance(status: .running),
+            instance: instance,
             isRenaming: false,
             installPromptDisabled: false,
             isBusy: { isBusy },
@@ -217,11 +220,13 @@ struct SidebarViewControllerTests {
     /// which stays `.running` (pause) or `.paused` (resume) throughout.
     @Test("The row swaps its OS icon for the spinner while busy")
     func rowSpinsWhileBusy() {
-        let busy = makeBusyStateRow(isBusy: true)
+        let busyInstance = makeInstance(status: .running)
+        let busy = makeBusyStateRow(instance: busyInstance, isBusy: true)
         #expect(firstSubview(NSProgressIndicator.self, in: busy)?.isHidden == false)
         #expect(firstSubview(NSImageView.self, in: busy)?.isHidden == true)
 
-        let idle = makeBusyStateRow(isBusy: false)
+        let idleInstance = makeInstance(status: .running)
+        let idle = makeBusyStateRow(instance: idleInstance, isBusy: false)
         #expect(firstSubview(NSProgressIndicator.self, in: idle)?.isHidden == true)
         #expect(firstSubview(NSImageView.self, in: idle)?.isHidden == false)
     }

--- a/KernovaTests/SidebarViewControllerTests.swift
+++ b/KernovaTests/SidebarViewControllerTests.swift
@@ -196,6 +196,36 @@ struct SidebarViewControllerTests {
                 == .expectedMissing(expected: "1.2.3"))
     }
 
+    // MARK: - Row busy state
+
+    private func makeBusyStateRow(isBusy: Bool) -> SidebarVMRowCellView {
+        let cell = SidebarVMRowCellView()
+        cell.configure(
+            instance: makeInstance(status: .running),
+            isRenaming: false,
+            installPromptDisabled: false,
+            isBusy: { isBusy },
+            onCommitRename: { _, _ in },
+            onCancelRename: {},
+            onMountAgent: {},
+            onDismissAgentNudge: {})
+        return cell
+    }
+
+    /// The row is the only surface that can show a settling pause or resume, so
+    /// its spinner follows the view model's busy read rather than the status —
+    /// which stays `.running` (pause) or `.paused` (resume) throughout.
+    @Test("The row swaps its OS icon for the spinner while busy")
+    func rowSpinsWhileBusy() {
+        let busy = makeBusyStateRow(isBusy: true)
+        #expect(firstSubview(NSProgressIndicator.self, in: busy)?.isHidden == false)
+        #expect(firstSubview(NSImageView.self, in: busy)?.isHidden == true)
+
+        let idle = makeBusyStateRow(isBusy: false)
+        #expect(firstSubview(NSProgressIndicator.self, in: idle)?.isHidden == true)
+        #expect(firstSubview(NSImageView.self, in: idle)?.isHidden == false)
+    }
+
     /// Re-arming an observation reports only changes made *after* it registers.
     ///
     /// So anything that moved while the sidebar was off screen — a collapsed

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -51,6 +51,26 @@ struct VMLibraryViewModelTests {
         return (vm, storageService, diskImageService, virtualizationService, usbDeviceService)
     }
 
+    /// A view model whose virtualization service holds one lifecycle call
+    /// suspended, standing in for the window where a VZ call is still in flight.
+    private func makeSuspendingViewModel(
+        storage: MockVMStorageService = MockVMStorageService()
+    ) -> (VMLibraryViewModel, SuspendingMockVirtualizationService) {
+        let suspending = SuspendingMockVirtualizationService()
+        let vm = VMLibraryViewModel(
+            storageService: storage,
+            diskImageService: MockDiskImageService(),
+            virtualizationService: suspending,
+            installService: MockMacOSInstallService(),
+            ipswService: MockIPSWService(),
+            usbDeviceService: MockUSBDeviceService(),
+            fileSystem: fileSystem,
+            preferences: preferences
+        )
+        vm.presenter = presenter
+        return (vm, suspending)
+    }
+
     private func makeInstance(name: String = "Test VM", guestOS: VMGuestOS = .linux) -> VMInstance {
         let config = VMConfiguration(
             name: name,
@@ -414,19 +434,8 @@ struct VMLibraryViewModelTests {
     @Test("deleteConfirmed refuses a cold-paused VM whose resume is still in flight")
     func deleteConfirmedRefusesDuringInFlightResume() async throws {
         let storage = MockVMStorageService()
-        let suspending = SuspendingMockVirtualizationService()
+        let (viewModel, suspending) = makeSuspendingViewModel(storage: storage)
         suspending.shouldSuspendOnResume = true
-        let viewModel = VMLibraryViewModel(
-            storageService: storage,
-            diskImageService: MockDiskImageService(),
-            virtualizationService: suspending,
-            installService: MockMacOSInstallService(),
-            ipswService: MockIPSWService(),
-            usbDeviceService: MockUSBDeviceService(),
-            fileSystem: fileSystem,
-            preferences: preferences
-        )
-        viewModel.presenter = presenter
         let instance = makeInstance()
         instance.status = .paused
         viewModel.instances.append(instance)
@@ -3109,6 +3118,75 @@ struct VMLibraryViewModelTests {
     func hasSaveInFlightIsFalseWhenEmpty() {
         let (viewModel, _, _, _, _) = makeViewModel()
         #expect(!viewModel.hasSaveInFlight)
+    }
+
+    @Test("isBusy is false for a settled VM")
+    func isBusyIsFalseWhenSettled() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        viewModel.instances = [instance]
+
+        for status in [VMStatus.stopped, .running, .paused] {
+            instance.status = status
+            #expect(!viewModel.isBusy(instance))
+        }
+    }
+
+    @Test("isBusy covers a preparing row and every transitioning status")
+    func isBusyCoversPreparingAndTransitions() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let instance = makeInstance()
+        viewModel.instances = [instance]
+
+        for status in [VMStatus.starting, .saving, .restoring, .installing] {
+            instance.status = status
+            #expect(viewModel.isBusy(instance))
+        }
+
+        instance.status = .stopped
+        instance.preparingState = VMInstance.PreparingState(operation: .cloning, task: Task {})
+        #expect(viewModel.isBusy(instance))
+    }
+
+    /// The state that motivates the lifecycle term: a pause holds `.running`
+    /// until the VZ call returns, so no status-driven surface can render it —
+    /// and a call that never returns stays invisible.
+    @Test("isBusy reads true through a settling pause whose status still says running")
+    func isBusyCoversSettlingPause() async throws {
+        let (viewModel, suspending) = makeSuspendingViewModel()
+        let instance = makeInstance()
+        instance.status = .running
+        viewModel.instances = [instance]
+
+        let pause = Task { @MainActor in try await viewModel.lifecycle.pause(instance) }
+        await suspending.waitUntilSuspended()
+
+        #expect(instance.status == .running)
+        #expect(!instance.status.isTransitioning)
+        #expect(viewModel.isBusy(instance))
+
+        suspending.resumeSuspended()
+        try await pause.value
+        #expect(!viewModel.isBusy(instance))
+    }
+
+    @Test("An isBusy wait resolves by observation when a settling pause ends")
+    func isBusyWakesAnObservedWait() async throws {
+        let (viewModel, suspending) = makeSuspendingViewModel()
+        let instance = makeInstance()
+        instance.status = .running
+        viewModel.instances = [instance]
+
+        let pause = Task { @MainActor in try await viewModel.lifecycle.pause(instance) }
+        await suspending.waitUntilSuspended()
+        #expect(viewModel.isBusy(instance))
+
+        // Released from a separate task so the wait below arms first, making the
+        // resolution an observation wake rather than an already-true predicate.
+        Task { @MainActor in suspending.resumeSuspended() }
+        try await waitForChange { !viewModel.isBusy(instance) }
+
+        try await pause.value
     }
 
     @Test("keepInMenuBarOnQuit defaults on and persists in both directions")


### PR DESCRIPTION
Closes #809.

## The policy question, answered

#809 asks what bounds the termination save pass when a `Virtualization.framework` call never returns. The answer is that **nothing does, deliberately** — no deadline, no watchdog, no automatic fallback. The pass keeps waiting.

A deadline is only as good as what it falls back to, and both candidates are bugs this project has already shipped and fixed:

- **Force-stop the VM** discards the guest RAM the pass exists to save — that is #805.
- **Reply and exit with the guest live** leaves it to unclean power loss — that is #807.

Adding a budget would mean re-introducing one of them on a timer. And no wall-clock number separates the two cases it would have to distinguish: a wedged VZ call and a legitimately slow save (a large-memory VM writing to a slow disk) look identical from the outside, so any budget either fires on healthy saves or is too long to matter.

So the resolution is user-decided rather than automatic. That already works: the GUI stays interactive while the reply is deferred, and Force Stop bypasses lifecycle serialization, so a user can release a stalled pass by hand at any point. What was missing is the *noticing*.

## What this changes

A pause holds `.running` and a resume holds `.paused` for the entire VZ await — no `VMStatus` case represents either — so every status-driven surface showed nothing while one was in flight, wedged or not. It was the only busy state that could hold a quit invisibly.

#808 made `VMLifecycleCoordinator` `@Observable` and gave it `hasUnsettledOperation(for:)`, so the signal exists. This wires it into the sidebar row's existing spinner condition, via a new `VMLibraryViewModel.isBusy(_:)` that the row calls from both `applyLiveState()` and its observation track block. The row now spins for an unsettled operation exactly as it does for other transitions — and keeps spinning after a Force Stop breaks in, until the VZ call actually unwinds, which is precisely the state worth showing.

**Deliberately not** shown in the VM display window's transition overlay: an ordinary pause/resume is sub-second, and the overlay would flicker on every one. And no new window or panel — the sidebar row is the whole surface.

No termination code is touched; the three unbounded waits in `AppDelegate` stay as they are.

## Test plan
- [x] `make build`
- [x] `make lint`
- [x] `make test`
- [ ] Pause and resume a running VM; the sidebar row briefly shows the spinner in place of its OS icon, and the display window does not flicker.