### PR TITLE
fix: Attach one guest input device pair, chosen by version with an override

### DIFF
--- a/Kernova/Models/GuestAgentDiskDelivery.swift
+++ b/Kernova/Models/GuestAgentDiskDelivery.swift
@@ -1,5 +1,4 @@
 import Foundation
-import KernovaKit
 
 /// How the bundled guest-agent installer image reaches a macOS guest.
 ///
@@ -32,28 +31,7 @@ enum GuestAgentDiskDelivery: Equatable, Sendable {
         // `guestOS`, not `bootMode`: a Linux guest has no Kernova agent at all,
         // and both enums carry a `.macOS` case.
         guard config.guestOS == .macOS else { return .usb }
-        guard let version = effectiveGuestVersion(for: config) else { return .usb }
+        guard let version = config.effectiveGuestMacOSVersion else { return .usb }
         return version.isAtLeast(usbMassStorageFloor) ? .usb : .virtio
-    }
-
-    /// The best available reading of what macOS the guest is running.
-    ///
-    /// ``VMConfiguration/lastSeenGuestOSVersion`` wins: the agent rewrites it
-    /// whenever the guest reports something new, so it survives an in-guest
-    /// upgrade that leaves ``VMConfiguration/installedImage`` describing a
-    /// release no longer installed. It is peer-supplied free text, though, so a
-    /// report that parses to nothing falls through to the install record rather
-    /// than erasing its vote.
-    static func effectiveGuestVersion(for config: VMConfiguration) -> MacOSVersion? {
-        if let reported = config.lastSeenGuestOSVersion,
-            let numeric = KernovaOSVersion.numericVersion(in: reported),
-            let version = MacOSVersion(numeric)
-        {
-            return version
-        }
-        if case .macOSRestoreImage(let version, _) = config.installedImage {
-            return MacOSVersion(version)
-        }
-        return nil
     }
 }

