### PR TITLE
feat: Host-only and VM-to-VM networking

### DIFF
--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -11,6 +11,7 @@ enum VMDisplayPreference: String, Codable, Sendable, Equatable {
 enum VMNetworkMode: String, Codable, Sendable, Equatable {
     case shared
     case bridged
+    case hostOnly
 }
 
 /// Persistent configuration for a virtual machine, serialized to `config.json`

--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -31,6 +31,9 @@ struct ConfigurationBuilder: Sendable {
     /// Host state behind a bridged attachment's interface choice.
     var bridgedInterfaces: any BridgedInterfaceProviding = HostBridgedInterfaceProvider()
 
+    /// The app-managed vmnet networks behind a Host Only attachment.
+    var vmnetNetworks: any VmnetNetworkProviding = VmnetNetworkService.shared
+
     /// What this build's signature authorizes; a fresh instance rather than
     /// `.shared`, which is `@MainActor` while assembly runs off the main actor.
     var entitlements = EntitlementService()
@@ -578,6 +581,8 @@ struct ConfigurationBuilder: Sendable {
             networkDevice.attachment = VZNATNetworkDeviceAttachment()
         case .bridged:
             networkDevice.attachment = try bridgedAttachment(config: config)
+        case .hostOnly:
+            networkDevice.attachment = try hostOnlyAttachment(config: config)
         }
 
         if let macString = config.macAddress,
@@ -631,6 +636,31 @@ struct ConfigurationBuilder: Sendable {
             Self.logger.info("Bridging over '\(chosen, privacy: .public)'")
         }
         return VZBridgedNetworkDeviceAttachment(interface: interface)
+    }
+
+    /// The attachment joining the app-managed Host Only network.
+    ///
+    /// A network that cannot be materialized builds the device detached (`nil`)
+    /// rather than failing the build, for the same reason the bridged
+    /// no-interface path does: a throwing build fails a save-file restore,
+    /// which deletes the saved state and cold-boots. Attachment recovery
+    /// retries once the session runs.
+    private func hostOnlyAttachment(config: VMConfiguration) throws -> VZNetworkDeviceAttachment? {
+        guard entitlements.hasVMNetworking else {
+            Self.logger.error(
+                "Host-only networking requested for '\(config.name, privacy: .public)' in a build without com.apple.vm.networking"
+            )
+            throw ConfigurationBuilderError.hostOnlyNetworkingNotEntitled
+        }
+
+        do {
+            return try vmnetNetworks.attachment(for: .hostOnly)
+        } catch {
+            Self.logger.error(
+                "Host Only network for '\(config.name, privacy: .public)' could not be materialized — starting detached: \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
     }
 
     private func configureEntropy(_ vzConfig: VZVirtualMachineConfiguration) {
@@ -935,6 +965,9 @@ enum ConfigurationBuilderError: LocalizedError {
     /// Bridged mode was chosen in a build whose signature omits
     /// `com.apple.vm.networking`, which VZ needs for any non-NAT attachment.
     case bridgedNetworkingNotEntitled
+    /// Host Only counterpart of `bridgedNetworkingNotEntitled` — vmnet needs
+    /// the same entitlement for all API use.
+    case hostOnlyNetworkingNotEntitled
     case sharedDirectoryNotFound(String)
     case sharedDirectoryNotADirectory(String)
     case sharedDirectoryNotReadable(String)
@@ -974,6 +1007,8 @@ enum ConfigurationBuilderError: LocalizedError {
             "Couldn't open removable media '\(label)' at \(path). The file may have been moved or replaced, or Kernova may no longer have permission to read it. (\(underlying.localizedDescription))"
         case .bridgedNetworkingNotEntitled:
             "This build of Kernova can't provide bridged networking. Switch the VM's network mode to Shared Network."
+        case .hostOnlyNetworkingNotEntitled:
+            "This build of Kernova can't provide host-only networking. Switch the VM's network mode to Shared Network."
         case .sharedDirectoryNotFound(let path):
             "Shared directory not found at \(path)."
         case .sharedDirectoryNotADirectory(let path):

--- a/Kernova/Services/NetworkAttachmentRecovery.swift
+++ b/Kernova/Services/NetworkAttachmentRecovery.swift
@@ -10,18 +10,18 @@ enum NetworkAttachmentPlan: Equatable {
     case bridged(String)
     case hostOnly
 
-    /// Whether this plan realizes `mode` — a NAT attachment realizes Shared
-    /// Network, a bridged attachment over any interface realizes Bridged, a
-    /// vmnet attachment on the app's Host Only network realizes Host Only.
-    func matches(_ mode: VMNetworkMode) -> Bool {
-        switch (self, mode) {
-        case (.nat, .shared), (.bridged, .bridged), (.hostOnly, .hostOnly):
-            true
-        case (.nat, .bridged), (.nat, .hostOnly),
-            (.bridged, .shared), (.bridged, .hostOnly),
-            (.hostOnly, .shared), (.hostOnly, .bridged):
-            false
+    /// The mode this plan realizes. The bridged interface is deliberately
+    /// ignored: an attachment over any interface realizes Bridged.
+    var realizedMode: VMNetworkMode {
+        switch self {
+        case .nat: .shared
+        case .bridged: .bridged
+        case .hostOnly: .hostOnly
         }
+    }
+
+    func matches(_ mode: VMNetworkMode) -> Bool {
+        realizedMode == mode
     }
 }
 
@@ -97,9 +97,10 @@ final class VZNetworkDeviceHandle: NetworkDeviceControlling {
             device.attachment = VZBridgedNetworkDeviceAttachment(interface: interface)
             return true
         case .hostOnly:
-            // The provider logs the failure detail; the coordinator paces the
-            // retry.
-            guard let attachment = try? vmnetNetworks.attachment(for: .hostOnly) else {
+            // Non-blocking: an unmaterialized network refuses the apply, and
+            // the coordinator materializes it off-main and reconciles when
+            // it's ready.
+            guard let attachment = vmnetNetworks.attachmentIfMaterialized(for: .hostOnly) else {
                 return false
             }
             device.attachment = attachment
@@ -170,12 +171,13 @@ final class HostNetworkLinkObserver: NetworkLinkObserving {
     }
 }
 
-// `SCDynamicStore` invokes these on the store's dispatch queue, so they must
-// be `nonisolated` file-scope functions, never closure literals formed inside
-// the `@MainActor` class: the compiler gives such a literal main-actor
-// isolation plus a dynamic check, which traps (`EXC_BREAKPOINT` in
-// `dispatch_assert_queue`) the moment a real link event fires — observed
-// 2026-08-13, first host-only VM boot.
+// RATIONALE (2026-08-13): `SCDynamicStore` invokes these on the store's
+// dispatch queue, so they must be `nonisolated` file-scope functions, never
+// closure literals formed inside the `@MainActor` class: the compiler gives
+// such a literal main-actor isolation plus a dynamic check, which traps
+// (`EXC_BREAKPOINT` in `dispatch_assert_queue`) the moment a real link event
+// fires — observed on the first host-only VM boot, which reconfigures host
+// interfaces and fires the event immediately.
 
 private nonisolated func hostLinkObserverRetain(_ info: UnsafeRawPointer) -> UnsafeRawPointer {
     _ = Unmanaged<AnyObject>.fromOpaque(info).retain()
@@ -227,12 +229,20 @@ final class NetworkAttachmentCoordinator {
     /// would spin at VZ's failure cadence.
     static let defaultDisconnectBurstWindow: TimeInterval = 1
 
+    /// Reattempt cadence, in seconds, after a failed vmnet materialization
+    /// while a Host Only session sits detached. The NetworkSharing daemon
+    /// publishes no recovery notification, so attempts pace themselves —
+    /// bounded like the attach ladder; a later reconcile trigger re-enters.
+    static let defaultVmnetRematerializeDelays: [TimeInterval] = [8, 16, 32]
+
     private let vmName: String
     private let device: any NetworkDeviceControlling
     private let interfaces: any BridgedInterfaceProviding
     private let linkObserver: any NetworkLinkObserving
+    private let vmnetNetworks: any VmnetNetworkProviding
     private let retryDelays: [TimeInterval]
     private let disconnectBurstWindow: TimeInterval
+    private let vmnetRematerializeDelays: [TimeInterval]
     private let clock: any EngineClock
     private var lastAttachAttemptAt: EngineInstant?
     private let isEligible: @MainActor () -> Bool
@@ -245,14 +255,22 @@ final class NetworkAttachmentCoordinator {
     private var isActive = false
     private var retryTask: Task<Void, Never>?
     private var nextRetryIndex = 0
+    private var vmnetMaterializationTask: Task<Void, Never>?
+    /// Whether this pending episode already dropped the cached vmnet network —
+    /// once per episode bounds the recreate churn of a persistently failing
+    /// attachment.
+    private var didInvalidateVmnetNetwork = false
 
     init(
         vmName: String,
         device: any NetworkDeviceControlling,
         interfaces: any BridgedInterfaceProviding,
         linkObserver: any NetworkLinkObserving,
+        vmnetNetworks: (any VmnetNetworkProviding)? = nil,
         retryDelays: [TimeInterval] = NetworkAttachmentCoordinator.defaultRetryDelays,
         disconnectBurstWindow: TimeInterval = NetworkAttachmentCoordinator.defaultDisconnectBurstWindow,
+        vmnetRematerializeDelays: [TimeInterval] =
+            NetworkAttachmentCoordinator.defaultVmnetRematerializeDelays,
         clock: any EngineClock = makePlatformEngineClock(),
         isEligible: @escaping @MainActor () -> Bool = { true },
         choice: @escaping @MainActor () -> NetworkChoice?,
@@ -262,8 +280,10 @@ final class NetworkAttachmentCoordinator {
         self.device = device
         self.interfaces = interfaces
         self.linkObserver = linkObserver
+        self.vmnetNetworks = vmnetNetworks ?? VmnetNetworkService.shared
         self.retryDelays = retryDelays
         self.disconnectBurstWindow = disconnectBurstWindow
+        self.vmnetRematerializeDelays = vmnetRematerializeDelays
         self.clock = clock
         self.isEligible = isEligible
         self.choice = choice
@@ -284,6 +304,8 @@ final class NetworkAttachmentCoordinator {
         isActive = false
         linkObserver.stop()
         cancelRetry()
+        vmnetMaterializationTask?.cancel()
+        vmnetMaterializationTask = nil
     }
 
     /// VZ's attachment-disconnect callback: the framework has nil'd the
@@ -371,7 +393,38 @@ final class NetworkAttachmentCoordinator {
 
         let pending = device.currentPlan == nil
         setPending(pending)
-        if pending { scheduleRetry() }
+        if pending {
+            scheduleRetry()
+            if choice.mode == .hostOnly { ensureVmnetMaterialization() }
+        }
+    }
+
+    /// Drives the app's vmnet network toward materialized while a Host Only
+    /// session sits detached, reconciling the moment it is ready — the wake-up
+    /// signal ladder exhaustion would otherwise leave missing, since host link
+    /// changes are a bridged signal and a detached device fires no disconnects.
+    private func ensureVmnetMaterialization() {
+        guard vmnetMaterializationTask == nil else { return }
+        vmnetMaterializationTask = Task {
+            [weak self, clock, vmnetNetworks, vmnetRematerializeDelays] in
+            var attempt = 0
+            while !Task.isCancelled {
+                guard let coordinator = self, coordinator.isActive, coordinator.isPending else {
+                    break
+                }
+                if await vmnetNetworks.materializeNetwork(for: .hostOnly) {
+                    self?.vmnetMaterializationTask = nil
+                    if let coordinator = self, coordinator.isActive {
+                        coordinator.reconcile(trigger: "vmnet network materialized")
+                    }
+                    return
+                }
+                guard attempt < vmnetRematerializeDelays.count else { break }
+                do { try await clock.sleep(for: vmnetRematerializeDelays[attempt]) } catch { break }
+                attempt += 1
+            }
+            self?.vmnetMaterializationTask = nil
+        }
     }
 
     /// The plan the chosen mode resolves to right now, `nil` when Bridged has
@@ -406,7 +459,10 @@ final class NetworkAttachmentCoordinator {
     }
 
     private func scheduleRetry() {
-        guard nextRetryIndex < retryDelays.count else { return }
+        guard nextRetryIndex < retryDelays.count else {
+            ladderExhausted()
+            return
+        }
         let delay = retryDelays[nextRetryIndex]
         nextRetryIndex += 1
         retryTask = Task { [weak self, clock] in
@@ -422,9 +478,22 @@ final class NetworkAttachmentCoordinator {
         retryTask = nil
     }
 
+    /// A Host Only ladder burning out with the network materialized is the
+    /// defective-network signature — VZ accepts each attachment, then
+    /// disconnects it — so drop the cached network once per pending episode
+    /// and let materialization recreate it, pinned to the same persisted
+    /// addressing so the recreate cannot drift the subnet.
+    private func ladderExhausted() {
+        guard choice()?.mode == .hostOnly, !didInvalidateVmnetNetwork else { return }
+        didInvalidateVmnetNetwork = true
+        vmnetNetworks.invalidateNetwork(for: .hostOnly)
+        ensureVmnetMaterialization()
+    }
+
     private func setPending(_ pending: Bool) {
         guard pending != isPending else { return }
         isPending = pending
+        if !pending { didInvalidateVmnetNetwork = false }
         Self.logger.notice(
             "Network attachment for '\(self.vmName, privacy: .public)' is \(pending ? "pending reattach" : "attached", privacy: .public)"
         )
@@ -434,5 +503,7 @@ final class NetworkAttachmentCoordinator {
     #if DEBUG
     /// The in-flight backoff retry, for event-driven test waits.
     var retryTaskForTesting: Task<Void, Never>? { retryTask }
+    /// The in-flight vmnet materialization, for event-driven test waits.
+    var vmnetMaterializationTaskForTesting: Task<Void, Never>? { vmnetMaterializationTask }
     #endif
 }

--- a/Kernova/Services/NetworkAttachmentRecovery.swift
+++ b/Kernova/Services/NetworkAttachmentRecovery.swift
@@ -8,13 +8,19 @@ import os
 enum NetworkAttachmentPlan: Equatable {
     case nat
     case bridged(String)
+    case hostOnly
 
     /// Whether this plan realizes `mode` — a NAT attachment realizes Shared
-    /// Network, a bridged attachment over any interface realizes Bridged.
+    /// Network, a bridged attachment over any interface realizes Bridged, a
+    /// vmnet attachment on the app's Host Only network realizes Host Only.
     func matches(_ mode: VMNetworkMode) -> Bool {
         switch (self, mode) {
-        case (.nat, .shared), (.bridged, .bridged): true
-        case (.nat, .bridged), (.bridged, .shared): false
+        case (.nat, .shared), (.bridged, .bridged), (.hostOnly, .hostOnly):
+            true
+        case (.nat, .bridged), (.nat, .hostOnly),
+            (.bridged, .shared), (.bridged, .hostOnly),
+            (.hostOnly, .shared), (.hostOnly, .bridged):
+            false
         }
     }
 }
@@ -52,9 +58,14 @@ protocol NetworkDeviceControlling: AnyObject {
 @MainActor
 final class VZNetworkDeviceHandle: NetworkDeviceControlling {
     private let device: VZNetworkDevice
+    private let vmnetNetworks: any VmnetNetworkProviding
 
-    init(device: VZNetworkDevice) {
+    init(
+        device: VZNetworkDevice,
+        vmnetNetworks: any VmnetNetworkProviding = VmnetNetworkService.shared
+    ) {
         self.device = device
+        self.vmnetNetworks = vmnetNetworks
     }
 
     var currentPlan: NetworkAttachmentPlan? {
@@ -63,6 +74,10 @@ final class VZNetworkDeviceHandle: NetworkDeviceControlling {
             .nat
         case let bridged as VZBridgedNetworkDeviceAttachment:
             .bridged(bridged.interface.identifier)
+        case is VZVmnetNetworkDeviceAttachment:
+            // The app manages exactly one vmnet network today, so any vmnet
+            // attachment realizes Host Only.
+            .hostOnly
         default:
             nil
         }
@@ -80,6 +95,14 @@ final class VZNetworkDeviceHandle: NetworkDeviceControlling {
                 })
             else { return false }
             device.attachment = VZBridgedNetworkDeviceAttachment(interface: interface)
+            return true
+        case .hostOnly:
+            // The provider logs the failure detail; the coordinator paces the
+            // retry.
+            guard let attachment = try? vmnetNetworks.attachment(for: .hostOnly) else {
+                return false
+            }
+            device.attachment = attachment
             return true
         }
     }
@@ -105,7 +128,8 @@ final class HostNetworkLinkObserver: NetworkLinkObserving {
         subsystem: "app.kernova", category: "HostNetworkLinkObserver")
 
     private var store: SCDynamicStore?
-    private var onChange: (() -> Void)?
+    /// `fileprivate` for the file-scope callout below.
+    fileprivate var onChange: (() -> Void)?
 
     func start(onChange: @escaping @MainActor () -> Void) {
         stop()
@@ -117,23 +141,13 @@ final class HostNetworkLinkObserver: NetworkLinkObserving {
         var context = SCDynamicStoreContext(
             version: 0,
             info: Unmanaged.passUnretained(self).toOpaque(),
-            retain: { info in
-                _ = Unmanaged<AnyObject>.fromOpaque(info).retain()
-                return info
-            },
-            release: { info in
-                Unmanaged<AnyObject>.fromOpaque(info).release()
-            },
+            retain: hostLinkObserverRetain,
+            release: hostLinkObserverRelease,
             copyDescription: nil)
         guard
             let store = SCDynamicStoreCreate(
                 nil, "Kernova.NetworkLinkObserver" as CFString,
-                { _, _, info in
-                    guard let info else { return }
-                    let observer = Unmanaged<HostNetworkLinkObserver>.fromOpaque(info)
-                        .takeUnretainedValue()
-                    Task { @MainActor in observer.onChange?() }
-                },
+                hostLinkObserverCallout,
                 &context)
         else {
             Self.logger.fault("SCDynamicStoreCreate returned nil — link changes go unobserved")
@@ -154,6 +168,30 @@ final class HostNetworkLinkObserver: NetworkLinkObserving {
         SCDynamicStoreSetDispatchQueue(store, nil)
         self.store = nil
     }
+}
+
+// `SCDynamicStore` invokes these on the store's dispatch queue, so they must
+// be `nonisolated` file-scope functions, never closure literals formed inside
+// the `@MainActor` class: the compiler gives such a literal main-actor
+// isolation plus a dynamic check, which traps (`EXC_BREAKPOINT` in
+// `dispatch_assert_queue`) the moment a real link event fires — observed
+// 2026-08-13, first host-only VM boot.
+
+private nonisolated func hostLinkObserverRetain(_ info: UnsafeRawPointer) -> UnsafeRawPointer {
+    _ = Unmanaged<AnyObject>.fromOpaque(info).retain()
+    return info
+}
+
+private nonisolated func hostLinkObserverRelease(_ info: UnsafeRawPointer) {
+    Unmanaged<AnyObject>.fromOpaque(info).release()
+}
+
+private nonisolated func hostLinkObserverCallout(
+    _ store: SCDynamicStore, _ changedKeys: CFArray, _ info: UnsafeMutableRawPointer?
+) {
+    guard let info else { return }
+    let observer = Unmanaged<HostNetworkLinkObserver>.fromOpaque(info).takeUnretainedValue()
+    Task { @MainActor in observer.onChange?() }
 }
 
 /// Keeps one VM session's live network attachment realizing the mode the user
@@ -342,6 +380,8 @@ final class NetworkAttachmentCoordinator {
         switch choice.mode {
         case .shared:
             return .nat
+        case .hostOnly:
+            return .hostOnly
         case .bridged:
             let available = interfaces.interfaces().map(\.identifier)
             // The persisted interface is reclaimed the moment the host offers

--- a/Kernova/Services/VMStorageService.swift
+++ b/Kernova/Services/VMStorageService.swift
@@ -17,18 +17,24 @@ struct VMStorageService: Sendable {
 
     // MARK: - Directory Helpers
 
-    var vmsDirectory: URL {
+    /// The `Application Support/Kernova` root every app-level store hangs off —
+    /// the single derivation of the path, so stores can never strand each other
+    /// by recomputing it differently.
+    static var supportDirectory: URL {
         get throws {
-            let appSupport = try FileManager.default.url(
+            try FileManager.default.url(
                 for: .applicationSupportDirectory,
                 in: .userDomainMask,
                 appropriateFor: nil,
                 create: true
             )
-            let vmsDir =
-                appSupport
-                .appendingPathComponent("Kernova", isDirectory: true)
-                .appendingPathComponent("VMs", isDirectory: true)
+            .appendingPathComponent("Kernova", isDirectory: true)
+        }
+    }
+
+    var vmsDirectory: URL {
+        get throws {
+            let vmsDir = try Self.supportDirectory.appendingPathComponent("VMs", isDirectory: true)
 
             if !FileManager.default.fileExists(atPath: vmsDir.path(percentEncoded: false)) {
                 try FileManager.default.createDirectory(at: vmsDir, withIntermediateDirectories: true)

--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -71,14 +71,6 @@ struct VmnetOperationError: Error, LocalizedError {
 }
 
 /// The real `VmnetNetworkOperating`, over the macOS 26 vmnet network APIs.
-///
-/// RATIONALE (2026-08-13): a serialization from
-/// `vmnet_network_copy_serialization` is usable only while its source network
-/// still exists. `vmnet_network_create_with_serialization` returns success
-/// either way, but interfaces start only on a rebuild made while the source
-/// lives (measured; the headers state no validity window). The pair therefore
-/// cannot carry a network across launches — persistence here pins the
-/// reserved addressing onto a fresh configuration instead.
 struct HostVmnetNetworkOperator: VmnetNetworkOperating {
     private static let logger = Logger(subsystem: "app.kernova", category: "HostVmnetNetworkOperator")
 

--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -26,11 +26,10 @@ struct VmnetNetworkAddressing: Codable, Sendable, Equatable {
 
 /// A materialized app-managed vmnet network.
 ///
-/// The wrapped ref is returned retained by vmnet and never released: Swift
-/// imports it as a bare `OpaquePointer` with no release path, and the app
-/// holds every materialized network for its lifetime anyway — the subnet
-/// reservation lives exactly as long as the ref (vmnet.h), and a network must
-/// outlive any single VM session so concurrent VMs can share it.
+/// The wrapped ref stays alive as long as the service caches the handle — the
+/// subnet reservation lives exactly as long as the ref (vmnet.h), and a
+/// network must outlive any single VM session so concurrent VMs can share it.
+/// Only `invalidateNetwork(for:)` releases one.
 struct VmnetNetworkHandle: @unchecked Sendable {
     /// Feed to `VZVmnetNetworkDeviceAttachment(network:)`. Safe to cross
     /// isolation domains: the ref is an immutable reservation handle.
@@ -46,6 +45,15 @@ protocol VmnetNetworkOperating: Sendable {
     /// the network actually reserved.
     func createNetwork(_ kind: VmnetNetworkKind, addressing: VmnetNetworkAddressing?) throws
         -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing)
+    /// Releases `handle`'s network ref, ending its subnet reservation.
+    func releaseNetwork(_ handle: VmnetNetworkHandle)
+}
+
+/// Releases a vmnet object Swift imports as a bare `OpaquePointer`. The vmnet
+/// header documents these as `CFRelease()`-able; Swift refuses a direct
+/// `CFRelease` on an unmanaged import, so route through `Unmanaged`.
+func releaseVmnetRef(_ ref: OpaquePointer) {
+    Unmanaged<AnyObject>.fromOpaque(UnsafeRawPointer(ref)).release()
 }
 
 /// A vmnet call that failed.
@@ -83,6 +91,7 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
         guard let configuration = vmnet_network_configuration_create(mode(for: kind), &status) else {
             throw VmnetOperationError(operation: "vmnet_network_configuration_create", status: status)
         }
+        defer { releaseVmnetRef(configuration) }
         if let addressing {
             try pin(addressing, onto: configuration)
         }
@@ -95,6 +104,10 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
             "Created \(kind.rawValue, privacy: .public) network (\(addressing == nil ? "fresh" : "pinned", privacy: .public)): \(reserved.ipv4Subnet, privacy: .public) mask \(reserved.ipv4Mask, privacy: .public), \(reserved.ipv6Prefix, privacy: .public)/\(reserved.ipv6PrefixLength, privacy: .public)"
         )
         return (VmnetNetworkHandle(network: network), reserved)
+    }
+
+    func releaseNetwork(_ handle: VmnetNetworkHandle) {
+        releaseVmnetRef(handle.network)
     }
 
     private func mode(for kind: VmnetNetworkKind) -> operating_modes_t {
@@ -165,12 +178,24 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
     }
 }
 
-/// App-managed vmnet networks, as attachment construction consumes them.
+/// App-managed vmnet networks, as attachment construction and attachment
+/// recovery consume them.
 protocol VmnetNetworkProviding: Sendable {
     /// A VZ attachment joining the app-managed network of `kind`, materializing
-    /// the network first if this launch hasn't yet. Throws when it cannot be
-    /// materialized.
+    /// the network first if this launch hasn't yet. Blocks for the vmnet XPC
+    /// round-trip — never call on the main actor; config assembly runs
+    /// off-main. Throws when the network cannot be materialized.
     func attachment(for kind: VmnetNetworkKind) throws -> VZNetworkDeviceAttachment
+    /// The non-blocking variant for the main-actor live-attach path: an
+    /// attachment when the network is already materialized, `nil` otherwise.
+    func attachmentIfMaterialized(for kind: VmnetNetworkKind) -> VZNetworkDeviceAttachment?
+    /// Materializes the network of `kind` off the caller's actor. `true` on
+    /// success (or when already materialized); failures are logged here.
+    func materializeNetwork(for kind: VmnetNetworkKind) async -> Bool
+    /// Drops (and releases) the materialized network of `kind`, so the next
+    /// materialization creates it anew — pinned to the persisted addressing,
+    /// so recovery cannot drift the subnet.
+    func invalidateNetwork(for kind: VmnetNetworkKind)
 }
 
 /// Owns the app's managed vmnet networks — today the Host Only network; the
@@ -195,8 +220,13 @@ final class VmnetNetworkService: @unchecked Sendable {
 
     private let operations: any VmnetNetworkOperating
     private let storeURL: URL?
-    private let lock = NSLock()
+    /// Guards `handles` only — never held across a vmnet call or file I/O, so
+    /// the main-actor `attachmentIfMaterialized` path can never block behind a
+    /// materialization in flight.
+    private let stateLock = NSLock()
     private var handles: [VmnetNetworkKind: VmnetNetworkHandle] = [:]
+    /// Serializes materialization, so concurrent callers produce one network.
+    private let materializeLock = NSLock()
 
     /// `storeURL: nil` disables persistence — networks still materialize, with
     /// addressing stable only within the session.
@@ -210,34 +240,49 @@ final class VmnetNetworkService: @unchecked Sendable {
 
     /// `networks.json` beside the `VMs/` directory.
     static func defaultStoreURL() -> URL? {
-        try? FileManager.default.url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )
-        .appendingPathComponent("Kernova", isDirectory: true)
-        .appendingPathComponent("networks.json", isDirectory: false)
+        try? VMStorageService.supportDirectory
+            .appendingPathComponent("networks.json", isDirectory: false)
     }
 
     /// The app-managed network of `kind`, materializing it on first use.
+    /// Blocks for the vmnet XPC round-trip — never call on the main actor.
     func network(for kind: VmnetNetworkKind) throws -> VmnetNetworkHandle {
-        lock.lock()
-        defer { lock.unlock() }
-        if let handle = handles[kind] { return handle }
+        if let handle = cachedHandle(for: kind) { return handle }
+        materializeLock.lock()
+        defer { materializeLock.unlock() }
+        if let handle = cachedHandle(for: kind) { return handle }
         let handle = try materialize(kind)
+        stateLock.lock()
         handles[kind] = handle
+        stateLock.unlock()
         return handle
+    }
+
+    private func cachedHandle(for kind: VmnetNetworkKind) -> VmnetNetworkHandle? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return handles[kind]
     }
 
     private func materialize(_ kind: VmnetNetworkKind) throws -> VmnetNetworkHandle {
         var store = loadStore()
         if let stored = store[kind] {
             do {
-                let (handle, _) = try operations.createNetwork(kind, addressing: stored)
-                Self.logger.info(
-                    "Recreated the \(kind.rawValue, privacy: .public) network with its stored addressing"
-                )
+                let (handle, reserved) = try operations.createNetwork(kind, addressing: stored)
+                if reserved == stored {
+                    Self.logger.info(
+                        "Recreated the \(kind.rawValue, privacy: .public) network with its stored addressing"
+                    )
+                } else {
+                    // vmnet accepted the pin but reserved something else; the
+                    // store must follow what the network actually is, or every
+                    // later launch re-pins a value no network carries.
+                    store[kind] = reserved
+                    try? persist(store)
+                    Self.logger.warning(
+                        "Pinned \(kind.rawValue, privacy: .public) network addressing was adjusted by the system — persisting the reserved values"
+                    )
+                }
                 return handle
             } catch {
                 Self.logger.warning(
@@ -287,5 +332,38 @@ final class VmnetNetworkService: @unchecked Sendable {
 extension VmnetNetworkService: VmnetNetworkProviding {
     func attachment(for kind: VmnetNetworkKind) throws -> VZNetworkDeviceAttachment {
         VZVmnetNetworkDeviceAttachment(network: try network(for: kind).network)
+    }
+
+    func attachmentIfMaterialized(for kind: VmnetNetworkKind) -> VZNetworkDeviceAttachment? {
+        guard let handle = cachedHandle(for: kind) else { return nil }
+        return VZVmnetNetworkDeviceAttachment(network: handle.network)
+    }
+
+    // A nonisolated async method runs off the caller's actor, so the blocking
+    // vmnet round-trip inside `network(for:)` never lands on the main thread.
+    func materializeNetwork(for kind: VmnetNetworkKind) async -> Bool {
+        do {
+            _ = try network(for: kind)
+            return true
+        } catch {
+            Self.logger.error(
+                "Could not materialize the \(kind.rawValue, privacy: .public) network: \(error.localizedDescription, privacy: .public)"
+            )
+            return false
+        }
+    }
+
+    func invalidateNetwork(for kind: VmnetNetworkKind) {
+        stateLock.lock()
+        let dropped = handles.removeValue(forKey: kind)
+        stateLock.unlock()
+        guard let dropped else { return }
+        // Releasing the ref ends its subnet reservation; without this, the
+        // dropped network would keep the subnet and the pinned recreate of the
+        // same addressing would be refused as a conflict. The only caller is
+        // ladder exhaustion, where VZ has already torn down every attachment
+        // to the network.
+        operations.releaseNetwork(dropped)
+        Self.logger.notice("Invalidated the \(kind.rawValue, privacy: .public) network")
     }
 }

--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -72,15 +72,13 @@ struct VmnetOperationError: Error, LocalizedError {
 
 /// The real `VmnetNetworkOperating`, over the macOS 26 vmnet network APIs.
 ///
-/// RATIONALE (2026-08-13): `vmnet_network_copy_serialization` /
-/// `vmnet_network_create_with_serialization` look like the intended
-/// persistence path, but a rebuilt network is defective: VZ accepts an
-/// attachment to it and then disconnects within milliseconds ("Internal
-/// Network Error"), every time, while a freshly created network attaches
-/// cleanly — observed on macOS 27 beta (Darwin 27.0), with the serialization
-/// round-trip verified lossless via `xpc_equal`. Creating fresh with the
-/// persisted addressing pinned delivers the same relaunch stability on the
-/// path that works.
+/// RATIONALE (2026-08-13): a serialization from
+/// `vmnet_network_copy_serialization` is usable only while its source network
+/// still exists. `vmnet_network_create_with_serialization` returns success
+/// either way, but interfaces start only on a rebuild made while the source
+/// lives (measured; the headers state no validity window). The pair therefore
+/// cannot carry a network across launches — persistence here pins the
+/// reserved addressing onto a fresh configuration instead.
 struct HostVmnetNetworkOperator: VmnetNetworkOperating {
     private static let logger = Logger(subsystem: "app.kernova", category: "HostVmnetNetworkOperator")
 

--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -1,0 +1,291 @@
+import Foundation
+import Virtualization
+import os
+import vmnet
+
+/// An app-managed vmnet network, keyed by role. Each case is one logical
+/// network the app owns; every VM whose mode maps to that role joins the same
+/// network, so membership is what expresses guest↔guest reachability
+/// (docs/NETWORKING.md).
+// `CodingKeyRepresentable` so a `[VmnetNetworkKind: …]` store encodes as a
+// JSON object keyed by kind, not Codable's array-of-pairs fallback.
+enum VmnetNetworkKind: String, Codable, CodingKeyRepresentable, Sendable {
+    /// The Host Only network: guests on it reach the host and each other,
+    /// never the LAN or the internet.
+    case hostOnly
+}
+
+/// The addressing an app-managed network keeps stable across launches:
+/// dotted-quad IPv4 subnet and mask, plus the IPv6 prefix and its bit length.
+struct VmnetNetworkAddressing: Codable, Sendable, Equatable {
+    var ipv4Subnet: String
+    var ipv4Mask: String
+    var ipv6Prefix: String
+    var ipv6PrefixLength: UInt8
+}
+
+/// A materialized app-managed vmnet network.
+///
+/// The wrapped ref is returned retained by vmnet and never released: Swift
+/// imports it as a bare `OpaquePointer` with no release path, and the app
+/// holds every materialized network for its lifetime anyway — the subnet
+/// reservation lives exactly as long as the ref (vmnet.h), and a network must
+/// outlive any single VM session so concurrent VMs can share it.
+struct VmnetNetworkHandle: @unchecked Sendable {
+    /// Feed to `VZVmnetNetworkDeviceAttachment(network:)`. Safe to cross
+    /// isolation domains: the ref is an immutable reservation handle.
+    let network: vmnet_network_ref
+}
+
+/// The vmnet calls `VmnetNetworkService` makes, abstracted so tests run
+/// without `com.apple.vm.networking` — the real call is an XPC round-trip to
+/// the NetworkSharing daemon that fails unentitled.
+protocol VmnetNetworkOperating: Sendable {
+    /// Creates a network of `kind` — reserving `addressing` when given, the
+    /// system's choice when `nil` — and returns the handle plus the addressing
+    /// the network actually reserved.
+    func createNetwork(_ kind: VmnetNetworkKind, addressing: VmnetNetworkAddressing?) throws
+        -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing)
+}
+
+/// A vmnet call that failed.
+struct VmnetOperationError: Error, LocalizedError {
+    let operation: String
+    let status: vmnet_return_t?
+
+    var errorDescription: String? {
+        if let status {
+            "\(operation) failed (vmnet status \(status.rawValue))"
+        } else {
+            "\(operation) failed"
+        }
+    }
+}
+
+/// The real `VmnetNetworkOperating`, over the macOS 26 vmnet network APIs.
+///
+/// RATIONALE (2026-08-13): `vmnet_network_copy_serialization` /
+/// `vmnet_network_create_with_serialization` look like the intended
+/// persistence path, but a rebuilt network is defective: VZ accepts an
+/// attachment to it and then disconnects within milliseconds ("Internal
+/// Network Error"), every time, while a freshly created network attaches
+/// cleanly — observed on macOS 27 beta (Darwin 27.0), with the serialization
+/// round-trip verified lossless via `xpc_equal`. Creating fresh with the
+/// persisted addressing pinned delivers the same relaunch stability on the
+/// path that works.
+struct HostVmnetNetworkOperator: VmnetNetworkOperating {
+    private static let logger = Logger(subsystem: "app.kernova", category: "HostVmnetNetworkOperator")
+
+    func createNetwork(_ kind: VmnetNetworkKind, addressing: VmnetNetworkAddressing?) throws
+        -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing)
+    {
+        var status = vmnet_return_t.VMNET_SUCCESS
+        guard let configuration = vmnet_network_configuration_create(mode(for: kind), &status) else {
+            throw VmnetOperationError(operation: "vmnet_network_configuration_create", status: status)
+        }
+        if let addressing {
+            try pin(addressing, onto: configuration)
+        }
+        guard let network = vmnet_network_create(configuration, &status) else {
+            throw VmnetOperationError(operation: "vmnet_network_create", status: status)
+        }
+
+        let reserved = Self.reservedAddressing(of: network)
+        Self.logger.notice(
+            "Created \(kind.rawValue, privacy: .public) network (\(addressing == nil ? "fresh" : "pinned", privacy: .public)): \(reserved.ipv4Subnet, privacy: .public) mask \(reserved.ipv4Mask, privacy: .public), \(reserved.ipv6Prefix, privacy: .public)/\(reserved.ipv6PrefixLength, privacy: .public)"
+        )
+        return (VmnetNetworkHandle(network: network), reserved)
+    }
+
+    private func mode(for kind: VmnetNetworkKind) -> operating_modes_t {
+        switch kind {
+        case .hostOnly: .VMNET_HOST_MODE
+        }
+    }
+
+    private func pin(
+        _ addressing: VmnetNetworkAddressing, onto configuration: vmnet_network_configuration_ref
+    ) throws {
+        var subnet = in_addr()
+        var mask = in_addr()
+        guard
+            addressing.ipv4Subnet.withCString({ inet_pton(AF_INET, $0, &subnet) }) == 1,
+            addressing.ipv4Mask.withCString({ inet_pton(AF_INET, $0, &mask) }) == 1
+        else {
+            throw VmnetOperationError(operation: "parsing stored IPv4 addressing", status: nil)
+        }
+        let ipv4Status = vmnet_network_configuration_set_ipv4_subnet(configuration, &subnet, &mask)
+        guard ipv4Status == .VMNET_SUCCESS else {
+            throw VmnetOperationError(
+                operation: "vmnet_network_configuration_set_ipv4_subnet", status: ipv4Status)
+        }
+
+        var prefix = in6_addr()
+        guard addressing.ipv6Prefix.withCString({ inet_pton(AF_INET6, $0, &prefix) }) == 1 else {
+            throw VmnetOperationError(operation: "parsing stored IPv6 prefix", status: nil)
+        }
+        let ipv6Status = vmnet_network_configuration_set_ipv6_prefix(
+            configuration, &prefix, addressing.ipv6PrefixLength)
+        guard ipv6Status == .VMNET_SUCCESS else {
+            throw VmnetOperationError(
+                operation: "vmnet_network_configuration_set_ipv6_prefix", status: ipv6Status)
+        }
+    }
+
+    private static func reservedAddressing(of network: vmnet_network_ref) -> VmnetNetworkAddressing {
+        var subnet = in_addr()
+        var mask = in_addr()
+        vmnet_network_get_ipv4_subnet(network, &subnet, &mask)
+        var prefix = in6_addr()
+        var prefixLength: UInt8 = 0
+        vmnet_network_get_ipv6_prefix(network, &prefix, &prefixLength)
+        return VmnetNetworkAddressing(
+            ipv4Subnet: ipv4String(subnet),
+            ipv4Mask: ipv4String(mask),
+            ipv6Prefix: ipv6String(prefix),
+            ipv6PrefixLength: prefixLength)
+    }
+
+    private static func ipv4String(_ address: in_addr) -> String {
+        var address = address
+        var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+        guard inet_ntop(AF_INET, &address, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else {
+            return "?"
+        }
+        return String(cString: buffer)
+    }
+
+    private static func ipv6String(_ address: in6_addr) -> String {
+        var address = address
+        var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+        guard inet_ntop(AF_INET6, &address, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil else {
+            return "?"
+        }
+        return String(cString: buffer)
+    }
+}
+
+/// App-managed vmnet networks, as attachment construction consumes them.
+protocol VmnetNetworkProviding: Sendable {
+    /// A VZ attachment joining the app-managed network of `kind`, materializing
+    /// the network first if this launch hasn't yet. Throws when it cannot be
+    /// materialized.
+    func attachment(for kind: VmnetNetworkKind) throws -> VZNetworkDeviceAttachment
+}
+
+/// Owns the app's managed vmnet networks — today the Host Only network; the
+/// networks behind DHCP reservations and port forwarding extend this.
+///
+/// vmnet networks do not survive the process, so each network's addressing is
+/// persisted to `Application Support/Kernova/networks.json` and pinned onto
+/// the recreated network in later launches, keeping guest addressing stable.
+/// Materialization is lazy — a launch that never uses a kind never creates it —
+/// and a materialized network is held until the app exits: the subnet
+/// reservation lives as long as the ref, and every concurrent VM in the mode
+/// shares the one network.
+///
+/// Lock-guarded `Sendable` rather than `@MainActor`: it never touches
+/// `VZVirtualMachine`, and `ConfigurationBuilder` consumes it during off-main
+/// config assembly while the live-switch path consumes it on the main actor.
+final class VmnetNetworkService: @unchecked Sendable {
+    private static let logger = Logger(subsystem: "app.kernova", category: "VmnetNetworkService")
+
+    /// The process-wide instance over the real vmnet calls and store location.
+    static let shared = VmnetNetworkService()
+
+    private let operations: any VmnetNetworkOperating
+    private let storeURL: URL?
+    private let lock = NSLock()
+    private var handles: [VmnetNetworkKind: VmnetNetworkHandle] = [:]
+
+    /// `storeURL: nil` disables persistence — networks still materialize, with
+    /// addressing stable only within the session.
+    init(
+        operations: any VmnetNetworkOperating = HostVmnetNetworkOperator(),
+        storeURL: URL? = VmnetNetworkService.defaultStoreURL()
+    ) {
+        self.operations = operations
+        self.storeURL = storeURL
+    }
+
+    /// `networks.json` beside the `VMs/` directory.
+    static func defaultStoreURL() -> URL? {
+        try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        .appendingPathComponent("Kernova", isDirectory: true)
+        .appendingPathComponent("networks.json", isDirectory: false)
+    }
+
+    /// The app-managed network of `kind`, materializing it on first use.
+    func network(for kind: VmnetNetworkKind) throws -> VmnetNetworkHandle {
+        lock.lock()
+        defer { lock.unlock() }
+        if let handle = handles[kind] { return handle }
+        let handle = try materialize(kind)
+        handles[kind] = handle
+        return handle
+    }
+
+    private func materialize(_ kind: VmnetNetworkKind) throws -> VmnetNetworkHandle {
+        var store = loadStore()
+        if let stored = store[kind] {
+            do {
+                let (handle, _) = try operations.createNetwork(kind, addressing: stored)
+                Self.logger.info(
+                    "Recreated the \(kind.rawValue, privacy: .public) network with its stored addressing"
+                )
+                return handle
+            } catch {
+                Self.logger.warning(
+                    "Stored \(kind.rawValue, privacy: .public) network addressing is no longer reservable — creating fresh, guest addressing may change: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+
+        let (handle, addressing) = try operations.createNetwork(kind, addressing: nil)
+        store[kind] = addressing
+        do {
+            try persist(store)
+            Self.logger.notice("Created and persisted the \(kind.rawValue, privacy: .public) network")
+        } catch {
+            // Non-fatal: the network works for this session; only relaunch
+            // addressing stability is lost.
+            Self.logger.warning(
+                "Created the \(kind.rawValue, privacy: .public) network but could not persist it — addressing may change at next launch: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+        return handle
+    }
+
+    // MARK: - Store
+
+    private func loadStore() -> [VmnetNetworkKind: VmnetNetworkAddressing] {
+        guard let storeURL, let data = try? Data(contentsOf: storeURL) else { return [:] }
+        do {
+            return try VMConfiguration.makeJSONDecoder()
+                .decode([VmnetNetworkKind: VmnetNetworkAddressing].self, from: data)
+        } catch {
+            Self.logger.warning(
+                "networks.json is unreadable — treating as empty: \(error.localizedDescription, privacy: .public)"
+            )
+            return [:]
+        }
+    }
+
+    private func persist(_ store: [VmnetNetworkKind: VmnetNetworkAddressing]) throws {
+        guard let storeURL else { return }
+        try FileManager.default.createDirectory(
+            at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try VMConfiguration.makeJSONEncoder().encode(store).write(to: storeURL, options: .atomic)
+    }
+}
+
+extension VmnetNetworkService: VmnetNetworkProviding {
+    func attachment(for kind: VmnetNetworkKind) throws -> VZNetworkDeviceAttachment {
+        VZVmnetNetworkDeviceAttachment(network: try network(for: kind).network)
+    }
+}

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -919,6 +919,7 @@ extension VMSettingsViewController {
     /// `bridged`'s payload is the host interface identifier, `nil` for Automatic.
     private enum NetworkModeChoice: Equatable {
         case shared
+        case hostOnly
         case none
         case bridged(String?)
     }
@@ -942,7 +943,7 @@ extension VMSettingsViewController {
 
         var paragraphs: [InfoPopoverParagraph] = [
             .body(
-                "The mode sets how the guest reaches the network. Shared Network gives it outbound access through the host: the guest gets a DHCP address on a private subnet, other machines on your network cannot reach it, and there is no port forwarding from host to guest — incoming connections require knowing the guest's IP. Bridged puts the guest on your network through the chosen host interface, where it requests its own address like a separate machine."
+                "The mode sets how the guest reaches the network. Shared Network gives it outbound access through the host: the guest gets a DHCP address on a private subnet, other machines on your network cannot reach it, and there is no port forwarding from host to guest — incoming connections require knowing the guest's IP. Host Only puts the guest on a private network reachable only from this Mac: it can talk to the host and to other Host Only guests, with no access to your network or the internet. Bridged puts the guest on your network through the chosen host interface, where it requests its own address like a separate machine."
             ),
             .body(
                 "Bridged traffic bypasses a VPN running on the host. Bridging over Wi-Fi is best-effort — the Wi-Fi standard does not bridge additional stations and there is no client-side fix, so prefer a wired interface."
@@ -994,12 +995,21 @@ extension VMSettingsViewController {
         guard let menu = networkModePopUp.menu else { return }
         menu.removeAllItems()
         let liveSwitchable = networkModeIsLiveSwitchable
+        let current = currentNetworkChoice
         addNetworkModeItem("Shared Network", choice: .shared, to: menu)
+        if entitlements.hasVMNetworking {
+            addNetworkModeItem("Host Only", choice: .hostOnly, to: menu)
+        } else if current == .hostOnly {
+            // A host-only VM in a build the entitlement doesn't cover: the
+            // picker offers no Host Only entry, so this one shows the mode
+            // without offering it — carrying the current choice so it still
+            // selects.
+            addNetworkModeItem("Host Only (unavailable)", choice: .hostOnly, to: menu, enabled: false)
+        }
         // While the session runs, every attachable mode can hot-swap; None
         // cannot — network devices cannot be added or removed at runtime.
         addNetworkModeItem("None", choice: .none, to: menu, enabled: !liveSwitchable)
 
-        let current = currentNetworkChoice
         renderedNetworkChoice = current
         renderedNetworkLiveSwitchable = liveSwitchable
         if entitlements.hasVMNetworking {
@@ -1069,6 +1079,8 @@ extension VMSettingsViewController {
         switch config.networkMode {
         case .shared:
             return .shared
+        case .hostOnly:
+            return .hostOnly
         case .bridged:
             return .bridged(config.bridgedInterfaceIdentifier)
         }
@@ -2033,6 +2045,12 @@ extension VMSettingsViewController: NSMenuItemValidation {
             writeConfig {
                 $0.networkEnabled = true
                 $0.networkMode = .shared
+                Self.mintMACAddressIfNeeded(&$0)
+            }
+        case .hostOnly:
+            writeConfig {
+                $0.networkEnabled = true
+                $0.networkMode = .hostOnly
                 Self.mintMACAddressIfNeeded(&$0)
             }
         case .none:

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -45,7 +45,11 @@ extension VMInstance {
         if status == .initialBoot { return "Click Start to install macOS" }
         if status == .error { return errorMessage }
         if status == .running, networkAttachmentPending {
-            return "The network interface is unavailable. Kernova reconnects automatically when one is available."
+            // Host Only waits on the app's own network, not a host interface —
+            // pointing the user at Wi-Fi/Ethernet would misdirect them.
+            return configuration.networkMode == .hostOnly
+                ? "The Host Only network is unavailable. Kernova reconnects automatically."
+                : "The network interface is unavailable. Kernova reconnects automatically when one is available."
         }
         guard status == .paused else { return nil }
         return isColdPaused

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import KernovaTestSupport
 import Virtualization
 @testable import Kernova
 
@@ -36,7 +37,7 @@ struct ConfigurationBuilderTests {
             Issue.record("Unexpected path validation error: \(error)")
         case .invalidHardwareModel, .invalidMachineIdentifier, .missingKernelPath,
             .storageDiskAttachFailed, .removableMediaAttachFailed,
-            .bridgedNetworkingNotEntitled:
+            .bridgedNetworkingNotEntitled, .hostOnlyNetworkingNotEntitled:
             break
         }
     }
@@ -46,6 +47,13 @@ struct ConfigurationBuilderTests {
         VMConfiguration(
             name: "Test Linux", guestOS: .linux, bootMode: .efi,
             networkEnabled: true, networkMode: .bridged)
+    }
+
+    /// Returns a Linux/EFI config set to host-only networking.
+    private func makeHostOnlyConfig() -> VMConfiguration {
+        VMConfiguration(
+            name: "Test Linux", guestOS: .linux, bootMode: .efi,
+            networkEnabled: true, networkMode: .hostOnly)
     }
 
     /// Returns a Linux/EFI config with optional shared directories.
@@ -1113,6 +1121,68 @@ struct ConfigurationBuilderTests {
             else { return false }
             return true
         }
+    }
+
+    @Test("Host Only mode attaches the app-managed network")
+    func hostOnlyModeAttachesTheManagedNetwork() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        let networks = MockVmnetNetworkProvider()
+        var builder = ConfigurationBuilder()
+        builder.vmnetNetworks = networks
+        builder.entitlements = EntitlementService(
+            reader: MockEntitlementReader(granted: ["com.apple.vm.networking"]))
+
+        let devices = try builder.assemble(
+            from: makeHostOnlyConfig(), bundleURL: bundleURL, validate: false
+        ).configuration.networkDevices
+        #expect(devices.count == 1)
+        #expect(devices[0].attachment === networks.scriptedAttachment)
+        #expect(networks.requestedKinds == [.hostOnly])
+    }
+
+    @Test("Host Only mode in a build without the entitlement names the entitlement")
+    func hostOnlyModeWithoutTheEntitlementThrows() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        let networks = MockVmnetNetworkProvider()
+        var builder = ConfigurationBuilder()
+        builder.vmnetNetworks = networks
+        builder.entitlements = EntitlementService(reader: MockEntitlementReader())
+
+        #expect {
+            try builder.assemble(from: makeHostOnlyConfig(), bundleURL: bundleURL, validate: false)
+        } throws: { error in
+            guard let e = error as? ConfigurationBuilderError,
+                case .hostOnlyNetworkingNotEntitled = e
+            else { return false }
+            return true
+        }
+        // The entitlement is checked before the network is asked for.
+        #expect(networks.requestedKinds.isEmpty)
+    }
+
+    @Test("A Host Only network that cannot be materialized builds the device detached")
+    func hostOnlyModeWithoutANetworkBuildsDetached() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        let networks = MockVmnetNetworkProvider()
+        networks.attachmentError = TestFailure("vmnet refused")
+        var builder = ConfigurationBuilder()
+        builder.vmnetNetworks = networks
+        builder.entitlements = EntitlementService(
+            reader: MockEntitlementReader(granted: ["com.apple.vm.networking"]))
+
+        // The boot (and a restore from saved state, which rebuilds the same
+        // configuration) must succeed; attachment recovery reattaches later.
+        let devices = try builder.assemble(
+            from: makeHostOnlyConfig(), bundleURL: bundleURL, validate: false
+        ).configuration.networkDevices
+        #expect(devices.count == 1)
+        #expect(devices[0].attachment == nil)
     }
 
     // MARK: - Input Devices

--- a/KernovaTests/Mocks/MockNetworkDeviceControl.swift
+++ b/KernovaTests/Mocks/MockNetworkDeviceControl.swift
@@ -7,9 +7,10 @@ final class MockNetworkDeviceControl: NetworkDeviceControlling {
     /// The attachment the device currently realizes; tests nil it to simulate
     /// the framework's disconnect behavior.
     var plan: NetworkAttachmentPlan?
-    /// Bridge identifiers `apply` refuses, simulating the interface vanishing
-    /// between resolution and attach.
-    var refusedBridgeIdentifiers: Set<String> = []
+    /// Plans `apply` refuses, simulating the host withdrawing what the plan
+    /// names between resolution and attach — a bridge interface vanishing, a
+    /// vmnet network that will not materialize.
+    var refusedPlans: [NetworkAttachmentPlan] = []
     private(set) var appliedPlans: [NetworkAttachmentPlan] = []
     private(set) var detachCount = 0
 
@@ -20,11 +21,7 @@ final class MockNetworkDeviceControl: NetworkDeviceControlling {
     var currentPlan: NetworkAttachmentPlan? { plan }
 
     func apply(_ plan: NetworkAttachmentPlan) -> Bool {
-        if case .bridged(let identifier) = plan,
-            refusedBridgeIdentifiers.contains(identifier)
-        {
-            return false
-        }
+        guard !refusedPlans.contains(plan) else { return false }
         appliedPlans.append(plan)
         self.plan = plan
         return true

--- a/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
+++ b/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
@@ -25,8 +25,13 @@ final class MockVmnetNetworkOperator: VmnetNetworkOperating, @unchecked Sendable
 
     // MARK: - Recorded calls
 
+    /// When set, a pinned create reserves this instead of the pin — the
+    /// "system adjusted the addressing" case.
+    var reservedAddressingOverride: VmnetNetworkAddressing?
+
     private(set) var createdKinds: [VmnetNetworkKind] = []
     private(set) var pinnedAddressings: [VmnetNetworkAddressing?] = []
+    private(set) var releasedNetworks: [OpaquePointer] = []
 
     private var fabricatedNetworks: [UnsafeMutableRawPointer] = []
 
@@ -39,7 +44,11 @@ final class MockVmnetNetworkOperator: VmnetNetworkOperating, @unchecked Sendable
         pinnedAddressings.append(addressing)
         if let createNetworkError { throw createNetworkError }
         if addressing != nil, let pinnedCreateError { throw pinnedCreateError }
-        return (makeHandle(), addressing ?? freshAddressing)
+        return (makeHandle(), reservedAddressingOverride ?? addressing ?? freshAddressing)
+    }
+
+    func releaseNetwork(_ handle: VmnetNetworkHandle) {
+        releasedNetworks.append(handle.network)
     }
 
     /// A handle over a one-byte allocation standing in for the vmnet ref:
@@ -58,16 +67,42 @@ final class MockVmnetNetworkOperator: VmnetNetworkOperating, @unchecked Sendable
 /// callers only compare its identity.
 final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable {
     var scriptedAttachment: VZNetworkDeviceAttachment = VZNATNetworkDeviceAttachment()
+    /// Whether the network counts as materialized: `attachmentIfMaterialized`
+    /// answers `nil` while `false`, and `materializeNetwork` flips it `true`
+    /// unless scripted to fail.
+    var isMaterialized = true
+    /// When `true`, `materializeNetwork` fails and leaves `isMaterialized` as is.
+    var materializeFails = false
 
     // MARK: - Error Injection
 
     var attachmentError: (any Error)?
 
     private(set) var requestedKinds: [VmnetNetworkKind] = []
+    private(set) var materializeCount = 0
+    private(set) var invalidatedKinds: [VmnetNetworkKind] = []
 
     func attachment(for kind: VmnetNetworkKind) throws -> VZNetworkDeviceAttachment {
         requestedKinds.append(kind)
         if let attachmentError { throw attachmentError }
         return scriptedAttachment
+    }
+
+    func attachmentIfMaterialized(for kind: VmnetNetworkKind) -> VZNetworkDeviceAttachment? {
+        requestedKinds.append(kind)
+        guard isMaterialized, attachmentError == nil else { return nil }
+        return scriptedAttachment
+    }
+
+    func materializeNetwork(for kind: VmnetNetworkKind) async -> Bool {
+        materializeCount += 1
+        guard !materializeFails else { return false }
+        isMaterialized = true
+        return true
+    }
+
+    func invalidateNetwork(for kind: VmnetNetworkKind) {
+        invalidatedKinds.append(kind)
+        isMaterialized = false
     }
 }

--- a/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
+++ b/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Virtualization
+
+@testable import Kernova
+
+/// Scripted stand-in for `VmnetNetworkOperating`, so service tests run without
+/// the real vmnet call — an XPC round-trip to the NetworkSharing daemon that
+/// fails in a build without `com.apple.vm.networking`.
+///
+/// Every handle wraps a fabricated pointer, distinct per call so a test can
+/// tell a cached handle from a freshly materialized one.
+final class MockVmnetNetworkOperator: VmnetNetworkOperating, @unchecked Sendable {
+    /// The addressing a fresh (unpinned) create reserves.
+    var freshAddressing = VmnetNetworkAddressing(
+        ipv4Subnet: "192.168.213.0", ipv4Mask: "255.255.255.0",
+        ipv6Prefix: "fd5a:1c2b:3d4e:5f60::", ipv6PrefixLength: 64)
+
+    // MARK: - Error Injection
+
+    /// Thrown by every create when set.
+    var createNetworkError: (any Error)?
+    /// Thrown only by pinned creates when set — the "stored addressing is no
+    /// longer reservable" case.
+    var pinnedCreateError: (any Error)?
+
+    // MARK: - Recorded calls
+
+    private(set) var createdKinds: [VmnetNetworkKind] = []
+    private(set) var pinnedAddressings: [VmnetNetworkAddressing?] = []
+
+    private var fabricatedNetworks: [UnsafeMutableRawPointer] = []
+
+    deinit { fabricatedNetworks.forEach { $0.deallocate() } }
+
+    func createNetwork(_ kind: VmnetNetworkKind, addressing: VmnetNetworkAddressing?) throws
+        -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing)
+    {
+        createdKinds.append(kind)
+        pinnedAddressings.append(addressing)
+        if let createNetworkError { throw createNetworkError }
+        if addressing != nil, let pinnedCreateError { throw pinnedCreateError }
+        return (makeHandle(), addressing ?? freshAddressing)
+    }
+
+    /// A handle over a one-byte allocation standing in for the vmnet ref:
+    /// distinct per call, and nothing ever reads what it points at.
+    private func makeHandle() -> VmnetNetworkHandle {
+        let network = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+        fabricatedNetworks.append(network)
+        return VmnetNetworkHandle(network: OpaquePointer(network))
+    }
+}
+
+/// Scripted stand-in for `VmnetNetworkProviding`, so attachment-building tests
+/// name a Host Only attachment without materializing a vmnet network.
+///
+/// `scriptedAttachment` is a NAT attachment purely as a stand-in object —
+/// callers only compare its identity.
+final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable {
+    var scriptedAttachment: VZNetworkDeviceAttachment = VZNATNetworkDeviceAttachment()
+
+    // MARK: - Error Injection
+
+    var attachmentError: (any Error)?
+
+    private(set) var requestedKinds: [VmnetNetworkKind] = []
+
+    func attachment(for kind: VmnetNetworkKind) throws -> VZNetworkDeviceAttachment {
+        requestedKinds.append(kind)
+        if let attachmentError { throw attachmentError }
+        return scriptedAttachment
+    }
+}

--- a/KernovaTests/NetworkAttachmentCoordinatorTests.swift
+++ b/KernovaTests/NetworkAttachmentCoordinatorTests.swift
@@ -29,6 +29,7 @@ struct NetworkAttachmentCoordinatorTests {
         let coordinator: NetworkAttachmentCoordinator
         let device: MockNetworkDeviceControl
         let provider: MockBridgedInterfaceProvider
+        let vmnet: MockVmnetNetworkProvider
         let observer: MockNetworkLinkObserver
         let clock: TestEngineClock
         let eligibility: EligibilityBox
@@ -54,6 +55,7 @@ struct NetworkAttachmentCoordinatorTests {
     ) -> Harness {
         let device = MockNetworkDeviceControl(plan: devicePlan)
         let provider = MockBridgedInterfaceProvider(available: available, primary: primary)
+        let vmnet = MockVmnetNetworkProvider()
         let observer = MockNetworkLinkObserver()
         let clock = TestEngineClock()
         let eligibility = EligibilityBox()
@@ -64,6 +66,7 @@ struct NetworkAttachmentCoordinatorTests {
             device: device,
             interfaces: provider,
             linkObserver: observer,
+            vmnetNetworks: vmnet,
             retryDelays: retryDelays,
             clock: clock,
             isEligible: { eligibility.isEligible },
@@ -71,7 +74,7 @@ struct NetworkAttachmentCoordinatorTests {
             onPendingChange: { pendingChanges.record($0) })
         return Harness(
             coordinator: coordinator, device: device, provider: provider,
-            observer: observer, clock: clock, eligibility: eligibility,
+            vmnet: vmnet, observer: observer, clock: clock, eligibility: eligibility,
             choiceBox: choiceBox, pendingChanges: pendingChanges)
     }
 
@@ -131,6 +134,47 @@ struct NetworkAttachmentCoordinatorTests {
 
         #expect(h.device.appliedPlans == [.hostOnly])
         #expect(!h.coordinator.isPending)
+    }
+
+    @Test("An unmaterialized Host Only network materializes in the background and reconciles")
+    func unmaterializedHostOnlyMaterializesAndReconciles() async {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .hostOnly, bridgedInterfaceIdentifier: nil),
+            retryDelays: [])
+        h.vmnet.isMaterialized = false
+        h.device.refusedPlans = [.hostOnly]
+
+        h.coordinator.activate()
+        #expect(h.coordinator.isPending)
+
+        // The network comes up between the refused apply and the
+        // materialization task running; its completion is the reconcile
+        // trigger — no ladder rung remains to deliver one.
+        h.device.refusedPlans = []
+        await h.coordinator.vmnetMaterializationTaskForTesting?.value
+
+        #expect(h.device.appliedPlans == [.hostOnly])
+        #expect(!h.coordinator.isPending)
+        #expect(h.vmnet.materializeCount == 1)
+    }
+
+    @Test("Ladder exhaustion invalidates the cached network once per pending episode")
+    func ladderExhaustionInvalidatesNetworkOnce() async {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .hostOnly, bridgedInterfaceIdentifier: nil),
+            retryDelays: [])
+        h.device.refusedPlans = [.hostOnly]
+        h.vmnet.materializeFails = true
+
+        h.coordinator.activate()
+        #expect(h.vmnet.invalidatedKinds == [.hostOnly])
+        await h.coordinator.vmnetMaterializationTaskForTesting?.value
+
+        // A later trigger while still pending exhausts the ladder again but
+        // must not drop the network a second time.
+        h.observer.fire()
+        #expect(h.vmnet.invalidatedKinds == [.hostOnly])
+        h.coordinator.stop()
     }
 
     @Test("A bridged VM with no usable interface goes pending, then a link event reattaches it")

--- a/KernovaTests/NetworkAttachmentCoordinatorTests.swift
+++ b/KernovaTests/NetworkAttachmentCoordinatorTests.swift
@@ -101,6 +101,38 @@ struct NetworkAttachmentCoordinatorTests {
         #expect(!h.coordinator.isPending)
     }
 
+    @Test("Activation attaches the app-managed Host Only network")
+    func activationAttachesHostOnlyNetwork() {
+        let h = makeHarness(choice: NetworkChoice(mode: .hostOnly, bridgedInterfaceIdentifier: nil))
+
+        h.coordinator.activate()
+
+        #expect(h.device.appliedPlans == [.hostOnly])
+        #expect(!h.coordinator.isPending)
+    }
+
+    @Test("A Host Only network that won't materialize goes pending and retries on the ladder")
+    func refusedHostOnlyAttachRetriesOnBackoff() async {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .hostOnly, bridgedInterfaceIdentifier: nil),
+            retryDelays: [1])
+        h.device.refusedPlans = [.hostOnly]
+
+        h.coordinator.activate()
+        #expect(h.coordinator.isPending)
+        #expect(h.device.appliedPlans.isEmpty)
+
+        h.device.refusedPlans = []
+        guard let retry = h.coordinator.retryTaskForTesting else {
+            Issue.record("Expected a scheduled retry")
+            return
+        }
+        await retry.value
+
+        #expect(h.device.appliedPlans == [.hostOnly])
+        #expect(!h.coordinator.isPending)
+    }
+
     @Test("A bridged VM with no usable interface goes pending, then a link event reattaches it")
     func degradedBridgedStartRecoversOnLinkEvent() {
         let h = makeHarness(choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0"))
@@ -331,6 +363,42 @@ struct NetworkAttachmentCoordinatorTests {
         #expect(!h.coordinator.isPending)
     }
 
+    @Test("A live switch to Host Only swaps the attachment, and back")
+    func liveHostOnlySwitchSwapsAttachment() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
+            devicePlan: .nat)
+        h.coordinator.activate()
+
+        h.choiceBox.choice = NetworkChoice(mode: .hostOnly, bridgedInterfaceIdentifier: nil)
+        h.coordinator.configurationChanged()
+        #expect(h.device.appliedPlans == [.hostOnly])
+        #expect(!h.coordinator.isPending)
+
+        h.choiceBox.choice = NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil)
+        h.coordinator.configurationChanged()
+        #expect(h.device.appliedPlans == [.hostOnly, .nat])
+        #expect(!h.coordinator.isPending)
+    }
+
+    @Test("Switching to a Host Only network that won't materialize detaches rather than staying Shared")
+    func refusedHostOnlySwitchDetaches() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
+            devicePlan: .nat)
+        h.coordinator.activate()
+        h.device.refusedPlans = [.hostOnly]
+
+        h.choiceBox.choice = NetworkChoice(mode: .hostOnly, bridgedInterfaceIdentifier: nil)
+        h.coordinator.configurationChanged()
+
+        // The NAT attachment must not survive as a silent substitute for the
+        // chosen mode (docs/NETWORKING.md).
+        #expect(h.device.detachCount == 1)
+        #expect(h.device.currentPlan == nil)
+        #expect(h.coordinator.isPending)
+    }
+
     @Test("A live interface switch swaps the bridge")
     func liveInterfaceSwitchSwapsBridge() {
         let h = makeHarness(
@@ -372,12 +440,12 @@ struct NetworkAttachmentCoordinatorTests {
             retryDelays: [1])
         // The interface is listed but the attach refuses — the VZ interface
         // list lagging the dynamic store.
-        h.device.refusedBridgeIdentifiers = ["en0"]
+        h.device.refusedPlans = [.bridged("en0")]
 
         h.coordinator.activate()
         #expect(h.coordinator.isPending)
 
-        h.device.refusedBridgeIdentifiers = []
+        h.device.refusedPlans = []
         guard let retry = h.coordinator.retryTaskForTesting else {
             Issue.record("Expected a scheduled retry")
             return
@@ -393,13 +461,13 @@ struct NetworkAttachmentCoordinatorTests {
         let h = makeHarness(
             choice: NetworkChoice(mode: .bridged, bridgedInterfaceIdentifier: "en0"),
             available: [Self.wiFi])
-        h.device.refusedBridgeIdentifiers = ["en0"]
+        h.device.refusedPlans = [.bridged("en0")]
 
         h.coordinator.activate()
         #expect(h.coordinator.isPending)
         #expect(h.coordinator.retryTaskForTesting == nil)
 
-        h.device.refusedBridgeIdentifiers = []
+        h.device.refusedPlans = []
         h.observer.fire()
 
         #expect(h.device.appliedPlans == [.bridged("en0")])

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -1224,6 +1224,37 @@ struct VMConfigurationTests {
         #expect(decoded.bridgedInterfaceIdentifier == "en0")
     }
 
+    @Test("Configuration preserves the host-only mode")
+    func hostOnlyModeRoundTrip() throws {
+        let config = VMConfiguration(
+            name: "Host Only VM",
+            guestOS: .linux,
+            bootMode: .efi,
+            networkMode: .hostOnly
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(config)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: data)
+
+        #expect(decoded.networkMode == .hostOnly)
+        #expect(decoded.networkChoice == NetworkChoice(mode: .hostOnly, bridgedInterfaceIdentifier: nil))
+    }
+
+    @Test("A host-only config decodes from the stored raw value")
+    func hostOnlyModeDecodesFromRawValue() throws {
+        let json = Self.makeBaseJSON(extraFields: "\"networkMode\": \"hostOnly\"")
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: Data(json.utf8))
+
+        #expect(decoded.networkMode == .hostOnly)
+    }
+
     @Test("A bridged config decodes Automatic from a stored mode without an interface")
     func bridgedModeWithoutInterfaceDecodesAutomatic() throws {
         let json = Self.makeBaseJSON(extraFields: "\"networkMode\": \"bridged\"")

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -862,10 +862,51 @@ struct VMSettingsViewControllerTests {
         let popUp = try #require(networkModePopUp(in: vc.view))
         #expect(
             popUp.itemTitles == [
-                "Shared Network", "None", "Bridged", "Automatic", "Wi-Fi (en0)", "Ethernet (en1)",
+                "Shared Network", "Host Only", "None", "Bridged", "Automatic", "Wi-Fi (en0)",
+                "Ethernet (en1)",
             ])
         let header = try #require(popUp.menu?.items.first { $0.title == "Bridged" })
         #expect(header.isSectionHeader)
+    }
+
+    @Test("An entitled build offers Host Only between Shared Network and None")
+    func entitledPickerOffersHostOnly() throws {
+        let (vc, _) = makeNetworkController()
+
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        let titles = popUp.itemTitles
+        let hostOnly = try #require(titles.firstIndex(of: "Host Only"))
+        let shared = try #require(titles.firstIndex(of: "Shared Network"))
+        let none = try #require(titles.firstIndex(of: "None"))
+        #expect(hostOnly == shared + 1)
+        #expect(hostOnly < none)
+        #expect(popUp.menu?.items.first { $0.title == "Host Only" }?.isEnabled == true)
+    }
+
+    @Test("An unentitled build still reports a host-only VM's mode")
+    func unentitledBuildReportsAHostOnlyVM() throws {
+        let (vc, _) = makeNetworkController(mode: .hostOnly, entitled: false)
+
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        #expect(popUp.titleOfSelectedItem == "Host Only (unavailable)")
+        #expect(
+            popUp.menu?.items.first { $0.title == "Host Only (unavailable)" }?.isEnabled == false)
+        #expect(popUp.menu?.items.first { $0.title == "Host Only" } == nil)
+    }
+
+    @Test("Choosing Host Only writes the mode and mints a MAC address")
+    func selectingHostOnlyWritesConfigAndMintsAMACAddress() throws {
+        // From a VM created with networking off, so the MAC is minted here.
+        let (vc, instance) = makeNetworkController(networkEnabled: false, macAddress: nil)
+        let popUp = try #require(networkModePopUp(in: vc.view))
+
+        popUp.selectItem(withTitle: "Host Only")
+        popUp.sendAction(popUp.action, to: popUp.target)
+
+        #expect(instance.configuration.networkEnabled == true)
+        #expect(instance.configuration.networkMode == .hostOnly)
+        let mac = try #require(instance.configuration.macAddress)
+        #expect(VZMACAddress(string: mac) != nil)
     }
 
     @Test("An unentitled build offers no bridged entries")
@@ -1050,6 +1091,7 @@ struct VMSettingsViewControllerTests {
         #expect(popUp.isEnabled)
         #expect(popUp.menu?.items.first { $0.title == "None" }?.isEnabled == false)
         #expect(popUp.menu?.items.first { $0.title == "Shared Network" }?.isEnabled == true)
+        #expect(popUp.menu?.items.first { $0.title == "Host Only" }?.isEnabled == true)
         #expect(popUp.menu?.items.first { $0.title == "Wi-Fi (en0)" }?.isEnabled == true)
     }
 

--- a/KernovaTests/VmnetNetworkServiceTests.swift
+++ b/KernovaTests/VmnetNetworkServiceTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import KernovaTestSupport
+import Testing
+
+@testable import Kernova
+
+@Suite("VmnetNetworkService Tests")
+struct VmnetNetworkServiceTests {
+    // MARK: - Helpers
+
+    private static let storedAddressing = VmnetNetworkAddressing(
+        ipv4Subnet: "192.168.77.0", ipv4Mask: "255.255.255.0",
+        ipv6Prefix: "fd00:aaaa:bbbb:cccc::", ipv6PrefixLength: 64)
+
+    /// A store location inside a directory unique to the calling test, so
+    /// suites running in parallel never share `networks.json`.
+    ///
+    /// Caller must `defer` removal of the returned directory.
+    private func makeStoreLocation() -> (directory: URL, storeURL: URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VmnetNetworkServiceTests-\(UUID().uuidString)", isDirectory: true)
+        return (directory, directory.appendingPathComponent("networks.json", isDirectory: false))
+    }
+
+    /// Writes `store` where the service reads it, creating the directory.
+    private func seed(_ store: [VmnetNetworkKind: VmnetNetworkAddressing], at storeURL: URL) throws {
+        try FileManager.default.createDirectory(
+            at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try VMConfiguration.makeJSONEncoder().encode(store).write(to: storeURL)
+    }
+
+    /// The persisted store, or `nil` when nothing was written.
+    private func readStore(at storeURL: URL) throws -> [VmnetNetworkKind: VmnetNetworkAddressing]? {
+        guard let data = try? Data(contentsOf: storeURL) else { return nil }
+        return try VMConfiguration.makeJSONDecoder()
+            .decode([VmnetNetworkKind: VmnetNetworkAddressing].self, from: data)
+    }
+
+    // MARK: - First materialization
+
+    @Test("The first request creates the network fresh and persists its addressing")
+    func firstRequestCreatesAndPersists() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        _ = try service.network(for: .hostOnly)
+
+        #expect(operations.createdKinds == [.hostOnly])
+        #expect(operations.pinnedAddressings == [nil])
+        let store = try readStore(at: location.storeURL)
+        #expect(store == [.hostOnly: operations.freshAddressing])
+    }
+
+    @Test("A second request returns the held network without touching vmnet again")
+    func secondRequestReturnsTheHeldNetwork() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        let first = try service.network(for: .hostOnly)
+        let second = try service.network(for: .hostOnly)
+
+        // Every concurrent VM in the mode shares the one network, and its
+        // subnet reservation lives as long as the ref.
+        #expect(first.network == second.network)
+        #expect(operations.createdKinds == [.hostOnly])
+    }
+
+    // MARK: - Recreating from the store
+
+    @Test("Stored addressing is pinned onto the recreated network, not re-persisted")
+    func storedAddressingPinsTheRecreatedNetwork() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        try seed([.hostOnly: Self.storedAddressing], at: location.storeURL)
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        _ = try service.network(for: .hostOnly)
+
+        #expect(operations.pinnedAddressings == [Self.storedAddressing])
+        let store = try readStore(at: location.storeURL)
+        #expect(store == [.hostOnly: Self.storedAddressing])
+    }
+
+    @Test("Unreservable stored addressing falls back to a fresh network and rewrites the store")
+    func unreservableStoredAddressingCreatesFresh() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        try seed([.hostOnly: Self.storedAddressing], at: location.storeURL)
+        let operations = MockVmnetNetworkOperator()
+        operations.pinnedCreateError = TestFailure("subnet taken")
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        _ = try service.network(for: .hostOnly)
+
+        #expect(operations.pinnedAddressings == [Self.storedAddressing, nil])
+        let store = try readStore(at: location.storeURL)
+        #expect(store == [.hostOnly: operations.freshAddressing])
+    }
+
+    @Test("An unreadable store is treated as empty rather than failing the request")
+    func corruptStoreIsTreatedAsEmpty() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        try FileManager.default.createDirectory(at: location.directory, withIntermediateDirectories: true)
+        try Data("not the store".utf8).write(to: location.storeURL)
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        _ = try service.network(for: .hostOnly)
+
+        #expect(operations.pinnedAddressings == [nil])
+        let store = try readStore(at: location.storeURL)
+        #expect(store == [.hostOnly: operations.freshAddressing])
+    }
+
+    // MARK: - Failures
+
+    @Test("A creation failure reaches the caller")
+    func creationFailureReachesTheCaller() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        operations.createNetworkError = TestFailure("vmnet refused")
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        #expect(throws: TestFailure.self) {
+            try service.network(for: .hostOnly)
+        }
+        let store = try readStore(at: location.storeURL)
+        #expect(store == nil)
+    }
+
+    @Test("Persistence disabled materializes the network and writes nothing")
+    func disabledPersistenceMaterializesWithoutWriting() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: nil)
+
+        let first = try service.network(for: .hostOnly)
+        let second = try service.network(for: .hostOnly)
+
+        #expect(first.network == second.network)
+        #expect(operations.createdKinds == [.hostOnly])
+        #expect(!FileManager.default.fileExists(atPath: location.directory.path(percentEncoded: false)))
+    }
+}

--- a/KernovaTests/VmnetNetworkServiceTests.swift
+++ b/KernovaTests/VmnetNetworkServiceTests.swift
@@ -102,6 +102,41 @@ struct VmnetNetworkServiceTests {
         #expect(store == [.hostOnly: operations.freshAddressing])
     }
 
+    @Test("Addressing the system adjusts on a pinned create is what gets persisted")
+    func adjustedPinnedAddressingRewritesTheStore() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        try seed([.hostOnly: Self.storedAddressing], at: location.storeURL)
+        let operations = MockVmnetNetworkOperator()
+        operations.reservedAddressingOverride = operations.freshAddressing
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        _ = try service.network(for: .hostOnly)
+
+        // The store must follow what the network actually reserved, or every
+        // later launch re-pins a value no network carries.
+        let store = try readStore(at: location.storeURL)
+        #expect(store == [.hostOnly: operations.freshAddressing])
+    }
+
+    @Test("Invalidation releases the network and the next request recreates it pinned")
+    func invalidationReleasesAndRecreatesPinned() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        let first = try service.network(for: .hostOnly)
+        service.invalidateNetwork(for: .hostOnly)
+        #expect(operations.releasedNetworks == [first.network])
+
+        let second = try service.network(for: .hostOnly)
+        #expect(second.network != first.network)
+        // The recreate pins the addressing the first create persisted, so
+        // invalidation can never drift the subnet.
+        #expect(operations.pinnedAddressings == [nil, operations.freshAddressing])
+    }
+
     @Test("An unreadable store is treated as empty rather than failing the request")
     func corruptStoreIsTreatedAsEmpty() throws {
         let location = makeStoreLocation()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,10 +124,19 @@ substitute mocks. Services split by concurrency: those that touch
 single VZ-facing translation point, covering boot loader, CPU, memory, storage, network, display,
 input, audio, the Linux SPICE console port, and the macOS `VZVirtioSocketDeviceConfiguration`.
 
-The network attachment follows the VM's persisted mode: shared NAT, or bridged over a host
+The network attachment follows the VM's persisted mode: shared NAT, bridged over a host
 interface resolved through `BridgedInterfaceProviding` — the same seam the settings section's Mode
-picker reads its interface list from. A bridged VM whose interface cannot resolve builds the
-device detached rather than failing the boot or restore.
+picker reads its interface list from — or host-only on the app-managed vmnet network reached
+through `VmnetNetworkProviding`. A bridged VM whose interface cannot resolve, or a host-only
+network that cannot materialize, builds the device detached rather than failing the boot or
+restore.
+
+`VmnetNetworkService` (lock-guarded `Sendable`, process-wide — it serves `ConfigurationBuilder`'s
+off-main assembly and the main-actor live-switch path) owns the app's managed vmnet networks. It
+materializes each lazily over the `VmnetNetworkOperating` seam and holds the ref until the app
+exits, so every concurrent VM in the mode shares the one network; addressing stays stable across
+launches by persisting each network's addressing to `Application Support/Kernova/networks.json`
+and pinning it onto the recreated network at next use.
 
 While a session runs, `NetworkAttachmentCoordinator` (one per session, owned by `VMInstance`,
 activated when the VM reaches `.running`) keeps the live attachment realizing the persisted mode.

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -81,3 +81,12 @@ consequences no one observed.
 omits Bridged and Host Only rather than presenting entries that would fail; the modes
 the build can deliver keep working unchanged. Absence is the honest degraded state —
 never a visible-but-broken control.
+
+### 9. Guest-to-guest reach is network membership
+
+**A guest reaches another guest exactly when the user placed both on the same
+app-managed network.** Host Only is one such network: every guest the user puts in that
+mode shares it, reaching the host and each other and nothing wider. Isolation is
+expressed by membership — separate networks are mutually isolated — never by per-VM
+flags; a stricter grouping is a new network, not a mode variant. A network's addressing
+is part of what the user relies on, so it stays stable across app launches.


### PR DESCRIPTION
Closes #815

## Summary

- **"Host Only" joins the per-VM network Mode picker** (the #815 slice of the fixed design in docs/research/2026-08-12-network-settings-ui.md): an app-managed host-mode vmnet network shared by every VM in the mode — guests reach the host and each other, never the LAN or the internet. Built on `VZVmnetNetworkDeviceAttachment` over the macOS 26 vmnet network APIs; the entry is entitlement-gated (design decision 9), with a disabled `Host Only (unavailable)` fallback mirroring bridged when a host-only config lands in an unentitled build.
- **Topology decision** (the design note's open point): one shared host-only network, not per-VM strict isolation. Isolation is network membership — #279's spike established `vmnet_enable_isolation_key` is unreachable through the VZ attachment path, so strict host-only would mean one network per VM and a second picker entry. Matches Fusion/Parallels/UTM and the issue's own framing (host-only *and* VM-to-VM as one feature). Documented as NETWORKING.md principle 9.
- **The custom-network backbone #816/#817 extend**: a new `VmnetNetworkService` (lock-guarded `Sendable` — it serves `ConfigurationBuilder`'s off-main assembly and the main-actor live-switch path) owns app-managed networks keyed by kind, materializes lazily, and holds each ref for the app's lifetime so concurrent VMs share one network. Addressing persists to `Application Support/Kernova/networks.json` — a readable record (`{"hostOnly": {ipv4Subnet, ipv4Mask, ipv6Prefix, ipv6PrefixLength}}`) that DHCP reservations (#816) and forwarding rules (#817) extend naturally.
- **Persistence pins addressing instead of using vmnet's serialization API — deliberately.** `vmnet_network_copy_serialization`/`create_with_serialization` is the obvious path (and what #815 sketched), but measured on this host, a serialization is usable only while its source network still exists: rebuilt-while-alive networks start interfaces fine, while a rebuild after the source is torn down — the cross-launch case — returns success yet fails every interface start (`VMNET_FAILURE`, surfacing through VZ as "Internal Network Error" disconnects riding the recovery ladder forever). The headers document no validity window, so the pair reads as a live-network hand-off mechanism, not persistence. Creating fresh each launch with `vmnet_network_configuration_set_ipv4_subnet`/`set_ipv6_prefix` pinned to the persisted values delivers identical relaunch stability on documented behavior (verified: same subnet and ULA prefix across relaunches). This paragraph is the durable record of that argument — the code carries no annotation, per the docs convention that a rejected alternative's defense lives in the PR body. Unreservable pinned addressing (e.g. subnet conflict) falls back to a fresh subnet with a rewritten store and a `.warning` — mode preserved, addressing narrows.
- **Live switching includes Host Only** — Shared ↔ Bridged ↔ Host Only hot-swap under #813's uniform rule; a network that cannot materialize builds the device detached (mirroring bridged's no-interface path so save-file restores keep composing) and attachment recovery retries.
- **Fixes a latent #813 crash** that host-only boots surface deterministically: `HostNetworkLinkObserver`'s SCDynamicStore callbacks were closure literals formed inside the `@MainActor` class, carrying main-actor isolation plus a dynamic check that traps (`EXC_BREAKPOINT` in `dispatch_assert_queue`) when a real link event fires on the store's queue — and materializing the vmnet network fires one immediately (bridge100 appears). The callbacks are now `nonisolated` file-scope functions. Found because the app crashed on the very first host-only boot; any link change while a networked VM ran (undock, Wi-Fi drop) would have hit it.

## Changes

- `Kernova/Services/VmnetNetworkService.swift` (new): `VmnetNetworkKind`, `VmnetNetworkAddressing`, `VmnetNetworkHandle`, `VmnetNetworkOperating` seam + `HostVmnetNetworkOperator`, `VmnetNetworkService`, `VmnetNetworkProviding`
- `Kernova/Models/VMConfiguration.swift`: `VMNetworkMode.hostOnly`
- `Kernova/Services/ConfigurationBuilder.swift`: `hostOnlyAttachment(config:)`, entitlement gate (`hostOnlyNetworkingNotEntitled`), detached-on-materialization-failure
- `Kernova/Services/NetworkAttachmentRecovery.swift`: `NetworkAttachmentPlan.hostOnly`, `VZNetworkDeviceHandle` vmnet apply via the provider seam, nonisolated SC callbacks
- `Kernova/Views/Detail/VMSettingsViewController.swift`: picker entry between Shared Network and None, unentitled fallback, info-popover sentence for the new mode
- `KernovaTests/`: `VmnetNetworkServiceTests` (7), `MockVmnetNetworkOperator`/`MockVmnetNetworkProvider`; host-only cases in ConfigurationBuilder (3), coordinator (4), settings (5 incl. two updated), VMConfiguration codec (2); `MockNetworkDeviceControl` refusal generalized from bridge identifiers to plans
- `docs/NETWORKING.md` principle 9; `docs/ARCHITECTURE.md` service boundary

## Test plan

- [x] `make test` — full suite passes; `make lint` clean
- [x] Manual on an entitled build, two macOS guests in Host Only: guest↔guest ping (0% loss), host↔guest ping both directions, guest↔internet correctly dead (100% loss to 8.8.8.8), both guests leased from the app's subnet on `bridge100`
- [x] Relaunch: pinned recreate reserves the identical IPv4 subnet and IPv6 ULA prefix; a suspended guest resumes holding its lease; no attachment churn in the log
- [x] Stale/corrupt `networks.json` self-heals through the unreadable-store path (fresh network, store rewritten)
- [x] Live switch Shared → Host Only on a running VM attaches without a restart

## Notes

- The serialization-API behavior deserves a Feedback to Apple as a documentation/API-contract gap: nothing documents the serialization's validity window, and `vmnet_network_create_with_serialization` returns success for a serialization whose source network is gone, yielding a network that fails every interface start. Filing it is follow-up, not part of this PR.
- The SC-callback isolation fix has no unit test — the trap is runtime isolation enforcement of a C callback, and firing a real SCDynamicStore event deterministically in a test isn't practical; the coordinator logic behind it stays covered through `MockNetworkLinkObserver`. The constraint is recorded as a `RATIONALE:` on the callback functions.
- **Review round** (`/code-review high`, 17 candidates → 10 survivors after adversarial verification, all fixed in the second commit): the main actor no longer blocks on the service lock or vmnet XPC (non-blocking `attachmentIfMaterialized` + async off-actor materialization; the lock now guards only the handle cache); Host Only recovery gains its failure-mode-matched wake-up (a bounded materialization ladder whose success reconciles immediately — link changes are a bridged signal, and a detached device fires no disconnects); attach-ladder exhaustion invalidates the cached network once per pending episode and recreates it pinned, so a network VZ keeps rejecting can't wedge Host Only until relaunch and the recreate can't drift the subnet; a pinned create the system adjusts persists what was actually reserved; the vmnet configuration ref is released after create and network refs on invalidation; materialization failures log on every path; the pending tooltip stops blaming a host interface for Host Only; `VMStorageService.supportDirectory` becomes the single Application Support/Kernova derivation; `NetworkAttachmentPlan.matches` derives from `realizedMode`. The remaining seven candidates were refuted in verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUSBfZXhGb16kRohBBkGQn
