### PR TITLE
chore: Wire the com.apple.vm.networking entitlement into signing

### DIFF
--- a/Config/Base.xcconfig
+++ b/Config/Base.xcconfig
@@ -10,9 +10,18 @@
 // no-ops when Local.xcconfig doesn't exist, so a fresh clone builds with
 // neither a team nor a certificate.
 
-// Debug's signing identity. Every Release configuration pins its own at
-// target level, which outranks a project xcconfig, so the Local.xcconfig
-// override below reaches Debug alone.
+// The default signing identity, ad-hoc. Targets that must stay ad-hoc (and
+// the guest agent's Developer ID lane) pin their own at target level, which
+// outranks this file; the app target deliberately leaves Release unpinned
+// so the Local.xcconfig override below can sign an entitled archive.
 CODE_SIGN_IDENTITY = -
+
+// The app target's CODE_SIGN_ENTITLEMENTS, both configurations. The default
+// Development variant omits the restricted com.apple.vm.networking key an
+// ad-hoc signature cannot carry, keeping a profile-less checkout building
+// in both configurations. Local.xcconfig opts a machine holding the
+// capability-enabled profile into the full Kernova.entitlements set — see
+// docs/BUILD.md "Signing identity".
+KERNOVA_APP_ENTITLEMENTS = Kernova/Resources/Kernova.Development.entitlements
 
 #include? "Local.xcconfig"

--- a/Config/Base.xcconfig
+++ b/Config/Base.xcconfig
@@ -10,10 +10,12 @@
 // no-ops when Local.xcconfig doesn't exist, so a fresh clone builds with
 // neither a team nor a certificate.
 
-// The default signing identity, ad-hoc. Targets that must stay ad-hoc (and
-// the guest agent's Developer ID lane) pin their own at target level, which
-// outranks this file; the app target deliberately leaves Release unpinned
-// so the Local.xcconfig override below can sign an entitled archive.
+// The default signing identity, ad-hoc. The relaunch helper (re-signed at
+// export) and the guest agent (its own Developer ID lane) pin Release at
+// target level, which outranks this file; the app and both test bundles
+// leave Release unpinned so the Local.xcconfig override below reaches them —
+// an entitled archive needs the real identity, and a test bundle must sign
+// with the same team as its now team-signed host to pass library validation.
 CODE_SIGN_IDENTITY = -
 
 // The app target's CODE_SIGN_ENTITLEMENTS, both configurations. The default

--- a/Config/Local.xcconfig.example
+++ b/Config/Local.xcconfig.example
@@ -13,3 +13,12 @@ DEVELOPMENT_TEAM = ABCDE12345
 // Drop the line to sign ad-hoc; keep it alongside DEVELOPMENT_TEAM, since
 // automatic signing resolves the certificate through the team.
 CODE_SIGN_IDENTITY = Apple Development
+
+// Opts the app (both configurations) into the full entitlement set,
+// including the restricted com.apple.vm.networking key, which automatic
+// signing must authorize through a capability-enabled profile — uncomment
+// only with the capability enabled on the team's App ID and a certificate
+// set above; otherwise the default (the Development variant, set in
+// Base.xcconfig) keeps profile-less builds signing. Archives inherit the
+// choice: comment it back out to cut an unentitled build.
+// KERNOVA_APP_ENTITLEMENTS = Kernova/Resources/Kernova.entitlements

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -766,7 +766,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
@@ -904,7 +903,6 @@
 		A100030B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -692,7 +692,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = Kernova/Resources/Kernova.entitlements;
+				CODE_SIGN_ENTITLEMENTS = "$(KERNOVA_APP_ENTITLEMENTS)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -720,8 +720,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = Kernova/Resources/Kernova.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_ENTITLEMENTS = "$(KERNOVA_APP_ENTITLEMENTS)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -354,7 +354,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         let provenance = Self.residentProvenanceLine(
             bundlePath: Bundle.main.bundlePath,
             build: Self.buildNumber,
-            configuration: Self.buildConfiguration)
+            configuration: Self.buildConfiguration,
+            vmNetworkingEntitled: EntitlementService.shared.hasVMNetworking)
         Self.logger.notice("Kernova resident app ready — \(provenance, privacy: .public)")
 
         summonUserInterface()