--- a/Kernova/Models/GuestInputDevices.swift
+++ b/Kernova/Models/GuestInputDevices.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The single pointing/keyboard device pair a macOS guest's configuration
+/// carries.
+///
+/// Exactly one pair is ever attached: a macOS guest that merely *sees* the USB
+/// pointing device — bound or not, and regardless of array order — treats it
+/// as a mouse and pins its scrollbars always-visible via the default
+/// "Automatically based on mouse or trackpad" setting (observed on a macOS 26
+/// guest, 2026-08-12/13). A 13+ guest binds the Mac devices and an earlier
+/// guest recognizes only the USB pair (`VZMacTrackpadConfiguration.h`,
+/// `VZMacKeyboardConfiguration.h`).
+enum GuestInputDevices: Equatable, Sendable {
+    /// The Mac trackpad and keyboard, for a guest running macOS 13+.
+    case mac
+    /// The USB pointer and keyboard, for an earlier guest.
+    case usb
+
+    /// The first macOS release whose guests bind the Mac-specific input
+    /// devices (`VZMacTrackpadConfiguration.h`).
+    static let macInputFloor = MacOSVersion(major: 13, minor: 0)
+
+    /// The device pair the macOS guest described by `config` carries.
+    ///
+    /// An explicit ``VMConfiguration/inputDeviceMode`` choice wins; automatic
+    /// resolves from the guest's effective macOS version, and a guest with no
+    /// version signal takes the Mac pair — pre-13 guests are the exception,
+    /// and the explicit setting covers one arriving with no version record.
+    static func resolve(for config: VMConfiguration) -> GuestInputDevices {
+        switch config.inputDeviceMode {
+        case .mac: return .mac
+        case .usb: return .usb
+        case .automatic:
+            guard let version = config.effectiveGuestMacOSVersion else { return .mac }
+            return version.isAtLeast(macInputFloor) ? .mac : .usb
+        }
+    }
+}

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KernovaKit
 
 /// The user's preferred display hosting for a VM on start/resume.
 enum VMDisplayPreference: String, Codable, Sendable, Equatable {
@@ -12,6 +13,17 @@ enum VMNetworkMode: String, Codable, Sendable, Equatable {
     case shared
     case bridged
     case hostOnly
+}
+
+/// The user's choice of pointing/keyboard device pair for a macOS guest.
+enum VMInputDeviceMode: String, Codable, Sendable, Equatable {
+    /// Resolve the pair from the guest's effective macOS version.
+    case automatic
+    /// The Mac trackpad and keyboard, which only macOS 13+ guests recognize.
+    case mac
+    /// The USB pointer and keyboard, which every guest recognizes — but a
+    /// 13+ guest reads the pointer as a mouse and pins its scrollbars visible.
+    case usb
 }
 
 /// Persistent configuration for a virtual machine, serialized to `config.json`
@@ -121,6 +133,15 @@ struct VMConfiguration: Codable, Sendable, Equatable {
     /// When both this and `audioInputEnabled` are `false`, no virtio sound
     /// device is configured at all.
     var audioOutputEnabled: Bool
+
+    // MARK: - Input Devices
+
+    /// Which pointing/keyboard device pair a macOS guest carries; ignored by
+    /// Linux guests, which always take the USB pair.
+    ///
+    /// `.automatic` resolves through ``GuestInputDevices``. Applied at the
+    /// next boot, like the rest of the device configuration.
+    var inputDeviceMode: VMInputDeviceMode
 
     // MARK: - Guest Agent
 
@@ -252,6 +273,7 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         serialSocketRelayEnabled: Bool = false,
         audioInputEnabled: Bool = false,
         audioOutputEnabled: Bool = true,
+        inputDeviceMode: VMInputDeviceMode = .automatic,
         agentLogForwardingEnabled: Bool = false,
         lastSeenAgentVersion: String? = nil,
         lastSeenGuestOSVersion: String? = nil,
@@ -297,6 +319,7 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         self.serialSocketRelayEnabled = serialSocketRelayEnabled
         self.audioInputEnabled = audioInputEnabled
         self.audioOutputEnabled = audioOutputEnabled
+        self.inputDeviceMode = inputDeviceMode
         self.agentLogForwardingEnabled = agentLogForwardingEnabled
         self.lastSeenAgentVersion = lastSeenAgentVersion
         self.lastSeenGuestOSVersion = lastSeenGuestOSVersion
@@ -356,6 +379,8 @@ struct VMConfiguration: Codable, Sendable, Equatable {
             try c.decodeIfPresent(Bool.self, forKey: .serialSocketRelayEnabled) ?? false
         self.audioInputEnabled = try c.decodeIfPresent(Bool.self, forKey: .audioInputEnabled) ?? false
         self.audioOutputEnabled = try c.decodeIfPresent(Bool.self, forKey: .audioOutputEnabled) ?? true
+        self.inputDeviceMode =
+            try c.decodeIfPresent(VMInputDeviceMode.self, forKey: .inputDeviceMode) ?? .automatic
         self.agentLogForwardingEnabled = try c.decodeIfPresent(Bool.self, forKey: .agentLogForwardingEnabled) ?? false
         self.lastSeenAgentVersion = try c.decodeIfPresent(String.self, forKey: .lastSeenAgentVersion)
         self.lastSeenGuestOSVersion = try c.decodeIfPresent(String.self, forKey: .lastSeenGuestOSVersion)
@@ -495,6 +520,31 @@ struct VMConfiguration: Codable, Sendable, Equatable {
 
     static func removableMediaChanged(old: VMConfiguration, new: VMConfiguration) -> Bool {
         (old.removableMedia ?? []) != (new.removableMedia ?? [])
+    }
+}
+
+// MARK: - Effective guest version
+
+extension VMConfiguration {
+    /// The best available reading of what macOS the guest is running, or `nil`
+    /// when nothing has vouched for one.
+    ///
+    /// ``lastSeenGuestOSVersion`` wins: the agent rewrites it whenever the
+    /// guest reports something new, so it survives an in-guest upgrade that
+    /// leaves ``installedImage`` describing a release no longer installed. It
+    /// is peer-supplied free text, though, so a report that parses to nothing
+    /// falls through to the install record rather than erasing its vote.
+    var effectiveGuestMacOSVersion: MacOSVersion? {
+        if let reported = lastSeenGuestOSVersion,
+            let numeric = KernovaOSVersion.numericVersion(in: reported),
+            let version = MacOSVersion(numeric)
+        {
+            return version
+        }
+        if case .macOSRestoreImage(let version, _) = installedImage {
+            return MacOSVersion(version)
+        }
+        return nil
     }
 }
 

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -153,10 +153,8 @@ struct ConfigurationBuilder: Sendable {
 
     /// Attaches the display, pointing, and keyboard devices for a macOS guest.
     ///
-    /// Both input arrays pair the Mac device with its USB equivalent: a guest running
-    /// macOS 13.0 or later binds `VZMacTrackpadConfiguration`/`VZMacKeyboardConfiguration`
-    /// and ignores the USB devices, while an earlier guest recognizes only the USB ones
-    /// (`VZMacTrackpadConfiguration.h`, `VZMacKeyboardConfiguration.h`).
+    /// The input arrays carry exactly the one pair ``GuestInputDevices``
+    /// resolves for the guest — never both.
     private func configureMacOSDevices(_ vzConfig: VZVirtualMachineConfiguration, config: VMConfiguration) {
         let graphics = VZMacGraphicsDeviceConfiguration()
         graphics.displays = [
@@ -168,14 +166,14 @@ struct ConfigurationBuilder: Sendable {
         ]
         vzConfig.graphicsDevices = [graphics]
 
-        vzConfig.pointingDevices = [
-            VZMacTrackpadConfiguration(),
-            VZUSBScreenCoordinatePointingDeviceConfiguration(),
-        ]
-        vzConfig.keyboards = [
-            VZMacKeyboardConfiguration(),
-            VZUSBKeyboardConfiguration(),
-        ]
+        switch GuestInputDevices.resolve(for: config) {
+        case .mac:
+            vzConfig.pointingDevices = [VZMacTrackpadConfiguration()]
+            vzConfig.keyboards = [VZMacKeyboardConfiguration()]
+        case .usb:
+            vzConfig.pointingDevices = [VZUSBScreenCoordinatePointingDeviceConfiguration()]
+            vzConfig.keyboards = [VZUSBKeyboardConfiguration()]
+        }
     }
 
     #if DEBUG

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -1465,7 +1465,7 @@ extension VMSettingsViewController {
     /// Info copy for the macOS-only input devices picker.
     private static let inputDevicesInfoParagraphs: [InfoPopoverParagraph] = [
         .body(
-            "Chooses the virtual keyboard and pointing device the guest sees. Automatic picks by the guest's macOS version: the Mac devices for macOS 13 and later, the USB devices for earlier guests, which don't recognize the Mac ones."
+            "Chooses the virtual keyboard and pointing device the guest sees. Automatic picks by the guest's macOS version: the Mac devices for macOS 13 and later, the USB devices for earlier guests, which don't recognize the Mac ones. When the guest's version isn't known, Automatic picks the Mac devices — choose USB here if such a guest has no working input."
         ),
         .body(
             "The USB pointer reads as a mouse inside the guest, so macOS shows permanently visible scroll bars instead of trackpad-style overlay scroll bars."

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -193,6 +193,9 @@ final class VMSettingsViewController: NSViewController {
     private var audioOutputSwitch = NSSwitch()
     private var audioWarningContainer = NSStackView()
 
+    // Input devices (macOS guests only)
+    private var inputDevicesPopUp = NSPopUpButton()
+
     // Guest Agent
     private var logForwardingSwitch = NSSwitch()
     private var installReminderSwitch = NSSwitch()
@@ -514,6 +517,9 @@ extension VMSettingsViewController {
         addSection(buildSharedDirectoriesSection())
         addSection(buildNetworkSection())
         addSection(buildAudioSection())
+        if instance.configuration.guestOS == .macOS {
+            addSection(buildInputDevicesSection())
+        }
         if isGuestAgentSectionVisible(guestOS: instance.configuration.guestOS) {
             // macOS: clipboard rides the agent's vsock channel, so it nests in
             // the agent group rather than forming a sibling section.
@@ -1447,6 +1453,48 @@ extension VMSettingsViewController {
         ])
     }
 
+    // MARK: Input Devices
+
+    /// Titles and modes for the input devices popup, in menu order.
+    private static let inputDeviceChoices: [(title: String, mode: VMInputDeviceMode)] = [
+        ("Automatic", .automatic),
+        ("Mac Keyboard and Trackpad", .mac),
+        ("USB Keyboard and Mouse", .usb),
+    ]
+
+    /// Info copy for the macOS-only input devices picker.
+    private static let inputDevicesInfoParagraphs: [InfoPopoverParagraph] = [
+        .body(
+            "Chooses the virtual keyboard and pointing device the guest sees. Automatic picks by the guest's macOS version: the Mac devices for macOS 13 and later, the USB devices for earlier guests, which don't recognize the Mac ones."
+        ),
+        .body(
+            "The USB pointer reads as a mouse inside the guest, so macOS shows permanently visible scroll bars instead of trackpad-style overlay scroll bars."
+        ),
+    ]
+
+    private func buildInputDevicesSection() -> NSView {
+        inputDevicesPopUp = makeInputDevicesPopUp()
+        persistentLockableControls.append(inputDevicesPopUp)
+        return makeSection([
+            makeHeader("Input", lockable: true, paragraphs: Self.inputDevicesInfoParagraphs),
+            makeGroupedFormCard(rows: [
+                makeGroupedFormCardRow("Devices", control: inputDevicesPopUp)
+            ]),
+        ])
+    }
+
+    private func makeInputDevicesPopUp() -> NSPopUpButton {
+        let popUp = NSPopUpButton()
+        popUp.controlSize = .small
+        for choice in Self.inputDeviceChoices {
+            popUp.addItem(withTitle: choice.title)
+            popUp.lastItem?.representedObject = choice.mode
+        }
+        popUp.target = self
+        popUp.action = #selector(inputDevicesChanged)
+        return popUp
+    }
+
     // MARK: Guest Agent
 
     /// Caption shown beneath the macOS Guest Agent card.
@@ -1763,6 +1811,7 @@ extension VMSettingsViewController {
         refreshDisplay()
         refreshNetwork()
         refreshAudio()
+        refreshInputDevices()
         refreshGuestAgent()
         refreshClipboard()
         refreshSerialRelay()
@@ -2016,6 +2065,20 @@ extension VMSettingsViewController {
                 trailingButtons: [info])
             addFullWidth(banner, to: audioWarningContainer)
         }
+    }
+
+    private func refreshInputDevices() {
+        guard instance.configuration.guestOS == .macOS else { return }
+        let mode = instance.configuration.inputDeviceMode
+        let index = inputDevicesPopUp.itemArray.firstIndex {
+            ($0.representedObject as? VMInputDeviceMode) == mode
+        }
+        guard let index else {
+            Self.logger.fault("No popup item for input device mode '\(mode.rawValue, privacy: .public)'")
+            assertionFailure("No popup item for input device mode: \(mode.rawValue)")
+            return
+        }
+        inputDevicesPopUp.selectItem(at: index)
     }
 
     private func refreshGuestAgent() {
@@ -2518,6 +2581,17 @@ extension VMSettingsViewController: NSMenuItemValidation {
 
     @objc private func audioOutputToggled() {
         writeConfig { $0.audioOutputEnabled = audioOutputSwitch.state == .on }
+    }
+
+    @objc private func inputDevicesChanged() {
+        guard
+            let mode = inputDevicesPopUp.selectedItem?.representedObject as? VMInputDeviceMode
+        else {
+            Self.logger.fault("Input devices popup selection carries no mode")
+            assertionFailure("Input devices popup selection carries no mode")
+            return
+        }
+        writeConfig { $0.inputDeviceMode = mode }
     }
 
     @objc private func logForwardingToggled() {

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -1238,22 +1238,59 @@ struct ConfigurationBuilderTests {
 
     // MARK: - Input Devices
 
-    @Test("macOS guests get both the Mac and USB pointing/keyboard devices")
-    func macOSInputDevicesIncludeUSBFallbacks() {
+    @Test("A guest known to run macOS 13+ gets only the Mac input devices")
+    func macOSInputDevicesMacPairForModernGuest() {
         // Called directly rather than through `assemble`: the rest of
         // `configureMacOSBoot` needs a real `VZMacHardwareModel`, which only a
         // restore image can mint.
         let vz = VZVirtualMachineConfiguration()
+        var config = VMConfiguration(name: "Test macOS", guestOS: .macOS, bootMode: .macOS)
+        config.lastSeenGuestOSVersion = "13.5"
+        ConfigurationBuilder().configureMacOSDevicesForTesting(vz, config: config)
+
+        #expect(vz.pointingDevices.count == 1)
+        #expect(vz.pointingDevices.first is VZMacTrackpadConfiguration)
+        #expect(vz.keyboards.count == 1)
+        #expect(vz.keyboards.first is VZMacKeyboardConfiguration)
+    }
+
+    @Test("A guest known to predate macOS 13 gets only the USB input devices")
+    func macOSInputDevicesUSBPairForOldGuest() {
+        let vz = VZVirtualMachineConfiguration()
+        var config = VMConfiguration(name: "Test macOS", guestOS: .macOS, bootMode: .macOS)
+        config.installedImage = .macOSRestoreImage(version: "12.0.1", build: "21A559")
+        ConfigurationBuilder().configureMacOSDevicesForTesting(vz, config: config)
+
+        #expect(vz.pointingDevices.count == 1)
+        #expect(vz.pointingDevices.first is VZUSBScreenCoordinatePointingDeviceConfiguration)
+        #expect(vz.keyboards.count == 1)
+        #expect(vz.keyboards.first is VZUSBKeyboardConfiguration)
+    }
+
+    @Test("A guest with no version signal still gets exactly the Mac pair")
+    func macOSInputDevicesMacPairWhenVersionUnknown() {
+        let vz = VZVirtualMachineConfiguration()
         let config = VMConfiguration(name: "Test macOS", guestOS: .macOS, bootMode: .macOS)
         ConfigurationBuilder().configureMacOSDevicesForTesting(vz, config: config)
 
-        #expect(vz.pointingDevices.count == 2)
+        #expect(vz.pointingDevices.count == 1)
         #expect(vz.pointingDevices.first is VZMacTrackpadConfiguration)
-        #expect(vz.pointingDevices.last is VZUSBScreenCoordinatePointingDeviceConfiguration)
-
-        #expect(vz.keyboards.count == 2)
+        #expect(vz.keyboards.count == 1)
         #expect(vz.keyboards.first is VZMacKeyboardConfiguration)
-        #expect(vz.keyboards.last is VZUSBKeyboardConfiguration)
+    }
+
+    @Test("An explicit USB choice overrides a 13+ guest's automatic Mac pair")
+    func macOSInputDevicesHonorExplicitUSBChoice() {
+        let vz = VZVirtualMachineConfiguration()
+        var config = VMConfiguration(name: "Test macOS", guestOS: .macOS, bootMode: .macOS)
+        config.lastSeenGuestOSVersion = "26.0"
+        config.inputDeviceMode = .usb
+        ConfigurationBuilder().configureMacOSDevicesForTesting(vz, config: config)
+
+        #expect(vz.pointingDevices.count == 1)
+        #expect(vz.pointingDevices.first is VZUSBScreenCoordinatePointingDeviceConfiguration)
+        #expect(vz.keyboards.count == 1)
+        #expect(vz.keyboards.first is VZUSBKeyboardConfiguration)
     }
 
     @Test("macOS display device carries the configured size and pixel density")

--- a/KernovaTests/GuestAgentDiskDeliveryTests.swift
+++ b/KernovaTests/GuestAgentDiskDeliveryTests.swift
@@ -104,7 +104,7 @@ struct GuestAgentDiskDeliveryTests {
     func unparsableInstallRecord() {
         var config = Self.makeConfig()
         config.installedImage = .macOSRestoreImage(version: "not a version", build: "21A559")
-        #expect(GuestAgentDiskDelivery.effectiveGuestVersion(for: config) == nil)
+        #expect(config.effectiveGuestMacOSVersion == nil)
         #expect(GuestAgentDiskDelivery.mode(for: config) == .usb)
     }
 
@@ -112,7 +112,7 @@ struct GuestAgentDiskDeliveryTests {
     func linuxInstallRecordIsNotAVersion() {
         var config = Self.makeConfig()
         config.installedImage = .linuxCatalogImage(distribution: "Ubuntu", version: "12.0.1")
-        #expect(GuestAgentDiskDelivery.effectiveGuestVersion(for: config) == nil)
+        #expect(config.effectiveGuestMacOSVersion == nil)
         #expect(GuestAgentDiskDelivery.mode(for: config) == .usb)
     }
 

--- a/KernovaTests/GuestInputDevicesTests.swift
+++ b/KernovaTests/GuestInputDevicesTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("GuestInputDevices Tests")
+struct GuestInputDevicesTests {
+    // MARK: - Helpers
+
+    /// One row of the decision table.
+    struct Case: Sendable, CustomStringConvertible {
+        let lastSeen: String?
+        let installedVersion: String?
+        let expected: GuestInputDevices
+
+        init(_ lastSeen: String?, _ installedVersion: String?, _ expected: GuestInputDevices) {
+            self.lastSeen = lastSeen
+            self.installedVersion = installedVersion
+            self.expected = expected
+        }
+
+        var description: String {
+            "reported \(lastSeen ?? "nil"), installed \(installedVersion ?? "nil") → \(expected)"
+        }
+    }
+
+    private static func makeConfig(
+        lastSeen: String? = nil,
+        installedVersion: String? = nil,
+        mode: VMInputDeviceMode = .automatic
+    ) -> VMConfiguration {
+        var config = VMConfiguration(name: "Test", guestOS: .macOS, bootMode: .macOS)
+        config.lastSeenGuestOSVersion = lastSeen
+        config.inputDeviceMode = mode
+        if let installedVersion {
+            config.installedImage = .macOSRestoreImage(version: installedVersion, build: "21A559")
+        }
+        return config
+    }
+
+    // MARK: - Automatic decision table
+
+    @Test(
+        "Automatic resolves the pair from the guest's version",
+        arguments: [
+            // No signal at all resolves to the Mac pair — still exactly one.
+            Case(nil, nil, .mac),
+            // Install record alone, on both sides of the floor.
+            Case(nil, "12.7.6", .usb),
+            Case(nil, "12.9.9", .usb),
+            Case(nil, "13.0", .mac),
+            Case(nil, "13.0.1", .mac),
+            Case(nil, "26.0", .mac),
+            // The agent's report outranks the install record, both directions.
+            Case("13.5", "12.0.1", .mac),
+            Case("12.0.1", "13.5", .usb),
+            // Localized free-form reports still read as a version.
+            Case("Versión 12.2.1 (Compilación 21D62)", nil, .usb),
+            Case("Version 13.0 (Build 22A380)", nil, .mac),
+            // A report that parses to nothing falls through rather than
+            // erasing the install record's vote.
+            Case("macOS", "13.0", .mac),
+            Case("", "12.0.1", .usb),
+            Case("macOS", nil, .mac),
+        ])
+    func automaticFollowsGuestVersion(testCase: Case) {
+        let config = Self.makeConfig(
+            lastSeen: testCase.lastSeen, installedVersion: testCase.installedVersion)
+        #expect(GuestInputDevices.resolve(for: config) == testCase.expected)
+    }
+
+    @Test("A Linux install record leaves the version unknown, resolving to the Mac pair")
+    func linuxInstallRecordResolvesMac() {
+        var config = Self.makeConfig()
+        config.installedImage = .linuxCatalogImage(distribution: "Ubuntu", version: "22.04")
+        #expect(GuestInputDevices.resolve(for: config) == .mac)
+    }
+
+    // MARK: - Explicit modes
+
+    @Test("An explicit Mac choice wins over a pre-13 version")
+    func explicitMacBeatsOldVersion() {
+        let config = Self.makeConfig(lastSeen: "12.0.1", mode: .mac)
+        #expect(GuestInputDevices.resolve(for: config) == .mac)
+    }
+
+    @Test("An explicit USB choice wins over a 13+ version")
+    func explicitUSBBeatsModernVersion() {
+        let config = Self.makeConfig(lastSeen: "26.0", mode: .usb)
+        #expect(GuestInputDevices.resolve(for: config) == .usb)
+    }
+}

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -1305,6 +1305,34 @@ struct VMConfigurationTests {
         #expect(decoded.bridgedInterfaceIdentifier == nil)
     }
 
+    // MARK: - Input Device Mode Tests
+
+    @Test("inputDeviceMode defaults to automatic, in the initializer and on a missing key")
+    func inputDeviceModeDefaults() throws {
+        let config = VMConfiguration(name: "Test VM", guestOS: .macOS, bootMode: .macOS)
+        #expect(config.inputDeviceMode == .automatic)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
+        #expect(decoded.inputDeviceMode == .automatic)
+    }
+
+    @Test("Configuration preserves an explicit input device mode")
+    func inputDeviceModeRoundTrip() throws {
+        var config = VMConfiguration(name: "Test VM", guestOS: .macOS, bootMode: .macOS)
+        config.inputDeviceMode = .usb
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(config)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: data)
+        #expect(decoded.inputDeviceMode == .usb)
+    }
+
     // MARK: - Full-field round-trip
 
     /// Populates every property with a non-default value, encodes to JSON,

--- a/docs/research/2026-08-13-vz-input-device-side-effects.md
+++ b/docs/research/2026-08-13-vz-input-device-side-effects.md
@@ -1,0 +1,41 @@
+# A VZ USB pointing device's presence pins a 13+ macOS guest's scrollbars
+
+**Date:** 2026-08-13 · **Host:** M1 Max, 32 GB, macOS 27.0 beta 5 (26A5406e) · **Guest:** macOS 26
+
+## Summary
+
+A macOS guest configured with both `VZMacTrackpadConfiguration` and
+`VZUSBScreenCoordinatePointingDeviceConfiguration` shows permanent, legacy-width
+scrollbars: the guest binds the Mac trackpad for input (per the
+`VZMacTrackpadConfiguration.h` pairing guidance) but still *enumerates* the USB
+device as a mouse, and the default "Show scroll bars: Automatically based on
+mouse or trackpad" setting pins scrollbars visible whenever any mouse is
+present. Array order does not matter — USB-first and Mac-first both pin.
+Attaching only the Mac pair restores fading overlay scrollbars. Apple's headers
+and docs describe only which device a guest *uses*, never the presence side
+effect, and nothing documents the both-attached case beyond it.
+
+Separately, on this host `VZVirtualMachineView.capturesSystemKeys = true`
+forwards no system hot keys (⌘-Tab acts on the host) in an app build predating
+every Kernova input-device change, so the capture break is host-side, not
+app-side. The onset is unbracketed — beta 4 was gone before the symptom was
+isolated. Nothing in the macOS 27 release notes (all betas, diffed), the
+current class documentation, or the WWDC26 Virtualization session mentions any
+input or system-key change; groundwater/GhostVM#157 records the same capture
+failure appearing on a macOS Sequoia point release with no app change and
+resolving in a later one.
+
+## Method
+
+Three builds of the same app, same guest VM, same host session, judged by
+scrollbar persistence in the guest and by where ⌘-Tab lands with the VM view
+focused:
+
+1. Mac pair only (pre-`14e6519` build) — scrollbars fade; ⌘-Tab still host.
+2. Both pairs, Mac first (`14e6519`'s arrays) — scrollbars pinned.
+3. Both pairs, USB first (scratch probe) — scrollbars pinned, ruling out order.
+
+Release-notes comparison: Apple's `macos-27-release-notes` JSON data feed
+(current, beta 5) diffed against a 2026-06-23 Wayback capture of the same
+endpoint, full-text searched for input/hot-key/scrollbar terms alongside the
+five relevant class-documentation JSON feeds.


### PR DESCRIPTION
## Summary

#683 paired the Mac trackpad/keyboard with USB fallbacks so pre-13 macOS guests get working input — following the pattern Apple's headers recommend. It turns out the pairing isn't free: a macOS 13+ guest binds the Mac devices for input but still *enumerates* the USB pointing device as a mouse, and the guest's default "Show scroll bars: Automatically based on mouse or trackpad" setting pins scrollbars permanently visible whenever a mouse is present. A/B testing showed array order is irrelevant — presence alone triggers it — and Apple documents nothing about the both-attached case (method and findings in `docs/research/2026-08-13-vz-input-device-side-effects.md`).

A macOS guest now carries **exactly one** pointing/keyboard pair, never both:

- `GuestInputDevices.resolve(for:)` picks the Mac pair for guests known to run macOS 13+, the USB pair for known older guests, and the Mac pair when no version signal answers.
- A new per-VM **Input → Devices** setting (Automatic / Mac Keyboard and Trackpad / USB Keyboard and Mouse, default Automatic) is the explicit override — the escape hatch for a pre-13 guest that arrives with no version record.
- The guest-version reading (`effectiveGuestVersion`) moves from `GuestAgentDiskDelivery` onto `VMConfiguration.effectiveGuestMacOSVersion` now that two policies consume it.

The same investigation isolated a second, independent symptom: `capturesSystemKeys` no longer forwards ⌘-Tab into guests on macOS 27 beta 5 — reproduced with a build predating all input-device changes, so it's host-side (same failure class as groundwater/GhostVM#157 on Sequoia, which self-resolved in a later point update). Recorded in the research note; no app change addresses it.

## Changes

- `Kernova/Models/VMConfiguration.swift` — persisted `inputDeviceMode` (`VMInputDeviceMode`, `decodeIfPresent ?? .automatic`); `effectiveGuestMacOSVersion` extension
- `Kernova/Models/GuestInputDevices.swift` (new) — two-case resolved pair + resolution policy
- `Kernova/Models/GuestAgentDiskDelivery.swift` — reads the shared version property
- `Kernova/Services/ConfigurationBuilder.swift` — attaches the resolved single pair
- `Kernova/Views/Detail/VMSettingsViewController.swift` — macOS-only Input section
- `KernovaTests/` — `GuestInputDevicesTests` (new), builder device-pair cases, persistence coverage
- `docs/research/2026-08-13-vz-input-device-side-effects.md` (new)

## Test plan

- [x] `make test` — full suite green
- [x] `make lint`
- [x] Manual A/B on a macOS 26 guest: both pairs (either order) → pinned scrollbars; Mac pair only → fading overlay scrollbars restored
- [ ] Boot a pre-13 guest (or set Devices → USB) and confirm input works

## Notes

- A VM suspended under the two-pair config won't restore into the single-pair config; discard saved state and boot fresh (test VMs only — this never shipped in a release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAnL4N2neAWQUwEUR3g4sP