### PR TITLE
feat: Bridged networking with a host interface picker

### DIFF
--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -7,6 +7,12 @@ enum VMDisplayPreference: String, Codable, Sendable, Equatable {
     case fullscreen
 }
 
+/// How an enabled network device attaches to the world.
+enum VMNetworkMode: String, Codable, Sendable, Equatable {
+    case shared
+    case bridged
+}
+
 /// Persistent configuration for a virtual machine, serialized to `config.json`
 /// inside each VM bundle directory.
 ///
@@ -59,7 +65,16 @@ struct VMConfiguration: Codable, Sendable, Equatable {
 
     // MARK: - Network
 
+    /// When `false`, the VM has no network device at all — the "None" mode.
     var networkEnabled: Bool
+
+    /// How an enabled device attaches; ignored while `networkEnabled` is `false`.
+    var networkMode: VMNetworkMode
+
+    /// BSD name of the host interface a bridged VM attaches to (e.g. `en0`), or
+    /// `nil` for Automatic — resolved against the host's default route at start.
+    var bridgedInterfaceIdentifier: String?
+
     var macAddress: String?
 
     // MARK: - Clipboard Sharing
@@ -220,6 +235,8 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         displayPreference: VMDisplayPreference = .inline,
         lastFullscreenDisplayID: UInt32? = nil,
         networkEnabled: Bool = true,
+        networkMode: VMNetworkMode = .shared,
+        bridgedInterfaceIdentifier: String? = nil,
         macAddress: String? = nil,
         clipboardSharingEnabled: Bool = false,
         clipboardPassthroughEnabled: Bool = false,
@@ -262,6 +279,8 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         self.displayPreference = displayPreference
         self.lastFullscreenDisplayID = lastFullscreenDisplayID
         self.networkEnabled = networkEnabled
+        self.networkMode = networkMode
+        self.bridgedInterfaceIdentifier = bridgedInterfaceIdentifier
         self.macAddress = macAddress
         self.clipboardSharingEnabled = clipboardSharingEnabled
         self.clipboardPassthroughEnabled = clipboardPassthroughEnabled
@@ -314,6 +333,9 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         self.displayPreference = try c.decode(VMDisplayPreference.self, forKey: .displayPreference)
         self.lastFullscreenDisplayID = try c.decodeIfPresent(UInt32.self, forKey: .lastFullscreenDisplayID)
         self.networkEnabled = try c.decode(Bool.self, forKey: .networkEnabled)
+        self.networkMode = try c.decodeIfPresent(VMNetworkMode.self, forKey: .networkMode) ?? .shared
+        self.bridgedInterfaceIdentifier = try c.decodeIfPresent(
+            String.self, forKey: .bridgedInterfaceIdentifier)
         self.macAddress = try c.decodeIfPresent(String.self, forKey: .macAddress)
         self.clipboardSharingEnabled = try c.decode(Bool.self, forKey: .clipboardSharingEnabled)
         self.clipboardPassthroughEnabled =

--- a/Kernova/Services/BridgedNetworking.swift
+++ b/Kernova/Services/BridgedNetworking.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SystemConfiguration
 import Virtualization
+import os
 
 /// A host interface that supports bridged networking, decoupled from VZ for testability.
 struct BridgedInterface: Equatable, Sendable {
@@ -10,19 +11,18 @@ struct BridgedInterface: Equatable, Sendable {
 
 protocol BridgedInterfaceProviding: Sendable {
     /// Host interfaces currently available for bridging.
-    @MainActor func interfaces() -> [BridgedInterface]
+    func interfaces() -> [BridgedInterface]
     /// The identifier of the host's default-route (primary) interface, if known.
-    @MainActor func primaryInterfaceIdentifier() -> String?
+    func primaryInterfaceIdentifier() -> String?
 }
 
 /// Answers from the live host: `VZBridgedNetworkInterface` for the bridgeable
 /// list, the SystemConfiguration dynamic store for the default route.
-///
-/// Both methods are `nonisolated` — a wider isolation than the protocol asks for
-/// — so `ConfigurationBuilder`'s nonisolated assembly reads the same host state
-/// the settings picker shows, without a second path to it.
 struct HostBridgedInterfaceProvider: BridgedInterfaceProviding {
-    nonisolated func interfaces() -> [BridgedInterface] {
+    private static let logger = Logger(
+        subsystem: "app.kernova", category: "HostBridgedInterfaceProvider")
+
+    func interfaces() -> [BridgedInterface] {
         VZBridgedNetworkInterface.networkInterfaces.map { interface in
             BridgedInterface(
                 identifier: interface.identifier,
@@ -30,23 +30,32 @@ struct HostBridgedInterfaceProvider: BridgedInterfaceProviding {
         }
     }
 
-    nonisolated func primaryInterfaceIdentifier() -> String? {
+    func primaryInterfaceIdentifier() -> String? {
+        guard let store = SCDynamicStoreCreate(nil, "Kernova" as CFString, nil, nil) else {
+            Self.logger.fault("SCDynamicStoreCreate returned nil — reporting no primary interface")
+            assertionFailure("SCDynamicStoreCreate returned nil")
+            return nil
+        }
+        // Either family can carry the default route, so a host routing only over
+        // IPv6 still resolves.
+        for key in ["State:/Network/Global/IPv4", "State:/Network/Global/IPv6"] {
+            guard let global = SCDynamicStoreCopyValue(store, key as CFString) as? [String: Any],
+                let primary = global[kSCDynamicStorePropNetPrimaryInterface as String] as? String
+            else { continue }
+            return primary
+        }
         // A host with no default route (every interface down, or only interfaces
         // the store hasn't published) has no primary — `nil` is a normal answer.
-        guard let store = SCDynamicStoreCreate(nil, "Kernova" as CFString, nil, nil),
-            let global = SCDynamicStoreCopyValue(store, "State:/Network/Global/IPv4" as CFString)
-                as? [String: Any]
-        else { return nil }
-        return global[kSCDynamicStorePropNetPrimaryInterface as String] as? String
+        return nil
     }
 }
 
 enum BridgedInterfaceSelection {
-    /// Chooses the interface to bridge over: the persisted identifier when it is still
-    /// available, else the primary interface, else the first available; nil when none exist.
+    /// Chooses the interface to bridge over: the persisted identifier when it is
+    /// still available, else the primary interface; nil when neither resolves.
     static func choose(persisted: String?, available: [String], primary: String?) -> String? {
         if let persisted, available.contains(persisted) { return persisted }
         if let primary, available.contains(primary) { return primary }
-        return available.first
+        return nil
     }
 }

--- a/Kernova/Services/BridgedNetworking.swift
+++ b/Kernova/Services/BridgedNetworking.swift
@@ -1,0 +1,52 @@
+import Foundation
+import SystemConfiguration
+import Virtualization
+
+/// A host interface that supports bridged networking, decoupled from VZ for testability.
+struct BridgedInterface: Equatable, Sendable {
+    let identifier: String
+    let localizedDisplayName: String
+}
+
+protocol BridgedInterfaceProviding: Sendable {
+    /// Host interfaces currently available for bridging.
+    @MainActor func interfaces() -> [BridgedInterface]
+    /// The identifier of the host's default-route (primary) interface, if known.
+    @MainActor func primaryInterfaceIdentifier() -> String?
+}
+
+/// Answers from the live host: `VZBridgedNetworkInterface` for the bridgeable
+/// list, the SystemConfiguration dynamic store for the default route.
+///
+/// Both methods are `nonisolated` — a wider isolation than the protocol asks for
+/// — so `ConfigurationBuilder`'s nonisolated assembly reads the same host state
+/// the settings picker shows, without a second path to it.
+struct HostBridgedInterfaceProvider: BridgedInterfaceProviding {
+    nonisolated func interfaces() -> [BridgedInterface] {
+        VZBridgedNetworkInterface.networkInterfaces.map { interface in
+            BridgedInterface(
+                identifier: interface.identifier,
+                localizedDisplayName: interface.localizedDisplayName ?? interface.identifier)
+        }
+    }
+
+    nonisolated func primaryInterfaceIdentifier() -> String? {
+        // A host with no default route (every interface down, or only interfaces
+        // the store hasn't published) has no primary — `nil` is a normal answer.
+        guard let store = SCDynamicStoreCreate(nil, "Kernova" as CFString, nil, nil),
+            let global = SCDynamicStoreCopyValue(store, "State:/Network/Global/IPv4" as CFString)
+                as? [String: Any]
+        else { return nil }
+        return global[kSCDynamicStorePropNetPrimaryInterface as String] as? String
+    }
+}
+
+enum BridgedInterfaceSelection {
+    /// Chooses the interface to bridge over: the persisted identifier when it is still
+    /// available, else the primary interface, else the first available; nil when none exist.
+    static func choose(persisted: String?, available: [String], primary: String?) -> String? {
+        if let persisted, available.contains(persisted) { return persisted }
+        if let primary, available.contains(primary) { return primary }
+        return available.first
+    }
+}

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -66,7 +66,7 @@ struct ConfigurationBuilder: Sendable {
         try configureStorageDisks(vzConfig, config: config, bundleURL: bundleURL)
         let guestAgentDiskAttached = configureGuestAgentDisk(vzConfig, config: config, bundleURL: bundleURL)
         let coldRemovableMedia = try configureRemovableMedia(vzConfig, config: config)
-        configureNetwork(vzConfig, config: config)
+        try configureNetwork(vzConfig, config: config)
         configureEntropy(vzConfig)
         configureAudio(vzConfig, config: config)
         try configureDirectorySharing(vzConfig, config: config)
@@ -560,11 +560,18 @@ struct ConfigurationBuilder: Sendable {
             ))
     }
 
-    private func configureNetwork(_ vzConfig: VZVirtualMachineConfiguration, config: VMConfiguration) {
+    private func configureNetwork(_ vzConfig: VZVirtualMachineConfiguration, config: VMConfiguration)
+        throws
+    {
         guard config.networkEnabled else { return }
 
         let networkDevice = VZVirtioNetworkDeviceConfiguration()
-        networkDevice.attachment = VZNATNetworkDeviceAttachment()
+        switch config.networkMode {
+        case .shared:
+            networkDevice.attachment = VZNATNetworkDeviceAttachment()
+        case .bridged:
+            networkDevice.attachment = try bridgedAttachment(config: config)
+        }
 
         if let macString = config.macAddress,
             let macAddress = VZMACAddress(string: macString)
@@ -573,6 +580,38 @@ struct ConfigurationBuilder: Sendable {
         }
 
         vzConfig.networkDevices = [networkDevice]
+    }
+
+    /// Resolves the host interface a bridged VM attaches to.
+    ///
+    /// A persisted interface the host no longer offers narrows to Automatic; the
+    /// mode itself is never substituted — with nothing to bridge over the start
+    /// fails rather than quietly becoming Shared Network (docs/NETWORKING.md).
+    private func bridgedAttachment(config: VMConfiguration) throws
+        -> VZBridgedNetworkDeviceAttachment
+    {
+        let interfaces = VZBridgedNetworkInterface.networkInterfaces
+        guard
+            let chosen = BridgedInterfaceSelection.choose(
+                persisted: config.bridgedInterfaceIdentifier,
+                available: interfaces.map(\.identifier),
+                primary: HostBridgedInterfaceProvider().primaryInterfaceIdentifier()),
+            let interface = interfaces.first(where: { $0.identifier == chosen })
+        else {
+            Self.logger.error(
+                "Bridged networking requested for '\(config.name, privacy: .public)' with no bridgeable host interface"
+            )
+            throw ConfigurationBuilderError.noBridgeableInterface
+        }
+
+        if let persisted = config.bridgedInterfaceIdentifier, persisted != chosen {
+            Self.logger.notice(
+                "Bridged interface '\(persisted, privacy: .public)' is unavailable — bridging over '\(chosen, privacy: .public)' instead"
+            )
+        } else {
+            Self.logger.info("Bridging over '\(chosen, privacy: .public)'")
+        }
+        return VZBridgedNetworkDeviceAttachment(interface: interface)
     }
 
     private func configureEntropy(_ vzConfig: VZVirtualMachineConfiguration) {
@@ -874,6 +913,8 @@ enum ConfigurationBuilderError: LocalizedError {
     case removableMediaNotWritable(String, String)
     /// Removable-media counterpart of `storageDiskAttachFailed`.
     case removableMediaAttachFailed(id: UUID, path: String, label: String, underlying: any Error)
+    /// Bridged mode was chosen but the host offers no interface to bridge over.
+    case noBridgeableInterface
     case sharedDirectoryNotFound(String)
     case sharedDirectoryNotADirectory(String)
     case sharedDirectoryNotReadable(String)
@@ -911,6 +952,8 @@ enum ConfigurationBuilderError: LocalizedError {
             "Removable media '\(label)' is not writable: \(path). Change it to read-only or select a writable file."
         case .removableMediaAttachFailed(_, let path, let label, let underlying):
             "Couldn't open removable media '\(label)' at \(path). The file may have been moved or replaced, or Kernova may no longer have permission to read it. (\(underlying.localizedDescription))"
+        case .noBridgeableInterface:
+            "No host network interface is available for bridged networking."
         case .sharedDirectoryNotFound(let path):
             "Shared directory not found at \(path)."
         case .sharedDirectoryNotADirectory(let path):

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -28,6 +28,13 @@ struct ConfigurationBuilder: Sendable {
     /// virtio, `nil` when this build carries none.
     var guestAgentDiskURL: URL? = KernovaMacOSAgentInfo.installerDiskImageURL
 
+    /// Host state behind a bridged attachment's interface choice.
+    var bridgedInterfaces: any BridgedInterfaceProviding = HostBridgedInterfaceProvider()
+
+    /// What this build's signature authorizes; a fresh instance rather than
+    /// `.shared`, which is `@MainActor` while assembly runs off the main actor.
+    var entitlements = EntitlementService()
+
     /// Builds a validated `VZVirtualMachineConfiguration` from the given VM configuration and bundle URL.
     func build(from config: VMConfiguration, bundleURL: URL) throws -> BuildResult {
         try assemble(from: config, bundleURL: bundleURL, validate: true)
@@ -584,19 +591,29 @@ struct ConfigurationBuilder: Sendable {
 
     /// Resolves the host interface a bridged VM attaches to.
     ///
-    /// A persisted interface the host no longer offers narrows to Automatic; the
-    /// mode itself is never substituted — with nothing to bridge over the start
-    /// fails rather than quietly becoming Shared Network (docs/NETWORKING.md).
+    /// A persisted interface the host no longer offers narrows to Automatic — the
+    /// default-route interface. When neither resolves the start fails: the mode is
+    /// never substituted, so the VM neither bridges over an arbitrary interface
+    /// nor quietly becomes Shared Network (docs/NETWORKING.md).
     private func bridgedAttachment(config: VMConfiguration) throws
         -> VZBridgedNetworkDeviceAttachment
     {
-        let interfaces = VZBridgedNetworkInterface.networkInterfaces
+        guard entitlements.hasVMNetworking else {
+            Self.logger.error(
+                "Bridged networking requested for '\(config.name, privacy: .public)' in a build without com.apple.vm.networking"
+            )
+            throw ConfigurationBuilderError.bridgedNetworkingNotEntitled
+        }
+
+        let available = bridgedInterfaces.interfaces()
         guard
             let chosen = BridgedInterfaceSelection.choose(
                 persisted: config.bridgedInterfaceIdentifier,
-                available: interfaces.map(\.identifier),
-                primary: HostBridgedInterfaceProvider().primaryInterfaceIdentifier()),
-            let interface = interfaces.first(where: { $0.identifier == chosen })
+                available: available.map(\.identifier),
+                primary: bridgedInterfaces.primaryInterfaceIdentifier()),
+            let interface = VZBridgedNetworkInterface.networkInterfaces.first(where: {
+                $0.identifier == chosen
+            })
         else {
             Self.logger.error(
                 "Bridged networking requested for '\(config.name, privacy: .public)' with no bridgeable host interface"
@@ -605,7 +622,7 @@ struct ConfigurationBuilder: Sendable {
         }
 
         if let persisted = config.bridgedInterfaceIdentifier, persisted != chosen {
-            Self.logger.notice(
+            Self.logger.warning(
                 "Bridged interface '\(persisted, privacy: .public)' is unavailable — bridging over '\(chosen, privacy: .public)' instead"
             )
         } else {
@@ -915,6 +932,9 @@ enum ConfigurationBuilderError: LocalizedError {
     case removableMediaAttachFailed(id: UUID, path: String, label: String, underlying: any Error)
     /// Bridged mode was chosen but the host offers no interface to bridge over.
     case noBridgeableInterface
+    /// Bridged mode was chosen in a build whose signature omits
+    /// `com.apple.vm.networking`, which VZ needs for any non-NAT attachment.
+    case bridgedNetworkingNotEntitled
     case sharedDirectoryNotFound(String)
     case sharedDirectoryNotADirectory(String)
     case sharedDirectoryNotReadable(String)
@@ -953,7 +973,9 @@ enum ConfigurationBuilderError: LocalizedError {
         case .removableMediaAttachFailed(_, let path, let label, let underlying):
             "Couldn't open removable media '\(label)' at \(path). The file may have been moved or replaced, or Kernova may no longer have permission to read it. (\(underlying.localizedDescription))"
         case .noBridgeableInterface:
-            "No host network interface is available for bridged networking."
+            "No host network interface could be chosen for bridged networking. Choose a specific interface in the VM's Network settings, or switch to Shared Network."
+        case .bridgedNetworkingNotEntitled:
+            "This build of Kernova can't provide bridged networking. Switch the VM's network mode to Shared Network."
         case .sharedDirectoryNotFound(let path):
             "Shared directory not found at \(path)."
         case .sharedDirectoryNotADirectory(let path):

--- a/Kernova/Views/Creation/ReviewContentViewController.swift
+++ b/Kernova/Views/Creation/ReviewContentViewController.swift
@@ -123,7 +123,7 @@ final class ReviewContentViewController: NSViewController {
 
         addSection(
             "Network",
-            rows: [valueRow("Networking", creationVM.networkEnabled ? "Enabled" : "Disabled")], to: summary)
+            rows: [valueRow("Mode", creationVM.networkEnabled ? "Shared Network" : "None")], to: summary)
 
         if creationVM.selectedOS == .macOS {
             var rows: [NSView] = []

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import AppKit
 import UniformTypeIdentifiers
+import Virtualization
 import os
 
 /// Pure-AppKit settings pane for editing a stopped VM's configuration, or
@@ -213,6 +214,10 @@ final class VMSettingsViewController: NSViewController {
     private var renderedRemovableRows: [RenderedRow]?
     private var renderedSharedRows: [RenderedRow]?
     private var renderedAudioWarning: MicWarningState?
+    /// The Mode menu's rendered selection, so an `apply()` pass that changed
+    /// nothing about networking skips a rebuild — which enumerates the host's
+    /// bridgeable interfaces and queries the process signature.
+    private var renderedNetworkChoice: NetworkModeChoice?
 
     // MARK: - Init
 
@@ -457,12 +462,13 @@ extension VMSettingsViewController {
         activeRemovableRename = nil
         storageRowsByID.removeAll()
         removableRowsByID.removeAll()
-        // The list stacks and audio-warning container are recreated below, so
-        // invalidate the render snapshots that guard their refreshes.
+        // The list stacks, audio-warning container, and Mode popup are recreated
+        // below, so invalidate the render snapshots that guard their refreshes.
         renderedStorageRows = nil
         renderedRemovableRows = nil
         renderedSharedRows = nil
         renderedAudioWarning = nil
+        renderedNetworkChoice = nil
 
         displayResolutionIsCustom = false
 
@@ -899,14 +905,12 @@ extension VMSettingsViewController {
     // MARK: Network
 
     /// What a Mode menu item selects, carried as the item's `representedObject`.
+    ///
+    /// `bridged`'s payload is the host interface identifier, `nil` for Automatic.
     private enum NetworkModeChoice: Equatable {
         case shared
         case none
-        case bridgedAutomatic
-        case bridgedInterface(String)
-        /// A bridged VM in a build the entitlement doesn't cover: the picker can
-        /// offer no Bridged entry, so this one shows the mode without offering it.
-        case bridgedUnavailable
+        case bridged(String?)
     }
 
     private func buildNetworkSection() -> NSView {
@@ -926,10 +930,10 @@ extension VMSettingsViewController {
 
         var paragraphs: [InfoPopoverParagraph] = [
             .body(
-                "The mode sets how the guest reaches the network. Shared Network gives it outbound access through the host: the guest gets a DHCP address on a private subnet, and other machines on your network cannot reach it. Bridged puts the guest on your network through the chosen host interface, where it requests its own address like a separate machine."
+                "The mode sets how the guest reaches the network. Shared Network gives it outbound access through the host: the guest gets a DHCP address on a private subnet, other machines on your network cannot reach it, and there is no port forwarding from host to guest — incoming connections require knowing the guest's IP. Bridged puts the guest on your network through the chosen host interface, where it requests its own address like a separate machine."
             ),
             .body(
-                "Bridged traffic bypasses any VPN running on the host. Bridging over Wi-Fi is best-effort — the Wi-Fi standard does not bridge additional stations and there is no client-side fix, so prefer a wired interface."
+                "Bridged traffic bypasses a VPN running on the host. Bridging over Wi-Fi is best-effort — the Wi-Fi standard does not bridge additional stations and there is no client-side fix, so prefer a wired interface."
             ),
         ]
         if instance.configuration.guestOS == .linux {
@@ -967,10 +971,11 @@ extension VMSettingsViewController {
         addNetworkModeItem("Shared Network", choice: .shared, to: menu)
         addNetworkModeItem("None", choice: .none, to: menu)
 
-        let config = instance.configuration
+        let current = currentNetworkChoice
+        renderedNetworkChoice = current
         if entitlements.hasVMNetworking {
             menu.addItem(.sectionHeader(title: "Bridged"))
-            addNetworkModeItem("Automatic", choice: .bridgedAutomatic, to: menu)
+            addNetworkModeItem("Automatic", choice: .bridged(nil), to: menu)
             let interfaces = bridgedInterfaces.interfaces()
             if interfaces.isEmpty {
                 addNetworkModePlaceholder("No Bridgeable Interfaces", to: menu)
@@ -978,23 +983,24 @@ extension VMSettingsViewController {
             for interface in interfaces {
                 addNetworkModeItem(
                     Self.networkInterfaceTitle(interface),
-                    choice: .bridgedInterface(interface.identifier), to: menu)
+                    choice: .bridged(interface.identifier), to: menu)
             }
             // Keep an interface the host isn't offering right now on the list, so
             // the picker shows what the VM is actually set to — only while it IS
             // what the VM is set to; an identifier merely remembered from an
             // earlier bridged choice adds no entry.
-            if config.networkEnabled, config.networkMode == .bridged,
-                let persisted = config.bridgedInterfaceIdentifier,
+            if case .bridged(.some(let persisted)) = current,
                 !interfaces.contains(where: { $0.identifier == persisted })
             {
                 addNetworkModeItem(
-                    "\(persisted) (unavailable)", choice: .bridgedInterface(persisted),
+                    "\(persisted) (unavailable)", choice: .bridged(persisted),
                     to: menu, enabled: false)
             }
-        } else if config.networkEnabled, config.networkMode == .bridged {
-            addNetworkModeItem(
-                "Bridged (unavailable)", choice: .bridgedUnavailable, to: menu, enabled: false)
+        } else if case .bridged = current {
+            // A bridged VM in a build the entitlement doesn't cover: the picker
+            // offers no Bridged entry, so this one shows the mode without
+            // offering it — carrying the current choice so it still selects.
+            addNetworkModeItem("Bridged (unavailable)", choice: current, to: menu, enabled: false)
         }
 
         selectNetworkModeItem()
@@ -1035,9 +1041,7 @@ extension VMSettingsViewController {
         case .shared:
             return .shared
         case .bridged:
-            guard entitlements.hasVMNetworking else { return .bridgedUnavailable }
-            guard let identifier = config.bridgedInterfaceIdentifier else { return .bridgedAutomatic }
-            return .bridgedInterface(identifier)
+            return .bridged(config.bridgedInterfaceIdentifier)
         }
     }
 
@@ -1594,7 +1598,9 @@ extension VMSettingsViewController {
     }
 
     private func refreshNetwork() {
-        rebuildNetworkModeMenu()
+        if currentNetworkChoice != renderedNetworkChoice {
+            rebuildNetworkModeMenu()
+        }
         // None leaves no device to describe, so the card's remaining rows give way
         // to a caption saying so.
         let hasDevice = instance.configuration.networkEnabled
@@ -1971,6 +1977,16 @@ extension VMSettingsViewController: NSMenuItemValidation {
         writeConfig { $0.memorySizeInGB = memoryStepper.integerValue }
     }
 
+    /// Gives a VM turning networking on its first MAC address.
+    ///
+    /// A VM created with networking off carries none, and VZ then generates a
+    /// fresh random one at every start — so the address the LAN sees, and any
+    /// DHCP reservation keyed on it, would change from one boot to the next.
+    private static func mintMACAddressIfNeeded(_ config: inout VMConfiguration) {
+        guard config.macAddress == nil else { return }
+        config.macAddress = VZMACAddress.randomLocallyAdministered().string
+    }
+
     @objc private func networkModeChanged() {
         guard let choice = networkModePopUp.selectedItem?.representedObject as? NetworkModeChoice
         else { return }
@@ -1981,23 +1997,17 @@ extension VMSettingsViewController: NSMenuItemValidation {
             writeConfig {
                 $0.networkEnabled = true
                 $0.networkMode = .shared
+                Self.mintMACAddressIfNeeded(&$0)
             }
         case .none:
             writeConfig { $0.networkEnabled = false }
-        case .bridgedAutomatic:
-            writeConfig {
-                $0.networkEnabled = true
-                $0.networkMode = .bridged
-                $0.bridgedInterfaceIdentifier = nil
-            }
-        case .bridgedInterface(let identifier):
+        case .bridged(let identifier):
             writeConfig {
                 $0.networkEnabled = true
                 $0.networkMode = .bridged
                 $0.bridgedInterfaceIdentifier = identifier
+                Self.mintMACAddressIfNeeded(&$0)
             }
-        case .bridgedUnavailable:
-            return
         }
         // The write flips the card's row visibility; refresh in case the value was
         // already what the model held.

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -20,6 +20,11 @@ final class VMSettingsViewController: NSViewController {
     private var viewModel: VMLibraryViewModel
     private var isReadOnly: Bool
 
+    /// Host interfaces offered by the Network section's Mode picker.
+    private let bridgedInterfaces: any BridgedInterfaceProviding
+    /// Decides whether the picker offers Bridged at all.
+    private let entitlements: EntitlementService
+
     // MARK: - Observation & live state
 
     private let fileMonitor = AttachmentFileMonitor()
@@ -156,7 +161,12 @@ final class VMSettingsViewController: NSViewController {
     private var sharedListStack = NSStackView()
 
     // Network
-    private var networkSwitch = NSSwitch()
+    private var networkModePopUp = NSPopUpButton()
+    /// The MAC Address row, hidden while the VM has no network device; `nil` for a
+    /// VM carrying no MAC address, whose row is never built.
+    private var macAddressRow: GroupedFormCollapsibleRow?
+    /// Stands in for the card's rows while the mode is None.
+    private var networkNoDeviceCaption = NSTextField()
 
     // Audio
     private var audioInputSwitch = NSSwitch()
@@ -206,10 +216,18 @@ final class VMSettingsViewController: NSViewController {
 
     // MARK: - Init
 
-    init(instance: VMInstance, viewModel: VMLibraryViewModel, isReadOnly: Bool) {
+    init(
+        instance: VMInstance,
+        viewModel: VMLibraryViewModel,
+        isReadOnly: Bool,
+        bridgedInterfaces: any BridgedInterfaceProviding = HostBridgedInterfaceProvider(),
+        entitlements: EntitlementService = .shared
+    ) {
         self.instance = instance
         self.viewModel = viewModel
         self.isReadOnly = isReadOnly
+        self.bridgedInterfaces = bridgedInterfaces
+        self.entitlements = entitlements
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -880,19 +898,39 @@ extension VMSettingsViewController {
 
     // MARK: Network
 
-    private func buildNetworkSection() -> NSView {
-        networkSwitch = makeSwitch(action: #selector(networkToggled))
-        persistentLockableControls.append(networkSwitch)
+    /// What a Mode menu item selects, carried as the item's `representedObject`.
+    private enum NetworkModeChoice: Equatable {
+        case shared
+        case none
+        case bridgedAutomatic
+        case bridgedInterface(String)
+        /// A bridged VM in a build the entitlement doesn't cover: the picker can
+        /// offer no Bridged entry, so this one shows the mode without offering it.
+        case bridgedUnavailable
+    }
 
-        var rows: [NSView] = [makeGroupedFormCardRow("Networking Enabled", control: networkSwitch)]
+    private func buildNetworkSection() -> NSView {
+        networkModePopUp = makeNetworkModePopUp()
+        persistentLockableControls.append(networkModePopUp)
+
+        var rows: [NSView] = [makeGroupedFormCardRow("Mode", control: networkModePopUp)]
         if let mac = instance.configuration.macAddress {
-            rows.append(makeGroupedFormCardRow("MAC Address", control: makeGroupedFormValueLabel(mac)))
+            let row = GroupedFormCollapsibleRow(
+                row: makeGroupedFormCardRow("MAC Address", control: makeGroupedFormValueLabel(mac)))
+            macAddressRow = row
+            rows.append(row)
+        } else {
+            macAddressRow = nil
         }
+        networkNoDeviceCaption = makeGroupedFormCaption("This virtual machine has no network device.")
 
         var paragraphs: [InfoPopoverParagraph] = [
             .body(
-                "NAT-mode networking. The host assigns the guest a DHCP address on a private subnet. Outbound connections work; there is no port forwarding from host to guest — incoming connections require knowing the guest's IP."
-            )
+                "The mode sets how the guest reaches the network. Shared Network gives it outbound access through the host: the guest gets a DHCP address on a private subnet, and other machines on your network cannot reach it. Bridged puts the guest on your network through the chosen host interface, where it requests its own address like a separate machine."
+            ),
+            .body(
+                "Bridged traffic bypasses any VPN running on the host. Bridging over Wi-Fi is best-effort — the Wi-Fi standard does not bridge additional stations and there is no client-side fix, so prefer a wired interface."
+            ),
         ]
         if instance.configuration.guestOS == .linux {
             paragraphs.append(
@@ -903,7 +941,114 @@ extension VMSettingsViewController {
         return makeSection([
             makeHeader("Network", lockable: true, paragraphs: paragraphs),
             makeGroupedFormCard(rows: rows),
+            networkNoDeviceCaption,
         ])
+    }
+
+    private func makeNetworkModePopUp() -> NSPopUpButton {
+        let popUp = NSPopUpButton()
+        popUp.controlSize = .small
+        // Otherwise AppKit re-derives each item's enabled state on every event,
+        // undoing the deliberately-disabled entries below.
+        popUp.autoenablesItems = false
+        popUp.target = self
+        popUp.action = #selector(networkModeChanged)
+        popUp.menu?.delegate = self
+        return popUp
+    }
+
+    /// Rebuilds the Mode menu and selects the entry matching the configuration.
+    ///
+    /// The bridgeable-interface list is live host state, so the menu is rebuilt
+    /// from scratch each time it opens rather than cached at build time.
+    private func rebuildNetworkModeMenu() {
+        guard let menu = networkModePopUp.menu else { return }
+        menu.removeAllItems()
+        addNetworkModeItem("Shared Network", choice: .shared, to: menu)
+        addNetworkModeItem("None", choice: .none, to: menu)
+
+        let config = instance.configuration
+        if entitlements.hasVMNetworking {
+            menu.addItem(.sectionHeader(title: "Bridged"))
+            addNetworkModeItem("Automatic", choice: .bridgedAutomatic, to: menu)
+            let interfaces = bridgedInterfaces.interfaces()
+            if interfaces.isEmpty {
+                addNetworkModePlaceholder("No Bridgeable Interfaces", to: menu)
+            }
+            for interface in interfaces {
+                addNetworkModeItem(
+                    Self.networkInterfaceTitle(interface),
+                    choice: .bridgedInterface(interface.identifier), to: menu)
+            }
+            // Keep an interface the host isn't offering right now on the list, so
+            // the picker shows what the VM is actually set to — only while it IS
+            // what the VM is set to; an identifier merely remembered from an
+            // earlier bridged choice adds no entry.
+            if config.networkEnabled, config.networkMode == .bridged,
+                let persisted = config.bridgedInterfaceIdentifier,
+                !interfaces.contains(where: { $0.identifier == persisted })
+            {
+                addNetworkModeItem(
+                    "\(persisted) (unavailable)", choice: .bridgedInterface(persisted),
+                    to: menu, enabled: false)
+            }
+        } else if config.networkEnabled, config.networkMode == .bridged {
+            addNetworkModeItem(
+                "Bridged (unavailable)", choice: .bridgedUnavailable, to: menu, enabled: false)
+        }
+
+        selectNetworkModeItem()
+    }
+
+    /// Appends one Mode entry.
+    ///
+    /// `choice` is deliberately non-optional: in an optional context Swift reads
+    /// the `.none` case as `nil`, which would strip the None entry's identity.
+    private func addNetworkModeItem(
+        _ title: String, choice: NetworkModeChoice, to menu: NSMenu, enabled: Bool = true
+    ) {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.representedObject = choice
+        item.isEnabled = enabled
+        menu.addItem(item)
+    }
+
+    /// Appends an entry that stands for no mode at all — readable, never chosen.
+    private func addNetworkModePlaceholder(_ title: String, to menu: NSMenu) {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        menu.addItem(item)
+    }
+
+    /// How one bridgeable interface reads in the picker — `Wi-Fi (en0)`, or the
+    /// bare identifier when the host names it nothing else.
+    private static func networkInterfaceTitle(_ interface: BridgedInterface) -> String {
+        guard interface.localizedDisplayName != interface.identifier else { return interface.identifier }
+        return "\(interface.localizedDisplayName) (\(interface.identifier))"
+    }
+
+    /// The entry standing for the current configuration.
+    private var currentNetworkChoice: NetworkModeChoice {
+        let config = instance.configuration
+        guard config.networkEnabled else { return .none }
+        switch config.networkMode {
+        case .shared:
+            return .shared
+        case .bridged:
+            guard entitlements.hasVMNetworking else { return .bridgedUnavailable }
+            guard let identifier = config.bridgedInterfaceIdentifier else { return .bridgedAutomatic }
+            return .bridgedInterface(identifier)
+        }
+    }
+
+    private func selectNetworkModeItem() {
+        let choice = currentNetworkChoice
+        guard
+            let item = networkModePopUp.menu?.items.first(where: {
+                $0.representedObject as? NetworkModeChoice == choice
+            })
+        else { return }
+        networkModePopUp.select(item)
     }
 
     // MARK: Audio
@@ -1449,7 +1594,12 @@ extension VMSettingsViewController {
     }
 
     private func refreshNetwork() {
-        networkSwitch.state = instance.configuration.networkEnabled ? .on : .off
+        rebuildNetworkModeMenu()
+        // None leaves no device to describe, so the card's remaining rows give way
+        // to a caption saying so.
+        let hasDevice = instance.configuration.networkEnabled
+        macAddressRow?.isHidden = !hasDevice
+        networkNoDeviceCaption.isHidden = hasDevice
     }
 
     private func refreshAudio() {
@@ -1821,8 +1971,37 @@ extension VMSettingsViewController: NSMenuItemValidation {
         writeConfig { $0.memorySizeInGB = memoryStepper.integerValue }
     }
 
-    @objc private func networkToggled() {
-        writeConfig { $0.networkEnabled = networkSwitch.state == .on }
+    @objc private func networkModeChanged() {
+        guard let choice = networkModePopUp.selectedItem?.representedObject as? NetworkModeChoice
+        else { return }
+        switch choice {
+        case .shared:
+            // `bridgedInterfaceIdentifier` is left alone so switching back to
+            // Bridged remembers the interface.
+            writeConfig {
+                $0.networkEnabled = true
+                $0.networkMode = .shared
+            }
+        case .none:
+            writeConfig { $0.networkEnabled = false }
+        case .bridgedAutomatic:
+            writeConfig {
+                $0.networkEnabled = true
+                $0.networkMode = .bridged
+                $0.bridgedInterfaceIdentifier = nil
+            }
+        case .bridgedInterface(let identifier):
+            writeConfig {
+                $0.networkEnabled = true
+                $0.networkMode = .bridged
+                $0.bridgedInterfaceIdentifier = identifier
+            }
+        case .bridgedUnavailable:
+            return
+        }
+        // The write flips the card's row visibility; refresh in case the value was
+        // already what the model held.
+        refreshNetwork()
     }
 
     // MARK: Display
@@ -2439,6 +2618,16 @@ extension VMSettingsViewController: NSMenuItemValidation {
             guard let self, response == .OK, let url = panel.url else { return }
             self.viewModel.createRemovableMedia(for: self.instance, sizeInGB: sizeInGB, destinationURL: url)
         }
+    }
+}
+
+// MARK: - NSMenuDelegate
+
+extension VMSettingsViewController: NSMenuDelegate {
+    /// Re-reads the host's bridgeable interfaces each time the Mode picker opens.
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        guard menu === networkModePopUp.menu else { return }
+        rebuildNetworkModeMenu()
     }
 }
 

--- a/KernovaTests/BridgedInterfaceSelectionTests.swift
+++ b/KernovaTests/BridgedInterfaceSelectionTests.swift
@@ -1,0 +1,44 @@
+import Testing
+
+@testable import Kernova
+
+@Suite("BridgedInterfaceSelection Tests")
+struct BridgedInterfaceSelectionTests {
+    @Test("A persisted interface that is still available wins over the primary one")
+    func persistedAvailableWins() {
+        #expect(
+            BridgedInterfaceSelection.choose(
+                persisted: "en1", available: ["en0", "en1"], primary: "en0") == "en1")
+    }
+
+    @Test("A persisted interface the host no longer offers falls back to the primary one")
+    func persistedAbsentFallsBackToPrimary() {
+        #expect(
+            BridgedInterfaceSelection.choose(
+                persisted: "en5", available: ["en0", "en1"], primary: "en1") == "en1")
+    }
+
+    @Test("Automatic resolves to the primary interface")
+    func automaticResolvesToPrimary() {
+        #expect(
+            BridgedInterfaceSelection.choose(
+                persisted: nil, available: ["en0", "en1"], primary: "en1") == "en1")
+    }
+
+    @Test("A primary interface that isn't bridgeable falls back to the first available")
+    func primaryAbsentFallsBackToFirst() {
+        #expect(
+            BridgedInterfaceSelection.choose(
+                persisted: nil, available: ["en2", "en3"], primary: "utun4") == "en2")
+        #expect(
+            BridgedInterfaceSelection.choose(
+                persisted: "en5", available: ["en2", "en3"], primary: nil) == "en2")
+    }
+
+    @Test("No bridgeable interfaces resolves to nothing")
+    func emptyAvailableResolvesToNil() {
+        #expect(
+            BridgedInterfaceSelection.choose(persisted: "en0", available: [], primary: "en0") == nil)
+        #expect(BridgedInterfaceSelection.choose(persisted: nil, available: [], primary: nil) == nil)
+    }
+}

--- a/KernovaTests/BridgedInterfaceSelectionTests.swift
+++ b/KernovaTests/BridgedInterfaceSelectionTests.swift
@@ -25,14 +25,14 @@ struct BridgedInterfaceSelectionTests {
                 persisted: nil, available: ["en0", "en1"], primary: "en1") == "en1")
     }
 
-    @Test("A primary interface that isn't bridgeable falls back to the first available")
-    func primaryAbsentFallsBackToFirst() {
+    @Test("A primary interface that isn't bridgeable resolves to nothing")
+    func unbridgeablePrimaryResolvesToNil() {
         #expect(
             BridgedInterfaceSelection.choose(
-                persisted: nil, available: ["en2", "en3"], primary: "utun4") == "en2")
+                persisted: nil, available: ["en2", "en3"], primary: "utun4") == nil)
         #expect(
             BridgedInterfaceSelection.choose(
-                persisted: "en5", available: ["en2", "en3"], primary: nil) == "en2")
+                persisted: "en5", available: ["en2", "en3"], primary: nil) == nil)
     }
 
     @Test("No bridgeable interfaces resolves to nothing")

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -20,6 +20,26 @@ struct ConfigurationBuilderTests {
         return tempDir
     }
 
+    /// Fails the test when `error` is a path-validation refusal.
+    ///
+    /// For the happy-path tests, which tolerate any other builder error: VZ
+    /// validation legitimately fails on a host without virtualization, and only
+    /// the path handling is under test.
+    private func expectNoPathValidationError(_ error: ConfigurationBuilderError) {
+        switch error {
+        case .sharedDirectoryNotFound, .sharedDirectoryNotADirectory,
+            .sharedDirectoryNotReadable, .sharedDirectoryNotWritable,
+            .kernelNotFound, .kernelPathIsDirectory,
+            .initrdNotFound, .initrdPathIsDirectory,
+            .storageDiskNotFound, .storageDiskPathIsDirectory, .storageDiskNotWritable,
+            .removableMediaNotFound, .removableMediaPathIsDirectory, .removableMediaNotWritable:
+            Issue.record("Unexpected path validation error: \(error)")
+        case .invalidHardwareModel, .invalidMachineIdentifier, .missingKernelPath,
+            .storageDiskAttachFailed, .removableMediaAttachFailed, .noBridgeableInterface:
+            break
+        }
+    }
+
     /// Returns a Linux/EFI config with optional shared directories.
     private func makeLinuxConfig(
         sharedDirectories: [SharedDirectory]? = nil
@@ -225,20 +245,7 @@ struct ConfigurationBuilderTests {
         do {
             _ = try builder.build(from: config, bundleURL: bundleURL)
         } catch let error as ConfigurationBuilderError {
-            switch error {
-            // Path validation errors — these MUST NOT occur:
-            case .sharedDirectoryNotFound, .sharedDirectoryNotADirectory,
-                .sharedDirectoryNotReadable, .sharedDirectoryNotWritable,
-                .kernelNotFound, .kernelPathIsDirectory,
-                .initrdNotFound, .initrdPathIsDirectory,
-                .storageDiskNotFound, .storageDiskPathIsDirectory, .storageDiskNotWritable,
-                .removableMediaNotFound, .removableMediaPathIsDirectory, .removableMediaNotWritable:
-                Issue.record("Unexpected path validation error: \(error)")
-            // Non-path-validation errors — tolerated if they occur:
-            case .invalidHardwareModel, .invalidMachineIdentifier,
-                .missingKernelPath, .storageDiskAttachFailed, .removableMediaAttachFailed:
-                break
-            }
+            expectNoPathValidationError(error)
         } catch {
             // VZ framework or other errors are expected
         }
@@ -614,18 +621,7 @@ struct ConfigurationBuilderTests {
         do {
             _ = try builder.build(from: config, bundleURL: bundleURL)
         } catch let error as ConfigurationBuilderError {
-            switch error {
-            case .sharedDirectoryNotFound, .sharedDirectoryNotADirectory,
-                .sharedDirectoryNotReadable, .sharedDirectoryNotWritable,
-                .kernelNotFound, .kernelPathIsDirectory,
-                .initrdNotFound, .initrdPathIsDirectory,
-                .storageDiskNotFound, .storageDiskPathIsDirectory, .storageDiskNotWritable,
-                .removableMediaNotFound, .removableMediaPathIsDirectory, .removableMediaNotWritable:
-                Issue.record("Unexpected path validation error: \(error)")
-            case .invalidHardwareModel, .invalidMachineIdentifier,
-                .missingKernelPath, .storageDiskAttachFailed, .removableMediaAttachFailed:
-                break
-            }
+            expectNoPathValidationError(error)
         } catch {
             // VZ framework or other errors are expected
         }
@@ -656,20 +652,7 @@ struct ConfigurationBuilderTests {
         do {
             _ = try builder.build(from: config, bundleURL: bundleURL)
         } catch let error as ConfigurationBuilderError {
-            switch error {
-            // Path validation errors — these MUST NOT occur:
-            case .sharedDirectoryNotFound, .sharedDirectoryNotADirectory,
-                .sharedDirectoryNotReadable, .sharedDirectoryNotWritable,
-                .kernelNotFound, .kernelPathIsDirectory,
-                .initrdNotFound, .initrdPathIsDirectory,
-                .storageDiskNotFound, .storageDiskPathIsDirectory, .storageDiskNotWritable,
-                .removableMediaNotFound, .removableMediaPathIsDirectory, .removableMediaNotWritable:
-                Issue.record("Unexpected path validation error: \(error)")
-            // Non-path-validation errors — tolerated if they occur:
-            case .invalidHardwareModel, .invalidMachineIdentifier,
-                .missingKernelPath, .storageDiskAttachFailed, .removableMediaAttachFailed:
-                break
-            }
+            expectNoPathValidationError(error)
         } catch {
             // VZ framework or other errors are expected — the test only
             // verifies that shared directory validation itself passes.
@@ -931,20 +914,7 @@ struct ConfigurationBuilderTests {
         do {
             _ = try builder.build(from: config, bundleURL: bundleURL)
         } catch let error as ConfigurationBuilderError {
-            switch error {
-            // Path validation errors — these MUST NOT occur:
-            case .sharedDirectoryNotFound, .sharedDirectoryNotADirectory,
-                .sharedDirectoryNotReadable, .sharedDirectoryNotWritable,
-                .kernelNotFound, .kernelPathIsDirectory,
-                .initrdNotFound, .initrdPathIsDirectory,
-                .storageDiskNotFound, .storageDiskPathIsDirectory, .storageDiskNotWritable,
-                .removableMediaNotFound, .removableMediaPathIsDirectory, .removableMediaNotWritable:
-                Issue.record("Unexpected path validation error: \(error)")
-            // Non-path-validation errors — tolerated if they occur:
-            case .invalidHardwareModel, .invalidMachineIdentifier,
-                .missingKernelPath, .storageDiskAttachFailed, .removableMediaAttachFailed:
-                break
-            }
+            expectNoPathValidationError(error)
         } catch {
             // VZ framework or other errors are expected
         }
@@ -1047,6 +1017,56 @@ struct ConfigurationBuilderTests {
             #expect(hasOutput == c.hasOutput)
             #expect(deviceCount == c.deviceCount)
         }
+    }
+
+    // MARK: - Network
+
+    /// Assembles `config` and returns its network devices.
+    ///
+    /// `assemble(validate: false)` for the same reason as the audio helper: the
+    /// device is built regardless of the flag, and CI runners can't validate.
+    private func networkDevices(for config: VMConfiguration) throws
+        -> [VZNetworkDeviceConfiguration]
+    {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+        return try ConfigurationBuilder()
+            .assemble(from: config, bundleURL: bundleURL, validate: false)
+            .configuration.networkDevices
+    }
+
+    @Test("Mode None configures no network device at all")
+    func networkDisabledOmitsTheDevice() throws {
+        var config = makeLinuxConfig()
+        config.networkEnabled = false
+        // A bridged mode left behind by an earlier choice must not resurrect the
+        // device: `networkEnabled == false` is the None mode.
+        config.networkMode = .bridged
+        #expect(try networkDevices(for: config).isEmpty)
+    }
+
+    @Test("Shared Network attaches one virtio device over NAT")
+    func sharedModeAttachesNAT() throws {
+        let devices = try networkDevices(for: makeLinuxConfig())
+        #expect(devices.count == 1)
+        let device = try #require(devices.first as? VZVirtioNetworkDeviceConfiguration)
+        #expect(device.attachment is VZNATNetworkDeviceAttachment)
+    }
+
+    @Test("A configured MAC address reaches the network device")
+    func macAddressReachesTheDevice() throws {
+        var config = makeLinuxConfig()
+        config.macAddress = "aa:bb:cc:dd:ee:ff"
+        let device = try #require(try networkDevices(for: config).first)
+        #expect(device.macAddress.string == "aa:bb:cc:dd:ee:ff")
+    }
+
+    @Test("An unparsable MAC address leaves VZ's generated one in place")
+    func invalidMACAddressIsIgnored() throws {
+        var config = makeLinuxConfig()
+        config.macAddress = "not-a-mac"
+        let device = try #require(try networkDevices(for: config).first)
+        #expect(device.macAddress.string != "not-a-mac")
     }
 
     // MARK: - Input Devices

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -35,9 +35,17 @@ struct ConfigurationBuilderTests {
             .removableMediaNotFound, .removableMediaPathIsDirectory, .removableMediaNotWritable:
             Issue.record("Unexpected path validation error: \(error)")
         case .invalidHardwareModel, .invalidMachineIdentifier, .missingKernelPath,
-            .storageDiskAttachFailed, .removableMediaAttachFailed, .noBridgeableInterface:
+            .storageDiskAttachFailed, .removableMediaAttachFailed,
+            .noBridgeableInterface, .bridgedNetworkingNotEntitled:
             break
         }
+    }
+
+    /// Returns a Linux/EFI config set to bridged networking.
+    private func makeBridgedConfig() -> VMConfiguration {
+        VMConfiguration(
+            name: "Test Linux", guestOS: .linux, bootMode: .efi,
+            networkEnabled: true, networkMode: .bridged)
     }
 
     /// Returns a Linux/EFI config with optional shared directories.
@@ -1067,6 +1075,45 @@ struct ConfigurationBuilderTests {
         config.macAddress = "not-a-mac"
         let device = try #require(try networkDevices(for: config).first)
         #expect(device.macAddress.string != "not-a-mac")
+    }
+
+    @Test("Bridged mode with no bridgeable host interface refuses to start")
+    func bridgedModeWithoutAnInterfaceThrows() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        var builder = ConfigurationBuilder()
+        builder.bridgedInterfaces = MockBridgedInterfaceProvider()
+        builder.entitlements = EntitlementService(
+            reader: MockEntitlementReader(granted: ["com.apple.vm.networking"]))
+
+        #expect {
+            try builder.assemble(from: makeBridgedConfig(), bundleURL: bundleURL, validate: false)
+        } throws: { error in
+            guard let e = error as? ConfigurationBuilderError,
+                case .noBridgeableInterface = e
+            else { return false }
+            return true
+        }
+    }
+
+    @Test("Bridged mode in a build without the entitlement names the entitlement, not the interface")
+    func bridgedModeWithoutTheEntitlementThrows() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        var builder = ConfigurationBuilder()
+        builder.bridgedInterfaces = MockBridgedInterfaceProvider()
+        builder.entitlements = EntitlementService(reader: MockEntitlementReader())
+
+        #expect {
+            try builder.assemble(from: makeBridgedConfig(), bundleURL: bundleURL, validate: false)
+        } throws: { error in
+            guard let e = error as? ConfigurationBuilderError,
+                case .bridgedNetworkingNotEntitled = e
+            else { return false }
+            return true
+        }
     }
 
     // MARK: - Input Devices

--- a/KernovaTests/EntitlementServiceTests.swift
+++ b/KernovaTests/EntitlementServiceTests.swift
@@ -4,20 +4,16 @@ import Testing
 
 @Suite("EntitlementService")
 struct EntitlementServiceTests {
-    private struct FakeReader: EntitlementReading {
-        let granted: Set<String>
-        func hasEntitlement(_ key: String) -> Bool { granted.contains(key) }
-    }
-
     @Test("hasVMNetworking is true exactly when the signature claims com.apple.vm.networking")
     func vmNetworkingReflectsReader() {
         #expect(
-            EntitlementService(reader: FakeReader(granted: ["com.apple.vm.networking"]))
+            EntitlementService(reader: MockEntitlementReader(granted: ["com.apple.vm.networking"]))
                 .hasVMNetworking)
-        #expect(!EntitlementService(reader: FakeReader(granted: [])).hasVMNetworking)
+        #expect(!EntitlementService(reader: MockEntitlementReader()).hasVMNetworking)
         #expect(
-            !EntitlementService(reader: FakeReader(granted: ["com.apple.security.app-sandbox"]))
-                .hasVMNetworking)
+            !EntitlementService(
+                reader: MockEntitlementReader(granted: ["com.apple.security.app-sandbox"])
+            ).hasVMNetworking)
     }
 
     @Test("The process reader reports an unclaimed key as absent")

--- a/KernovaTests/Mocks/MockBridgedInterfaceProvider.swift
+++ b/KernovaTests/Mocks/MockBridgedInterfaceProvider.swift
@@ -1,0 +1,20 @@
+@testable import Kernova
+
+/// Scripted stand-in for `BridgedInterfaceProviding`, so tests resolve a bridged
+/// interface off a fixed list rather than the host's live one.
+///
+/// Both values stay mutable so a test can change what the host offers between
+/// menu rebuilds; `@unchecked Sendable` covers the nonisolated protocol, and
+/// every test touching one runs on the main thread.
+final class MockBridgedInterfaceProvider: BridgedInterfaceProviding, @unchecked Sendable {
+    var available: [BridgedInterface]
+    var primary: String?
+
+    init(available: [BridgedInterface] = [], primary: String? = nil) {
+        self.available = available
+        self.primary = primary
+    }
+
+    func interfaces() -> [BridgedInterface] { available }
+    func primaryInterfaceIdentifier() -> String? { primary }
+}

--- a/KernovaTests/Mocks/MockEntitlementReader.swift
+++ b/KernovaTests/Mocks/MockEntitlementReader.swift
@@ -1,0 +1,9 @@
+@testable import Kernova
+
+/// Stand-in for `EntitlementReading` answering from an explicit key set.
+struct MockEntitlementReader: EntitlementReading {
+    /// Keys the signature is treated as claiming with a `true` value.
+    var granted: Set<String> = []
+
+    func hasEntitlement(_ key: String) -> Bool { granted.contains(key) }
+}

--- a/KernovaTests/ReviewContentViewControllerTests.swift
+++ b/KernovaTests/ReviewContentViewControllerTests.swift
@@ -18,15 +18,20 @@ struct ReviewContentViewControllerTests {
         #expect(findLabel(withText: "\(vm.cpuCount)", in: vc.view) != nil)
     }
 
-    @Test("Networking row reflects the disabled state")
+    @Test("The network Mode row names the mode a new VM starts in")
     func networkingReflectsModel() {
         let vm = VMCreationViewModel()
-        vm.networkEnabled = false
-        let vc = ReviewContentViewController(creationVM: vm)
-        vc.loadViewIfNeeded()
+        #expect(vm.networkEnabled)
+        let sharedVC = ReviewContentViewController(creationVM: vm)
+        sharedVC.loadViewIfNeeded()
+        #expect(findLabel(withText: "Shared Network", in: sharedVC.view) != nil)
+        #expect(findLabel(withText: "None", in: sharedVC.view) == nil)
 
-        #expect(findLabel(withText: "Disabled", in: vc.view) != nil)
-        #expect(findLabel(withText: "Enabled", in: vc.view) == nil)
+        vm.networkEnabled = false
+        let noneVC = ReviewContentViewController(creationVM: vm)
+        noneVC.loadViewIfNeeded()
+        #expect(findLabel(withText: "None", in: noneVC.view) != nil)
+        #expect(findLabel(withText: "Shared Network", in: noneVC.view) == nil)
     }
 
     @Test("macOS + download shows the abbreviated save-to path")

--- a/KernovaTests/VMConfigurationCloneTests.swift
+++ b/KernovaTests/VMConfigurationCloneTests.swift
@@ -130,8 +130,24 @@ struct VMConfigurationCloneTests {
         let clone = original.clonedForNewInstance(existingNames: [])
 
         #expect(clone.networkEnabled == true)
+        #expect(clone.networkMode == .shared)
         // macAddress is copied as-is; caller regenerates it
         #expect(clone.macAddress == "aa:bb:cc:dd:ee:ff")
+    }
+
+    @Test("Clone preserves the bridged mode and its interface")
+    func clonePreservesBridgedInterface() {
+        let original = VMConfiguration(
+            name: "Test",
+            guestOS: .linux,
+            bootMode: .efi,
+            networkMode: .bridged,
+            bridgedInterfaceIdentifier: "en0"
+        )
+        let clone = original.clonedForNewInstance(existingNames: [])
+
+        #expect(clone.networkMode == .bridged)
+        #expect(clone.bridgedInterfaceIdentifier == "en0")
     }
 
     @Test("Clone preserves guest OS and boot mode")

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -1168,6 +1168,60 @@ struct VMConfigurationTests {
         #expect(decoded.audioOutputEnabled == true)
     }
 
+    // MARK: - Network Mode Tests
+
+    @Test("networkMode defaults to shared with no bridged interface")
+    func networkModeDefaults() {
+        let config = VMConfiguration(name: "Test VM", guestOS: .linux, bootMode: .efi)
+        #expect(config.networkMode == .shared)
+        #expect(config.bridgedInterfaceIdentifier == nil)
+    }
+
+    @Test("A config carrying neither network key decodes as Shared Network")
+    func networkModeKeysMissingUseDefaults() throws {
+        // `makeBaseJSON` carries `networkEnabled` but neither mode key.
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
+
+        #expect(decoded.networkEnabled == true)
+        #expect(decoded.networkMode == .shared)
+        #expect(decoded.bridgedInterfaceIdentifier == nil)
+    }
+
+    @Test("Configuration preserves a bridged mode and its interface")
+    func bridgedModeRoundTrip() throws {
+        let config = VMConfiguration(
+            name: "Bridged VM",
+            guestOS: .linux,
+            bootMode: .efi,
+            networkMode: .bridged,
+            bridgedInterfaceIdentifier: "en0"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(config)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: data)
+
+        #expect(decoded.networkMode == .bridged)
+        #expect(decoded.bridgedInterfaceIdentifier == "en0")
+    }
+
+    @Test("A bridged config decodes Automatic from a stored mode without an interface")
+    func bridgedModeWithoutInterfaceDecodesAutomatic() throws {
+        let json = Self.makeBaseJSON(extraFields: "\"networkMode\": \"bridged\"")
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: Data(json.utf8))
+
+        #expect(decoded.networkMode == .bridged)
+        #expect(decoded.bridgedInterfaceIdentifier == nil)
+    }
+
     // MARK: - Full-field round-trip
 
     /// Populates every property with a non-default value, encodes to JSON,
@@ -1199,6 +1253,8 @@ struct VMConfigurationTests {
             displayPreference: .popOut,
             lastFullscreenDisplayID: 0xDEAD_BEEF,
             networkEnabled: false,
+            networkMode: .bridged,
+            bridgedInterfaceIdentifier: "en1",
             macAddress: "aa:bb:cc:dd:ee:ff",
             clipboardSharingEnabled: true,
             clipboardPassthroughEnabled: true,

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Testing
+import Virtualization
 
 @testable import Kernova
 
@@ -809,26 +810,6 @@ struct VMSettingsViewControllerTests {
 
     // MARK: - Network mode picker
 
-    /// A bridgeable-interface list the test can change between menu rebuilds.
-    @MainActor
-    private final class FakeBridgedInterfaceProvider: BridgedInterfaceProviding {
-        var available: [BridgedInterface]
-        var primary: String?
-
-        init(available: [BridgedInterface] = [], primary: String? = nil) {
-            self.available = available
-            self.primary = primary
-        }
-
-        func interfaces() -> [BridgedInterface] { available }
-        func primaryInterfaceIdentifier() -> String? { primary }
-    }
-
-    private struct FakeEntitlementReader: EntitlementReading {
-        let granted: Set<String>
-        func hasEntitlement(_ key: String) -> Bool { granted.contains(key) }
-    }
-
     private static let wiFi = BridgedInterface(identifier: "en0", localizedDisplayName: "Wi-Fi")
     private static let ethernet = BridgedInterface(
         identifier: "en1", localizedDisplayName: "Ethernet")
@@ -838,7 +819,7 @@ struct VMSettingsViewControllerTests {
         mode: VMNetworkMode = .shared,
         bridgedInterfaceIdentifier: String? = nil,
         macAddress: String? = "aa:bb:cc:dd:ee:ff",
-        interfaces: FakeBridgedInterfaceProvider = FakeBridgedInterfaceProvider(),
+        interfaces: MockBridgedInterfaceProvider = MockBridgedInterfaceProvider(),
         entitled: Bool = true,
         isReadOnly: Bool = false
     ) -> (VMSettingsViewController, VMInstance) {
@@ -853,7 +834,7 @@ struct VMSettingsViewControllerTests {
             instance: instance, viewModel: makeViewModel(), isReadOnly: isReadOnly,
             bridgedInterfaces: interfaces,
             entitlements: EntitlementService(
-                reader: FakeEntitlementReader(
+                reader: MockEntitlementReader(
                     granted: entitled ? ["com.apple.vm.networking"] : [])))
         vc.loadViewIfNeeded()
         vc.viewDidAppear()
@@ -874,7 +855,7 @@ struct VMSettingsViewControllerTests {
     @Test("An entitled build lists a Bridged section with Automatic and each interface")
     func entitledPickerListsBridgedInterfaces() throws {
         let (vc, _) = makeNetworkController(
-            interfaces: FakeBridgedInterfaceProvider(
+            interfaces: MockBridgedInterfaceProvider(
                 available: [Self.wiFi, Self.ethernet], primary: "en0"))
 
         let popUp = try #require(networkModePopUp(in: vc.view))
@@ -889,7 +870,7 @@ struct VMSettingsViewControllerTests {
     @Test("An unentitled build offers no bridged entries")
     func unentitledPickerOmitsBridgedEntries() throws {
         let (vc, _) = makeNetworkController(
-            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi]), entitled: false)
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi]), entitled: false)
 
         let popUp = try #require(networkModePopUp(in: vc.view))
         #expect(popUp.itemTitles == ["Shared Network", "None"])
@@ -909,7 +890,7 @@ struct VMSettingsViewControllerTests {
 
     @Test("The interface list is rebuilt each time the menu opens")
     func menuRebuildPicksUpNewInterfaces() throws {
-        let provider = FakeBridgedInterfaceProvider(available: [Self.wiFi])
+        let provider = MockBridgedInterfaceProvider(available: [Self.wiFi])
         let (vc, _) = makeNetworkController(interfaces: provider)
         let popUp = try #require(networkModePopUp(in: vc.view))
         #expect(!popUp.itemTitles.contains("Ethernet (en1)"))
@@ -945,7 +926,7 @@ struct VMSettingsViewControllerTests {
     @Test("Choosing an interface sets the bridged mode and the interface in one gesture")
     func selectingInterfaceWritesModeAndIdentifier() throws {
         let (vc, instance) = makeNetworkController(
-            interfaces: FakeBridgedInterfaceProvider(
+            interfaces: MockBridgedInterfaceProvider(
                 available: [Self.wiFi, Self.ethernet], primary: "en0"))
         let popUp = try #require(networkModePopUp(in: vc.view))
 
@@ -961,7 +942,7 @@ struct VMSettingsViewControllerTests {
     func selectingAutomaticClearsTheInterface() throws {
         let (vc, instance) = makeNetworkController(
             mode: .bridged, bridgedInterfaceIdentifier: "en1",
-            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi, Self.ethernet]))
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi, Self.ethernet]))
         let popUp = try #require(networkModePopUp(in: vc.view))
 
         popUp.selectItem(withTitle: "Automatic")
@@ -975,7 +956,7 @@ struct VMSettingsViewControllerTests {
     func selectingSharedRemembersTheInterface() throws {
         let (vc, instance) = makeNetworkController(
             mode: .bridged, bridgedInterfaceIdentifier: "en1",
-            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi, Self.ethernet]))
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi, Self.ethernet]))
         let popUp = try #require(networkModePopUp(in: vc.view))
 
         popUp.selectItem(withTitle: "Shared Network")
@@ -990,7 +971,7 @@ struct VMSettingsViewControllerTests {
     func absentPersistedInterfaceRendersAsUnavailable() throws {
         let (vc, _) = makeNetworkController(
             mode: .bridged, bridgedInterfaceIdentifier: "en9",
-            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi]))
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi]))
 
         let popUp = try #require(networkModePopUp(in: vc.view))
         let item = try #require(popUp.menu?.items.first { $0.title == "en9 (unavailable)" })
@@ -1002,7 +983,7 @@ struct VMSettingsViewControllerTests {
     func rememberedInterfaceAddsNoEntryWhileShared() throws {
         let (vc, _) = makeNetworkController(
             mode: .shared, bridgedInterfaceIdentifier: "en9",
-            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi]))
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi]))
 
         let popUp = try #require(networkModePopUp(in: vc.view))
         #expect(popUp.menu?.items.first { $0.title == "en9 (unavailable)" } == nil)
@@ -1018,10 +999,50 @@ struct VMSettingsViewControllerTests {
         #expect(popUp.menu?.items.first { $0.title == "Bridged (unavailable)" }?.isEnabled == false)
     }
 
+    @Test("Turning networking on gives a VM without a MAC address a stable one")
+    func enablingNetworkingMintsAMACAddress() throws {
+        // Shared Network, from a VM created with networking off.
+        let (sharedVC, sharedInstance) = makeNetworkController(
+            networkEnabled: false, macAddress: nil,
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi], primary: "en0"))
+        let sharedPopUp = try #require(networkModePopUp(in: sharedVC.view))
+
+        sharedPopUp.selectItem(withTitle: "Shared Network")
+        sharedPopUp.sendAction(sharedPopUp.action, to: sharedPopUp.target)
+
+        let sharedMAC = try #require(sharedInstance.configuration.macAddress)
+        #expect(VZMACAddress(string: sharedMAC) != nil)
+
+        // Bridged, from the same starting state.
+        let (bridgedVC, bridgedInstance) = makeNetworkController(
+            networkEnabled: false, macAddress: nil,
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi], primary: "en0"))
+        let bridgedPopUp = try #require(networkModePopUp(in: bridgedVC.view))
+
+        bridgedPopUp.selectItem(withTitle: "Wi-Fi (en0)")
+        bridgedPopUp.sendAction(bridgedPopUp.action, to: bridgedPopUp.target)
+
+        #expect(bridgedInstance.configuration.bridgedInterfaceIdentifier == "en0")
+        let bridgedMAC = try #require(bridgedInstance.configuration.macAddress)
+        #expect(VZMACAddress(string: bridgedMAC) != nil)
+    }
+
+    @Test("A VM that already carries a MAC address keeps it")
+    func enablingNetworkingKeepsAnExistingMACAddress() throws {
+        let (vc, instance) = makeNetworkController(
+            networkEnabled: false, macAddress: "aa:bb:cc:dd:ee:ff")
+        let popUp = try #require(networkModePopUp(in: vc.view))
+
+        popUp.selectItem(withTitle: "Shared Network")
+        popUp.sendAction(popUp.action, to: popUp.target)
+
+        #expect(instance.configuration.macAddress == "aa:bb:cc:dd:ee:ff")
+    }
+
     @Test("Read-only disables the Mode picker")
     func readOnlyDisablesTheModePicker() throws {
         let (vc, _) = makeNetworkController(
-            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi]), isReadOnly: true)
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi]), isReadOnly: true)
         #expect(networkModePopUp(in: vc.view)?.isEnabled == false)
     }
 

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -289,9 +289,8 @@ struct VMSettingsViewControllerTests {
     func readOnlyDisablesLockableControls() {
         let (vc, _, _) = makeController(guestOS: .macOS, isReadOnly: true)
 
-        // Networking is lockable → disabled while read-only.
-        let network = firstSwitch(action: "networkToggled", in: vc.view)
-        #expect(network?.isEnabled == false)
+        // The network Mode picker is lockable → disabled while read-only.
+        #expect(networkModePopUp(in: vc.view)?.isEnabled == false)
 
         // Clipboard is hot-toggleable → stays enabled.
         let clipboard = firstSwitch(action: "clipboardToggled", in: vc.view)
@@ -301,8 +300,7 @@ struct VMSettingsViewControllerTests {
     @Test("Lockable controls are enabled when editable")
     func editableEnablesLockableControls() {
         let (vc, _, _) = makeController(guestOS: .macOS, isReadOnly: false)
-        let network = firstSwitch(action: "networkToggled", in: vc.view)
-        #expect(network?.isEnabled == true)
+        #expect(networkModePopUp(in: vc.view)?.isEnabled == true)
     }
 
     @Test("Lock icons are visible only while read-only")
@@ -333,21 +331,6 @@ struct VMSettingsViewControllerTests {
         clipboard.sendAction(clipboard.action, to: clipboard.target)
 
         #expect(instance.configuration.clipboardSharingEnabled == true)
-    }
-
-    @Test("Toggling Networking writes back to the configuration")
-    func networkToggleWritesConfig() {
-        let (vc, instance, _) = makeController(guestOS: .linux, isReadOnly: false)
-        let initial = instance.configuration.networkEnabled
-
-        guard let network = firstSwitch(action: "networkToggled", in: vc.view) else {
-            Issue.record("Expected a networking switch")
-            return
-        }
-        network.state = initial ? .off : .on
-        network.sendAction(network.action, to: network.target)
-
-        #expect(instance.configuration.networkEnabled == !initial)
     }
 
     // MARK: - Clipboard passthrough
@@ -824,7 +807,231 @@ struct VMSettingsViewControllerTests {
         #expect(!visibleLabel(caption, in: editableVC.view))
     }
 
+    // MARK: - Network mode picker
+
+    /// A bridgeable-interface list the test can change between menu rebuilds.
+    @MainActor
+    private final class FakeBridgedInterfaceProvider: BridgedInterfaceProviding {
+        var available: [BridgedInterface]
+        var primary: String?
+
+        init(available: [BridgedInterface] = [], primary: String? = nil) {
+            self.available = available
+            self.primary = primary
+        }
+
+        func interfaces() -> [BridgedInterface] { available }
+        func primaryInterfaceIdentifier() -> String? { primary }
+    }
+
+    private struct FakeEntitlementReader: EntitlementReading {
+        let granted: Set<String>
+        func hasEntitlement(_ key: String) -> Bool { granted.contains(key) }
+    }
+
+    private static let wiFi = BridgedInterface(identifier: "en0", localizedDisplayName: "Wi-Fi")
+    private static let ethernet = BridgedInterface(
+        identifier: "en1", localizedDisplayName: "Ethernet")
+
+    private func makeNetworkController(
+        networkEnabled: Bool = true,
+        mode: VMNetworkMode = .shared,
+        bridgedInterfaceIdentifier: String? = nil,
+        macAddress: String? = "aa:bb:cc:dd:ee:ff",
+        interfaces: FakeBridgedInterfaceProvider = FakeBridgedInterfaceProvider(),
+        entitled: Bool = true,
+        isReadOnly: Bool = false
+    ) -> (VMSettingsViewController, VMInstance) {
+        let config = VMConfiguration(
+            name: "Test VM", guestOS: .linux, bootMode: .efi,
+            networkEnabled: networkEnabled, networkMode: mode,
+            bridgedInterfaceIdentifier: bridgedInterfaceIdentifier, macAddress: macAddress)
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(config.id.uuidString, isDirectory: true)
+        let instance = VMInstance(configuration: config, bundleURL: bundleURL)
+        let vc = VMSettingsViewController(
+            instance: instance, viewModel: makeViewModel(), isReadOnly: isReadOnly,
+            bridgedInterfaces: interfaces,
+            entitlements: EntitlementService(
+                reader: FakeEntitlementReader(
+                    granted: entitled ? ["com.apple.vm.networking"] : [])))
+        vc.loadViewIfNeeded()
+        vc.viewDidAppear()
+        return (vc, instance)
+    }
+
+    @Test("The Mode picker replaces the networking switch and offers Shared Network and None")
+    func modePickerOffersSharedAndNone() throws {
+        let (vc, _) = makeNetworkController(entitled: false)
+        #expect(containsLabel("Mode", in: vc.view))
+        #expect(!containsLabel("Networking Enabled", in: vc.view))
+
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        #expect(popUp.itemTitles == ["Shared Network", "None"])
+        #expect(popUp.titleOfSelectedItem == "Shared Network")
+    }
+
+    @Test("An entitled build lists a Bridged section with Automatic and each interface")
+    func entitledPickerListsBridgedInterfaces() throws {
+        let (vc, _) = makeNetworkController(
+            interfaces: FakeBridgedInterfaceProvider(
+                available: [Self.wiFi, Self.ethernet], primary: "en0"))
+
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        #expect(
+            popUp.itemTitles == [
+                "Shared Network", "None", "Bridged", "Automatic", "Wi-Fi (en0)", "Ethernet (en1)",
+            ])
+        let header = try #require(popUp.menu?.items.first { $0.title == "Bridged" })
+        #expect(header.isSectionHeader)
+    }
+
+    @Test("An unentitled build offers no bridged entries")
+    func unentitledPickerOmitsBridgedEntries() throws {
+        let (vc, _) = makeNetworkController(
+            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi]), entitled: false)
+
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        #expect(popUp.itemTitles == ["Shared Network", "None"])
+    }
+
+    @Test("A host with nothing to bridge over shows one disabled placeholder")
+    func emptyInterfaceListShowsDisabledPlaceholder() throws {
+        let (vc, _) = makeNetworkController()
+
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        let placeholder = try #require(
+            popUp.menu?.items.first { $0.title == "No Bridgeable Interfaces" })
+        #expect(!placeholder.isEnabled)
+        // Automatic stays offered: it resolves at start, when an interface may be back.
+        #expect(popUp.itemTitles.contains("Automatic"))
+    }
+
+    @Test("The interface list is rebuilt each time the menu opens")
+    func menuRebuildPicksUpNewInterfaces() throws {
+        let provider = FakeBridgedInterfaceProvider(available: [Self.wiFi])
+        let (vc, _) = makeNetworkController(interfaces: provider)
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        #expect(!popUp.itemTitles.contains("Ethernet (en1)"))
+
+        provider.available = [Self.wiFi, Self.ethernet]
+        vc.menuNeedsUpdate(try #require(popUp.menu))
+
+        #expect(popUp.itemTitles.contains("Ethernet (en1)"))
+    }
+
+    @Test("Choosing None writes the mode, hides the MAC row, and says there's no device")
+    func selectingNoneWritesConfigAndEmptiesTheCard() throws {
+        let (vc, instance) = makeNetworkController()
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        #expect(visibleLabel("MAC Address", in: vc.view))
+
+        popUp.selectItem(withTitle: "None")
+        popUp.sendAction(popUp.action, to: popUp.target)
+
+        #expect(instance.configuration.networkEnabled == false)
+        #expect(!visibleLabel("MAC Address", in: vc.view))
+        #expect(visibleLabel("This virtual machine has no network device.", in: vc.view))
+    }
+
+    @Test("A VM with no network device builds with the caption already showing")
+    func noneModeBuildsWithTheCaptionShowing() throws {
+        let (vc, _) = makeNetworkController(networkEnabled: false)
+        #expect(!visibleLabel("MAC Address", in: vc.view))
+        #expect(visibleLabel("This virtual machine has no network device.", in: vc.view))
+        #expect(networkModePopUp(in: vc.view)?.titleOfSelectedItem == "None")
+    }
+
+    @Test("Choosing an interface sets the bridged mode and the interface in one gesture")
+    func selectingInterfaceWritesModeAndIdentifier() throws {
+        let (vc, instance) = makeNetworkController(
+            interfaces: FakeBridgedInterfaceProvider(
+                available: [Self.wiFi, Self.ethernet], primary: "en0"))
+        let popUp = try #require(networkModePopUp(in: vc.view))
+
+        popUp.selectItem(withTitle: "Ethernet (en1)")
+        popUp.sendAction(popUp.action, to: popUp.target)
+
+        #expect(instance.configuration.networkEnabled == true)
+        #expect(instance.configuration.networkMode == .bridged)
+        #expect(instance.configuration.bridgedInterfaceIdentifier == "en1")
+    }
+
+    @Test("Choosing Automatic clears the persisted interface")
+    func selectingAutomaticClearsTheInterface() throws {
+        let (vc, instance) = makeNetworkController(
+            mode: .bridged, bridgedInterfaceIdentifier: "en1",
+            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi, Self.ethernet]))
+        let popUp = try #require(networkModePopUp(in: vc.view))
+
+        popUp.selectItem(withTitle: "Automatic")
+        popUp.sendAction(popUp.action, to: popUp.target)
+
+        #expect(instance.configuration.networkMode == .bridged)
+        #expect(instance.configuration.bridgedInterfaceIdentifier == nil)
+    }
+
+    @Test("Going back to Shared Network keeps the interface for the next bridged choice")
+    func selectingSharedRemembersTheInterface() throws {
+        let (vc, instance) = makeNetworkController(
+            mode: .bridged, bridgedInterfaceIdentifier: "en1",
+            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi, Self.ethernet]))
+        let popUp = try #require(networkModePopUp(in: vc.view))
+
+        popUp.selectItem(withTitle: "Shared Network")
+        popUp.sendAction(popUp.action, to: popUp.target)
+
+        #expect(instance.configuration.networkEnabled == true)
+        #expect(instance.configuration.networkMode == .shared)
+        #expect(instance.configuration.bridgedInterfaceIdentifier == "en1")
+    }
+
+    @Test("An interface the host no longer offers stays visible as the selection")
+    func absentPersistedInterfaceRendersAsUnavailable() throws {
+        let (vc, _) = makeNetworkController(
+            mode: .bridged, bridgedInterfaceIdentifier: "en9",
+            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi]))
+
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        let item = try #require(popUp.menu?.items.first { $0.title == "en9 (unavailable)" })
+        #expect(!item.isEnabled)
+        #expect(popUp.titleOfSelectedItem == "en9 (unavailable)")
+    }
+
+    @Test("An identifier remembered from an earlier bridged choice adds no entry")
+    func rememberedInterfaceAddsNoEntryWhileShared() throws {
+        let (vc, _) = makeNetworkController(
+            mode: .shared, bridgedInterfaceIdentifier: "en9",
+            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi]))
+
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        #expect(popUp.menu?.items.first { $0.title == "en9 (unavailable)" } == nil)
+        #expect(popUp.titleOfSelectedItem == "Shared Network")
+    }
+
+    @Test("An unentitled build still reports a bridged VM's mode")
+    func unentitledBuildReportsABridgedVM() throws {
+        let (vc, _) = makeNetworkController(mode: .bridged, entitled: false)
+
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        #expect(popUp.titleOfSelectedItem == "Bridged (unavailable)")
+        #expect(popUp.menu?.items.first { $0.title == "Bridged (unavailable)" }?.isEnabled == false)
+    }
+
+    @Test("Read-only disables the Mode picker")
+    func readOnlyDisablesTheModePicker() throws {
+        let (vc, _) = makeNetworkController(
+            interfaces: FakeBridgedInterfaceProvider(available: [Self.wiFi]), isReadOnly: true)
+        #expect(networkModePopUp(in: vc.view)?.isEnabled == false)
+    }
+
     // MARK: - Helpers (view-tree introspection)
+
+    private func networkModePopUp(in view: NSView) -> NSPopUpButton? {
+        firstSubview(NSPopUpButton.self, in: view) {
+            $0.action.map(NSStringFromSelector) == "networkModeChanged"
+        }
+    }
 
     private func firstSwitch(action name: String, in view: NSView) -> NSSwitch? {
         firstSubview(NSSwitch.self, in: view) { $0.action.map(NSStringFromSelector) == name }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,6 +124,10 @@ substitute mocks. Services split by concurrency: those that touch
 single VZ-facing translation point, covering boot loader, CPU, memory, storage, network, display,
 input, audio, the Linux SPICE console port, and the macOS `VZVirtioSocketDeviceConfiguration`.
 
+The network attachment follows the VM's persisted mode: shared NAT, or bridged over a host
+interface resolved through `BridgedInterfaceProviding` — the same seam the settings section's Mode
+picker reads its interface list from.
+
 **VZ is only ever handed symlink-resolved URLs.** VZ resolves no symlinks and rejects a path
 containing one in any component, reporting it as a missing or invalid file while `FileManager`
 reports the file present and readable. `ConfigurationBuilder` and `MacOSInstallService` resolve


### PR DESCRIPTION
Closes #812

## Summary
- Adds bridged networking as a per-VM mode alongside shared (NAT), implementing #812's slice of the end-state design in `docs/research/2026-08-12-network-settings-ui.md`: the Mode picker replaces the "Networking Enabled" switch, the wizard Review copy changes, and the section's info popover is rewritten for modes.
- **Model:** `networkMode` (`shared`/`bridged`, existing configs decode as shared via `decodeIfPresent ?? .shared`) plus `bridgedInterfaceIdentifier` (nil = Automatic). `networkEnabled` is untouched and `false` remains the None mode, exactly as the design note maps it — no migration surface.
- **Builder:** `configureNetwork` selects the attachment from the mode. Bridged resolves the persisted identifier against `VZBridgedNetworkInterface.networkInterfaces`; an absent interface narrows to Automatic (the default-route interface via the SystemConfiguration dynamic store, else the first bridgeable one) per NETWORKING.md principle 2, and with nothing to bridge over the start fails with a new `noBridgeableInterface` error rather than quietly becoming Shared Network.
- **Picker:** Shared Network / None, then an entitlement-gated Bridged section (header + Automatic + `Wi-Fi (en0)`-style entries) rebuilt from live host state each time the menu opens (`NSMenuDelegate`). An absent persisted interface renders as a disabled `en9 (unavailable)` selection; an empty list renders one disabled "No Bridgeable Interfaces" item; None hides the MAC row and shows "This virtual machine has no network device." Locking stays baseline (whole section locks while running); the live-switch surface is #813.

## Deviations from the design note
- The unentitled-build picker reduction (design item 9) is nominally #811's slice, but #811 merged as the signing chore before any picker existed — the reduction ships here with the picker's introduction (NETWORKING.md principle 8). An unentitled build showing a VM already configured as bridged renders one disabled "Bridged (unavailable)" entry so the picker doesn't misreport the mode.
- The Review step row is `Mode: Shared Network` / `Mode: None` inside the existing "Network" section — the note's `Network: Shared Network` phrasing kept its section-plus-row structure, and "Mode" mirrors the settings card's row label.

## Changes
- `Kernova/Models/VMConfiguration.swift` — `VMNetworkMode`, two persisted fields
- `Kernova/Services/BridgedNetworking.swift` (new) — `BridgedInterface`, `BridgedInterfaceProviding`, `HostBridgedInterfaceProvider` (VZ list + SCDynamicStore primary), pure `BridgedInterfaceSelection.choose`
- `Kernova/Services/ConfigurationBuilder.swift` — mode-driven attachment, `noBridgeableInterface`
- `Kernova/Views/Detail/VMSettingsViewController.swift` — Mode picker, rebuild-on-open, entitlement gating, None caption, popover rewrite; injectable interface provider + entitlement service (defaults keep call sites unchanged)
- `Kernova/Views/Creation/ReviewContentViewController.swift` — Review row copy
- `docs/ARCHITECTURE.md` — one-sentence attachment-selection note
- Tests: config decode/round-trip/clone, builder network coverage (previously zero), new selection suite, 13 picker tests over fake provider/entitlements, review-step copy

## Test plan
- [x] `make test` — full suite green
- [x] `make test-suite SUITE=KernovaTests/VMSettingsViewControllerTests` — 60 passed
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAZW5GddM7F9Bab7kMMj1R