@@ -441,9 +442,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     /// Formats the resident-app startup provenance line.
     nonisolated static func residentProvenanceLine(
-        bundlePath: String, build: String, configuration: String
+        bundlePath: String, build: String, configuration: String, vmNetworkingEntitled: Bool
     ) -> String {
-        "bundle=\(bundlePath) build=\(build) config=\(configuration)"
+        "bundle=\(bundlePath) build=\(build) config=\(configuration) "
+            + "vmNetworking=\(vmNetworkingEntitled ? "entitled" : "unentitled")"
     }
 
     /// What a GUI summon puts on screen.

--- a/Kernova/Resources/Kernova.Development.entitlements
+++ b/Kernova/Resources/Kernova.Development.entitlements
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- The default entitlements: Kernova.entitlements minus the restricted
+	     com.apple.vm.networking key, which signing without an authorizing
+	     profile cannot carry (automatic signing refuses it, and amfid kills
+	     an ad-hoc-signed binary claiming it at exec). This variant is what
+	     lets a profile-less checkout build and run. Selected through
+	     KERNOVA_APP_ENTITLEMENTS in Config/Base.xcconfig; a machine holding
+	     the capability-enabled profile opts into the full set via
+	     Config/Local.xcconfig. Keep every key here identical to
+	     Kernova.entitlements — per-key rationale lives there. -->
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+	<key>com.apple.security.virtualization</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/Kernova/Resources/Kernova.entitlements
+++ b/Kernova/Resources/Kernova.entitlements
@@ -32,6 +32,15 @@
 	<true/>
 	<key>com.apple.security.virtualization</key>
 	<true/>
+	<!-- Guest networking beyond NAT: vmnet requires this entitlement for all
+	     API use, and a bridged attachment fails VZ configuration validation
+	     without it. A managed capability on the App ID — eligible provisioning
+	     profiles carry it automatically. It is restricted: signing must be
+	     authorized by such a profile, so the default build signs with
+	     Kernova.Development.entitlements instead (this file minus this key —
+	     keep the two in sync); see docs/BUILD.md "Signing identity". -->
+	<key>com.apple.vm.networking</key>
+	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
 </dict>

