### PR TITLE
feat: Recover the network attachment on host link changes

### DIFF
--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -502,12 +502,11 @@ final class VMInstance {
             device: VZNetworkDeviceHandle(device: device),
             interfaces: HostBridgedInterfaceProvider(),
             linkObserver: HostNetworkLinkObserver(),
-            choice: { [weak self] in
-                guard let self, self.configuration.networkEnabled else { return nil }
-                return NetworkChoice(
-                    mode: self.configuration.networkMode,
-                    bridgedInterfaceIdentifier: self.configuration.bridgedInterfaceIdentifier)
+            isEligible: { [weak self] in
+                guard let self else { return false }
+                return self.status == .running || self.status == .paused
             },
+            choice: { [weak self] in self?.configuration.networkChoice },
             onPendingChange: { [weak self] pending in
                 self?.networkAttachmentPending = pending
             })

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -247,6 +247,17 @@ final class VMInstance {
 
     private var delegateAdapter: VMDelegateAdapter?
 
+    // MARK: - Network Attachment Recovery
+
+    /// Keeps the live network attachment realizing the configured mode;
+    /// created with the `VZVirtualMachine` for network-enabled VMs, activated
+    /// once the session reaches `.running`, torn down with the session.
+    @ObservationIgnored var networkAttachmentCoordinator: NetworkAttachmentCoordinator?
+
+    /// `true` while a live session's network device is detached and recovery
+    /// is waiting for a usable host interface.
+    var networkAttachmentPending = false
+
     // MARK: - Bundle Layout
 
     let bundleLayout: VMBundleLayout
@@ -437,6 +448,9 @@ final class VMInstance {
     ///
     /// Does **not** change `status` — callers set the appropriate status after calling this.
     func tearDownSession() {
+        networkAttachmentCoordinator?.stop()
+        networkAttachmentCoordinator = nil
+        networkAttachmentPending = false
         clipboardPassthroughCoordinator?.stop()
         clipboardPassthroughCoordinator = nil
         stopVsockServices()
@@ -471,7 +485,32 @@ final class VMInstance {
         let vm = VZVirtualMachine(configuration: vzConfig)
         virtualMachine = vm
         setupDelegate()
+        setupNetworkAttachmentCoordinator(for: vm)
         return vm
+    }
+
+    /// Builds this session's attachment-recovery coordinator, replacing any
+    /// prior one — the restore-failure fallback attaches a second
+    /// `VZVirtualMachine` without an intervening teardown.
+    private func setupNetworkAttachmentCoordinator(for vm: VZVirtualMachine) {
+        networkAttachmentCoordinator?.stop()
+        networkAttachmentCoordinator = nil
+        networkAttachmentPending = false
+        guard configuration.networkEnabled, let device = vm.networkDevices.first else { return }
+        networkAttachmentCoordinator = NetworkAttachmentCoordinator(
+            vmName: name,
+            device: VZNetworkDeviceHandle(device: device),
+            interfaces: HostBridgedInterfaceProvider(),
+            linkObserver: HostNetworkLinkObserver(),
+            choice: { [weak self] in
+                guard let self, self.configuration.networkEnabled else { return nil }
+                return NetworkChoice(
+                    mode: self.configuration.networkMode,
+                    bridgedInterfaceIdentifier: self.configuration.bridgedInterfaceIdentifier)
+            },
+            onPendingChange: { [weak self] pending in
+                self?.networkAttachmentPending = pending
+            })
     }
 
     /// Removes the persisted save file from the bundle, if it exists.
@@ -1035,6 +1074,16 @@ final class VMInstance {
     /// restart-only there.
     func applyLivePolicy(oldConfig: VMConfiguration, newConfig: VMConfiguration) {
         guard status == .running || status == .paused else { return }
+
+        // Ahead of the live-VM guard: the coordinator exists exactly while the
+        // session has a network device, which is the guard this hot swap needs.
+        if oldConfig.networkEnabled != newConfig.networkEnabled
+            || oldConfig.networkMode != newConfig.networkMode
+            || oldConfig.bridgedInterfaceIdentifier != newConfig.bridgedInterfaceIdentifier
+        {
+            networkAttachmentCoordinator?.configurationChanged()
+        }
+
         guard let vm = virtualMachine else { return }
 
         // Host-only (no vsock device), so handle it before the socket-device
@@ -1165,6 +1214,20 @@ private final class VMDelegateAdapter: NSObject, VZVirtualMachineDelegate {
             }
             instance.resetToStopped()
             Self.logger.notice("Guest stopped for VM '\(instance.name, privacy: .public)'")
+        }
+    }
+
+    nonisolated func virtualMachine(
+        _ virtualMachine: VZVirtualMachine, networkDevice: VZNetworkDevice,
+        attachmentWasDisconnectedWithError error: any Error
+    ) {
+        MainActor.assumeIsolated {
+            guard let instance else {
+                Self.logger.warning(
+                    "attachmentWasDisconnected received but VMInstance has been deallocated")
+                return
+            }
+            instance.networkAttachmentCoordinator?.attachmentWasDisconnected(error: error)
         }
     }
 

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -592,11 +592,13 @@ struct ConfigurationBuilder: Sendable {
     /// Resolves the host interface a bridged VM attaches to.
     ///
     /// A persisted interface the host no longer offers narrows to Automatic — the
-    /// default-route interface. When neither resolves the start fails: the mode is
-    /// never substituted, so the VM neither bridges over an arbitrary interface
-    /// nor quietly becomes Shared Network (docs/NETWORKING.md).
+    /// default-route interface. When neither resolves the device is built detached
+    /// (`nil`): the boot or restore succeeds, attachment recovery reattaches once
+    /// an interface is available, and the mode is never substituted — the VM
+    /// neither bridges over an arbitrary interface nor quietly becomes Shared
+    /// Network (docs/NETWORKING.md).
     private func bridgedAttachment(config: VMConfiguration) throws
-        -> VZBridgedNetworkDeviceAttachment
+        -> VZBridgedNetworkDeviceAttachment?
     {
         guard entitlements.hasVMNetworking else {
             Self.logger.error(
@@ -615,10 +617,10 @@ struct ConfigurationBuilder: Sendable {
                 $0.identifier == chosen
             })
         else {
-            Self.logger.error(
-                "Bridged networking requested for '\(config.name, privacy: .public)' with no bridgeable host interface"
+            Self.logger.warning(
+                "Bridged networking for '\(config.name, privacy: .public)' has no bridgeable host interface — starting detached"
             )
-            throw ConfigurationBuilderError.noBridgeableInterface
+            return nil
         }
 
         if let persisted = config.bridgedInterfaceIdentifier, persisted != chosen {
@@ -930,8 +932,6 @@ enum ConfigurationBuilderError: LocalizedError {
     case removableMediaNotWritable(String, String)
     /// Removable-media counterpart of `storageDiskAttachFailed`.
     case removableMediaAttachFailed(id: UUID, path: String, label: String, underlying: any Error)
-    /// Bridged mode was chosen but the host offers no interface to bridge over.
-    case noBridgeableInterface
     /// Bridged mode was chosen in a build whose signature omits
     /// `com.apple.vm.networking`, which VZ needs for any non-NAT attachment.
     case bridgedNetworkingNotEntitled
@@ -972,8 +972,6 @@ enum ConfigurationBuilderError: LocalizedError {
             "Removable media '\(label)' is not writable: \(path). Change it to read-only or select a writable file."
         case .removableMediaAttachFailed(_, let path, let label, let underlying):
             "Couldn't open removable media '\(label)' at \(path). The file may have been moved or replaced, or Kernova may no longer have permission to read it. (\(underlying.localizedDescription))"
-        case .noBridgeableInterface:
-            "No host network interface could be chosen for bridged networking. Choose a specific interface in the VM's Network settings, or switch to Shared Network."
         case .bridgedNetworkingNotEntitled:
             "This build of Kernova can't provide bridged networking. Switch the VM's network mode to Shared Network."
         case .sharedDirectoryNotFound(let path):

--- a/Kernova/Services/NetworkAttachmentRecovery.swift
+++ b/Kernova/Services/NetworkAttachmentRecovery.swift
@@ -1,0 +1,366 @@
+import Foundation
+import SystemConfiguration
+import Virtualization
+import os
+
+/// A realizable network attachment for a live VM, decoupled from VZ for testability.
+enum NetworkAttachmentPlan: Equatable {
+    case nat
+    case bridged(String)
+
+    /// Whether this plan realizes `mode` — a NAT attachment realizes Shared
+    /// Network, a bridged attachment over any interface realizes Bridged.
+    func matches(_ mode: VMNetworkMode) -> Bool {
+        switch (self, mode) {
+        case (.nat, .shared), (.bridged, .bridged): true
+        case (.nat, .bridged), (.bridged, .shared): false
+        }
+    }
+}
+
+/// The network the user chose for a VM, as attachment recovery needs it.
+struct NetworkChoice: Equatable {
+    let mode: VMNetworkMode
+    /// The persisted bridged interface, `nil` for Automatic.
+    let bridgedInterfaceIdentifier: String?
+}
+
+/// A live VM's network device, as attachment recovery drives it.
+@MainActor
+protocol NetworkDeviceControlling: AnyObject {
+    /// The plan the device's current attachment realizes, `nil` while detached.
+    var currentPlan: NetworkAttachmentPlan? { get }
+    /// Realizes `plan` on the device. Returns `false` when the host cannot
+    /// provide it right now — the bridge interface vanished since resolution.
+    func apply(_ plan: NetworkAttachmentPlan) -> Bool
+    func detach()
+}
+
+/// Drives a `VZNetworkDevice`, re-fetching the concrete
+/// `VZBridgedNetworkInterface` by identifier at each attach — a VZ interface
+/// object held across a link change is stale.
+@MainActor
+final class VZNetworkDeviceHandle: NetworkDeviceControlling {
+    private let device: VZNetworkDevice
+
+    init(device: VZNetworkDevice) {
+        self.device = device
+    }
+
+    var currentPlan: NetworkAttachmentPlan? {
+        switch device.attachment {
+        case is VZNATNetworkDeviceAttachment:
+            .nat
+        case let bridged as VZBridgedNetworkDeviceAttachment:
+            .bridged(bridged.interface.identifier)
+        default:
+            nil
+        }
+    }
+
+    func apply(_ plan: NetworkAttachmentPlan) -> Bool {
+        switch plan {
+        case .nat:
+            device.attachment = VZNATNetworkDeviceAttachment()
+            return true
+        case .bridged(let identifier):
+            guard
+                let interface = VZBridgedNetworkInterface.networkInterfaces.first(where: {
+                    $0.identifier == identifier
+                })
+            else { return false }
+            device.attachment = VZBridgedNetworkDeviceAttachment(interface: interface)
+            return true
+        }
+    }
+
+    func detach() {
+        device.attachment = nil
+    }
+}
+
+/// Host link-change events, as attachment recovery consumes them.
+@MainActor
+protocol NetworkLinkObserving: AnyObject {
+    /// Starts delivering link-change events to `onChange` until `stop()`.
+    func start(onChange: @escaping @MainActor () -> Void)
+    func stop()
+}
+
+/// Observes host link changes through the SystemConfiguration dynamic store:
+/// the IPv4/IPv6 global (default-route) state plus every interface's link key.
+@MainActor
+final class HostNetworkLinkObserver: NetworkLinkObserving {
+    private static let logger = Logger(
+        subsystem: "app.kernova", category: "HostNetworkLinkObserver")
+
+    private var store: SCDynamicStore?
+    private var onChange: (() -> Void)?
+
+    func start(onChange: @escaping @MainActor () -> Void) {
+        stop()
+        self.onChange = onChange
+
+        // The store retains `self` through the context until `stop()` releases
+        // the store, so a callback queued behind teardown never sees a dangling
+        // pointer.
+        var context = SCDynamicStoreContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: { info in
+                _ = Unmanaged<AnyObject>.fromOpaque(info).retain()
+                return info
+            },
+            release: { info in
+                Unmanaged<AnyObject>.fromOpaque(info).release()
+            },
+            copyDescription: nil)
+        guard
+            let store = SCDynamicStoreCreate(
+                nil, "Kernova.NetworkLinkObserver" as CFString,
+                { _, _, info in
+                    guard let info else { return }
+                    let observer = Unmanaged<HostNetworkLinkObserver>.fromOpaque(info)
+                        .takeUnretainedValue()
+                    Task { @MainActor in observer.onChange?() }
+                },
+                &context)
+        else {
+            Self.logger.fault("SCDynamicStoreCreate returned nil — link changes go unobserved")
+            assertionFailure("SCDynamicStoreCreate returned nil")
+            return
+        }
+        SCDynamicStoreSetNotificationKeys(
+            store,
+            ["State:/Network/Global/IPv4", "State:/Network/Global/IPv6"] as CFArray,
+            ["State:/Network/Interface/.*/Link"] as CFArray)
+        SCDynamicStoreSetDispatchQueue(store, DispatchQueue.global(qos: .utility))
+        self.store = store
+    }
+
+    func stop() {
+        onChange = nil
+        guard let store else { return }
+        SCDynamicStoreSetDispatchQueue(store, nil)
+        self.store = nil
+    }
+}
+
+/// Keeps one VM session's live network attachment realizing the mode the user
+/// chose — across VZ's attachment-disconnect callback, a boot or restore that
+/// came up detached, host link changes, and live mode/interface edits.
+///
+/// Recovery narrows but never escalates: a bridged VM whose interface is gone
+/// falls back within Bridged (to the default-route interface) or runs detached
+/// until one returns — it never silently becomes Shared Network, and no mode
+/// is ever attached that the user didn't choose (docs/NETWORKING.md).
+///
+/// Created by `VMInstance` alongside the `VZVirtualMachine`; `activate()` is
+/// deferred until the session reaches `.running`, since VZ documents runtime
+/// attachment swapping for a running VM only.
+@MainActor
+final class NetworkAttachmentCoordinator {
+    private static let logger = Logger(
+        subsystem: "app.kernova", category: "NetworkAttachmentCoordinator")
+
+    /// Reattempt cadence after a failed attach, reset by each fresh trigger.
+    /// Bounded: once exhausted, the next link change or disconnect tries again.
+    /// It exists because `VZBridgedNetworkInterface.networkInterfaces` can lag
+    /// the dynamic-store event announcing the interface.
+    static let defaultRetryDelays: [Duration] = [
+        .seconds(1), .seconds(2), .seconds(4), .seconds(8),
+    ]
+
+    /// Two disconnects inside this window mean VZ is failing reattach attempts
+    /// as fast as they are made — setting `VZNetworkDevice.attachment` reports
+    /// failure only asynchronously, through another disconnect callback — so
+    /// the burst routes through the bounded retry ladder instead of
+    /// reattaching immediately, which would spin at VZ's failure cadence.
+    static let defaultDisconnectBurstWindow: Duration = .seconds(1)
+
+    private let vmName: String
+    private let device: any NetworkDeviceControlling
+    private let interfaces: any BridgedInterfaceProviding
+    private let linkObserver: any NetworkLinkObserving
+    private let retryDelays: [Duration]
+    private let disconnectBurstWindow: Duration
+    private let clock = ContinuousClock()
+    private var lastDisconnectAt: ContinuousClock.Instant?
+    private let choice: @MainActor () -> NetworkChoice?
+    private let onPendingChange: @MainActor (Bool) -> Void
+
+    /// `true` while the device is detached — no attachment realizes the chosen
+    /// mode and recovery is waiting to reattach.
+    private(set) var isPending = false
+    private var isActive = false
+    private var retryTask: Task<Void, Never>?
+    private var nextRetryIndex = 0
+
+    init(
+        vmName: String,
+        device: any NetworkDeviceControlling,
+        interfaces: any BridgedInterfaceProviding,
+        linkObserver: any NetworkLinkObserving,
+        retryDelays: [Duration] = NetworkAttachmentCoordinator.defaultRetryDelays,
+        disconnectBurstWindow: Duration = NetworkAttachmentCoordinator.defaultDisconnectBurstWindow,
+        choice: @escaping @MainActor () -> NetworkChoice?,
+        onPendingChange: @escaping @MainActor (Bool) -> Void
+    ) {
+        self.vmName = vmName
+        self.device = device
+        self.interfaces = interfaces
+        self.linkObserver = linkObserver
+        self.retryDelays = retryDelays
+        self.disconnectBurstWindow = disconnectBurstWindow
+        self.choice = choice
+        self.onPendingChange = onPendingChange
+    }
+
+    /// Starts link observation and reconciles once. Idempotent — a hot resume
+    /// re-activates the same session and just re-reconciles.
+    func activate() {
+        if !isActive {
+            isActive = true
+            linkObserver.start { [weak self] in self?.hostLinkChanged() }
+        }
+        reconcile(trigger: "activate")
+    }
+
+    func stop() {
+        isActive = false
+        linkObserver.stop()
+        cancelRetry()
+    }
+
+    /// VZ's attachment-disconnect callback: the framework has nil'd the
+    /// attachment. Benign by design — it also fires on initial boot, device
+    /// reset, and guest reboot — so it is never surfaced as a VM error; the
+    /// answer is always to reattach.
+    func attachmentWasDisconnected(error: any Error) {
+        Self.logger.warning(
+            "Network attachment for '\(self.vmName, privacy: .public)' disconnected: \(error.localizedDescription, privacy: .public)"
+        )
+        guard isActive else { return }
+        let now = clock.now
+        let isBurst = lastDisconnectAt.map { now - $0 < disconnectBurstWindow } ?? false
+        lastDisconnectAt = now
+        if isBurst {
+            // VZ has already nil'd the attachment; reflect that and let the
+            // ladder pace the next attempt rather than reattaching in lockstep
+            // with a persistently failing attach.
+            setPending(device.currentPlan == nil)
+            if retryTask == nil { scheduleRetry() }
+            return
+        }
+        reconcile(trigger: "disconnect")
+    }
+
+    /// A live mode or interface edit reached the persisted configuration.
+    func configurationChanged() {
+        guard isActive else { return }
+        reconcile(trigger: "configuration change")
+    }
+
+    private func hostLinkChanged() {
+        guard isActive else { return }
+        reconcile(trigger: "host link change")
+    }
+
+    private func reconcile(trigger: String, resetBackoff: Bool = true) {
+        cancelRetry()
+        if resetBackoff { nextRetryIndex = 0 }
+
+        guard let choice = choice() else {
+            // The picker disables None while the VM runs — a session losing its
+            // network device mid-flight has no supported path here.
+            Self.logger.warning(
+                "Network reconcile for '\(self.vmName, privacy: .public)' found no network choice — leaving the attachment alone"
+            )
+            setPending(false)
+            return
+        }
+
+        let desired = resolvePlan(for: choice)
+        if let desired, device.currentPlan != desired {
+            if device.apply(desired) {
+                Self.logger.notice(
+                    "Attached network for '\(self.vmName, privacy: .public)' (\(String(describing: desired), privacy: .public), on \(trigger, privacy: .public))"
+                )
+            } else {
+                Self.logger.warning(
+                    "Could not attach network for '\(self.vmName, privacy: .public)' (\(String(describing: desired), privacy: .public) refused, on \(trigger, privacy: .public))"
+                )
+            }
+        }
+
+        // Never leave an attachment realizing a mode other than the chosen one:
+        // when the chosen mode cannot attach, the honest state is detached, not
+        // a substituted mode (docs/NETWORKING.md).
+        if let current = device.currentPlan, !current.matches(choice.mode) {
+            device.detach()
+        }
+
+        let pending = device.currentPlan == nil
+        setPending(pending)
+        if pending { scheduleRetry() }
+    }
+
+    /// The plan the chosen mode resolves to right now, `nil` when Bridged has
+    /// no usable host interface.
+    private func resolvePlan(for choice: NetworkChoice) -> NetworkAttachmentPlan? {
+        switch choice.mode {
+        case .shared:
+            return .nat
+        case .bridged:
+            let available = interfaces.interfaces().map(\.identifier)
+            // A live Automatic bridge holds its interface while the host still
+            // offers it: Automatic resolves at boot and reattach, not
+            // continuously — chasing every default-route change would bounce
+            // the guest's link for nothing.
+            if choice.bridgedInterfaceIdentifier == nil,
+                case .bridged(let current)? = device.currentPlan,
+                available.contains(current)
+            {
+                return .bridged(current)
+            }
+            guard
+                let chosen = BridgedInterfaceSelection.choose(
+                    persisted: choice.bridgedInterfaceIdentifier,
+                    available: available,
+                    primary: interfaces.primaryInterfaceIdentifier())
+            else { return nil }
+            return .bridged(chosen)
+        }
+    }
+
+    private func scheduleRetry() {
+        guard nextRetryIndex < retryDelays.count else { return }
+        let delay = retryDelays[nextRetryIndex]
+        nextRetryIndex += 1
+        retryTask = Task { [weak self] in
+            do { try await Task.sleep(for: delay) } catch { return }
+            guard let self, !Task.isCancelled else { return }
+            self.retryTask = nil
+            self.reconcile(trigger: "retry", resetBackoff: false)
+        }
+    }
+
+    private func cancelRetry() {
+        retryTask?.cancel()
+        retryTask = nil
+    }
+
+    private func setPending(_ pending: Bool) {
+        guard pending != isPending else { return }
+        isPending = pending
+        Self.logger.notice(
+            "Network attachment for '\(self.vmName, privacy: .public)' is \(pending ? "pending reattach" : "attached", privacy: .public)"
+        )
+        onPendingChange(pending)
+    }
+
+    #if DEBUG
+    /// The in-flight backoff retry, for event-driven test waits.
+    var retryTaskForTesting: Task<Void, Never>? { retryTask }
+    #endif
+}

--- a/Kernova/Services/NetworkAttachmentRecovery.swift
+++ b/Kernova/Services/NetworkAttachmentRecovery.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KernovaKit
 import SystemConfiguration
 import Virtualization
 import os
@@ -23,6 +24,15 @@ struct NetworkChoice: Equatable {
     let mode: VMNetworkMode
     /// The persisted bridged interface, `nil` for Automatic.
     let bridgedInterfaceIdentifier: String?
+}
+
+extension VMConfiguration {
+    /// The network the user chose, as attachment recovery consumes it; `nil`
+    /// when the VM has no network device.
+    var networkChoice: NetworkChoice? {
+        guard networkEnabled else { return nil }
+        return NetworkChoice(mode: networkMode, bridgedInterfaceIdentifier: bridgedInterfaceIdentifier)
+    }
 }
 
 /// A live VM's network device, as attachment recovery drives it.
@@ -155,37 +165,39 @@ final class HostNetworkLinkObserver: NetworkLinkObserving {
 /// until one returns — it never silently becomes Shared Network, and no mode
 /// is ever attached that the user didn't choose (docs/NETWORKING.md).
 ///
-/// Created by `VMInstance` alongside the `VZVirtualMachine`; `activate()` is
-/// deferred until the session reaches `.running`, since VZ documents runtime
-/// attachment swapping for a running VM only.
+/// Created by `VMInstance` alongside the `VZVirtualMachine`. `activate()` is
+/// deferred until the session first reaches `.running`, and reconciliation is
+/// gated to running and live-paused sessions through `isEligible` — Kernova's
+/// choice to keep attachment churn away from boot, restore, and state saves;
+/// runtime attachment swaps themselves carry no VZ state precondition.
 @MainActor
 final class NetworkAttachmentCoordinator {
     private static let logger = Logger(
         subsystem: "app.kernova", category: "NetworkAttachmentCoordinator")
 
-    /// Reattempt cadence after a failed attach, reset by each fresh trigger.
-    /// Bounded: once exhausted, the next link change or disconnect tries again.
-    /// It exists because `VZBridgedNetworkInterface.networkInterfaces` can lag
+    /// Reattempt cadence, in seconds, after a failed attach; escalated while
+    /// attaches keep failing, reset by each fresh trigger. Bounded: once
+    /// exhausted, recovery waits for the next link change or disconnect. It
+    /// exists because `VZBridgedNetworkInterface.networkInterfaces` can lag
     /// the dynamic-store event announcing the interface.
-    static let defaultRetryDelays: [Duration] = [
-        .seconds(1), .seconds(2), .seconds(4), .seconds(8),
-    ]
+    static let defaultRetryDelays: [TimeInterval] = [1, 2, 4, 8]
 
-    /// Two disconnects inside this window mean VZ is failing reattach attempts
-    /// as fast as they are made — setting `VZNetworkDevice.attachment` reports
-    /// failure only asynchronously, through another disconnect callback — so
-    /// the burst routes through the bounded retry ladder instead of
-    /// reattaching immediately, which would spin at VZ's failure cadence.
-    static let defaultDisconnectBurstWindow: Duration = .seconds(1)
+    /// A disconnect this soon, in seconds, after an attach attempt is VZ
+    /// reporting that attempt failed — a live attachment set reports failure
+    /// only asynchronously, through another disconnect callback — so it routes
+    /// through the retry ladder instead of reattaching immediately, which
+    /// would spin at VZ's failure cadence.
+    static let defaultDisconnectBurstWindow: TimeInterval = 1
 
     private let vmName: String
     private let device: any NetworkDeviceControlling
     private let interfaces: any BridgedInterfaceProviding
     private let linkObserver: any NetworkLinkObserving
-    private let retryDelays: [Duration]
-    private let disconnectBurstWindow: Duration
-    private let clock = ContinuousClock()
-    private var lastDisconnectAt: ContinuousClock.Instant?
+    private let retryDelays: [TimeInterval]
+    private let disconnectBurstWindow: TimeInterval
+    private let clock: any EngineClock
+    private var lastAttachAttemptAt: EngineInstant?
+    private let isEligible: @MainActor () -> Bool
     private let choice: @MainActor () -> NetworkChoice?
     private let onPendingChange: @MainActor (Bool) -> Void
 
@@ -201,8 +213,10 @@ final class NetworkAttachmentCoordinator {
         device: any NetworkDeviceControlling,
         interfaces: any BridgedInterfaceProviding,
         linkObserver: any NetworkLinkObserving,
-        retryDelays: [Duration] = NetworkAttachmentCoordinator.defaultRetryDelays,
-        disconnectBurstWindow: Duration = NetworkAttachmentCoordinator.defaultDisconnectBurstWindow,
+        retryDelays: [TimeInterval] = NetworkAttachmentCoordinator.defaultRetryDelays,
+        disconnectBurstWindow: TimeInterval = NetworkAttachmentCoordinator.defaultDisconnectBurstWindow,
+        clock: any EngineClock = makePlatformEngineClock(),
+        isEligible: @escaping @MainActor () -> Bool = { true },
         choice: @escaping @MainActor () -> NetworkChoice?,
         onPendingChange: @escaping @MainActor (Bool) -> Void
     ) {
@@ -212,6 +226,8 @@ final class NetworkAttachmentCoordinator {
         self.linkObserver = linkObserver
         self.retryDelays = retryDelays
         self.disconnectBurstWindow = disconnectBurstWindow
+        self.clock = clock
+        self.isEligible = isEligible
         self.choice = choice
         self.onPendingChange = onPendingChange
     }
@@ -240,11 +256,10 @@ final class NetworkAttachmentCoordinator {
         Self.logger.warning(
             "Network attachment for '\(self.vmName, privacy: .public)' disconnected: \(error.localizedDescription, privacy: .public)"
         )
-        guard isActive else { return }
-        let now = clock.now
-        let isBurst = lastDisconnectAt.map { now - $0 < disconnectBurstWindow } ?? false
-        lastDisconnectAt = now
-        if isBurst {
+        guard isActive, isEligible() else { return }
+        let isFailedAttachReport =
+            lastAttachAttemptAt.map { clock.seconds(since: $0) < disconnectBurstWindow } ?? false
+        if isFailedAttachReport {
             // VZ has already nil'd the attachment; reflect that and let the
             // ladder pace the next attempt rather than reattaching in lockstep
             // with a persistently failing attach.
@@ -268,6 +283,11 @@ final class NetworkAttachmentCoordinator {
 
     private func reconcile(trigger: String, resetBackoff: Bool = true) {
         cancelRetry()
+        guard isEligible() else {
+            // A saving or otherwise ineligible session: drop the trigger —
+            // activation at the next `.running` re-reconciles.
+            return
+        }
         if resetBackoff { nextRetryIndex = 0 }
 
         guard let choice = choice() else {
@@ -281,21 +301,32 @@ final class NetworkAttachmentCoordinator {
         }
 
         let desired = resolvePlan(for: choice)
-        if let desired, device.currentPlan != desired {
-            if device.apply(desired) {
-                Self.logger.notice(
-                    "Attached network for '\(self.vmName, privacy: .public)' (\(String(describing: desired), privacy: .public), on \(trigger, privacy: .public))"
-                )
-            } else {
-                Self.logger.warning(
-                    "Could not attach network for '\(self.vmName, privacy: .public)' (\(String(describing: desired), privacy: .public) refused, on \(trigger, privacy: .public))"
-                )
+        if let desired {
+            if device.currentPlan != desired {
+                lastAttachAttemptAt = clock.now
+                if device.apply(desired) {
+                    Self.logger.notice(
+                        "Attached network for '\(self.vmName, privacy: .public)' (\(String(describing: desired), privacy: .public), on \(trigger, privacy: .public))"
+                    )
+                } else {
+                    Self.logger.warning(
+                        "Could not attach network for '\(self.vmName, privacy: .public)' (\(String(describing: desired), privacy: .public) refused, on \(trigger, privacy: .public))"
+                    )
+                }
             }
+        } else if device.currentPlan != nil {
+            // Nothing realizes the choice — a still-usable bridge would have
+            // been held by `resolvePlan` — so what remains is stale (its
+            // interface vanished) and the honest state is detached.
+            device.detach()
         }
 
-        // Never leave an attachment realizing a mode other than the chosen one:
-        // when the chosen mode cannot attach, the honest state is detached, not
-        // a substituted mode (docs/NETWORKING.md).
+        // Never leave an attachment realizing a mode other than the chosen one
+        // (a refused apply can leave the previous mode's attachment live): when
+        // the chosen mode cannot attach, the honest state is detached, not a
+        // substituted mode (docs/NETWORKING.md). A refused apply whose live
+        // attachment does match the mode is kept — a working bridge beats
+        // detaching, and the next trigger retries.
         if let current = device.currentPlan, !current.matches(choice.mode) {
             device.detach()
         }
@@ -313,14 +344,15 @@ final class NetworkAttachmentCoordinator {
             return .nat
         case .bridged:
             let available = interfaces.interfaces().map(\.identifier)
-            // A live Automatic bridge holds its interface while the host still
-            // offers it: Automatic resolves at boot and reattach, not
-            // continuously — chasing every default-route change would bounce
-            // the guest's link for nothing.
-            if choice.bridgedInterfaceIdentifier == nil,
-                case .bridged(let current)? = device.currentPlan,
-                available.contains(current)
-            {
+            // The persisted interface is reclaimed the moment the host offers
+            // it again; otherwise a live bridge is held while its interface
+            // remains available — for Automatic so a default-route change
+            // doesn't bounce the guest's link, and for a narrowed fallback so
+            // the default route flapping away doesn't detach a working bridge.
+            if let persisted = choice.bridgedInterfaceIdentifier, available.contains(persisted) {
+                return .bridged(persisted)
+            }
+            if case .bridged(let current)? = device.currentPlan, available.contains(current) {
                 return .bridged(current)
             }
             guard
@@ -337,8 +369,8 @@ final class NetworkAttachmentCoordinator {
         guard nextRetryIndex < retryDelays.count else { return }
         let delay = retryDelays[nextRetryIndex]
         nextRetryIndex += 1
-        retryTask = Task { [weak self] in
-            do { try await Task.sleep(for: delay) } catch { return }
+        retryTask = Task { [weak self, clock] in
+            do { try await clock.sleep(for: delay) } catch { return }
             guard let self, !Task.isCancelled else { return }
             self.retryTask = nil
             self.reconcile(trigger: "retry", resetBackoff: false)

--- a/Kernova/Services/VirtualizationService.swift
+++ b/Kernova/Services/VirtualizationService.swift
@@ -37,6 +37,10 @@ final class VirtualizationService {
             }
 
             instance.status = .running
+            // Activation waits for `.running`: VZ documents runtime attachment
+            // swapping for a running VM, and a boot or restore that came up
+            // detached is reconciled here.
+            instance.networkAttachmentCoordinator?.activate()
             // The watchdog flips `agentExpectedButMissing` when a VM that has seen
             // the agent before gets no Hello within the grace period. No-op for
             // fresh VMs (no `lastSeenAgentVersion`), for Linux, and for recovery
@@ -253,6 +257,9 @@ final class VirtualizationService {
             if let vm = instance.virtualMachine {
                 try await vm.resume()
                 instance.status = .running
+                // Idempotent re-activation reconciles an attachment the host
+                // link may have invalidated during the pause.
+                instance.networkAttachmentCoordinator?.activate()
                 instance.removeSaveFile()
                 // The guest is executing again, and this is the same session
                 // that was paused — so `bootedIntoRecovery` still governs, and
@@ -267,6 +274,7 @@ final class VirtualizationService {
                 // actually shows up.
                 try await restoreOrColdBoot(instance)
                 instance.status = .running
+                instance.networkAttachmentCoordinator?.activate()
             } else {
                 throw VirtualizationError.noSaveFile
             }

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -163,6 +163,9 @@ final class VMSettingsViewController: NSViewController {
 
     // Network
     private var networkModePopUp = NSPopUpButton()
+    /// The Network header's lock icon, hidden — unlike its `lockIcons` peers —
+    /// while the picker is the live-switch surface.
+    private var networkLockIcon: NSImageView?
     /// The MAC Address row, hidden while the VM has no network device; `nil` for a
     /// VM carrying no MAC address, whose row is never built.
     private var macAddressRow: GroupedFormCollapsibleRow?
@@ -218,6 +221,9 @@ final class VMSettingsViewController: NSViewController {
     /// nothing about networking skips a rebuild — which enumerates the host's
     /// bridgeable interfaces and queries the process signature.
     private var renderedNetworkChoice: NetworkModeChoice?
+    /// The live-switch state the Mode menu was last built for; a change rebuilds
+    /// so the None entry's enablement tracks it.
+    private var renderedNetworkLiveSwitchable = false
 
     // MARK: - Init
 
@@ -914,8 +920,10 @@ extension VMSettingsViewController {
     }
 
     private func buildNetworkSection() -> NSView {
+        // Deliberately outside `persistentLockableControls`: the picker is the
+        // live-switch surface while the VM runs, so `refreshNetwork()` owns its
+        // enablement (and the section lock icon it makes moot).
         networkModePopUp = makeNetworkModePopUp()
-        persistentLockableControls.append(networkModePopUp)
 
         var rows: [NSView] = [makeGroupedFormCardRow("Mode", control: networkModePopUp)]
         if let mac = instance.configuration.macAddress {
@@ -942,11 +950,23 @@ extension VMSettingsViewController {
                     "The interface usually appears as `enp0s1`. If networking doesn't come up, make sure your distro's DHCP client or NetworkManager is running."
                 ))
         }
+        let header = makeHeader("Network", lockable: true, paragraphs: paragraphs)
+        networkLockIcon = lockIcons.last
         return makeSection([
-            makeHeader("Network", lockable: true, paragraphs: paragraphs),
+            header,
             makeGroupedFormCard(rows: rows),
             networkNoDeviceCaption,
         ])
+    }
+
+    /// While the pane is read-only, whether the Mode picker stays live as the
+    /// hot-swap surface: swapping the attachment needs a running or live-paused
+    /// session and a network device to swap on — None-mode VMs have no device,
+    /// and devices cannot be added or removed at runtime.
+    private var networkModeIsLiveSwitchable: Bool {
+        guard isReadOnly else { return false }
+        return instance.configuration.networkEnabled
+            && (instance.status == .running || instance.isLivePaused)
     }
 
     private func makeNetworkModePopUp() -> NSPopUpButton {
@@ -968,11 +988,15 @@ extension VMSettingsViewController {
     private func rebuildNetworkModeMenu() {
         guard let menu = networkModePopUp.menu else { return }
         menu.removeAllItems()
+        let liveSwitchable = networkModeIsLiveSwitchable
         addNetworkModeItem("Shared Network", choice: .shared, to: menu)
-        addNetworkModeItem("None", choice: .none, to: menu)
+        // While the session runs, every attachable mode can hot-swap; None
+        // cannot — network devices cannot be added or removed at runtime.
+        addNetworkModeItem("None", choice: .none, to: menu, enabled: !liveSwitchable)
 
         let current = currentNetworkChoice
         renderedNetworkChoice = current
+        renderedNetworkLiveSwitchable = liveSwitchable
         if entitlements.hasVMNetworking {
             menu.addItem(.sectionHeader(title: "Bridged"))
             addNetworkModeItem("Automatic", choice: .bridged(nil), to: menu)
@@ -1598,7 +1622,14 @@ extension VMSettingsViewController {
     }
 
     private func refreshNetwork() {
-        if currentNetworkChoice != renderedNetworkChoice {
+        let liveSwitchable = networkModeIsLiveSwitchable
+        networkModePopUp.isEnabled = !isReadOnly || liveSwitchable
+        // `apply()` just showed every lock icon for the read-only pane; a live
+        // picker makes this section's lock a false claim, so re-hide it.
+        networkLockIcon?.isHidden = !isReadOnly || liveSwitchable
+        if currentNetworkChoice != renderedNetworkChoice
+            || liveSwitchable != renderedNetworkLiveSwitchable
+        {
             rebuildNetworkModeMenu()
         }
         // None leaves no device to describe, so the card's remaining rows give way

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -515,9 +515,12 @@ extension VMSettingsViewController {
     }
 
     /// Section header; any lock icon it creates is registered in ``lockIcons``
-    /// and toggled by ``apply()``.
+    /// and toggled by ``apply()``. A section whose lock is conditional passes
+    /// `lockIconSink` to keep its own reference — by handoff, not by position
+    /// in ``lockIcons``.
     private func makeHeader(
-        _ title: String, lockable: Bool = false, paragraphs: [InfoPopoverParagraph] = []
+        _ title: String, lockable: Bool = false, paragraphs: [InfoPopoverParagraph] = [],
+        lockIconSink: ((NSImageView) -> Void)? = nil
     ) -> NSView {
         var views: [NSView] = []
         if lockable {
@@ -529,6 +532,7 @@ extension VMSettingsViewController {
             lock.setContentHuggingPriority(.required, for: .horizontal)
             lock.isHidden = true
             lockIcons.append(lock)
+            lockIconSink?(lock)
             views.append(lock)
         }
         views.append(makeGroupedFormSectionHeader(title))
@@ -950,8 +954,9 @@ extension VMSettingsViewController {
                     "The interface usually appears as `enp0s1`. If networking doesn't come up, make sure your distro's DHCP client or NetworkManager is running."
                 ))
         }
-        let header = makeHeader("Network", lockable: true, paragraphs: paragraphs)
-        networkLockIcon = lockIcons.last
+        let header = makeHeader("Network", lockable: true, paragraphs: paragraphs) {
+            self.networkLockIcon = $0
+        }
         return makeSection([
             header,
             makeGroupedFormCard(rows: rows),

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -11,10 +11,11 @@ extension VMInstance {
 
     /// Color used to tint the sidebar's OS icon.
     ///
-    /// Preparing and cold-paused are orange, live-paused is yellow, and the
-    /// remaining states follow `status`.
+    /// Preparing, cold-paused, and running-while-awaiting-network-reattach are
+    /// orange, live-paused is yellow, and the remaining states follow `status`.
     var statusDisplayNSColor: NSColor {
         if isPreparing || isColdPaused { return StatusColor.warning }
+        if status == .running && networkAttachmentPending { return StatusColor.warning }
         switch status {
         // A concrete gray (not `.secondaryLabelColor`) so the icon keeps its
         // stopped color on the selection highlight instead of inverting to white.
@@ -43,6 +44,9 @@ extension VMInstance {
         if let state = preparingState { return state.displayLabel }
         if status == .initialBoot { return "Click Start to install macOS" }
         if status == .error { return errorMessage }
+        if status == .running, networkAttachmentPending {
+            return "The network interface is unavailable. Kernova reconnects automatically when one is available."
+        }
         guard status == .paused else { return nil }
         return isColdPaused
             ? "VM state is saved to disk"

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -36,7 +36,7 @@ struct ConfigurationBuilderTests {
             Issue.record("Unexpected path validation error: \(error)")
         case .invalidHardwareModel, .invalidMachineIdentifier, .missingKernelPath,
             .storageDiskAttachFailed, .removableMediaAttachFailed,
-            .noBridgeableInterface, .bridgedNetworkingNotEntitled:
+            .bridgedNetworkingNotEntitled:
             break
         }
     }
@@ -1077,8 +1077,8 @@ struct ConfigurationBuilderTests {
         #expect(device.macAddress.string != "not-a-mac")
     }
 
-    @Test("Bridged mode with no bridgeable host interface refuses to start")
-    func bridgedModeWithoutAnInterfaceThrows() throws {
+    @Test("Bridged mode with no bridgeable host interface builds the device detached")
+    func bridgedModeWithoutAnInterfaceBuildsDetached() throws {
         let bundleURL = try makeTempBundle(withDisk: true)
         defer { try? FileManager.default.removeItem(at: bundleURL) }
 
@@ -1087,14 +1087,13 @@ struct ConfigurationBuilderTests {
         builder.entitlements = EntitlementService(
             reader: MockEntitlementReader(granted: ["com.apple.vm.networking"]))
 
-        #expect {
-            try builder.assemble(from: makeBridgedConfig(), bundleURL: bundleURL, validate: false)
-        } throws: { error in
-            guard let e = error as? ConfigurationBuilderError,
-                case .noBridgeableInterface = e
-            else { return false }
-            return true
-        }
+        // The boot (and a restore from saved state, which rebuilds the same
+        // configuration) must succeed; attachment recovery reattaches later.
+        let devices = try builder.assemble(
+            from: makeBridgedConfig(), bundleURL: bundleURL, validate: false
+        ).configuration.networkDevices
+        #expect(devices.count == 1)
+        #expect(devices[0].attachment == nil)
     }
 
     @Test("Bridged mode in a build without the entitlement names the entitlement, not the interface")

--- a/KernovaTests/Mocks/MockNetworkDeviceControl.swift
+++ b/KernovaTests/Mocks/MockNetworkDeviceControl.swift
@@ -1,0 +1,37 @@
+@testable import Kernova
+
+/// Scripted stand-in for `NetworkDeviceControlling`, so coordinator tests drive
+/// attachment state without a `VZNetworkDevice`, which only a live VM has.
+@MainActor
+final class MockNetworkDeviceControl: NetworkDeviceControlling {
+    /// The attachment the device currently realizes; tests nil it to simulate
+    /// the framework's disconnect behavior.
+    var plan: NetworkAttachmentPlan?
+    /// Bridge identifiers `apply` refuses, simulating the interface vanishing
+    /// between resolution and attach.
+    var refusedBridgeIdentifiers: Set<String> = []
+    private(set) var appliedPlans: [NetworkAttachmentPlan] = []
+    private(set) var detachCount = 0
+
+    init(plan: NetworkAttachmentPlan? = nil) {
+        self.plan = plan
+    }
+
+    var currentPlan: NetworkAttachmentPlan? { plan }
+
+    func apply(_ plan: NetworkAttachmentPlan) -> Bool {
+        if case .bridged(let identifier) = plan,
+            refusedBridgeIdentifiers.contains(identifier)
+        {
+            return false
+        }
+        appliedPlans.append(plan)
+        self.plan = plan
+        return true
+    }
+
+    func detach() {
+        detachCount += 1
+        plan = nil
+    }
+}

--- a/KernovaTests/Mocks/MockNetworkLinkObserver.swift
+++ b/KernovaTests/Mocks/MockNetworkLinkObserver.swift
@@ -1,0 +1,26 @@
+@testable import Kernova
+
+/// Scripted stand-in for `NetworkLinkObserving`; tests fire link-change events
+/// with `fire()`.
+@MainActor
+final class MockNetworkLinkObserver: NetworkLinkObserving {
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+    private var onChange: (() -> Void)?
+
+    var isObserving: Bool { onChange != nil }
+
+    func start(onChange: @escaping @MainActor () -> Void) {
+        startCount += 1
+        self.onChange = onChange
+    }
+
+    func stop() {
+        stopCount += 1
+        onChange = nil
+    }
+
+    func fire() {
+        onChange?()
+    }
+}

--- a/KernovaTests/NetworkAttachmentCoordinatorTests.swift
+++ b/KernovaTests/NetworkAttachmentCoordinatorTests.swift
@@ -1,0 +1,364 @@
+import KernovaTestSupport
+import Testing
+@testable import Kernova
+
+@Suite("NetworkAttachmentCoordinator Tests")
+@MainActor
+struct NetworkAttachmentCoordinatorTests {
+    private static let wiFi = BridgedInterface(identifier: "en0", localizedDisplayName: "Wi-Fi")
+    private static let ethernet = BridgedInterface(
+        identifier: "en1", localizedDisplayName: "Ethernet")
+
+    /// Mutable choice the coordinator's `choice` closure reads, standing in for
+    /// the live `VMConfiguration`.
+    @MainActor
+    private final class ChoiceBox {
+        var choice: NetworkChoice?
+        init(_ choice: NetworkChoice?) { self.choice = choice }
+    }
+
+    private struct Harness {
+        let coordinator: NetworkAttachmentCoordinator
+        let device: MockNetworkDeviceControl
+        let provider: MockBridgedInterfaceProvider
+        let observer: MockNetworkLinkObserver
+        let choiceBox: ChoiceBox
+        let pendingChanges: PendingRecorder
+    }
+
+    /// Records every pending-state callback, standing in for
+    /// `VMInstance.networkAttachmentPending`.
+    @MainActor
+    private final class PendingRecorder {
+        private(set) var values: [Bool] = []
+        func record(_ value: Bool) { values.append(value) }
+        var latest: Bool { values.last ?? false }
+    }
+
+    private func makeHarness(
+        choice: NetworkChoice?,
+        devicePlan: NetworkAttachmentPlan? = nil,
+        available: [BridgedInterface] = [],
+        primary: String? = nil,
+        retryDelays: [Duration] = [],
+        disconnectBurstWindow: Duration = NetworkAttachmentCoordinator.defaultDisconnectBurstWindow
+    ) -> Harness {
+        let device = MockNetworkDeviceControl(plan: devicePlan)
+        let provider = MockBridgedInterfaceProvider(available: available, primary: primary)
+        let observer = MockNetworkLinkObserver()
+        let choiceBox = ChoiceBox(choice)
+        let pendingChanges = PendingRecorder()
+        let coordinator = NetworkAttachmentCoordinator(
+            vmName: "Test VM",
+            device: device,
+            interfaces: provider,
+            linkObserver: observer,
+            retryDelays: retryDelays,
+            disconnectBurstWindow: disconnectBurstWindow,
+            choice: { choiceBox.choice },
+            onPendingChange: { pendingChanges.record($0) })
+        return Harness(
+            coordinator: coordinator, device: device, provider: provider,
+            observer: observer, choiceBox: choiceBox, pendingChanges: pendingChanges)
+    }
+
+    // MARK: - Session start
+
+    @Test("Activation reattaches a shared VM that came up detached")
+    func activationReattachesDetachedSharedDevice() {
+        let h = makeHarness(choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil))
+
+        h.coordinator.activate()
+
+        #expect(h.device.appliedPlans == [.nat])
+        #expect(!h.coordinator.isPending)
+        #expect(h.observer.isObserving)
+    }
+
+    @Test("Activation leaves a matching attachment alone")
+    func activationLeavesMatchingAttachmentAlone() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0"),
+            devicePlan: .bridged("en0"),
+            available: [Self.wiFi])
+
+        h.coordinator.activate()
+
+        #expect(h.device.appliedPlans.isEmpty)
+        #expect(!h.coordinator.isPending)
+    }
+
+    @Test("A bridged VM with no usable interface goes pending, then a link event reattaches it")
+    func degradedBridgedStartRecoversOnLinkEvent() {
+        let h = makeHarness(choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0"))
+
+        h.coordinator.activate()
+        #expect(h.coordinator.isPending)
+        #expect(h.pendingChanges.values == [true])
+        #expect(h.device.appliedPlans.isEmpty)
+
+        h.provider.available = [Self.wiFi]
+        h.observer.fire()
+
+        #expect(h.device.appliedPlans == [.bridged("en0")])
+        #expect(!h.coordinator.isPending)
+        #expect(h.pendingChanges.values == [true, false])
+    }
+
+    // MARK: - Disconnect
+
+    @Test("A shared-mode disconnect reattaches NAT immediately")
+    func sharedDisconnectReattachesImmediately() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
+            devicePlan: .nat)
+        h.coordinator.activate()
+
+        // The framework nils the attachment before the delegate callback.
+        h.device.plan = nil
+        h.coordinator.attachmentWasDisconnected(error: TestFailure("link down"))
+
+        #expect(h.device.appliedPlans == [.nat])
+        #expect(!h.coordinator.isPending)
+        #expect(h.pendingChanges.values.isEmpty)
+    }
+
+    @Test("A disconnect burst paces reattach through the retry ladder")
+    func disconnectBurstPacesReattachThroughRetryLadder() async {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
+            devicePlan: .nat,
+            retryDelays: [.milliseconds(1)])
+        h.coordinator.activate()
+
+        // VZ fails the attachment: the first disconnect reattaches immediately.
+        h.device.plan = nil
+        h.coordinator.attachmentWasDisconnected(error: TestFailure("link down"))
+        #expect(h.device.appliedPlans == [.nat])
+
+        // VZ fails that reattach straight away — a live attach reports failure
+        // only through another disconnect. Within the burst window the ladder
+        // paces the next attempt instead of reattaching in lockstep.
+        h.device.plan = nil
+        h.coordinator.attachmentWasDisconnected(error: TestFailure("attach failed"))
+        #expect(h.device.appliedPlans == [.nat])
+        #expect(h.coordinator.isPending)
+
+        guard let retry = h.coordinator.retryTaskForTesting else {
+            Issue.record("Expected a scheduled retry")
+            return
+        }
+        await retry.value
+        #expect(h.device.appliedPlans == [.nat, .nat])
+        #expect(!h.coordinator.isPending)
+    }
+
+    @Test("Disconnects outside the burst window each reattach immediately")
+    func spacedDisconnectsReattachImmediately() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
+            devicePlan: .nat,
+            disconnectBurstWindow: .zero)
+        h.coordinator.activate()
+
+        for _ in 1...3 {
+            h.device.plan = nil
+            h.coordinator.attachmentWasDisconnected(error: TestFailure("link down"))
+        }
+
+        #expect(h.device.appliedPlans == [.nat, .nat, .nat])
+        #expect(!h.coordinator.isPending)
+    }
+
+    @Test("A bridged disconnect with the persisted interface gone narrows to the primary")
+    func bridgedDisconnectNarrowsToPrimary() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en1"),
+            devicePlan: .bridged("en1"),
+            available: [Self.ethernet],
+            primary: "en1")
+        h.coordinator.activate()
+
+        // en1 undocked: the host now offers only Wi-Fi.
+        h.provider.available = [Self.wiFi]
+        h.provider.primary = "en0"
+        h.device.plan = nil
+        h.coordinator.attachmentWasDisconnected(error: TestFailure("undock"))
+
+        #expect(h.device.appliedPlans == [.bridged("en0")])
+        #expect(!h.coordinator.isPending)
+    }
+
+    @Test("The persisted interface returning reclaims the bridge from its narrowed fallback")
+    func persistedInterfaceReturningReclaimsBridge() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en1"),
+            devicePlan: .bridged("en0"),
+            available: [Self.wiFi],
+            primary: "en0")
+        h.coordinator.activate()
+        #expect(h.device.appliedPlans.isEmpty)
+
+        h.provider.available = [Self.wiFi, Self.ethernet]
+        h.observer.fire()
+
+        #expect(h.device.appliedPlans == [.bridged("en1")])
+    }
+
+    @Test("An Automatic bridge holds its interface across a default-route change")
+    func automaticBridgeHoldsInterfaceAcrossPrimaryChange() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: nil),
+            devicePlan: .bridged("en0"),
+            available: [Self.wiFi, Self.ethernet],
+            primary: "en0")
+        h.coordinator.activate()
+
+        h.provider.primary = "en1"
+        h.observer.fire()
+
+        #expect(h.device.appliedPlans.isEmpty)
+        #expect(h.device.currentPlan == .bridged("en0"))
+    }
+
+    // MARK: - Live configuration changes
+
+    @Test("A live mode change swaps the attachment")
+    func liveModeChangeSwapsAttachment() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
+            devicePlan: .nat,
+            available: [Self.wiFi],
+            primary: "en0")
+        h.coordinator.activate()
+
+        h.choiceBox.choice = NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0")
+        h.coordinator.configurationChanged()
+        #expect(h.device.appliedPlans == [.bridged("en0")])
+
+        h.choiceBox.choice = NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: "en0")
+        h.coordinator.configurationChanged()
+        #expect(h.device.appliedPlans == [.bridged("en0"), .nat])
+        #expect(!h.coordinator.isPending)
+    }
+
+    @Test("A live interface switch swaps the bridge")
+    func liveInterfaceSwitchSwapsBridge() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0"),
+            devicePlan: .bridged("en0"),
+            available: [Self.wiFi, Self.ethernet])
+        h.coordinator.activate()
+
+        h.choiceBox.choice = NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en1")
+        h.coordinator.configurationChanged()
+
+        #expect(h.device.appliedPlans == [.bridged("en1")])
+    }
+
+    @Test("Switching to an unresolvable bridge detaches rather than keeping the old mode")
+    func unresolvableBridgeSwitchDetaches() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
+            devicePlan: .nat)
+        h.coordinator.activate()
+
+        h.choiceBox.choice = NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0")
+        h.coordinator.configurationChanged()
+
+        // The NAT attachment must not survive as a silent substitute for the
+        // chosen mode (docs/NETWORKING.md).
+        #expect(h.device.detachCount == 1)
+        #expect(h.device.currentPlan == nil)
+        #expect(h.coordinator.isPending)
+    }
+
+    // MARK: - Backoff retries
+
+    @Test("A refused attach retries on the backoff schedule until it lands")
+    func refusedAttachRetriesOnBackoff() async {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0"),
+            available: [Self.wiFi],
+            retryDelays: [.milliseconds(1)])
+        // The interface is listed but the attach refuses — the VZ interface
+        // list lagging the dynamic store.
+        h.device.refusedBridgeIdentifiers = ["en0"]
+
+        h.coordinator.activate()
+        #expect(h.coordinator.isPending)
+
+        h.device.refusedBridgeIdentifiers = []
+        guard let retry = h.coordinator.retryTaskForTesting else {
+            Issue.record("Expected a scheduled retry")
+            return
+        }
+        await retry.value
+
+        #expect(h.device.appliedPlans == [.bridged("en0")])
+        #expect(!h.coordinator.isPending)
+    }
+
+    @Test("Exhausted retries leave recovery to the next link event")
+    func exhaustedRetriesRecoverOnLinkEvent() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0"),
+            available: [Self.wiFi])
+        h.device.refusedBridgeIdentifiers = ["en0"]
+
+        h.coordinator.activate()
+        #expect(h.coordinator.isPending)
+        #expect(h.coordinator.retryTaskForTesting == nil)
+
+        h.device.refusedBridgeIdentifiers = []
+        h.observer.fire()
+
+        #expect(h.device.appliedPlans == [.bridged("en0")])
+        #expect(!h.coordinator.isPending)
+    }
+
+    // MARK: - Lifecycle
+
+    @Test("Events before activation are ignored")
+    func eventsBeforeActivationAreIgnored() {
+        let h = makeHarness(choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil))
+
+        // The disconnect that fires benignly during boot/restore, before the
+        // session reaches `.running`.
+        h.coordinator.attachmentWasDisconnected(error: TestFailure("initial boot"))
+        h.coordinator.configurationChanged()
+
+        #expect(h.device.appliedPlans.isEmpty)
+        #expect(!h.coordinator.isPending)
+    }
+
+    @Test("Stop cancels the retry and the link observation")
+    func stopCancelsRetryAndObservation() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0"),
+            retryDelays: [.seconds(60)])
+        h.coordinator.activate()
+        #expect(h.coordinator.isPending)
+        #expect(h.coordinator.retryTaskForTesting != nil)
+
+        h.coordinator.stop()
+
+        #expect(h.coordinator.retryTaskForTesting == nil)
+        #expect(!h.observer.isObserving)
+
+        // Stopped means torn down: a late event must not touch the device.
+        h.coordinator.attachmentWasDisconnected(error: TestFailure("late"))
+        #expect(h.device.appliedPlans.isEmpty)
+    }
+
+    @Test("A missing network choice leaves the attachment alone")
+    func missingChoiceLeavesAttachmentAlone() {
+        let h = makeHarness(choice: nil, devicePlan: .nat)
+
+        h.coordinator.activate()
+
+        #expect(h.device.appliedPlans.isEmpty)
+        #expect(h.device.detachCount == 0)
+        #expect(!h.coordinator.isPending)
+    }
+}

--- a/KernovaTests/NetworkAttachmentCoordinatorTests.swift
+++ b/KernovaTests/NetworkAttachmentCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KernovaTestSupport
 import Testing
 @testable import Kernova
@@ -17,11 +18,20 @@ struct NetworkAttachmentCoordinatorTests {
         init(_ choice: NetworkChoice?) { self.choice = choice }
     }
 
+    /// Mutable eligibility the coordinator's `isEligible` closure reads,
+    /// standing in for the live `VMInstance.status` gate.
+    @MainActor
+    private final class EligibilityBox {
+        var isEligible = true
+    }
+
     private struct Harness {
         let coordinator: NetworkAttachmentCoordinator
         let device: MockNetworkDeviceControl
         let provider: MockBridgedInterfaceProvider
         let observer: MockNetworkLinkObserver
+        let clock: TestEngineClock
+        let eligibility: EligibilityBox
         let choiceBox: ChoiceBox
         let pendingChanges: PendingRecorder
     }
@@ -40,12 +50,13 @@ struct NetworkAttachmentCoordinatorTests {
         devicePlan: NetworkAttachmentPlan? = nil,
         available: [BridgedInterface] = [],
         primary: String? = nil,
-        retryDelays: [Duration] = [],
-        disconnectBurstWindow: Duration = NetworkAttachmentCoordinator.defaultDisconnectBurstWindow
+        retryDelays: [TimeInterval] = []
     ) -> Harness {
         let device = MockNetworkDeviceControl(plan: devicePlan)
         let provider = MockBridgedInterfaceProvider(available: available, primary: primary)
         let observer = MockNetworkLinkObserver()
+        let clock = TestEngineClock()
+        let eligibility = EligibilityBox()
         let choiceBox = ChoiceBox(choice)
         let pendingChanges = PendingRecorder()
         let coordinator = NetworkAttachmentCoordinator(
@@ -54,12 +65,14 @@ struct NetworkAttachmentCoordinatorTests {
             interfaces: provider,
             linkObserver: observer,
             retryDelays: retryDelays,
-            disconnectBurstWindow: disconnectBurstWindow,
+            clock: clock,
+            isEligible: { eligibility.isEligible },
             choice: { choiceBox.choice },
             onPendingChange: { pendingChanges.record($0) })
         return Harness(
             coordinator: coordinator, device: device, provider: provider,
-            observer: observer, choiceBox: choiceBox, pendingChanges: pendingChanges)
+            observer: observer, clock: clock, eligibility: eligibility,
+            choiceBox: choiceBox, pendingChanges: pendingChanges)
     }
 
     // MARK: - Session start
@@ -123,12 +136,12 @@ struct NetworkAttachmentCoordinatorTests {
         #expect(h.pendingChanges.values.isEmpty)
     }
 
-    @Test("A disconnect burst paces reattach through the retry ladder")
-    func disconnectBurstPacesReattachThroughRetryLadder() async {
+    @Test("A persistent attach-fail loop escalates the ladder and ends pending")
+    func persistentAttachFailureEscalatesLadderThenRestsPending() async {
         let h = makeHarness(
             choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
             devicePlan: .nat,
-            retryDelays: [.milliseconds(1)])
+            retryDelays: [1, 2])
         h.coordinator.activate()
 
         // VZ fails the attachment: the first disconnect reattaches immediately.
@@ -136,34 +149,46 @@ struct NetworkAttachmentCoordinatorTests {
         h.coordinator.attachmentWasDisconnected(error: TestFailure("link down"))
         #expect(h.device.appliedPlans == [.nat])
 
-        // VZ fails that reattach straight away — a live attach reports failure
-        // only through another disconnect. Within the burst window the ladder
-        // paces the next attempt instead of reattaching in lockstep.
+        // Each reattach fails straight away — a live attach reports failure
+        // only through another disconnect inside the burst window — so the
+        // ladder paces every following attempt instead of reattaching in
+        // lockstep, walking both rungs.
+        for rung in 1...2 {
+            h.device.plan = nil
+            h.coordinator.attachmentWasDisconnected(error: TestFailure("attach failed"))
+            #expect(h.device.appliedPlans.count == rung)
+            #expect(h.coordinator.isPending)
+            guard let retry = h.coordinator.retryTaskForTesting else {
+                Issue.record("Expected a scheduled retry on rung \(rung)")
+                return
+            }
+            await retry.value
+            #expect(h.device.appliedPlans.count == rung + 1)
+        }
+
+        // Exhausted: the next failure report arms nothing and pending holds
+        // until a link event or a disconnect outside the burst window.
         h.device.plan = nil
         h.coordinator.attachmentWasDisconnected(error: TestFailure("attach failed"))
-        #expect(h.device.appliedPlans == [.nat])
+        #expect(h.coordinator.retryTaskForTesting == nil)
+        #expect(h.device.appliedPlans.count == 3)
         #expect(h.coordinator.isPending)
-
-        guard let retry = h.coordinator.retryTaskForTesting else {
-            Issue.record("Expected a scheduled retry")
-            return
-        }
-        await retry.value
-        #expect(h.device.appliedPlans == [.nat, .nat])
-        #expect(!h.coordinator.isPending)
     }
 
     @Test("Disconnects outside the burst window each reattach immediately")
     func spacedDisconnectsReattachImmediately() {
         let h = makeHarness(
             choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
-            devicePlan: .nat,
-            disconnectBurstWindow: .zero)
+            devicePlan: .nat)
         h.coordinator.activate()
 
-        for _ in 1...3 {
+        for round in 1...3 {
             h.device.plan = nil
             h.coordinator.attachmentWasDisconnected(error: TestFailure("link down"))
+            #expect(h.device.appliedPlans.count == round)
+            // The attachment holds long enough to outlive the burst window, so
+            // the next disconnect is a fresh link event, not a failure report.
+            h.clock.advance(seconds: NetworkAttachmentCoordinator.defaultDisconnectBurstWindow + 1)
         }
 
         #expect(h.device.appliedPlans == [.nat, .nat, .nat])
@@ -219,6 +244,70 @@ struct NetworkAttachmentCoordinatorTests {
 
         #expect(h.device.appliedPlans.isEmpty)
         #expect(h.device.currentPlan == .bridged("en0"))
+    }
+
+    @Test("A vanished interface detaches the stale bridge, goes pending, and arms a retry")
+    func vanishedInterfaceDetachesStaleBridge() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en1"),
+            devicePlan: .bridged("en1"),
+            available: [Self.ethernet],
+            primary: "en1",
+            retryDelays: [60])
+        h.coordinator.activate()
+        #expect(!h.coordinator.isPending)
+
+        // en1 pulled and the default route with it; the link event can land
+        // before (or without) VZ's disconnect callback, so the live attachment
+        // still names the vanished interface.
+        h.provider.available = []
+        h.provider.primary = nil
+        h.observer.fire()
+
+        #expect(h.device.detachCount == 1)
+        #expect(h.device.currentPlan == nil)
+        #expect(h.coordinator.isPending)
+        #expect(h.coordinator.retryTaskForTesting != nil)
+    }
+
+    @Test("A narrowed fallback holds while the default route flaps away")
+    func narrowedFallbackHeldWhilePrimaryGone() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en5"),
+            devicePlan: .bridged("en0"),
+            available: [Self.wiFi],
+            primary: "en0")
+        h.coordinator.activate()
+
+        h.provider.primary = nil
+        h.observer.fire()
+
+        #expect(h.device.appliedPlans.isEmpty)
+        #expect(h.device.detachCount == 0)
+        #expect(h.device.currentPlan == .bridged("en0"))
+        #expect(!h.coordinator.isPending)
+    }
+
+    @Test("An ineligible session drops triggers until re-activation")
+    func ineligibleSessionDropsTriggers() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
+            devicePlan: .nat)
+        h.coordinator.activate()
+
+        // Saving: the snapshot must not race an attachment mutation.
+        h.eligibility.isEligible = false
+        h.device.plan = nil
+        h.coordinator.attachmentWasDisconnected(error: TestFailure("mid-save"))
+        h.observer.fire()
+        h.coordinator.configurationChanged()
+        #expect(h.device.appliedPlans.isEmpty)
+        #expect(!h.coordinator.isPending)
+
+        // Back to .running: activation re-reconciles the dropped state.
+        h.eligibility.isEligible = true
+        h.coordinator.activate()
+        #expect(h.device.appliedPlans == [.nat])
     }
 
     // MARK: - Live configuration changes
@@ -280,7 +369,7 @@ struct NetworkAttachmentCoordinatorTests {
         let h = makeHarness(
             choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0"),
             available: [Self.wiFi],
-            retryDelays: [.milliseconds(1)])
+            retryDelays: [1])
         // The interface is listed but the attach refuses — the VZ interface
         // list lagging the dynamic store.
         h.device.refusedBridgeIdentifiers = ["en0"]
@@ -336,7 +425,7 @@ struct NetworkAttachmentCoordinatorTests {
     func stopCancelsRetryAndObservation() {
         let h = makeHarness(
             choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0"),
-            retryDelays: [.seconds(60)])
+            retryDelays: [60])
         h.coordinator.activate()
         #expect(h.coordinator.isPending)
         #expect(h.coordinator.retryTaskForTesting != nil)

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -1177,6 +1177,19 @@ struct VMConfigurationTests {
         #expect(config.bridgedInterfaceIdentifier == nil)
     }
 
+    @Test("networkChoice maps the persisted fields and is nil without a device")
+    func networkChoiceMapsPersistedFields() {
+        var config = VMConfiguration(name: "Test VM", guestOS: .linux, bootMode: .efi)
+        config.networkMode = .bridged
+        config.bridgedInterfaceIdentifier = "en0"
+        #expect(
+            config.networkChoice
+                == NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0"))
+
+        config.networkEnabled = false
+        #expect(config.networkChoice == nil)
+    }
+
     @Test("A config carrying neither network key decodes as Shared Network")
     func networkModeKeysMissingUseDefaults() throws {
         // `makeBaseJSON` carries `networkEnabled` but neither mode key.

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -498,12 +498,11 @@ struct VMInstanceTests {
             interfaces: provider,
             linkObserver: MockNetworkLinkObserver(),
             retryDelays: [],
-            choice: { [weak instance] in
-                guard let instance, instance.configuration.networkEnabled else { return nil }
-                return NetworkChoice(
-                    mode: instance.configuration.networkMode,
-                    bridgedInterfaceIdentifier: instance.configuration.bridgedInterfaceIdentifier)
+            isEligible: { [weak instance] in
+                guard let instance else { return false }
+                return instance.status == .running || instance.status == .paused
             },
+            choice: { [weak instance] in instance?.configuration.networkChoice },
             onPendingChange: { [weak instance] in instance?.networkAttachmentPending = $0 })
         instance.networkAttachmentCoordinator = coordinator
         return coordinator
@@ -543,13 +542,14 @@ struct VMInstanceTests {
 
     @Test("applyLivePolicy ignores a network change while the VM is stopped")
     func applyLivePolicyIgnoresNetworkChangeWhileStopped() {
-        let instance = makeInstance(status: .stopped)
+        let instance = makeInstance(status: .running)
         instance.configuration.networkEnabled = true
         instance.configuration.networkMode = .shared
         let device = MockNetworkDeviceControl()
         let coordinator = attachNetworkCoordinator(to: instance, device: device)
         coordinator.activate()
         #expect(device.appliedPlans == [.nat])
+        instance.status = .stopped
 
         let old = instance.configuration
         instance.configuration.networkMode = .bridged

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -483,6 +483,97 @@ struct VMInstanceTests {
         #expect(instance.statusToolTip == "The virtual machine failed to start.")
     }
 
+    // MARK: - Network Attachment Recovery
+
+    /// Wires a mock-backed coordinator onto `instance`, reading its live
+    /// configuration the way the production wiring does.
+    private func attachNetworkCoordinator(
+        to instance: VMInstance,
+        device: MockNetworkDeviceControl,
+        provider: MockBridgedInterfaceProvider = MockBridgedInterfaceProvider()
+    ) -> NetworkAttachmentCoordinator {
+        let coordinator = NetworkAttachmentCoordinator(
+            vmName: instance.name,
+            device: device,
+            interfaces: provider,
+            linkObserver: MockNetworkLinkObserver(),
+            retryDelays: [],
+            choice: { [weak instance] in
+                guard let instance, instance.configuration.networkEnabled else { return nil }
+                return NetworkChoice(
+                    mode: instance.configuration.networkMode,
+                    bridgedInterfaceIdentifier: instance.configuration.bridgedInterfaceIdentifier)
+            },
+            onPendingChange: { [weak instance] in instance?.networkAttachmentPending = $0 })
+        instance.networkAttachmentCoordinator = coordinator
+        return coordinator
+    }
+
+    @Test("A running VM awaiting network reattach shows the warning tint and says why")
+    func networkPendingShowsWarningTintAndToolTip() {
+        let instance = makeInstance(status: .running)
+        instance.networkAttachmentPending = true
+
+        #expect(instance.statusDisplayNSColor == StatusColor.warning)
+        let tip = instance.statusToolTip
+        #expect(tip != nil)
+        #expect(tip!.contains("network interface"))
+    }
+
+    @Test("applyLivePolicy forwards a network mode change to the coordinator")
+    func applyLivePolicyForwardsNetworkChange() {
+        let instance = makeInstance(status: .running)
+        instance.configuration.networkEnabled = true
+        instance.configuration.networkMode = .shared
+        let device = MockNetworkDeviceControl(plan: .nat)
+        let coordinator = attachNetworkCoordinator(
+            to: instance, device: device,
+            provider: MockBridgedInterfaceProvider(
+                available: [BridgedInterface(identifier: "en0", localizedDisplayName: "Wi-Fi")]))
+        coordinator.activate()
+        #expect(device.appliedPlans.isEmpty)
+
+        let old = instance.configuration
+        instance.configuration.networkMode = .bridged
+        instance.configuration.bridgedInterfaceIdentifier = "en0"
+        instance.applyLivePolicy(oldConfig: old, newConfig: instance.configuration)
+
+        #expect(device.appliedPlans == [.bridged("en0")])
+    }
+
+    @Test("applyLivePolicy ignores a network change while the VM is stopped")
+    func applyLivePolicyIgnoresNetworkChangeWhileStopped() {
+        let instance = makeInstance(status: .stopped)
+        instance.configuration.networkEnabled = true
+        instance.configuration.networkMode = .shared
+        let device = MockNetworkDeviceControl()
+        let coordinator = attachNetworkCoordinator(to: instance, device: device)
+        coordinator.activate()
+        #expect(device.appliedPlans == [.nat])
+
+        let old = instance.configuration
+        instance.configuration.networkMode = .bridged
+        instance.applyLivePolicy(oldConfig: old, newConfig: instance.configuration)
+
+        #expect(device.appliedPlans == [.nat])
+    }
+
+    @Test("tearDownSession stops network recovery and clears the pending flag")
+    func tearDownSessionStopsNetworkRecovery() {
+        let instance = makeInstance(status: .running)
+        instance.configuration.networkEnabled = true
+        instance.configuration.networkMode = .bridged
+        let device = MockNetworkDeviceControl()
+        let coordinator = attachNetworkCoordinator(to: instance, device: device)
+        coordinator.activate()
+        #expect(instance.networkAttachmentPending)
+
+        instance.tearDownSession()
+
+        #expect(instance.networkAttachmentCoordinator == nil)
+        #expect(!instance.networkAttachmentPending)
+    }
+
     // MARK: - Lifecycle Action Labels
 
     @Test("startAction is .start without a pending install context")

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -821,7 +821,8 @@ struct VMSettingsViewControllerTests {
         macAddress: String? = "aa:bb:cc:dd:ee:ff",
         interfaces: MockBridgedInterfaceProvider = MockBridgedInterfaceProvider(),
         entitled: Bool = true,
-        isReadOnly: Bool = false
+        isReadOnly: Bool = false,
+        status: VMStatus = .stopped
     ) -> (VMSettingsViewController, VMInstance) {
         let config = VMConfiguration(
             name: "Test VM", guestOS: .linux, bootMode: .efi,
@@ -829,7 +830,7 @@ struct VMSettingsViewControllerTests {
             bridgedInterfaceIdentifier: bridgedInterfaceIdentifier, macAddress: macAddress)
         let bundleURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(config.id.uuidString, isDirectory: true)
-        let instance = VMInstance(configuration: config, bundleURL: bundleURL)
+        let instance = VMInstance(configuration: config, bundleURL: bundleURL, status: status)
         let vc = VMSettingsViewController(
             instance: instance, viewModel: makeViewModel(), isReadOnly: isReadOnly,
             bridgedInterfaces: interfaces,
@@ -1039,11 +1040,62 @@ struct VMSettingsViewControllerTests {
         #expect(instance.configuration.macAddress == "aa:bb:cc:dd:ee:ff")
     }
 
-    @Test("Read-only disables the Mode picker")
-    func readOnlyDisablesTheModePicker() throws {
+    @Test("While a networked VM runs, the picker stays live with None disabled")
+    func runningVMKeepsThePickerLiveWithNoneDisabled() throws {
         let (vc, _) = makeNetworkController(
-            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi]), isReadOnly: true)
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi], primary: "en0"),
+            isReadOnly: true, status: .running)
+
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        #expect(popUp.isEnabled)
+        #expect(popUp.menu?.items.first { $0.title == "None" }?.isEnabled == false)
+        #expect(popUp.menu?.items.first { $0.title == "Shared Network" }?.isEnabled == true)
+        #expect(popUp.menu?.items.first { $0.title == "Wi-Fi (en0)" }?.isEnabled == true)
+    }
+
+    @Test("A live mode switch writes the config from the running picker")
+    func runningPickerWritesALiveModeSwitch() throws {
+        let (vc, instance) = makeNetworkController(
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi], primary: "en0"),
+            isReadOnly: true, status: .running)
+        let popUp = try #require(networkModePopUp(in: vc.view))
+
+        popUp.selectItem(withTitle: "Wi-Fi (en0)")
+        popUp.sendAction(popUp.action, to: popUp.target)
+
+        #expect(instance.configuration.networkMode == .bridged)
+        #expect(instance.configuration.bridgedInterfaceIdentifier == "en0")
+    }
+
+    @Test("A running VM in None mode keeps the picker locked")
+    func runningNoneModeVMKeepsThePickerLocked() throws {
+        let (vc, _) = makeNetworkController(
+            networkEnabled: false,
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi]),
+            isReadOnly: true, status: .running)
         #expect(networkModePopUp(in: vc.view)?.isEnabled == false)
+    }
+
+    @Test("Transitional and cold-paused states lock the picker")
+    func transitionalStatesLockThePicker() throws {
+        for status in [VMStatus.saving, .restoring, .paused] {
+            // `.paused` with no live `VZVirtualMachine` is cold-paused — there
+            // is no session to hot-swap an attachment on.
+            let (vc, _) = makeNetworkController(
+                interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi]),
+                isReadOnly: true, status: status)
+            #expect(networkModePopUp(in: vc.view)?.isEnabled == false)
+        }
+    }
+
+    @Test("A stopped VM keeps the fully editable picker, None included")
+    func stoppedVMKeepsTheEditablePicker() throws {
+        let (vc, _) = makeNetworkController(
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi]))
+
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        #expect(popUp.isEnabled)
+        #expect(popUp.menu?.items.first { $0.title == "None" }?.isEnabled == true)
     }
 
     // MARK: - Helpers (view-tree introspection)

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -1053,6 +1053,21 @@ struct VMSettingsViewControllerTests {
         #expect(popUp.menu?.items.first { $0.title == "Wi-Fi (en0)" }?.isEnabled == true)
     }
 
+    @Test("The Network lock icon hides while the picker is live, and only then")
+    func networkLockIconHidesWhileThePickerIsLive() {
+        let (liveVC, _) = makeNetworkController(
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi], primary: "en0"),
+            isReadOnly: true, status: .running)
+        // Every other lockable section still shows its lock; only the live
+        // picker's section drops the claim.
+        #expect(lockIcons(in: liveVC.view).filter(\.isHidden).count == 1)
+
+        let (savingVC, _) = makeNetworkController(
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi]),
+            isReadOnly: true, status: .saving)
+        #expect(lockIcons(in: savingVC.view).allSatisfy { !$0.isHidden })
+    }
+
     @Test("A live mode switch writes the config from the running picker")
     func runningPickerWritesALiveModeSwitch() throws {
         let (vc, instance) = makeNetworkController(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,7 +126,16 @@ input, audio, the Linux SPICE console port, and the macOS `VZVirtioSocketDeviceC
 
 The network attachment follows the VM's persisted mode: shared NAT, or bridged over a host
 interface resolved through `BridgedInterfaceProviding` — the same seam the settings section's Mode
-picker reads its interface list from.
+picker reads its interface list from. A bridged VM whose interface cannot resolve builds the
+device detached rather than failing the boot or restore.
+
+While a session runs, `NetworkAttachmentCoordinator` (one per session, owned by `VMInstance`,
+activated when the VM reaches `.running`) keeps the live attachment realizing the persisted mode.
+It reconciles on VZ's attachment-disconnect delegate callback, on host link changes observed
+through `NetworkLinkObserving` (`HostNetworkLinkObserver`, SCDynamicStore), and on live
+mode/interface edits arriving through the `applyLivePolicy` path, driving the device through the
+`NetworkDeviceControlling` seam. A session with no realizable attachment surfaces as
+`VMInstance.networkAttachmentPending`, which the sidebar status affordances read.
 
 **VZ is only ever handed symlink-resolved URLs.** VZ resolves no symlinks and rejects a path
 containing one in any component, reporting it as a missing or invalid file while `FileManager`


### PR DESCRIPTION
Closes #813

## Summary

- A new per-session `NetworkAttachmentCoordinator` keeps a live VM's network attachment realizing the configured mode: it reconciles on VZ's `attachmentWasDisconnectedWithError:` callback (benign by design — it also fires at boot, device reset, and guest reboot, so it is never surfaced as a VM error), on host link changes observed through SCDynamicStore, and with a bounded backoff ladder for `VZBridgedNetworkInterface.networkInterfaces` lagging the dynamic-store event that announces a returning interface.
- Recovery narrows but never escalates (docs/NETWORKING.md principle 2). Bridged resolution is reclaim → hold → narrow: a returning persisted interface is reclaimed; otherwise a live bridge is held while the host still offers its interface (so neither a default-route change nor the route flapping away bounces a working bridge); otherwise the default-route interface. When nothing resolves, any remaining attachment is stale and the device runs detached — never a substituted mode.
- Bridged now composes with save-suspend: a bridged configuration with no resolvable interface builds its network device detached (`nil` attachment — the documented configuration default) instead of throwing. Previously, restoring a suspended bridged VM into a network environment without its interface failed the restore, and the failure path deleted the saved state and cold-booted.
- The Mode picker becomes the live-switch surface while a networked VM runs or is live-paused. **Live mode transitions (Shared ↔ Bridged) are allowed** — the open decision the issue reserved for pickup: hot-swap supports them identically to interface switching, a live switch is an explicit per-VM user gesture (principle 1 is about silent widening, not user choices), and one uniform rule avoids a picker whose enablement depends on which mode the VM happens to be in. `None` stays disabled while running — network devices cannot be added or removed at runtime — and a VM in `None` mode keeps the picker locked.
- Degraded state surfaces through existing affordances only: `VMInstance.networkAttachmentPending` drives the sidebar warning tint and a status tooltip. No alerts, no new `VMStatus` case.

## Design notes

- A live `VZNetworkDevice.attachment` set reports failure only asynchronously, through another disconnect callback (VZNetworkDevice.h). An immediate reattach-on-disconnect would therefore spin in lockstep with a persistently failing attach — e.g. right after an undock, while VZ's interface list still names the vanished interface. A disconnect landing within one second of the last attach attempt is treated as that attempt's failure report and routes through the escalating retry ladder (1/2/4/8s, then rest until the next event); a disconnect with no recent attempt — the benign boot/reset callbacks — reattaches immediately.
- Attachment application re-fetches the concrete `VZBridgedNetworkInterface` by identifier at every attach; a VZ interface object held across a link change is stale.
- Reconciliation is gated to running and live-paused sessions (an `isEligible` seam reading VM status), keeping attachment churn away from boot, restore, and state saves — a swap mid-`saveMachineState` could fail the save. Activation at `.running` re-reconciles anything dropped while ineligible. VZ itself states no state precondition for runtime swaps; the gate is Kernova's choice.
- Time (the burst window, the retry ladder) goes through the injected `EngineClock` seam per docs/TESTING.md, as in the vsock/clipboard services; tests drive `TestEngineClock` across real window crossings.

## Changes

- `Kernova/Services/NetworkAttachmentRecovery.swift` (new): `NetworkAttachmentPlan`/`NetworkChoice`, `NetworkDeviceControlling` + `VZNetworkDeviceHandle`, `NetworkLinkObserving` + `HostNetworkLinkObserver` (SCDynamicStore), `NetworkAttachmentCoordinator`
- `Kernova/Models/VMInstance.swift`: coordinator lifecycle, `networkAttachmentPending`, disconnect delegate bridge, network diff in `applyLivePolicy`
- `Kernova/Services/VirtualizationService.swift`: coordinator activation at each `.running` transition
- `Kernova/Services/ConfigurationBuilder.swift`: unresolvable bridged interface builds the device detached; `noBridgeableInterface` error removed
- `Kernova/Views/Detail/VMSettingsViewController.swift`: live-switch picker enablement; `None` disabled while live; the Network header's lock icon hides while the picker is live
- `Kernova/Views/VMInstance+Display.swift`: warning tint and tooltip while a running VM awaits reattach
- `KernovaTests/`: `NetworkAttachmentCoordinatorTests` (17 cases incl. disconnect-burst pacing), VMInstance recovery/live-policy/display tests, picker enablement matrix, detached-bridged builder test, `MockNetworkDeviceControl` + `MockNetworkLinkObserver`
- `docs/ARCHITECTURE.md`: coordinator and link-observer boundary

## Test plan

- [x] `make test` — full suite passes
- [x] `make lint`

## Notes

- Attachment swaps are also applied while live-paused (the picker is enabled there, and a pause during a pending recovery still reconciles on events); if a paused-VM swap ever misbehaves, activation's re-reconcile at resume self-heals.
- Deviation-free against docs/research/2026-08-12-network-settings-ui.md item 7; the item's open question (live mode transitions) is decided here, as that doc assigns.
- Reviewed with `/code-review high` (recall-biased); the second commit addresses the six findings that survived adversarial verification — stale bridge reported healthy when no interface resolves, a burst heuristic that pinned the retry ladder to its first rung, reconciliation running during state saves, the missing `EngineClock` seam, a duplicated `VMConfiguration→NetworkChoice` mapping, and positional lock-icon recovery. One finding was dismissed deliberately: the degraded-network tint/tooltip stay scoped to `.running` — a paused guest has no traffic to lose, the scoping is documented at the property, and the flag restores the affordance at resume.
