### PR TITLE
chore: Slim Config xcconfig comments and declare DEVELOPMENT_TEAM in Base

### DIFF
--- a/Config/Base.xcconfig
+++ b/Config/Base.xcconfig
@@ -1,29 +1,20 @@
 // Project-level base configuration, wired to both the Debug and Release
-// project XCBuildConfigurations (targets without their own
-// baseConfigurationReference inherit it).
-//
-// DEVELOPMENT_TEAM and the CODE_SIGN_IDENTITY override live in the
-// gitignored, hand-maintained Local.xcconfig included below — see
-// docs/BUILD.md "Signing identity".
-//
-// `#include?` (with the trailing `?`) is the optional form: it silently
-// no-ops when Local.xcconfig doesn't exist, so a fresh clone builds with
-// neither a team nor a certificate.
+// project XCBuildConfigurations. Signing overrides live in the gitignored
+// Local.xcconfig included below — docs/BUILD.md "Signing identity" owns the
+// full story.
 
-// The default signing identity, ad-hoc. The relaunch helper (re-signed at
-// export) and the guest agent (its own Developer ID lane) pin Release at
-// target level, which outranks this file; the app and both test bundles
-// leave Release unpinned so the Local.xcconfig override below reaches them —
-// an entitled archive needs the real identity, and a test bundle must sign
-// with the same team as its now team-signed host to pass library validation.
+// Ad-hoc, so a fresh clone builds with no team or certificate.
 CODE_SIGN_IDENTITY = -
 
-// The app target's CODE_SIGN_ENTITLEMENTS, both configurations. The default
+// Empty on purpose: ad-hoc signing uses no team, and there is no value that
+// isn't someone's personal team ID.
+DEVELOPMENT_TEAM =
+
+// The app target's CODE_SIGN_ENTITLEMENTS, both configurations. The
 // Development variant omits the restricted com.apple.vm.networking key an
-// ad-hoc signature cannot carry, keeping a profile-less checkout building
-// in both configurations. Local.xcconfig opts a machine holding the
-// capability-enabled profile into the full Kernova.entitlements set — see
-// docs/BUILD.md "Signing identity".
+// ad-hoc signature cannot carry.
 KERNOVA_APP_ENTITLEMENTS = Kernova/Resources/Kernova.Development.entitlements
 
+// `#include?` (trailing `?`) is the optional form: it silently no-ops when
+// Local.xcconfig doesn't exist.
 #include? "Local.xcconfig"

--- a/Config/Local.xcconfig.example
+++ b/Config/Local.xcconfig.example
@@ -1,6 +1,6 @@
 // Template for the gitignored Config/Local.xcconfig — copy it there and set
-// your team. See docs/BUILD.md "Signing identity".
-//
+// your team. docs/BUILD.md "Signing identity" explains each setting.
+
 // The team ID is the OU of your signing certificate. On an Apple Development
 // certificate the CN parenthetical is a per-developer identifier that looks
 // like a team ID but isn't, so read OU rather than the name:
@@ -8,17 +8,13 @@
 //     | openssl x509 -noout -subject
 DEVELOPMENT_TEAM = ABCDE12345
 
-// Signs Debug with your development certificate rather than ad-hoc, giving
-// the app one code identity across rebuilds so macOS privacy grants stick.
-// Drop the line to sign ad-hoc; keep it alongside DEVELOPMENT_TEAM, since
-// automatic signing resolves the certificate through the team.
+// Signs Debug with your development certificate rather than ad-hoc, so macOS
+// privacy grants stick across rebuilds. Keep it alongside DEVELOPMENT_TEAM
+// (automatic signing resolves the certificate through the team); drop the
+// line to sign ad-hoc.
 CODE_SIGN_IDENTITY = Apple Development
 
-// Opts the app (both configurations) into the full entitlement set,
-// including the restricted com.apple.vm.networking key, which automatic
-// signing must authorize through a capability-enabled profile — uncomment
-// only with the capability enabled on the team's App ID and a certificate
-// set above; otherwise the default (the Development variant, set in
-// Base.xcconfig) keeps profile-less builds signing. Archives inherit the
-// choice: comment it back out to cut an unentitled build.
+// Uncomment to opt the app into the full entitlement set, including the
+// restricted com.apple.vm.networking key — only with the capability enabled
+// on the team's App ID and a certificate set above.
 // KERNOVA_APP_ENTITLEMENTS = Kernova/Resources/Kernova.entitlements


### PR DESCRIPTION
## Summary
- Trims the comment prose in `Config/Base.xcconfig` and `Config/Local.xcconfig.example` down to what is local to each file. Both were retelling the signing/entitlements story that docs/BUILD.md "Signing identity" owns — the ad-hoc default rationale, target-level Release pinning, and the entitled-archive/test-bundle reasoning all drop; each file keeps only per-setting one-liners, the `#include?` trailing-`?` semantics (Base), and the OU-not-CN certificate tip with its `security find-certificate` command (example), which BUILD.md does not hold.
- Declares `DEVELOPMENT_TEAM =` (empty) in Base.xcconfig so all three override knobs are visible in one place. Empty is the real default — ad-hoc signing uses no team, and any concrete value would be someone's personal team ID (removed deliberately in #484). The assignment precedes the `#include?`, so a Local.xcconfig override still wins.

## Changes
- `Config/Base.xcconfig`
- `Config/Local.xcconfig.example`

## Test plan
- [x] `make build` succeeds with a populated Local.xcconfig; override still wins (`_DEVELOPMENT_TEAM_IS_EMPTY=NO`, all targets signed with the Apple Development identity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013csq1woJ4d4YmWt9uZAMNT