--- a/Kernova/Services/EntitlementService.swift
+++ b/Kernova/Services/EntitlementService.swift
@@ -12,7 +12,7 @@ protocol EntitlementReading: Sendable {
 /// The real reader, answering from this process's own signature via
 /// `SecTaskCopyValueForEntitlement`.
 struct ProcessEntitlementReader: EntitlementReading {
-    private static let logger = Logger(subsystem: "app.kernova", category: "EntitlementService")
+    private static let logger = Logger(subsystem: "app.kernova", category: "ProcessEntitlementReader")
 
     func hasEntitlement(_ key: String) -> Bool {
         guard let task = SecTaskCreateFromSelf(nil) else {
@@ -22,7 +22,14 @@ struct ProcessEntitlementReader: EntitlementReading {
             assertionFailure("SecTaskCreateFromSelf returned nil")
             return false
         }
-        return (SecTaskCopyValueForEntitlement(task, key as CFString, nil) as? Bool) == true
+        var error: Unmanaged<CFError>?
+        let value = SecTaskCopyValueForEntitlement(task, key as CFString, &error)
+        if let error = error?.takeRetainedValue() {
+            Self.logger.warning(
+                "Entitlement query for '\(key, privacy: .public)' failed — treating as absent: \(String(describing: error), privacy: .public)"
+            )
+        }
+        return (value as? Bool) == true
     }
 }
 

--- a/Kernova/Services/EntitlementService.swift
+++ b/Kernova/Services/EntitlementService.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Security
+import os
+
+/// Reads entitlement values from a process's code signature, abstracted so
+/// tests can inject a fake in place of the Security framework.
+protocol EntitlementReading: Sendable {
+    /// Whether the signature claims `key` with a boolean `true` value.
+    func hasEntitlement(_ key: String) -> Bool
+}
+
+/// The real reader, answering from this process's own signature via
+/// `SecTaskCopyValueForEntitlement`.
+struct ProcessEntitlementReader: EntitlementReading {
+    private static let logger = Logger(subsystem: "app.kernova", category: "EntitlementService")
+
+    func hasEntitlement(_ key: String) -> Bool {
+        guard let task = SecTaskCreateFromSelf(nil) else {
+            Self.logger.fault(
+                "SecTaskCreateFromSelf returned nil — treating entitlement '\(key, privacy: .public)' as absent"
+            )
+            assertionFailure("SecTaskCreateFromSelf returned nil")
+            return false
+        }
+        return (SecTaskCopyValueForEntitlement(task, key as CFString, nil) as? Bool) == true
+    }
+}
+
+/// Answers what this build's signature authorizes, so feature UI can degrade
+/// gracefully in builds signed without a restricted entitlement.
+///
+/// The answer is a property of the signature, not the code: the default
+/// signing omits `com.apple.vm.networking` so profile-less builds run — see
+/// docs/BUILD.md "Signing identity".
+struct EntitlementService: Sendable {
+    private let reader: any EntitlementReading
+
+    /// The process-wide instance over the real signature reader.
+    @MainActor static let shared = EntitlementService()
+
+    init(reader: any EntitlementReading = ProcessEntitlementReader()) {
+        self.reader = reader
+    }
+
+    /// Whether VZ networking beyond NAT — bridged, host-only, and app-managed
+    /// vmnet networks — is authorized (`com.apple.vm.networking`).
+    var hasVMNetworking: Bool { reader.hasEntitlement("com.apple.vm.networking") }
+}

--- a/KernovaTests/AppDelegateProvenanceTests.swift
+++ b/KernovaTests/AppDelegateProvenanceTests.swift
@@ -2,7 +2,7 @@ import Testing
 
 @testable import Kernova
 
-/// Unit tests for `AppDelegate.residentProvenanceLine(bundlePath:build:configuration:)`.
+/// Unit tests for `AppDelegate.residentProvenanceLine`.
 ///
 /// The pure formatter behind the resident app's startup `.notice` log line
 /// (#455). Launch Services elects among every on-disk copy by `CFBundleVersion`,
@@ -11,14 +11,26 @@ import Testing
 /// log alone.
 @Suite("AppDelegate.residentProvenanceLine")
 struct AppDelegateProvenanceTests {
-    @Test("formats bundle path, build, and configuration into one line")
+    @Test("formats bundle path, build, configuration, and entitlement state into one line")
     func formatsAllFields() {
         #expect(
             AppDelegate.residentProvenanceLine(
                 bundlePath: "/Applications/Kernova.app",
                 build: "142",
-                configuration: "Release")
-                == "bundle=/Applications/Kernova.app build=142 config=Release")
+                configuration: "Release",
+                vmNetworkingEntitled: true)
+                == "bundle=/Applications/Kernova.app build=142 config=Release vmNetworking=entitled")
+    }
+
+    @Test("reports an unentitled signature")
+    func unentitledSignature() {
+        #expect(
+            AppDelegate.residentProvenanceLine(
+                bundlePath: "/Applications/Kernova.app",
+                build: "142",
+                configuration: "Debug",
+                vmNetworkingEntitled: false)
+                == "bundle=/Applications/Kernova.app build=142 config=Debug vmNetworking=unentitled")
     }
 
     @Test("tolerates a missing build number without crashing")
@@ -27,7 +39,8 @@ struct AppDelegateProvenanceTests {
             AppDelegate.residentProvenanceLine(
                 bundlePath: "/Applications/Kernova.app",
                 build: "?",
-                configuration: "Debug")
-                == "bundle=/Applications/Kernova.app build=? config=Debug")
+                configuration: "Debug",
+                vmNetworkingEntitled: false)
+                == "bundle=/Applications/Kernova.app build=? config=Debug vmNetworking=unentitled")
     }
 }

--- a/KernovaTests/EntitlementServiceTests.swift
+++ b/KernovaTests/EntitlementServiceTests.swift
@@ -1,0 +1,27 @@
+import Testing
+
+@testable import Kernova
+
+@Suite("EntitlementService")
+struct EntitlementServiceTests {
+    private struct FakeReader: EntitlementReading {
+        let granted: Set<String>
+        func hasEntitlement(_ key: String) -> Bool { granted.contains(key) }
+    }
+
+    @Test("hasVMNetworking is true exactly when the signature claims com.apple.vm.networking")
+    func vmNetworkingReflectsReader() {
+        #expect(
+            EntitlementService(reader: FakeReader(granted: ["com.apple.vm.networking"]))
+                .hasVMNetworking)
+        #expect(!EntitlementService(reader: FakeReader(granted: [])).hasVMNetworking)
+        #expect(
+            !EntitlementService(reader: FakeReader(granted: ["com.apple.security.app-sandbox"]))
+                .hasVMNetworking)
+    }
+
+    @Test("The process reader reports an unclaimed key as absent")
+    func processReaderUnclaimedKeyIsAbsent() {
+        #expect(!ProcessEntitlementReader().hasEntitlement("app.kernova.test.never-claimed"))
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ format: ## Rewrite Swift sources in place via swift-format
 # merges rather than silently skipping. Project-wide directives live in
 # .shellcheckrc. Shell runs first: it is the faster half, so an obvious script
 # error surfaces without waiting on swift-format.
-lint: ## Lint Swift sources (swift-format --strict), shell scripts, and docs
+lint: ## Lint Swift sources (swift-format --strict), shell scripts, docs, and entitlement parity
 	@for f in $(SHELL_SOURCES); do bash -n "$$f" || exit 1; done
 	@if command -v shellcheck >/dev/null 2>&1; then \
 		shellcheck $(SHELL_SOURCES); \
@@ -150,6 +150,7 @@ lint: ## Lint Swift sources (swift-format --strict), shell scripts, and docs
 	@test -n '$(strip $(SWIFT_SOURCE_DIRS))' || { echo 'No tracked Swift sources found — not a git checkout?' >&2; exit 1; }
 	$(SWIFT_FORMAT) lint --strict --recursive $(SWIFT_SOURCE_DIRS)
 	@bash Tools/check-docs.sh
+	@bash Tools/check-entitlements.sh
 
 # Environment sanity check: verifies the local toolchain (macOS, Xcode, Swift,
 # swift-format) and repo setup (git hooks, .worktreeinclude) match what Kernova

--- a/Tools/check-entitlements.sh
+++ b/Tools/check-entitlements.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# The two app entitlement plists are parallel by design:
+# Kernova.entitlements is the shipping set, Kernova.Development.entitlements
+# the same set minus the restricted key an unauthorized signature cannot
+# carry. Nothing else enforces that parity — Xcode's Signing & Capabilities
+# editor writes only to whichever file KERNOVA_APP_ENTITLEMENTS selects, so a
+# capability added there would otherwise drift into one variant silently.
+# Fails lint when the key sets differ by anything other than the restricted
+# key. Values are not compared: every key is a boolean grant, and a key
+# present with a non-true value fails at signing, not silently.
+
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+full="Kernova/Resources/Kernova.entitlements"
+dev="Kernova/Resources/Kernova.Development.entitlements"
+restricted="com.apple.vm.networking"
+
+keys() {
+    plutil -convert xml1 -o - "$1" | sed -n 's/.*<key>\(.*\)<\/key>.*/\1/p' | sort
+}
+
+status=0
+
+if ! keys "$full" | grep -Fxq "$restricted"; then
+    echo "check-entitlements: $restricted missing from $full" >&2
+    status=1
+fi
+
+if keys "$dev" | grep -Fxq "$restricted"; then
+    echo "check-entitlements: $restricted must not be in $dev" >&2
+    status=1
+fi
+
+if ! diff_out=$(diff <(keys "$full" | grep -Fxv "$restricted") <(keys "$dev")); then
+    echo "check-entitlements: key sets diverge beyond the restricted key ($restricted):" >&2
+    echo "$diff_out" >&2
+    status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "  ✓ entitlements: variant key parity"
+fi
+exit "$status"

--- a/Tools/doctor.sh
+++ b/Tools/doctor.sh
@@ -191,10 +191,13 @@ fi
 
 section 'Signing'
 
-# Debug signs ad-hoc unless the gitignored, hand-maintained
-# Config/Local.xcconfig overrides CODE_SIGN_IDENTITY; the same file supplies
-# DEVELOPMENT_TEAM, which automatic signing resolves the certificate through
-# and the agent's Release Developer ID signing needs. CI has no Local.xcconfig
+# The app signs ad-hoc in both configurations unless the gitignored,
+# hand-maintained Config/Local.xcconfig overrides CODE_SIGN_IDENTITY (the app
+# target leaves Release unpinned, so the override also governs archives); the
+# same file supplies DEVELOPMENT_TEAM, which automatic signing resolves the
+# certificate through and the agent's Release Developer ID signing needs, and
+# optionally KERNOVA_APP_ENTITLEMENTS, which decides whether an archive
+# carries the restricted com.apple.vm.networking key. CI has no Local.xcconfig
 # and signs ad-hoc too, so it can't catch a broken team here either.
 local_xcconfig="Config/Local.xcconfig"
 resolved_team=""
@@ -214,10 +217,25 @@ else
 fi
 
 if [ -n "$resolved_identity" ] && [ "$resolved_identity" != "-" ]; then
-    pass "Debug CODE_SIGN_IDENTITY = $resolved_identity ($local_xcconfig)"
+    pass "CODE_SIGN_IDENTITY = $resolved_identity ($local_xcconfig) — Debug and app archives"
 else
-    warn "Debug signs ad-hoc — macOS privacy grants re-prompt after every rebuild"
+    warn "The app signs ad-hoc — macOS privacy grants re-prompt after every rebuild"
     detail "With a development certificate, add to $local_xcconfig: CODE_SIGN_IDENTITY = Apple Development"
+fi
+
+# KERNOVA_APP_ENTITLEMENTS selects the app's entitlement set; unset means the
+# Development variant without the restricted com.apple.vm.networking key.
+# Surfaced here because archives inherit it silently — RELEASING.md's Archive
+# step gates which distribution lane may carry the key.
+resolved_entitlements=$(sed -n 's/^[[:space:]]*KERNOVA_APP_ENTITLEMENTS[[:space:]]*=[[:space:]]*//p' "$local_xcconfig" 2>/dev/null | head -1 | sed 's/[[:space:]]*$//')
+if [ "$resolved_entitlements" = "Kernova/Resources/Kernova.entitlements" ]; then
+    pass "KERNOVA_APP_ENTITLEMENTS = $resolved_entitlements ($local_xcconfig)"
+    detail 'archives cut on this machine carry the restricted com.apple.vm.networking key — see docs/RELEASING.md "Archive"'
+elif [ -n "$resolved_entitlements" ]; then
+    pass "KERNOVA_APP_ENTITLEMENTS = $resolved_entitlements ($local_xcconfig)"
+    detail 'not the full Kernova.entitlements set — archives will NOT carry the restricted com.apple.vm.networking key'
+else
+    pass 'App entitlements: Development variant (default — no restricted key; archives need the full set for VM networking)'
 fi
 
 # `security find-identity` lists every codesigning-capable identity in the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,9 +188,11 @@ Clipboard (principles and trade-off rules: [CLIPBOARD.md](CLIPBOARD.md)):
   ([BUILD.md](BUILD.md)).
 
 Also here: `LoginItemService` (the `SMAppService.mainApp` wrapper behind the login-item toggle),
-`AttachmentFileMonitor` (existence watching for the settings attachment rows), `RuntimeFileAccess`
-(per-boot security-scoped access, released once in `tearDownSession`), and `SerialSocketRelay`
-(below).
+`EntitlementService` (what this build's signature authorizes, read from the process's own
+signature via `SecTaskCopyValueForEntitlement`, so feature UI can degrade in builds signed
+without a restricted entitlement), `AttachmentFileMonitor` (existence watching for the settings
+attachment rows), `RuntimeFileAccess` (per-boot security-scoped access, released once in
+`tearDownSession`), and `SerialSocketRelay` (below).
 
 **Configuration writes have one door.** Every write — settings controls, install/uninstall flows,
 rename, and guest-driven `VMInstance.onUpdateConfiguration` callbacks — routes through

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -20,7 +20,11 @@ Set `CODE_SIGN_IDENTITY = Apple Development` there whenever you have a certifica
 
 `DEVELOPMENT_TEAM` is what automatic signing resolves that certificate through, and the guest agent's Release Developer ID signing needs it too ([RELEASING.md](RELEASING.md)) — keep the two lines together.
 
-Every Release configuration pins its identity at target level, which outranks a project xcconfig, so the override reaches Debug alone. The guest agent stays ad-hoc in Debug as well: it runs inside the guest, where a host code identity buys nothing.
+Every Release configuration except the app's own pins its identity at target level, which outranks a project xcconfig — the app leaves Release unpinned so an entitled archive can sign with the real identity the override supplies. The guest agent stays ad-hoc in Debug as well: it runs inside the guest, where a host code identity buys nothing.
+
+The app's entitlements resolve through the same override point. `com.apple.vm.networking` is restricted — automatic signing refuses to sign it without an authorizing profile, and amfid kills an ad-hoc-signed binary that claims it at exec ("adhoc signed but contains restricted entitlements") — so the app's `CODE_SIGN_ENTITLEMENTS` resolves through `KERNOVA_APP_ENTITLEMENTS` in both configurations, defaulting in `Base.xcconfig` to `Kernova/Resources/Kernova.Development.entitlements`: the shipping set minus that key, keeping a profile-less checkout building and launchable.
+
+With the capability enabled on the team's App ID, setting `KERNOVA_APP_ENTITLEMENTS = Kernova/Resources/Kernova.entitlements` in `Local.xcconfig` opts the app into the full set — automatic signing then embeds the authorizing Xcode-managed profile, and an archive cut this way carries the key ([RELEASING.md](RELEASING.md) owns the per-lane choice). Code asks which set it was signed with through `EntitlementService`, never `#if DEBUG`.
 
 ## One test invocation, three test targets
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -20,7 +20,8 @@ Set `CODE_SIGN_IDENTITY = Apple Development` there whenever you have a certifica
 
 `DEVELOPMENT_TEAM` is what automatic signing resolves that certificate through, and the guest agent's Release Developer ID signing needs it too ([RELEASING.md](RELEASING.md)) — keep the two lines together.
 
-Every Release configuration except the app's own pins its identity at target level, which outranks a project xcconfig — the app leaves Release unpinned so an entitled archive can sign with the real identity the override supplies. The guest agent stays ad-hoc in Debug as well: it runs inside the guest, where a host code identity buys nothing.
+The guest agent and `KernovaRelaunchHelper` pin their Release identities at target level, which outranks a project xcconfig; the app and both test bundles leave Release unpinned, so the override reaches them too — an entitled archive needs the real identity, and a team-signed, hardened test host rejects an ad-hoc test bundle under library validation, so host and bundle must sign together.
+The guest agent stays ad-hoc in Debug as well: it runs inside the guest, where a host code identity buys nothing.
 
 The app's entitlements resolve through the same override point. `com.apple.vm.networking` is restricted — automatic signing refuses to sign it without an authorizing profile, and amfid kills an ad-hoc-signed binary that claims it at exec ("adhoc signed but contains restricted entitlements") — so the app's `CODE_SIGN_ENTITLEMENTS` resolves through `KERNOVA_APP_ENTITLEMENTS` in both configurations, defaulting in `Base.xcconfig` to `Kernova/Resources/Kernova.Development.entitlements`: the shipping set minus that key, keeping a profile-less checkout building and launchable.
 
@@ -40,7 +41,7 @@ That works because `KernovaKit` is referenced as a top-level peer — a `PBXFile
 
 Three of the workflows in `.github/workflows/` are required status checks: `lint`, `build-and-test`, and `proto-drift`. The "Required actions" ruleset matches them **by job name**, and that ruleset lives in GitHub's settings rather than in this repo — so renaming a job means editing the ruleset in the same change, or every PR waits on a check that never reports.
 
-The `lint` job runs `make lint`, which is therefore what gates a merge: `swift-format --strict`, shell (`bash -n` plus shellcheck, which it treats as required once `$CI` is set), and `Tools/check-docs.sh` for the documentation line cap and link validity. Each workflow's own header explains its trigger design; read it there before changing one.
+The `lint` job runs `make lint`, which is therefore what gates a merge: `swift-format --strict`, shell (`bash -n` plus shellcheck, which it treats as required once `$CI` is set), `Tools/check-docs.sh` for the documentation line cap and link validity, and `Tools/check-entitlements.sh` for key parity between the two app entitlement variants. Each workflow's own header explains its trigger design; read it there before changing one.
 
 `Kernova.xctestplan` sets `retryOnFailure` with two repetitions, so a test that fails once and passes on the retry still greens the job. The "Report flaky (retried) tests" step reads the result bundle and names those tests, which is where to look — a green conclusion on its own says nothing about flakes.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -68,8 +68,10 @@ set to the profile name above, `ENABLE_HARDENED_RUNTIME = YES`, and
 runtime and a secure timestamp on every binary, and since export re-signing
 can't add either inside the DMG, they have to be baked in at build time.
 
-The outer app and `KernovaRelaunchHelper` sign **ad-hoc** at build time and
-receive their Developer ID signatures from the Organizer export.
+`KernovaRelaunchHelper` signs **ad-hoc** at build time; the outer app signs
+with whatever identity `Config/Local.xcconfig` supplies (ad-hoc on a bare
+checkout). Both receive their Developer ID signatures from the Organizer
+export.
 
 Xcode injects `com.apple.security.get-task-allow` into *build*-action products
 for debugger attachment — the agent target sets
@@ -112,8 +114,12 @@ disabled**.
    It writes nothing unless every entry resolves, so a failure names a mirror
    that moved: repair that entry by hand and re-run. Read the diff before
    committing it — every value in it came off a mirror.
-4. **Archive.** In Xcode, select the **Kernova** scheme, then **Product →
-   Archive** (archiving builds Release).
+4. **Archive.** First check `KERNOVA_APP_ENTITLEMENTS` in
+   `Config/Local.xcconfig`: the full set — with the restricted
+   `com.apple.vm.networking` key — belongs in an archive only when this
+   distribution lane's provisioning profile authorizes the key; amfid kills a
+   launched build whose embedded profile does not. Then, in Xcode, select the
+   **Kernova** scheme and **Product → Archive** (archiving builds Release).
 5. **Confirm the archive type.** In the Organizer, verify the new archive
    appears as a **macOS app** archive, not *Other Items*. If it's *Other
    Items*, a `SKIP_INSTALL` regressed on the agent or `KernovaRelaunchHelper`.
@@ -135,9 +141,11 @@ spctl -a -vv Kernova.app
 codesign -dvvv Kernova.app
 # → Authority=Developer ID Application: Nicholas Lonsinger (8MT4P4GZL2)
 
-# Entitlements: debug entitlement absent
+# Entitlements: debug entitlement absent, networking key matching the lane
 codesign -d --entitlements - Kernova.app
 # → NO com.apple.security.get-task-allow
+# → com.apple.vm.networking present exactly when Local.xcconfig opted the
+#   archive into the full set (see the Archive step)
 
 # Deep structural verification
 codesign -dvv --verify --strict --deep Kernova.app

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -16,13 +16,14 @@ Everything `Kernova/Resources/Kernova.entitlements` claims:
 | `com.apple.security.files.downloads.read-write` | The fixed download destination in `~/Downloads` — macOS restore images and Linux installer ISOs — and their `.kernovadownload` resume sidecars |
 | `com.apple.security.files.bookmarks.app-scope` | Persisting those panel grants across launches |
 | `com.apple.security.virtualization` | Running guests |
+| `com.apple.vm.networking` | Guest networking beyond NAT — vmnet requires it for all API use, and a bridged attachment fails VZ configuration validation without it. Granted by Apple as a managed capability on the App ID; compatible with the sandbox on the store — UTM's store build carries it |
 | `com.apple.security.device.audio-input` | Opt-in per-VM microphone passthrough |
 
-Two absences are deliberate:
+`com.apple.vm.networking` is restricted — it must be authorized by the embedded provisioning profile — so the default build signs with `Kernova/Resources/Kernova.Development.entitlements`, the same set minus that key. [BUILD.md](BUILD.md) "Signing identity" owns the selection mechanics and the per-machine opt-in. The sandbox profile needs nothing further: `application.sb` grants the `com.apple.NetworkSharing` mach-lookup exactly when the entitlement is present.
+
+One absence is deliberate:
 
 **`com.apple.security.network.server`.** The app never calls `socket()`/`bind()`/`listen()` — `VZVirtioSocketListener`/`VZVirtioSocketConnection` hand it already-connected fds, and the sandbox's network entitlements gate socket *acquisition*, not I/O on granted fds. The serial relay's `AF_UNIX` listener binds inside the app's own temp directory, which file rules already allow. Neither vsock nor the relay needs it.
-
-**Any entitlement unavailable to Mac App Store apps.** The virtualization entitlement is compatible with the sandbox on the store — UTM ships exactly this combination there, macOS guests included. `com.apple.vm.networking` (bridged networking) is *not* in this category, despite being widely assumed Developer ID-only: Apple grants it on request for App Store distribution too — UTM's store build carries it. It is absent because nothing creates bridged network devices, not for eligibility.
 
 The only executable the app spawns is its own bundled `KernovaRelaunchHelper`, sandboxed with `app-sandbox` + `inherit` and nothing else.
 

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -15,7 +15,7 @@ Everything `Kernova/Resources/Kernova.entitlements` claims:
 | `com.apple.security.files.user-selected.read-write` | Powerbox grants from open/save panels — disk images, ISOs, shared folders, Linux kernel/initrd, local IPSWs |
 | `com.apple.security.files.downloads.read-write` | The fixed download destination in `~/Downloads` — macOS restore images and Linux installer ISOs — and their `.kernovadownload` resume sidecars |
 | `com.apple.security.files.bookmarks.app-scope` | Persisting those panel grants across launches |
-| `com.apple.security.virtualization` | Running guests |
+| `com.apple.security.virtualization` | Running guests — compatible with the sandbox on the store: UTM ships exactly this combination there, macOS guests included |
 | `com.apple.vm.networking` | Guest networking beyond NAT — vmnet requires it for all API use, and a bridged attachment fails VZ configuration validation without it. Granted by Apple as a managed capability on the App ID; compatible with the sandbox on the store — UTM's store build carries it |
 | `com.apple.security.device.audio-input` | Opt-in per-VM microphone passthrough |
 


### PR DESCRIPTION
Closes #811

## Summary
- `Kernova.entitlements` gains the granted `com.apple.vm.networking` key; the new `Kernova.Development.entitlements` variant (the same set minus the restricted key) is the default via `KERNOVA_APP_ENTITLEMENTS` in `Config/Base.xcconfig`, so a profile-less checkout builds and runs in both configurations.
- `Config/Local.xcconfig` opts a machine holding the capability-enabled profile into the full set — both configurations — and the app target's Release ad-hoc identity pin is removed so an entitled archive signs with the real identity the same override supplies.
- New `EntitlementService` (protocol-seamed `SecTaskCopyValueForEntitlement` on self, the VirtualBuddy `hasEntitlement` pattern) reports what the signature actually authorizes; the launch provenance `.notice` now includes `vmNetworking=entitled|unentitled`. This is #811's slice of the network-settings design (decision 9): the current switch already offers exactly the unentitled mode set, so the slice lands as the runtime check the #812 picker will consult — no UI change.
- Docs: SANDBOX.md's inventory gains the key and drops the now-false deliberate-absence paragraph; BUILD.md "Signing identity" owns the variant mechanics; RELEASING.md's Archive step owns the per-lane entitlement choice; ARCHITECTURE.md lists the service.

## Deviation from the issue
#811 scoped the key into Release unconditionally, Debug varying. Measured: `xcodebuild`'s automatic-signing planner refuses a restricted entitlement against an ad-hoc identity ("entitlements that require signing with a development certificate"), and Release pinned `CODE_SIGN_IDENTITY = "-"` at target level — so an unconditionally entitled Release failed to build on every machine, the maintainer's included. The issue's SIGKILL-after-successful-codesign measurement holds only for manual `codesign`. Hence the opt-in covering both configurations: archives inherit the `Local.xcconfig` choice, and RELEASING.md documents keeping Developer ID exports unentitled unless that lane's profile can authorize the key.

## Changes
- `Kernova/Resources/Kernova.entitlements`, `Kernova/Resources/Kernova.Development.entitlements`
- `Config/Base.xcconfig`, `Config/Local.xcconfig.example`, `Kernova.xcodeproj/project.pbxproj`
- `Kernova/Services/EntitlementService.swift`, `Kernova/App/AppDelegate.swift`
- `KernovaTests/EntitlementServiceTests.swift`, `KernovaTests/AppDelegateProvenanceTests.swift`
- `docs/SANDBOX.md`, `docs/BUILD.md`, `docs/RELEASING.md`, `docs/ARCHITECTURE.md`

## Test plan
- [x] `make lint`; `make test` — 2613 tests pass
- [x] Debug and Release both build; neither default product carries `com.apple.vm.networking` (`codesign -d --entitlements`)
- [x] Fresh-clone simulation (`Local.xcconfig` parked): Debug builds ad-hoc (fresh-clone Release fails on the guest agent's manual Developer ID profile, pre-existing)
- [x] Entitled opt-in on the maintainer's machine: Xcode build succeeds; signature carries the key and the embedded Xcode-managed profile (`Mac Team Provisioning Profile: app.kernova`) authorizes it
- [ ] MAS/TestFlight submission with the key present — next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjBUtr9JabfynpmJbymVUw