### PR TITLE
feat: Show each VM's IP address

### DIFF
--- a/Kernova/Services/ConfigurationBuilder.swift
+++ b/Kernova/Services/ConfigurationBuilder.swift
@@ -578,7 +578,7 @@ struct ConfigurationBuilder: Sendable {
         let networkDevice = VZVirtioNetworkDeviceConfiguration()
         switch config.networkMode {
         case .shared:
-            networkDevice.attachment = VZNATNetworkDeviceAttachment()
+            networkDevice.attachment = sharedAttachment(config: config)
         case .bridged:
             networkDevice.attachment = try bridgedAttachment(config: config)
         case .hostOnly:
@@ -636,6 +636,23 @@ struct ConfigurationBuilder: Sendable {
             Self.logger.info("Bridging over '\(chosen, privacy: .public)'")
         }
         return VZBridgedNetworkDeviceAttachment(interface: interface)
+    }
+
+    /// The Shared Network attachment: the app-managed vmnet shared network in
+    /// an entitled build — whose DHCP reservations back the IP display — and
+    /// the system NAT attachment otherwise. A vmnet network that cannot be
+    /// materialized builds the device detached (`nil`) like the Host Only
+    /// path, and attachment recovery retries once the session runs.
+    private func sharedAttachment(config: VMConfiguration) -> VZNetworkDeviceAttachment? {
+        guard entitlements.hasVMNetworking else { return VZNATNetworkDeviceAttachment() }
+        do {
+            return try vmnetNetworks.attachment(for: .shared)
+        } catch {
+            Self.logger.error(
+                "Shared network for '\(config.name, privacy: .public)' could not be materialized — starting detached: \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
     }
 
     /// The attachment joining the app-managed Host Only network.

--- a/Kernova/Services/NetworkAttachmentRecovery.swift
+++ b/Kernova/Services/NetworkAttachmentRecovery.swift
@@ -3,18 +3,23 @@ import KernovaKit
 import SystemConfiguration
 import Virtualization
 import os
+import vmnet
 
 /// A realizable network attachment for a live VM, decoupled from VZ for testability.
 enum NetworkAttachmentPlan: Equatable {
+    /// The system NAT attachment — Shared Network in an unentitled build.
     case nat
     case bridged(String)
     case hostOnly
+    /// The app-managed vmnet shared network — Shared Network in an entitled
+    /// build, where DHCP reservations back the IP display.
+    case sharedVmnet
 
     /// The mode this plan realizes. The bridged interface is deliberately
     /// ignored: an attachment over any interface realizes Bridged.
     var realizedMode: VMNetworkMode {
         switch self {
-        case .nat: .shared
+        case .nat, .sharedVmnet: .shared
         case .bridged: .bridged
         case .hostOnly: .hostOnly
         }
@@ -22,6 +27,16 @@ enum NetworkAttachmentPlan: Equatable {
 
     func matches(_ mode: VMNetworkMode) -> Bool {
         realizedMode == mode
+    }
+
+    /// The app-managed network this plan attaches to, `nil` for plans vmnet
+    /// does not back.
+    var vmnetKind: VmnetNetworkKind? {
+        switch self {
+        case .hostOnly: .hostOnly
+        case .sharedVmnet: .shared
+        case .nat, .bridged: nil
+        }
     }
 }
 
@@ -74,10 +89,15 @@ final class VZNetworkDeviceHandle: NetworkDeviceControlling {
             .nat
         case let bridged as VZBridgedNetworkDeviceAttachment:
             .bridged(bridged.interface.identifier)
-        case is VZVmnetNetworkDeviceAttachment:
-            // The app manages exactly one vmnet network today, so any vmnet
-            // attachment realizes Host Only.
-            .hostOnly
+        case let vmnet as VZVmnetNetworkDeviceAttachment:
+            // Map the attachment back to the app-managed network it joined; a
+            // network the service no longer holds realizes nothing, so
+            // reconciliation replaces it.
+            switch vmnetNetworks.kind(ofNetwork: vmnet.network) {
+            case .hostOnly: .hostOnly
+            case .shared: .sharedVmnet
+            case nil: nil
+            }
         default:
             nil
         }
@@ -96,13 +116,13 @@ final class VZNetworkDeviceHandle: NetworkDeviceControlling {
             else { return false }
             device.attachment = VZBridgedNetworkDeviceAttachment(interface: interface)
             return true
-        case .hostOnly:
+        case .hostOnly, .sharedVmnet:
             // Non-blocking: an unmaterialized network refuses the apply, and
             // the coordinator materializes it off-main and reconciles when
             // it's ready.
-            guard let attachment = vmnetNetworks.attachmentIfMaterialized(for: .hostOnly) else {
-                return false
-            }
+            guard let kind = plan.vmnetKind,
+                let attachment = vmnetNetworks.attachmentIfMaterialized(for: kind)
+            else { return false }
             device.attachment = attachment
             return true
         }
@@ -240,6 +260,10 @@ final class NetworkAttachmentCoordinator {
     private let interfaces: any BridgedInterfaceProviding
     private let linkObserver: any NetworkLinkObserving
     private let vmnetNetworks: any VmnetNetworkProviding
+    /// Whether this build realizes Shared over the app-managed vmnet network
+    /// (`.sharedVmnet`) or the system NAT attachment (`.nat`). A process-wide
+    /// constant, snapshotted at init.
+    private let isVMNetworkingEntitled: Bool
     private let retryDelays: [TimeInterval]
     private let disconnectBurstWindow: TimeInterval
     private let vmnetRematerializeDelays: [TimeInterval]
@@ -267,6 +291,7 @@ final class NetworkAttachmentCoordinator {
         interfaces: any BridgedInterfaceProviding,
         linkObserver: any NetworkLinkObserving,
         vmnetNetworks: (any VmnetNetworkProviding)? = nil,
+        isVMNetworkingEntitled: Bool = EntitlementService.shared.hasVMNetworking,
         retryDelays: [TimeInterval] = NetworkAttachmentCoordinator.defaultRetryDelays,
         disconnectBurstWindow: TimeInterval = NetworkAttachmentCoordinator.defaultDisconnectBurstWindow,
         vmnetRematerializeDelays: [TimeInterval] =
@@ -281,6 +306,7 @@ final class NetworkAttachmentCoordinator {
         self.interfaces = interfaces
         self.linkObserver = linkObserver
         self.vmnetNetworks = vmnetNetworks ?? VmnetNetworkService.shared
+        self.isVMNetworkingEntitled = isVMNetworkingEntitled
         self.retryDelays = retryDelays
         self.disconnectBurstWindow = disconnectBurstWindow
         self.vmnetRematerializeDelays = vmnetRematerializeDelays
@@ -395,15 +421,16 @@ final class NetworkAttachmentCoordinator {
         setPending(pending)
         if pending {
             scheduleRetry()
-            if choice.mode == .hostOnly { ensureVmnetMaterialization() }
+            if let kind = desired?.vmnetKind { ensureVmnetMaterialization(of: kind) }
         }
     }
 
-    /// Drives the app's vmnet network toward materialized while a Host Only
-    /// session sits detached, reconciling the moment it is ready — the wake-up
-    /// signal ladder exhaustion would otherwise leave missing, since host link
-    /// changes are a bridged signal and a detached device fires no disconnects.
-    private func ensureVmnetMaterialization() {
+    /// Drives the app's vmnet network toward materialized while a session in
+    /// a vmnet-backed mode sits detached, reconciling the moment it is ready —
+    /// the wake-up signal ladder exhaustion would otherwise leave missing,
+    /// since host link changes are a bridged signal and a detached device
+    /// fires no disconnects.
+    private func ensureVmnetMaterialization(of kind: VmnetNetworkKind) {
         guard vmnetMaterializationTask == nil else { return }
         vmnetMaterializationTask = Task {
             [weak self, clock, vmnetNetworks, vmnetRematerializeDelays] in
@@ -412,7 +439,7 @@ final class NetworkAttachmentCoordinator {
                 guard let coordinator = self, coordinator.isActive, coordinator.isPending else {
                     break
                 }
-                if await vmnetNetworks.materializeNetwork(for: .hostOnly) {
+                if await vmnetNetworks.materializeNetwork(for: kind) {
                     self?.vmnetMaterializationTask = nil
                     if let coordinator = self, coordinator.isActive {
                         coordinator.reconcile(trigger: "vmnet network materialized")
@@ -432,7 +459,7 @@ final class NetworkAttachmentCoordinator {
     private func resolvePlan(for choice: NetworkChoice) -> NetworkAttachmentPlan? {
         switch choice.mode {
         case .shared:
-            return .nat
+            return isVMNetworkingEntitled ? .sharedVmnet : .nat
         case .hostOnly:
             return .hostOnly
         case .bridged:
@@ -478,16 +505,18 @@ final class NetworkAttachmentCoordinator {
         retryTask = nil
     }
 
-    /// A Host Only ladder burning out with the network materialized is the
-    /// defective-network signature — VZ accepts each attachment, then
+    /// A vmnet-backed mode's ladder burning out with the network materialized
+    /// is the defective-network signature — VZ accepts each attachment, then
     /// disconnects it — so drop the cached network once per pending episode
     /// and let materialization recreate it, pinned to the same persisted
     /// addressing so the recreate cannot drift the subnet.
     private func ladderExhausted() {
-        guard choice()?.mode == .hostOnly, !didInvalidateVmnetNetwork else { return }
+        guard let choice = choice(), let kind = resolvePlan(for: choice)?.vmnetKind,
+            !didInvalidateVmnetNetwork
+        else { return }
         didInvalidateVmnetNetwork = true
-        vmnetNetworks.invalidateNetwork(for: .hostOnly)
-        ensureVmnetMaterialization()
+        vmnetNetworks.invalidateNetwork(for: kind)
+        ensureVmnetMaterialization(of: kind)
     }
 
     private func setPending(_ pending: Bool) {

--- a/Kernova/Services/NetworkAttachmentRecovery.swift
+++ b/Kernova/Services/NetworkAttachmentRecovery.swift
@@ -280,6 +280,13 @@ final class NetworkAttachmentCoordinator {
     private var retryTask: Task<Void, Never>?
     private var nextRetryIndex = 0
     private var vmnetMaterializationTask: Task<Void, Never>?
+    /// The kind the in-flight materialization serves — a live mode switch to
+    /// the other vmnet-backed mode must supersede it, not be swallowed by the
+    /// single-flight guard.
+    private var vmnetMaterializationKind: VmnetNetworkKind?
+    /// Identifies the current materialization task, so a superseded
+    /// (cancelled) task resuming late cannot clear its replacement's handle.
+    private var vmnetMaterializationGeneration = 0
     /// Whether this pending episode already dropped the cached vmnet network —
     /// once per episode bounds the recreate churn of a persistently failing
     /// attachment.
@@ -332,6 +339,7 @@ final class NetworkAttachmentCoordinator {
         cancelRetry()
         vmnetMaterializationTask?.cancel()
         vmnetMaterializationTask = nil
+        vmnetMaterializationKind = nil
     }
 
     /// VZ's attachment-disconnect callback: the framework has nil'd the
@@ -431,7 +439,14 @@ final class NetworkAttachmentCoordinator {
     /// since host link changes are a bridged signal and a detached device
     /// fires no disconnects.
     private func ensureVmnetMaterialization(of kind: VmnetNetworkKind) {
-        guard vmnetMaterializationTask == nil else { return }
+        if vmnetMaterializationTask != nil {
+            guard vmnetMaterializationKind != kind else { return }
+            vmnetMaterializationTask?.cancel()
+            vmnetMaterializationTask = nil
+        }
+        vmnetMaterializationKind = kind
+        vmnetMaterializationGeneration += 1
+        let generation = vmnetMaterializationGeneration
         vmnetMaterializationTask = Task {
             [weak self, clock, vmnetNetworks, vmnetRematerializeDelays] in
             var attempt = 0
@@ -440,7 +455,7 @@ final class NetworkAttachmentCoordinator {
                     break
                 }
                 if await vmnetNetworks.materializeNetwork(for: kind) {
-                    self?.vmnetMaterializationTask = nil
+                    self?.clearMaterializationTask(generation: generation)
                     if let coordinator = self, coordinator.isActive {
                         coordinator.reconcile(trigger: "vmnet network materialized")
                     }
@@ -450,8 +465,17 @@ final class NetworkAttachmentCoordinator {
                 do { try await clock.sleep(for: vmnetRematerializeDelays[attempt]) } catch { break }
                 attempt += 1
             }
-            self?.vmnetMaterializationTask = nil
+            self?.clearMaterializationTask(generation: generation)
         }
+    }
+
+    /// Clears the in-flight materialization handle — only if it still belongs
+    /// to the task of `generation`, so a superseded (cancelled) task resuming
+    /// late cannot drop its replacement's handle.
+    private func clearMaterializationTask(generation: Int) {
+        guard vmnetMaterializationGeneration == generation else { return }
+        vmnetMaterializationTask = nil
+        vmnetMaterializationKind = nil
     }
 
     /// The plan the chosen mode resolves to right now, `nil` when Bridged has

--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -77,6 +77,11 @@ struct VmnetNetworkRecord: Codable, Sendable, Equatable {
     /// `nil` until the network first materializes.
     var addressing: VmnetNetworkAddressing?
     var reservedMACs: [String]
+
+    init(addressing: VmnetNetworkAddressing? = nil, reservedMACs: [String] = []) {
+        self.addressing = addressing
+        self.reservedMACs = reservedMACs
+    }
 }
 
 /// A materialized app-managed vmnet network.
@@ -175,12 +180,10 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
     ) throws {
         for entry in reservations {
             let octets = entry.mac.split(separator: ":").compactMap { UInt8($0, radix: 16) }
-            var address = in_addr()
-            guard octets.count == 6,
-                entry.address.withCString({ inet_pton(AF_INET, $0, &address) }) == 1
-            else {
+            guard octets.count == 6, let addressValue = IPv4Value.parse(entry.address) else {
                 throw VmnetOperationError(operation: "parsing DHCP reservation", status: nil)
             }
+            var address = in_addr(s_addr: addressValue.bigEndian)
             var mac = ether_addr_t(
                 octet: (octets[0], octets[1], octets[2], octets[3], octets[4], octets[5]))
             let status = vmnet_network_configuration_add_dhcp_reservation(
@@ -195,14 +198,13 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
     private func pin(
         _ addressing: VmnetNetworkAddressing, onto configuration: vmnet_network_configuration_ref
     ) throws {
-        var subnet = in_addr()
-        var mask = in_addr()
-        guard
-            addressing.ipv4Subnet.withCString({ inet_pton(AF_INET, $0, &subnet) }) == 1,
-            addressing.ipv4Mask.withCString({ inet_pton(AF_INET, $0, &mask) }) == 1
+        guard let subnetValue = IPv4Value.parse(addressing.ipv4Subnet),
+            let maskValue = IPv4Value.parse(addressing.ipv4Mask)
         else {
             throw VmnetOperationError(operation: "parsing stored IPv4 addressing", status: nil)
         }
+        var subnet = in_addr(s_addr: subnetValue.bigEndian)
+        var mask = in_addr(s_addr: maskValue.bigEndian)
         let ipv4Status = vmnet_network_configuration_set_ipv4_subnet(configuration, &subnet, &mask)
         guard ipv4Status == .VMNET_SUCCESS else {
             throw VmnetOperationError(
@@ -229,19 +231,10 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
         var prefixLength: UInt8 = 0
         vmnet_network_get_ipv6_prefix(network, &prefix, &prefixLength)
         return VmnetNetworkAddressing(
-            ipv4Subnet: ipv4String(subnet),
-            ipv4Mask: ipv4String(mask),
+            ipv4Subnet: IPv4Value.string(UInt32(bigEndian: subnet.s_addr)),
+            ipv4Mask: IPv4Value.string(UInt32(bigEndian: mask.s_addr)),
             ipv6Prefix: ipv6String(prefix),
             ipv6PrefixLength: prefixLength)
-    }
-
-    private static func ipv4String(_ address: in_addr) -> String {
-        var address = address
-        var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
-        guard inet_ntop(AF_INET, &address, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else {
-            return "?"
-        }
-        return String(cString: buffer)
     }
 
     private static func ipv6String(_ address: in6_addr) -> String {
@@ -320,6 +313,17 @@ final class VmnetNetworkService: @unchecked Sendable {
     private let stateLock = NSLock()
     private var handles: [VmnetNetworkKind: VmnetNetworkHandle] = [:]
     private var records: [VmnetNetworkKind: VmnetNetworkRecord]
+    /// The MAC → address reservations each materialized network was created
+    /// with. `reservedAddress` answers only what the live network honors, so
+    /// a slot assigned after materialization reads as pending rather than as
+    /// an address the guest never receives.
+    private var installedAddresses: [VmnetNetworkKind: [String: String]] = [:]
+    /// Kinds whose next materialization must reserve the stored addressing or
+    /// fail. Set by invalidation: its recreate races VZ still holding the old
+    /// network's refs (a sibling VM's live attachment keeps the subnet
+    /// reserved), and falling back to a fresh subnet there would silently
+    /// shift every VM's reserved address.
+    private var pinnedOnlyKinds: Set<VmnetNetworkKind> = []
     /// Serializes materialization, so concurrent callers produce one network.
     private let materializeLock = NSLock()
     /// Store writes happen here, off whatever thread mutated the records.
@@ -349,9 +353,12 @@ final class VmnetNetworkService: @unchecked Sendable {
         materializeLock.lock()
         defer { materializeLock.unlock() }
         if let handle = cachedHandle(for: kind) { return handle }
-        let handle = try materialize(kind)
+        let (handle, installed) = try materialize(kind)
         stateLock.lock()
         handles[kind] = handle
+        installedAddresses[kind] = Dictionary(
+            installed.map { ($0.mac, $0.address) }, uniquingKeysWith: { first, _ in first })
+        pinnedOnlyKinds.remove(kind)
         stateLock.unlock()
         return handle
     }
@@ -362,30 +369,42 @@ final class VmnetNetworkService: @unchecked Sendable {
         return handles[kind]
     }
 
-    private func materialize(_ kind: VmnetNetworkKind) throws -> VmnetNetworkHandle {
+    private func materialize(_ kind: VmnetNetworkKind) throws
+        -> (handle: VmnetNetworkHandle, installed: [(mac: String, address: String)])
+    {
         let record = currentRecord(for: kind)
         if let stored = record.addressing {
             do {
+                let installing = reservations(for: record.reservedMACs, addressing: stored, kind: kind)
                 let (handle, reserved) = try operations.createNetwork(
-                    kind, addressing: stored,
-                    reservations: reservations(for: record.reservedMACs, addressing: stored, kind: kind))
+                    kind, addressing: stored, reservations: installing)
                 if reserved == stored {
                     Self.logger.info(
                         "Recreated the \(kind.rawValue, privacy: .public) network with its stored addressing"
                     )
-                } else {
-                    // vmnet accepted the pin but reserved something else; the
-                    // store must follow what the network actually is, or every
-                    // later launch re-pins a value no network carries. The
-                    // installed reservations were derived from the old
-                    // addressing — the next materialization re-derives them.
-                    updateRecord(for: kind) { $0.addressing = reserved }
-                    Self.logger.warning(
-                        "Pinned \(kind.rawValue, privacy: .public) network addressing was adjusted by the system — persisting the reserved values"
-                    )
+                    return (handle, installing)
                 }
-                return handle
+                // vmnet accepted the pin but reserved something else; the
+                // store must follow what the network actually is, or every
+                // later launch re-pins a value no network carries. The
+                // installed reservations were derived from the old addressing,
+                // so none of them holds on this network — report none.
+                updateRecord(for: kind) { $0.addressing = reserved }
+                Self.logger.warning(
+                    "Pinned \(kind.rawValue, privacy: .public) network addressing was adjusted by the system — persisting the reserved values"
+                )
+                return (handle, [])
             } catch {
+                if isPinnedOnly(kind) {
+                    // An invalidation recreate racing VZ's own refs on the old
+                    // network: a fresh-subnet fallback here would silently
+                    // shift every VM's reserved address, so fail and let the
+                    // recovery ladder retry once the old refs drain.
+                    Self.logger.warning(
+                        "Recreating the invalidated \(kind.rawValue, privacy: .public) network at its stored addressing failed — retrying later rather than drifting the subnet: \(error.localizedDescription, privacy: .public)"
+                    )
+                    throw error
+                }
                 Self.logger.warning(
                     "Stored \(kind.rawValue, privacy: .public) network addressing is no longer reservable — creating fresh, guest addressing may change: \(error.localizedDescription, privacy: .public)"
                 )
@@ -394,30 +413,38 @@ final class VmnetNetworkService: @unchecked Sendable {
         return try materializeFresh(kind)
     }
 
+    private func isPinnedOnly(_ kind: VmnetNetworkKind) -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return pinnedOnlyKinds.contains(kind)
+    }
+
     /// First-ever (or fallback) materialization: the reservation slots' IPs
     /// depend on the subnet, which is only known once a network exists — so
     /// create fresh to discover the addressing, then release and recreate
     /// pinned to it with the reservations installed.
-    private func materializeFresh(_ kind: VmnetNetworkKind) throws -> VmnetNetworkHandle {
+    private func materializeFresh(_ kind: VmnetNetworkKind) throws
+        -> (handle: VmnetNetworkHandle, installed: [(mac: String, address: String)])
+    {
         let (probe, discovered) = try operations.createNetwork(
             kind, addressing: nil, reservations: [])
         let macs = currentRecord(for: kind).reservedMACs
         guard !macs.isEmpty else {
             updateRecord(for: kind) { $0.addressing = discovered }
             Self.logger.notice("Created and persisted the \(kind.rawValue, privacy: .public) network")
-            return probe
+            return (probe, [])
         }
 
         operations.releaseNetwork(probe)
         do {
+            let installing = reservations(for: macs, addressing: discovered, kind: kind)
             let (handle, reserved) = try operations.createNetwork(
-                kind, addressing: discovered,
-                reservations: reservations(for: macs, addressing: discovered, kind: kind))
+                kind, addressing: discovered, reservations: installing)
             updateRecord(for: kind) { $0.addressing = reserved }
             Self.logger.notice(
                 "Created and persisted the \(kind.rawValue, privacy: .public) network with \(macs.count, privacy: .public) reservation slots"
             )
-            return handle
+            return (handle, reserved == discovered ? installing : [])
         } catch {
             // The discovered subnet was re-grabbed between release and
             // recreate. Fall back to a working network without reservations —
@@ -429,17 +456,23 @@ final class VmnetNetworkService: @unchecked Sendable {
             let (handle, addressing) = try operations.createNetwork(
                 kind, addressing: nil, reservations: [])
             updateRecord(for: kind) { $0.addressing = addressing }
-            return handle
+            return (handle, [])
         }
     }
 
     /// The MAC → IPv4 pairs to install for `macs` on a network of
-    /// `addressing`, in slot order; slots past the subnet's capacity are
-    /// dropped with a warning.
+    /// `addressing`, in slot order; slots past the subnet's capacity and MACs
+    /// that no longer parse (a hand-edited store) are dropped with a warning.
     private func reservations(
         for macs: [String], addressing: VmnetNetworkAddressing, kind: VmnetNetworkKind
     ) -> [(mac: String, address: String)] {
         macs.enumerated().compactMap { index, mac in
+            guard VZMACAddress(string: mac) != nil else {
+                Self.logger.warning(
+                    "Skipping unparseable MAC in \(kind.rawValue, privacy: .public) reservation slot \(index, privacy: .public)"
+                )
+                return nil
+            }
             guard let address = addressing.reservedAddress(slot: index) else {
                 Self.logger.warning(
                     "No address left in the \(kind.rawValue, privacy: .public) subnet for reservation slot \(index, privacy: .public)"
@@ -455,18 +488,26 @@ final class VmnetNetworkService: @unchecked Sendable {
     private func currentRecord(for kind: VmnetNetworkKind) -> VmnetNetworkRecord {
         stateLock.lock()
         defer { stateLock.unlock() }
-        return records[kind] ?? VmnetNetworkRecord(addressing: nil, reservedMACs: [])
+        return records[kind] ?? VmnetNetworkRecord()
     }
 
-    /// Mutates `kind`'s record under the state lock and schedules a persist.
+    /// Mutates `kind`'s record under the state lock and schedules a persist
+    /// when the mutation changed it. The enqueue happens inside the critical
+    /// section (it does no I/O on the calling thread) so snapshots reach the
+    /// serial persist queue in mutation order — enqueued after unlock, two
+    /// racing mutators could write the stale snapshot last.
     private func updateRecord(for kind: VmnetNetworkKind, _ mutate: (inout VmnetNetworkRecord) -> Void) {
         stateLock.lock()
-        var record = records[kind] ?? VmnetNetworkRecord(addressing: nil, reservedMACs: [])
+        let original = records[kind] ?? VmnetNetworkRecord()
+        var record = original
         mutate(&record)
+        guard record != original else {
+            stateLock.unlock()
+            return
+        }
         records[kind] = record
-        let snapshot = records
+        persistAsync(records)
         stateLock.unlock()
-        persistAsync(snapshot)
     }
 
     // MARK: - Store
@@ -537,33 +578,39 @@ extension VmnetNetworkService: VmnetNetworkProviding {
     func invalidateNetwork(for kind: VmnetNetworkKind) {
         stateLock.lock()
         let dropped = handles.removeValue(forKey: kind)
+        installedAddresses[kind] = nil
+        // A sibling VM's live attachment may still hold the old network (VZ
+        // retains its own ref), keeping the subnet reserved past our release —
+        // so the recreate must reserve the stored addressing or fail, never
+        // drift to a fresh subnet that would shift every reserved address.
+        if dropped != nil { pinnedOnlyKinds.insert(kind) }
         stateLock.unlock()
         guard let dropped else { return }
-        // Releasing the ref ends its subnet reservation; without this, the
-        // dropped network would keep the subnet and the pinned recreate of the
-        // same addressing would be refused as a conflict. The only caller is
-        // ladder exhaustion, where VZ has already torn down every attachment
-        // to the network.
+        // Releasing the ref ends this process's claim on the subnet; without
+        // it, a fully torn-down network would still block the pinned recreate
+        // as a conflict.
         operations.releaseNetwork(dropped)
         Self.logger.notice("Invalidated the \(kind.rawValue, privacy: .public) network")
     }
 
     func reserveAddressIfNeeded(for mac: String, kind: VmnetNetworkKind) {
         let normalized = mac.lowercased()
-        stateLock.lock()
-        var record = records[kind] ?? VmnetNetworkRecord(addressing: nil, reservedMACs: [])
-        guard !record.reservedMACs.contains(normalized) else {
-            stateLock.unlock()
+        guard VZMACAddress(string: normalized) != nil else {
+            // A malformed MAC (hand-edited config) would poison every later
+            // materialization of the kind — refuse it a slot instead.
+            Self.logger.warning(
+                "Refusing a \(kind.rawValue, privacy: .public) reservation slot for an unparseable MAC"
+            )
             return
         }
-        record.reservedMACs.append(normalized)
-        records[kind] = record
-        let snapshot = records
-        stateLock.unlock()
-        persistAsync(snapshot)
-        Self.logger.info(
-            "Reserved \(kind.rawValue, privacy: .public) address slot \(record.reservedMACs.count - 1, privacy: .public)"
-        )
+        updateRecord(for: kind) { record in
+            guard !record.reservedMACs.contains(normalized) else { return }
+            record.reservedMACs.append(normalized)
+            let slot = record.reservedMACs.count - 1
+            Self.logger.info(
+                "Reserved \(kind.rawValue, privacy: .public) address slot \(slot, privacy: .public)"
+            )
+        }
     }
 
     func reservedAddress(for mac: String, kind: VmnetNetworkKind) -> String? {
@@ -571,9 +618,18 @@ extension VmnetNetworkService: VmnetNetworkProviding {
         stateLock.lock()
         defer { stateLock.unlock() }
         guard let record = records[kind], let addressing = record.addressing,
-            let slot = record.reservedMACs.firstIndex(of: normalized)
+            let slot = record.reservedMACs.firstIndex(of: normalized),
+            let derived = addressing.reservedAddress(slot: slot)
         else { return nil }
-        return addressing.reservedAddress(slot: slot)
+        // While the network is materialized, answer only what it actually
+        // installed: reservations are fixed at creation, so a slot assigned
+        // (or re-derived) after that is pending until the next
+        // materialization — showing it now would display an address the
+        // guest never receives.
+        if handles[kind] != nil, installedAddresses[kind]?[normalized] != derived {
+            return nil
+        }
+        return derived
     }
 
     func kind(ofNetwork network: vmnet_network_ref) -> VmnetNetworkKind? {

--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -13,6 +13,20 @@ enum VmnetNetworkKind: String, Codable, CodingKeyRepresentable, Sendable {
     /// The Host Only network: guests on it reach the host and each other,
     /// never the LAN or the internet.
     case hostOnly
+    /// The Shared Network network: guests reach the internet through the
+    /// host's connection (NAT44/NAT66, DHCP, DNS proxy), and the host reaches
+    /// them at their reserved addresses.
+    case shared
+
+    /// The network backing `mode`, `nil` for a mode no app-managed network
+    /// realizes (Bridged — external DHCP owns addressing there).
+    init?(mode: VMNetworkMode) {
+        switch mode {
+        case .shared: self = .shared
+        case .hostOnly: self = .hostOnly
+        case .bridged: return nil
+        }
+    }
 }
 
 /// The addressing an app-managed network keeps stable across launches:
@@ -22,6 +36,47 @@ struct VmnetNetworkAddressing: Codable, Sendable, Equatable {
     var ipv4Mask: String
     var ipv6Prefix: String
     var ipv6PrefixLength: UInt8
+
+    /// The IPv4 address reservation slot `index` maps to: host `2 + index`
+    /// within the subnet (the gateway holds host 1), `nil` once the slot
+    /// index runs past the subnet's last usable address or when the stored
+    /// strings do not parse.
+    func reservedAddress(slot index: Int) -> String? {
+        guard let subnet = IPv4Value.parse(ipv4Subnet), let mask = IPv4Value.parse(ipv4Mask)
+        else { return nil }
+        let network = subnet & mask
+        let broadcast = network | ~mask
+        let host = network &+ UInt32(2 + index)
+        guard host < broadcast else { return nil }
+        return IPv4Value.string(host)
+    }
+}
+
+/// Dotted-quad IPv4 conversions over host-byte-order values.
+enum IPv4Value {
+    static func parse(_ dottedQuad: String) -> UInt32? {
+        var address = in_addr()
+        guard dottedQuad.withCString({ inet_pton(AF_INET, $0, &address) }) == 1 else { return nil }
+        return UInt32(bigEndian: address.s_addr)
+    }
+
+    static func string(_ value: UInt32) -> String {
+        var address = in_addr(s_addr: value.bigEndian)
+        var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+        guard inet_ntop(AF_INET, &address, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else {
+            return "?"
+        }
+        return String(cString: buffer)
+    }
+}
+
+/// What one app-managed network persists across launches: its addressing once
+/// first reserved, and the ordered MACs holding DHCP reservation slots —
+/// slot order is the address assignment, so the list only ever appends.
+struct VmnetNetworkRecord: Codable, Sendable, Equatable {
+    /// `nil` until the network first materializes.
+    var addressing: VmnetNetworkAddressing?
+    var reservedMACs: [String]
 }
 
 /// A materialized app-managed vmnet network.
@@ -41,10 +96,14 @@ struct VmnetNetworkHandle: @unchecked Sendable {
 /// the NetworkSharing daemon that fails unentitled.
 protocol VmnetNetworkOperating: Sendable {
     /// Creates a network of `kind` — reserving `addressing` when given, the
-    /// system's choice when `nil` — and returns the handle plus the addressing
-    /// the network actually reserved.
-    func createNetwork(_ kind: VmnetNetworkKind, addressing: VmnetNetworkAddressing?) throws
-        -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing)
+    /// system's choice when `nil` — installing the given MAC → IPv4 DHCP
+    /// reservations, and returns the handle plus the addressing the network
+    /// actually reserved. Reservations are fixed for the life of the network.
+    func createNetwork(
+        _ kind: VmnetNetworkKind,
+        addressing: VmnetNetworkAddressing?,
+        reservations: [(mac: String, address: String)]
+    ) throws -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing)
     /// Releases `handle`'s network ref, ending its subnet reservation.
     func releaseNetwork(_ handle: VmnetNetworkHandle)
 }
@@ -74,9 +133,11 @@ struct VmnetOperationError: Error, LocalizedError {
 struct HostVmnetNetworkOperator: VmnetNetworkOperating {
     private static let logger = Logger(subsystem: "app.kernova", category: "HostVmnetNetworkOperator")
 
-    func createNetwork(_ kind: VmnetNetworkKind, addressing: VmnetNetworkAddressing?) throws
-        -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing)
-    {
+    func createNetwork(
+        _ kind: VmnetNetworkKind,
+        addressing: VmnetNetworkAddressing?,
+        reservations: [(mac: String, address: String)]
+    ) throws -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing) {
         var status = vmnet_return_t.VMNET_SUCCESS
         guard let configuration = vmnet_network_configuration_create(mode(for: kind), &status) else {
             throw VmnetOperationError(operation: "vmnet_network_configuration_create", status: status)
@@ -85,13 +146,14 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
         if let addressing {
             try pin(addressing, onto: configuration)
         }
+        try install(reservations, onto: configuration)
         guard let network = vmnet_network_create(configuration, &status) else {
             throw VmnetOperationError(operation: "vmnet_network_create", status: status)
         }
 
         let reserved = Self.reservedAddressing(of: network)
         Self.logger.notice(
-            "Created \(kind.rawValue, privacy: .public) network (\(addressing == nil ? "fresh" : "pinned", privacy: .public)): \(reserved.ipv4Subnet, privacy: .public) mask \(reserved.ipv4Mask, privacy: .public), \(reserved.ipv6Prefix, privacy: .public)/\(reserved.ipv6PrefixLength, privacy: .public)"
+            "Created \(kind.rawValue, privacy: .public) network (\(addressing == nil ? "fresh" : "pinned", privacy: .public), \(reservations.count, privacy: .public) reservations): \(reserved.ipv4Subnet, privacy: .public) mask \(reserved.ipv4Mask, privacy: .public), \(reserved.ipv6Prefix, privacy: .public)/\(reserved.ipv6PrefixLength, privacy: .public)"
         )
         return (VmnetNetworkHandle(network: network), reserved)
     }
@@ -103,6 +165,30 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
     private func mode(for kind: VmnetNetworkKind) -> operating_modes_t {
         switch kind {
         case .hostOnly: .VMNET_HOST_MODE
+        case .shared: .VMNET_SHARED_MODE
+        }
+    }
+
+    private func install(
+        _ reservations: [(mac: String, address: String)],
+        onto configuration: vmnet_network_configuration_ref
+    ) throws {
+        for entry in reservations {
+            let octets = entry.mac.split(separator: ":").compactMap { UInt8($0, radix: 16) }
+            var address = in_addr()
+            guard octets.count == 6,
+                entry.address.withCString({ inet_pton(AF_INET, $0, &address) }) == 1
+            else {
+                throw VmnetOperationError(operation: "parsing DHCP reservation", status: nil)
+            }
+            var mac = ether_addr_t(
+                octet: (octets[0], octets[1], octets[2], octets[3], octets[4], octets[5]))
+            let status = vmnet_network_configuration_add_dhcp_reservation(
+                configuration, &mac, &address)
+            guard status == .VMNET_SUCCESS else {
+                throw VmnetOperationError(
+                    operation: "vmnet_network_configuration_add_dhcp_reservation", status: status)
+            }
         }
     }
 
@@ -186,18 +272,35 @@ protocol VmnetNetworkProviding: Sendable {
     /// materialization creates it anew — pinned to the persisted addressing,
     /// so recovery cannot drift the subnet.
     func invalidateNetwork(for kind: VmnetNetworkKind)
+    /// Ensures `mac` holds a DHCP reservation slot on the network of `kind`.
+    /// Cheap and non-blocking — safe from the main actor; the reservation is
+    /// installed at the network's next materialization.
+    func reserveAddressIfNeeded(for mac: String, kind: VmnetNetworkKind)
+    /// The IPv4 address reserved for `mac` on the network of `kind`; `nil`
+    /// while `mac` holds no slot or the network has never materialized (its
+    /// addressing is not yet known).
+    func reservedAddress(for mac: String, kind: VmnetNetworkKind) -> String?
+    /// The kind whose materialized network `network` is, `nil` for a network
+    /// this service does not hold.
+    func kind(ofNetwork network: vmnet_network_ref) -> VmnetNetworkKind?
 }
 
-/// Owns the app's managed vmnet networks — today the Host Only network; the
-/// networks behind DHCP reservations and port forwarding extend this.
+/// Owns the app's managed vmnet networks — the Host Only network and the
+/// Shared Network network — and the per-VM DHCP reservations riding them.
 ///
-/// vmnet networks do not survive the process, so each network's addressing is
-/// persisted to `Application Support/Kernova/networks.json` and pinned onto
-/// the recreated network in later launches, keeping guest addressing stable.
-/// Materialization is lazy — a launch that never uses a kind never creates it —
-/// and a materialized network is held until the app exits: the subnet
-/// reservation lives as long as the ref, and every concurrent VM in the mode
-/// shares the one network.
+/// vmnet networks do not survive the process, so each network's record —
+/// addressing plus reservation slots — is persisted to
+/// `Application Support/Kernova/networks.json`, and the addressing is pinned
+/// onto the recreated network in later launches, keeping guest addressing
+/// stable. Materialization is lazy — a launch that never uses a kind never
+/// creates it — and a materialized network is held until the app exits: the
+/// subnet reservation lives as long as the ref, and every concurrent VM in
+/// the mode shares the one network.
+///
+/// Reservations are fixed at network creation (vmnet.h: modifying them is not
+/// allowed while a network is active), so a slot assigned while its network
+/// is materialized takes effect at the next materialization — the next app
+/// launch, or a recovery-driven recreate.
 ///
 /// Lock-guarded `Sendable` rather than `@MainActor`: it never touches
 /// `VZVirtualMachine`, and `ConfigurationBuilder` consumes it during off-main
@@ -210,22 +313,27 @@ final class VmnetNetworkService: @unchecked Sendable {
 
     private let operations: any VmnetNetworkOperating
     private let storeURL: URL?
-    /// Guards `handles` only — never held across a vmnet call or file I/O, so
-    /// the main-actor `attachmentIfMaterialized` path can never block behind a
+    /// Guards `handles` and `records` only — never held across a vmnet call
+    /// or file I/O, so the main-actor paths (`attachmentIfMaterialized`,
+    /// `reserveAddressIfNeeded`, `reservedAddress`) can never block behind a
     /// materialization in flight.
     private let stateLock = NSLock()
     private var handles: [VmnetNetworkKind: VmnetNetworkHandle] = [:]
+    private var records: [VmnetNetworkKind: VmnetNetworkRecord]
     /// Serializes materialization, so concurrent callers produce one network.
     private let materializeLock = NSLock()
+    /// Store writes happen here, off whatever thread mutated the records.
+    private let persistQueue = DispatchQueue(label: "app.kernova.vmnet-store", qos: .utility)
 
     /// `storeURL: nil` disables persistence — networks still materialize, with
-    /// addressing stable only within the session.
+    /// addressing and reservations stable only within the session.
     init(
         operations: any VmnetNetworkOperating = HostVmnetNetworkOperator(),
         storeURL: URL? = VmnetNetworkService.defaultStoreURL()
     ) {
         self.operations = operations
         self.storeURL = storeURL
+        self.records = Self.loadRecords(from: storeURL)
     }
 
     /// `networks.json` beside the `VMs/` directory.
@@ -255,10 +363,12 @@ final class VmnetNetworkService: @unchecked Sendable {
     }
 
     private func materialize(_ kind: VmnetNetworkKind) throws -> VmnetNetworkHandle {
-        var store = loadStore()
-        if let stored = store[kind] {
+        let record = currentRecord(for: kind)
+        if let stored = record.addressing {
             do {
-                let (handle, reserved) = try operations.createNetwork(kind, addressing: stored)
+                let (handle, reserved) = try operations.createNetwork(
+                    kind, addressing: stored,
+                    reservations: reservations(for: record.reservedMACs, addressing: stored, kind: kind))
                 if reserved == stored {
                     Self.logger.info(
                         "Recreated the \(kind.rawValue, privacy: .public) network with its stored addressing"
@@ -266,9 +376,10 @@ final class VmnetNetworkService: @unchecked Sendable {
                 } else {
                     // vmnet accepted the pin but reserved something else; the
                     // store must follow what the network actually is, or every
-                    // later launch re-pins a value no network carries.
-                    store[kind] = reserved
-                    try? persist(store)
+                    // later launch re-pins a value no network carries. The
+                    // installed reservations were derived from the old
+                    // addressing — the next materialization re-derives them.
+                    updateRecord(for: kind) { $0.addressing = reserved }
                     Self.logger.warning(
                         "Pinned \(kind.rawValue, privacy: .public) network addressing was adjusted by the system — persisting the reserved values"
                     )
@@ -280,43 +391,123 @@ final class VmnetNetworkService: @unchecked Sendable {
                 )
             }
         }
+        return try materializeFresh(kind)
+    }
 
-        let (handle, addressing) = try operations.createNetwork(kind, addressing: nil)
-        store[kind] = addressing
-        do {
-            try persist(store)
+    /// First-ever (or fallback) materialization: the reservation slots' IPs
+    /// depend on the subnet, which is only known once a network exists — so
+    /// create fresh to discover the addressing, then release and recreate
+    /// pinned to it with the reservations installed.
+    private func materializeFresh(_ kind: VmnetNetworkKind) throws -> VmnetNetworkHandle {
+        let (probe, discovered) = try operations.createNetwork(
+            kind, addressing: nil, reservations: [])
+        let macs = currentRecord(for: kind).reservedMACs
+        guard !macs.isEmpty else {
+            updateRecord(for: kind) { $0.addressing = discovered }
             Self.logger.notice("Created and persisted the \(kind.rawValue, privacy: .public) network")
-        } catch {
-            // Non-fatal: the network works for this session; only relaunch
-            // addressing stability is lost.
-            Self.logger.warning(
-                "Created the \(kind.rawValue, privacy: .public) network but could not persist it — addressing may change at next launch: \(error.localizedDescription, privacy: .public)"
-            )
+            return probe
         }
-        return handle
+
+        operations.releaseNetwork(probe)
+        do {
+            let (handle, reserved) = try operations.createNetwork(
+                kind, addressing: discovered,
+                reservations: reservations(for: macs, addressing: discovered, kind: kind))
+            updateRecord(for: kind) { $0.addressing = reserved }
+            Self.logger.notice(
+                "Created and persisted the \(kind.rawValue, privacy: .public) network with \(macs.count, privacy: .public) reservation slots"
+            )
+            return handle
+        } catch {
+            // The discovered subnet was re-grabbed between release and
+            // recreate. Fall back to a working network without reservations —
+            // the mode beats the IP display — and let the next
+            // materialization install them.
+            Self.logger.warning(
+                "Recreating the \(kind.rawValue, privacy: .public) network with reservations failed — falling back to a fresh network without them: \(error.localizedDescription, privacy: .public)"
+            )
+            let (handle, addressing) = try operations.createNetwork(
+                kind, addressing: nil, reservations: [])
+            updateRecord(for: kind) { $0.addressing = addressing }
+            return handle
+        }
+    }
+
+    /// The MAC → IPv4 pairs to install for `macs` on a network of
+    /// `addressing`, in slot order; slots past the subnet's capacity are
+    /// dropped with a warning.
+    private func reservations(
+        for macs: [String], addressing: VmnetNetworkAddressing, kind: VmnetNetworkKind
+    ) -> [(mac: String, address: String)] {
+        macs.enumerated().compactMap { index, mac in
+            guard let address = addressing.reservedAddress(slot: index) else {
+                Self.logger.warning(
+                    "No address left in the \(kind.rawValue, privacy: .public) subnet for reservation slot \(index, privacy: .public)"
+                )
+                return nil
+            }
+            return (mac: mac, address: address)
+        }
+    }
+
+    // MARK: - Records
+
+    private func currentRecord(for kind: VmnetNetworkKind) -> VmnetNetworkRecord {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return records[kind] ?? VmnetNetworkRecord(addressing: nil, reservedMACs: [])
+    }
+
+    /// Mutates `kind`'s record under the state lock and schedules a persist.
+    private func updateRecord(for kind: VmnetNetworkKind, _ mutate: (inout VmnetNetworkRecord) -> Void) {
+        stateLock.lock()
+        var record = records[kind] ?? VmnetNetworkRecord(addressing: nil, reservedMACs: [])
+        mutate(&record)
+        records[kind] = record
+        let snapshot = records
+        stateLock.unlock()
+        persistAsync(snapshot)
     }
 
     // MARK: - Store
 
-    private func loadStore() -> [VmnetNetworkKind: VmnetNetworkAddressing] {
+    private static func loadRecords(from storeURL: URL?) -> [VmnetNetworkKind: VmnetNetworkRecord] {
         guard let storeURL, let data = try? Data(contentsOf: storeURL) else { return [:] }
         do {
             return try VMConfiguration.makeJSONDecoder()
-                .decode([VmnetNetworkKind: VmnetNetworkAddressing].self, from: data)
+                .decode([VmnetNetworkKind: VmnetNetworkRecord].self, from: data)
         } catch {
-            Self.logger.warning(
+            logger.warning(
                 "networks.json is unreadable — treating as empty: \(error.localizedDescription, privacy: .public)"
             )
             return [:]
         }
     }
 
-    private func persist(_ store: [VmnetNetworkKind: VmnetNetworkAddressing]) throws {
+    private func persistAsync(_ snapshot: [VmnetNetworkKind: VmnetNetworkRecord]) {
         guard let storeURL else { return }
-        try FileManager.default.createDirectory(
-            at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try VMConfiguration.makeJSONEncoder().encode(store).write(to: storeURL, options: .atomic)
+        persistQueue.async {
+            do {
+                try FileManager.default.createDirectory(
+                    at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try VMConfiguration.makeJSONEncoder().encode(snapshot)
+                    .write(to: storeURL, options: .atomic)
+            } catch {
+                // Non-fatal: networks work for this session; only relaunch
+                // stability of addressing and reservations is lost.
+                Self.logger.warning(
+                    "Could not persist networks.json — addressing may change at next launch: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
     }
+
+    #if DEBUG
+    /// Blocks until every scheduled store write has landed, for tests.
+    func flushPersistsForTesting() {
+        persistQueue.sync {}
+    }
+    #endif
 }
 
 extension VmnetNetworkService: VmnetNetworkProviding {
@@ -355,5 +546,39 @@ extension VmnetNetworkService: VmnetNetworkProviding {
         // to the network.
         operations.releaseNetwork(dropped)
         Self.logger.notice("Invalidated the \(kind.rawValue, privacy: .public) network")
+    }
+
+    func reserveAddressIfNeeded(for mac: String, kind: VmnetNetworkKind) {
+        let normalized = mac.lowercased()
+        stateLock.lock()
+        var record = records[kind] ?? VmnetNetworkRecord(addressing: nil, reservedMACs: [])
+        guard !record.reservedMACs.contains(normalized) else {
+            stateLock.unlock()
+            return
+        }
+        record.reservedMACs.append(normalized)
+        records[kind] = record
+        let snapshot = records
+        stateLock.unlock()
+        persistAsync(snapshot)
+        Self.logger.info(
+            "Reserved \(kind.rawValue, privacy: .public) address slot \(record.reservedMACs.count - 1, privacy: .public)"
+        )
+    }
+
+    func reservedAddress(for mac: String, kind: VmnetNetworkKind) -> String? {
+        let normalized = mac.lowercased()
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard let record = records[kind], let addressing = record.addressing,
+            let slot = record.reservedMACs.firstIndex(of: normalized)
+        else { return nil }
+        return addressing.reservedAddress(slot: slot)
+    }
+
+    func kind(ofNetwork network: vmnet_network_ref) -> VmnetNetworkKind? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return handles.first(where: { $0.value.network == network })?.key
     }
 }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -14,6 +14,8 @@ final class VMLibraryViewModel {
     let diskImageService: any DiskImageProviding
     let lifecycle: VMLifecycleCoordinator
 
+    private let vmnetNetworks: any VmnetNetworkProviding
+
     private let fileSystem: any FileSystemOperating
 
     private let preferences: AppPreferences
@@ -181,10 +183,12 @@ final class VMLibraryViewModel {
         downloadsDirectory: URL? = FileManager.default.urls(
             for: .downloadsDirectory, in: .userDomainMask
         ).first,
-        preferences: AppPreferences = .shared
+        preferences: AppPreferences = .shared,
+        vmnetNetworks: any VmnetNetworkProviding = VmnetNetworkService.shared
     ) {
         self.storageService = storageService
         self.diskImageService = diskImageService
+        self.vmnetNetworks = vmnetNetworks
         self.fileSystem = fileSystem
         self.preferences = preferences
         self.agentInstallPromptDisabled = preferences.agentInstallPromptDisabled
@@ -1454,6 +1458,19 @@ final class VMLibraryViewModel {
             guard let self, let instance else { return }
             self.unmountGuestAgentInstaller(from: instance)
         }
+        syncAddressReservation(for: instance.configuration)
+    }
+
+    /// Keeps the VM's DHCP reservation slot in step with its configuration:
+    /// any VM that can join an app-managed network holds a slot keyed on its
+    /// persisted MAC, so its address is assigned before the network next
+    /// materializes. Runs at every instance construction and configuration
+    /// change; cheap and idempotent.
+    private func syncAddressReservation(for config: VMConfiguration) {
+        guard config.networkEnabled, let mac = config.macAddress,
+            let kind = VmnetNetworkKind(mode: config.networkMode)
+        else { return }
+        vmnetNetworks.reserveAddressIfNeeded(for: mac, kind: kind)
     }
 
     /// The single entry point for any UI-driven or programmatic mutation of
@@ -1475,6 +1492,7 @@ final class VMLibraryViewModel {
         mutate(&new)
         guard new != old else { return true }
         instance.configuration = new
+        syncAddressReservation(for: new)
         let saved = saveConfiguration(for: instance)
         applyLivePolicy(for: instance, old: old, new: new)
         return saved

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -16,6 +16,10 @@ final class VMLibraryViewModel {
 
     private let vmnetNetworks: any VmnetNetworkProviding
 
+    /// Whether this build's reservation machinery is live — a process-wide
+    /// constant, snapshotted at init.
+    private let isVMNetworkingEntitled: Bool
+
     private let fileSystem: any FileSystemOperating
 
     private let preferences: AppPreferences
@@ -184,11 +188,13 @@ final class VMLibraryViewModel {
             for: .downloadsDirectory, in: .userDomainMask
         ).first,
         preferences: AppPreferences = .shared,
-        vmnetNetworks: any VmnetNetworkProviding = VmnetNetworkService.shared
+        vmnetNetworks: any VmnetNetworkProviding = VmnetNetworkService.shared,
+        isVMNetworkingEntitled: Bool = EntitlementService.shared.hasVMNetworking
     ) {
         self.storageService = storageService
         self.diskImageService = diskImageService
         self.vmnetNetworks = vmnetNetworks
+        self.isVMNetworkingEntitled = isVMNetworkingEntitled
         self.fileSystem = fileSystem
         self.preferences = preferences
         self.agentInstallPromptDisabled = preferences.agentInstallPromptDisabled
@@ -1465,9 +1471,11 @@ final class VMLibraryViewModel {
     /// any VM that can join an app-managed network holds a slot keyed on its
     /// persisted MAC, so its address is assigned before the network next
     /// materializes. Runs at every instance construction and configuration
-    /// change; cheap and idempotent.
+    /// change; cheap and idempotent. Entitlement-gated like every other
+    /// consumer of the reservation machinery — an unentitled build never
+    /// materializes a network, so slots taken there would be dead weight.
     private func syncAddressReservation(for config: VMConfiguration) {
-        guard config.networkEnabled, let mac = config.macAddress,
+        guard isVMNetworkingEntitled, config.networkEnabled, let mac = config.macAddress,
             let kind = VmnetNetworkKind(mode: config.networkMode)
         else { return }
         vmnetNetworks.reserveAddressIfNeeded(for: mac, kind: kind)

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -1061,8 +1061,12 @@ extension VMSettingsViewController {
         let networks = vmnetNetworks
         ipAddressMaterializeTask = Task { [weak self] in
             let materialized = await networks.materializeNetwork(for: kind)
-            self?.ipAddressMaterializeTask = nil
+            // Re-render before clearing the single-flight token: a slot the
+            // materialized network can't serve (subnet capacity, pending
+            // reservation) leaves the address underivable, and re-arming from
+            // that refresh would spin materialize→refresh forever.
             if materialized { self?.refreshIPAddressRow() }
+            self?.ipAddressMaterializeTask = nil
         }
     }
 

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -26,6 +26,8 @@ final class VMSettingsViewController: NSViewController {
     /// Decides whether the picker offers Bridged at all.
     private let entitlements: EntitlementService
 
+    private let vmnetNetworks: any VmnetNetworkProviding
+
     // MARK: - Observation & live state
 
     private let fileMonitor = AttachmentFileMonitor()
@@ -169,6 +171,13 @@ final class VMSettingsViewController: NSViewController {
     /// The MAC Address row, hidden while the VM has no network device; `nil` for a
     /// VM carrying no MAC address, whose row is never built.
     private var macAddressRow: GroupedFormCollapsibleRow?
+    private var ipAddressRow: GroupedFormCollapsibleRow?
+    private var ipAddressValueLabel: NSTextField?
+    private var ipAddressCopyButton: NSButton?
+    /// What the copy button copies — the reserved address, `nil` while the
+    /// row shows anything else.
+    private var ipAddressCopyValue: String?
+    private var ipAddressMaterializeTask: Task<Void, Never>?
     /// Stands in for the card's rows while the mode is None.
     private var networkNoDeviceCaption = NSTextField()
 
@@ -232,13 +241,15 @@ final class VMSettingsViewController: NSViewController {
         viewModel: VMLibraryViewModel,
         isReadOnly: Bool,
         bridgedInterfaces: any BridgedInterfaceProviding = HostBridgedInterfaceProvider(),
-        entitlements: EntitlementService = .shared
+        entitlements: EntitlementService = .shared,
+        vmnetNetworks: any VmnetNetworkProviding = VmnetNetworkService.shared
     ) {
         self.instance = instance
         self.viewModel = viewModel
         self.isReadOnly = isReadOnly
         self.bridgedInterfaces = bridgedInterfaces
         self.entitlements = entitlements
+        self.vmnetNetworks = vmnetNetworks
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -931,6 +942,7 @@ extension VMSettingsViewController {
         networkModePopUp = makeNetworkModePopUp()
 
         var rows: [NSView] = [makeGroupedFormCardRow("Mode", control: networkModePopUp)]
+        rows.append(makeIPAddressRow())
         if let mac = instance.configuration.macAddress {
             let row = GroupedFormCollapsibleRow(
                 row: makeGroupedFormCardRow("MAC Address", control: makeGroupedFormValueLabel(mac)))
@@ -941,9 +953,16 @@ extension VMSettingsViewController {
         }
         networkNoDeviceCaption = makeGroupedFormCaption("This virtual machine has no network device.")
 
+        // With the entitlement, Shared and Host Only assign each guest a
+        // deterministic address the IP Address row shows; without it there is
+        // no row, so the copy concedes the gap instead.
+        let sharedReachClause =
+            entitlements.hasVMNetworking
+            ? "there is no port forwarding from host to guest — this Mac reaches it at the address in the IP Address row"
+            : "there is no port forwarding from host to guest — incoming connections require knowing the guest's IP"
         var paragraphs: [InfoPopoverParagraph] = [
             .body(
-                "The mode sets how the guest reaches the network. Shared Network gives it outbound access through the host: the guest gets a DHCP address on a private subnet, other machines on your network cannot reach it, and there is no port forwarding from host to guest — incoming connections require knowing the guest's IP. Host Only puts the guest on a private network reachable only from this Mac: it can talk to the host and to other Host Only guests, with no access to your network or the internet. Bridged puts the guest on your network through the chosen host interface, where it requests its own address like a separate machine."
+                "The mode sets how the guest reaches the network. Shared Network gives it outbound access through the host: the guest gets a DHCP address on a private subnet, other machines on your network cannot reach it, and \(sharedReachClause). Host Only puts the guest on a private network reachable only from this Mac: it can talk to the host and to other Host Only guests, with no access to your network or the internet. Bridged puts the guest on your network through the chosen host interface, where it requests its own address like a separate machine."
             ),
             .body(
                 "Bridged traffic bypasses a VPN running on the host. Bridging over Wi-Fi is best-effort — the Wi-Fi standard does not bridge additional stations and there is no client-side fix, so prefer a wired interface."
@@ -963,6 +982,98 @@ extension VMSettingsViewController {
             makeGroupedFormCard(rows: rows),
             networkNoDeviceCaption,
         ])
+    }
+
+    /// The IP Address row: the reserved address with a copy affordance for
+    /// the modes the app assigns addressing in, "Assigned by your network"
+    /// for Bridged (external DHCP — nothing deterministic to show).
+    /// `refreshIPAddressRow()` owns its content and visibility.
+    private func makeIPAddressRow() -> GroupedFormCollapsibleRow {
+        let value = makeGroupedFormValueLabel("")
+        ipAddressValueLabel = value
+
+        let copy = NSButton()
+        copy.image = .systemSymbol("doc.on.doc", accessibilityDescription: "Copy IP Address")
+        copy.imagePosition = .imageOnly
+        copy.isBordered = false
+        copy.contentTintColor = .secondaryLabelColor
+        copy.toolTip = "Copy IP Address"
+        copy.target = self
+        copy.action = #selector(copyIPAddressTapped)
+        ipAddressCopyButton = copy
+
+        let control = NSStackView(views: [value, copy])
+        control.orientation = .horizontal
+        control.spacing = Spacing.tight
+        let row = GroupedFormCollapsibleRow(
+            row: makeGroupedFormCardRow("IP Address", control: control))
+        ipAddressRow = row
+        return row
+    }
+
+    /// Renders the IP Address row for the current mode, kicking a
+    /// materialization when the address is not yet derivable — the network's
+    /// addressing is only known once it has materialized, and the reservation
+    /// is meant to be shown even while the VM is stopped.
+    private func refreshIPAddressRow() {
+        let config = instance.configuration
+        guard config.networkEnabled else {
+            ipAddressRow?.isHidden = true
+            return
+        }
+
+        let mode = config.networkMode
+        ipAddressCopyValue = nil
+        switch mode {
+        case .bridged:
+            ipAddressRow?.isHidden = false
+            ipAddressCopyButton?.isHidden = true
+            ipAddressValueLabel?.stringValue = "Assigned by your network"
+        case .shared, .hostOnly:
+            guard entitlements.hasVMNetworking, let mac = config.macAddress,
+                let kind = VmnetNetworkKind(mode: mode)
+            else {
+                // Without the entitlement (or a MAC to key on) there is no
+                // reservation machinery behind the row — absence over a
+                // visible-but-empty control.
+                ipAddressRow?.isHidden = true
+                return
+            }
+            ipAddressRow?.isHidden = false
+            vmnetNetworks.reserveAddressIfNeeded(for: mac, kind: kind)
+            if let address = vmnetNetworks.reservedAddress(for: mac, kind: kind) {
+                ipAddressCopyValue = address
+                ipAddressCopyButton?.isHidden = false
+                ipAddressValueLabel?.stringValue = address
+            } else {
+                ipAddressCopyButton?.isHidden = true
+                ipAddressValueLabel?.stringValue = "—"
+                materializeForIPAddressDisplay(kind)
+            }
+        }
+    }
+
+    /// Materializes `kind`'s network off-main so the pending IP Address row
+    /// can fill in; re-renders on success. Single-flight — every refresh of a
+    /// still-pending row lands here, and one materialization serves them all.
+    private func materializeForIPAddressDisplay(_ kind: VmnetNetworkKind) {
+        guard ipAddressMaterializeTask == nil else { return }
+        let networks = vmnetNetworks
+        ipAddressMaterializeTask = Task { [weak self] in
+            let materialized = await networks.materializeNetwork(for: kind)
+            self?.ipAddressMaterializeTask = nil
+            if materialized { self?.refreshIPAddressRow() }
+        }
+    }
+
+    #if DEBUG
+    /// The in-flight IP-row materialization, for event-driven test waits.
+    var ipAddressMaterializeTaskForTesting: Task<Void, Never>? { ipAddressMaterializeTask }
+    #endif
+
+    @objc private func copyIPAddressTapped() {
+        guard let value = ipAddressCopyValue else { return }
+        copyToPasteboard(value)
     }
 
     /// While the pane is read-only, whether the Mode picker stays live as the
@@ -1654,6 +1765,7 @@ extension VMSettingsViewController {
         let hasDevice = instance.configuration.networkEnabled
         macAddressRow?.isHidden = !hasDevice
         networkNoDeviceCaption.isHidden = hasDevice
+        refreshIPAddressRow()
     }
 
     private func refreshAudio() {

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -45,11 +45,17 @@ extension VMInstance {
         if status == .initialBoot { return "Click Start to install macOS" }
         if status == .error { return errorMessage }
         if status == .running, networkAttachmentPending {
-            // Host Only waits on the app's own network, not a host interface —
-            // pointing the user at Wi-Fi/Ethernet would misdirect them.
-            return configuration.networkMode == .hostOnly
-                ? "The Host Only network is unavailable. Kernova reconnects automatically."
-                : "The network interface is unavailable. Kernova reconnects automatically when one is available."
+            // Shared and Host Only wait on the app's own network, not a host
+            // interface — pointing the user at Wi-Fi/Ethernet would misdirect
+            // them.
+            return switch configuration.networkMode {
+            case .hostOnly:
+                "The Host Only network is unavailable. Kernova reconnects automatically."
+            case .shared:
+                "The Shared Network is unavailable. Kernova reconnects automatically."
+            case .bridged:
+                "The network interface is unavailable. Kernova reconnects automatically when one is available."
+            }
         }
         guard status == .paused else { return nil }
         return isColdPaused

--- a/KernovaTests/ConfigurationBuilderTests.swift
+++ b/KernovaTests/ConfigurationBuilderTests.swift
@@ -1061,12 +1061,63 @@ struct ConfigurationBuilderTests {
         #expect(try networkDevices(for: config).isEmpty)
     }
 
-    @Test("Shared Network attaches one virtio device over NAT")
+    @Test("Shared Network without the entitlement attaches one virtio device over NAT")
     func sharedModeAttachesNAT() throws {
-        let devices = try networkDevices(for: makeLinuxConfig())
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        let networks = MockVmnetNetworkProvider()
+        var builder = ConfigurationBuilder()
+        builder.vmnetNetworks = networks
+        builder.entitlements = EntitlementService(reader: MockEntitlementReader())
+
+        let devices = try builder.assemble(
+            from: makeLinuxConfig(), bundleURL: bundleURL, validate: false
+        ).configuration.networkDevices
         #expect(devices.count == 1)
         let device = try #require(devices.first as? VZVirtioNetworkDeviceConfiguration)
         #expect(device.attachment is VZNATNetworkDeviceAttachment)
+        #expect(networks.requestedKinds.isEmpty)
+    }
+
+    @Test("Shared Network with the entitlement attaches the app-managed shared network")
+    func entitledSharedModeAttachesTheManagedNetwork() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        let networks = MockVmnetNetworkProvider()
+        var builder = ConfigurationBuilder()
+        builder.vmnetNetworks = networks
+        builder.entitlements = EntitlementService(
+            reader: MockEntitlementReader(granted: ["com.apple.vm.networking"]))
+
+        let devices = try builder.assemble(
+            from: makeLinuxConfig(), bundleURL: bundleURL, validate: false
+        ).configuration.networkDevices
+        #expect(devices.count == 1)
+        #expect(devices[0].attachment === networks.scriptedAttachment)
+        #expect(networks.requestedKinds == [.shared])
+    }
+
+    @Test("A shared network that cannot be materialized builds the device detached")
+    func entitledSharedModeWithoutANetworkBuildsDetached() throws {
+        let bundleURL = try makeTempBundle(withDisk: true)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        let networks = MockVmnetNetworkProvider()
+        networks.attachmentError = TestFailure("vmnet refused")
+        var builder = ConfigurationBuilder()
+        builder.vmnetNetworks = networks
+        builder.entitlements = EntitlementService(
+            reader: MockEntitlementReader(granted: ["com.apple.vm.networking"]))
+
+        // The boot (and a restore from saved state, which rebuilds the same
+        // configuration) must succeed; attachment recovery reattaches later.
+        let devices = try builder.assemble(
+            from: makeLinuxConfig(), bundleURL: bundleURL, validate: false
+        ).configuration.networkDevices
+        #expect(devices.count == 1)
+        #expect(devices[0].attachment == nil)
     }
 
     @Test("A configured MAC address reaches the network device")

--- a/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
+++ b/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Virtualization
+import vmnet
 
 @testable import Kernova
 
@@ -31,17 +32,21 @@ final class MockVmnetNetworkOperator: VmnetNetworkOperating, @unchecked Sendable
 
     private(set) var createdKinds: [VmnetNetworkKind] = []
     private(set) var pinnedAddressings: [VmnetNetworkAddressing?] = []
+    private(set) var installedReservations: [[(mac: String, address: String)]] = []
     private(set) var releasedNetworks: [OpaquePointer] = []
 
     private var fabricatedNetworks: [UnsafeMutableRawPointer] = []
 
     deinit { fabricatedNetworks.forEach { $0.deallocate() } }
 
-    func createNetwork(_ kind: VmnetNetworkKind, addressing: VmnetNetworkAddressing?) throws
-        -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing)
-    {
+    func createNetwork(
+        _ kind: VmnetNetworkKind,
+        addressing: VmnetNetworkAddressing?,
+        reservations: [(mac: String, address: String)]
+    ) throws -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing) {
         createdKinds.append(kind)
         pinnedAddressings.append(addressing)
+        installedReservations.append(reservations)
         if let createNetworkError { throw createNetworkError }
         if addressing != nil, let pinnedCreateError { throw pinnedCreateError }
         return (makeHandle(), reservedAddressingOverride ?? addressing ?? freshAddressing)
@@ -104,5 +109,30 @@ final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable
     func invalidateNetwork(for kind: VmnetNetworkKind) {
         invalidatedKinds.append(kind)
         isMaterialized = false
+    }
+
+    // MARK: - Reservations
+
+    /// Scripted answer for `reservedAddress(for:kind:)`, keyed by lowercased MAC.
+    var scriptedAddresses: [String: String] = [:]
+    private(set) var reservedMACs: [(mac: String, kind: VmnetNetworkKind)] = []
+
+    func reserveAddressIfNeeded(for mac: String, kind: VmnetNetworkKind) {
+        let normalized = mac.lowercased()
+        guard !reservedMACs.contains(where: { $0.mac == normalized && $0.kind == kind }) else {
+            return
+        }
+        reservedMACs.append((mac: normalized, kind: kind))
+    }
+
+    func reservedAddress(for mac: String, kind: VmnetNetworkKind) -> String? {
+        scriptedAddresses[mac.lowercased()]
+    }
+
+    /// Scripted answer for `kind(ofNetwork:)`.
+    var scriptedNetworkKind: VmnetNetworkKind?
+
+    func kind(ofNetwork network: vmnet_network_ref) -> VmnetNetworkKind? {
+        scriptedNetworkKind
     }
 }

--- a/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
+++ b/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
@@ -85,6 +85,7 @@ final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable
 
     private(set) var requestedKinds: [VmnetNetworkKind] = []
     private(set) var materializeCount = 0
+    private(set) var materializedKinds: [VmnetNetworkKind] = []
     private(set) var invalidatedKinds: [VmnetNetworkKind] = []
 
     func attachment(for kind: VmnetNetworkKind) throws -> VZNetworkDeviceAttachment {
@@ -101,6 +102,7 @@ final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable
 
     func materializeNetwork(for kind: VmnetNetworkKind) async -> Bool {
         materializeCount += 1
+        materializedKinds.append(kind)
         guard !materializeFails else { return false }
         isMaterialized = true
         return true

--- a/KernovaTests/NetworkAttachmentCoordinatorTests.swift
+++ b/KernovaTests/NetworkAttachmentCoordinatorTests.swift
@@ -51,6 +51,7 @@ struct NetworkAttachmentCoordinatorTests {
         devicePlan: NetworkAttachmentPlan? = nil,
         available: [BridgedInterface] = [],
         primary: String? = nil,
+        entitled: Bool = false,
         retryDelays: [TimeInterval] = []
     ) -> Harness {
         let device = MockNetworkDeviceControl(plan: devicePlan)
@@ -67,6 +68,7 @@ struct NetworkAttachmentCoordinatorTests {
             interfaces: provider,
             linkObserver: observer,
             vmnetNetworks: vmnet,
+            isVMNetworkingEntitled: entitled,
             retryDelays: retryDelays,
             clock: clock,
             isEligible: { eligibility.isEligible },
@@ -112,6 +114,45 @@ struct NetworkAttachmentCoordinatorTests {
 
         #expect(h.device.appliedPlans == [.hostOnly])
         #expect(!h.coordinator.isPending)
+    }
+
+    @Test("An entitled build realizes Shared over the app-managed vmnet network")
+    func entitledSharedRealizesVmnetPlan() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
+            entitled: true)
+
+        h.coordinator.activate()
+
+        #expect(h.device.appliedPlans == [.sharedVmnet])
+        #expect(!h.coordinator.isPending)
+    }
+
+    @Test("An entitled build swaps a NAT attachment over to the vmnet shared network")
+    func entitledSharedReplacesNATAttachment() {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
+            devicePlan: .nat,
+            entitled: true)
+
+        h.coordinator.activate()
+
+        #expect(h.device.appliedPlans == [.sharedVmnet])
+    }
+
+    @Test("A Shared ladder burning out invalidates the shared network once per episode")
+    func sharedLadderExhaustionInvalidatesSharedNetwork() async {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil),
+            entitled: true,
+            retryDelays: [])
+        h.device.refusedPlans = [.sharedVmnet]
+        h.vmnet.materializeFails = true
+
+        h.coordinator.activate()
+        #expect(h.vmnet.invalidatedKinds == [.shared])
+        await h.coordinator.vmnetMaterializationTaskForTesting?.value
+        h.coordinator.stop()
     }
 
     @Test("A Host Only network that won't materialize goes pending and retries on the ladder")

--- a/KernovaTests/NetworkAttachmentCoordinatorTests.swift
+++ b/KernovaTests/NetworkAttachmentCoordinatorTests.swift
@@ -155,6 +155,37 @@ struct NetworkAttachmentCoordinatorTests {
         h.coordinator.stop()
     }
 
+    @Test("A live switch between vmnet-backed modes supersedes the in-flight materialization")
+    func liveSwitchSupersedesInFlightMaterialization() async {
+        let h = makeHarness(
+            choice: NetworkChoice(mode: .hostOnly, bridgedInterfaceIdentifier: nil),
+            entitled: true,
+            retryDelays: [])
+        h.vmnet.isMaterialized = false
+        h.vmnet.materializeFails = true
+        h.device.refusedPlans = [.hostOnly, .sharedVmnet]
+
+        h.coordinator.activate()
+        #expect(h.coordinator.isPending)
+
+        // The Host Only drive is still in flight; switching to Shared must
+        // replace it with one for the shared network, not be swallowed by the
+        // single-flight guard — the old task's ladder would otherwise strand
+        // the VM detached with no wake-up signal for the new kind. The
+        // refusals lift only after the switch, so the supersede path (not a
+        // direct attach) is what recovers the session.
+        h.vmnet.materializeFails = false
+        h.choiceBox.choice = NetworkChoice(mode: .shared, bridgedInterfaceIdentifier: nil)
+        h.coordinator.configurationChanged()
+        h.device.refusedPlans = []
+
+        await h.coordinator.vmnetMaterializationTaskForTesting?.value
+        #expect(h.vmnet.materializedKinds.contains(.shared))
+        #expect(h.device.appliedPlans.last == .sharedVmnet)
+        #expect(!h.coordinator.isPending)
+        h.coordinator.stop()
+    }
+
     @Test("A Host Only network that won't materialize goes pending and retries on the ladder")
     func refusedHostOnlyAttachRetriesOnBackoff() async {
         let h = makeHarness(

--- a/KernovaTests/VMInstanceTests.swift
+++ b/KernovaTests/VMInstanceTests.swift
@@ -497,6 +497,9 @@ struct VMInstanceTests {
             device: device,
             interfaces: provider,
             linkObserver: MockNetworkLinkObserver(),
+            // Pinned rather than read from the test host's signature, so the
+            // plans these tests assert on don't vary with how it was signed.
+            isVMNetworkingEntitled: false,
             retryDelays: [],
             isEligible: { [weak instance] in
                 guard let instance else { return false }
@@ -514,9 +517,18 @@ struct VMInstanceTests {
         instance.networkAttachmentPending = true
 
         #expect(instance.statusDisplayNSColor == StatusColor.warning)
-        let tip = instance.statusToolTip
-        #expect(tip != nil)
-        #expect(tip!.contains("network interface"))
+        // The wording names what is actually unavailable: the app-managed
+        // network for Shared and Host Only, a host interface for Bridged.
+        instance.configuration.networkMode = .shared
+        #expect(
+            instance.statusToolTip
+                == "The Shared Network is unavailable. Kernova reconnects automatically.")
+        instance.configuration.networkMode = .hostOnly
+        #expect(
+            instance.statusToolTip
+                == "The Host Only network is unavailable. Kernova reconnects automatically.")
+        instance.configuration.networkMode = .bridged
+        #expect(instance.statusToolTip?.contains("network interface") == true)
     }
 
     @Test("applyLivePolicy forwards a network mode change to the coordinator")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -29,7 +29,8 @@ struct VMLibraryViewModelTests {
         downloadService: MockDownloadService = MockDownloadService(),
         downloadsDirectory: URL? = FileManager.default.urls(
             for: .downloadsDirectory, in: .userDomainMask
-        ).first
+        ).first,
+        vmnetNetworks: MockVmnetNetworkProvider = MockVmnetNetworkProvider()
     ) -> (
         VMLibraryViewModel, MockVMStorageService, MockDiskImageService, MockVirtualizationService,
         any USBDeviceProviding
@@ -45,7 +46,8 @@ struct VMLibraryViewModelTests {
             downloadService: downloadService,
             fileSystem: fileSystem,
             downloadsDirectory: downloadsDirectory,
-            preferences: preferences
+            preferences: preferences,
+            vmnetNetworks: vmnetNetworks
         )
         vm.presenter = presenter
         return (vm, storageService, diskImageService, virtualizationService, usbDeviceService)
@@ -2112,6 +2114,43 @@ struct VMLibraryViewModelTests {
 
         #expect(presenter.showError == true)
         #expect(presenter.errorMessage != nil)
+    }
+
+    // MARK: - Address Reservation Sync
+
+    @Test("A configuration change syncs the VM's DHCP reservation slot for its mode's network")
+    func updateConfigurationSyncsAddressReservation() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeInstance()
+
+        viewModel.updateConfiguration(of: instance) {
+            $0.networkEnabled = true
+            $0.networkMode = .shared
+            $0.macAddress = "AA:BB:CC:DD:EE:0F"
+        }
+
+        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f"])
+        #expect(vmnet.reservedMACs.map(\.kind) == [.shared])
+    }
+
+    @Test("A bridged or MAC-less configuration takes no reservation slot")
+    func bridgedConfigurationTakesNoReservationSlot() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeInstance()
+
+        viewModel.updateConfiguration(of: instance) {
+            $0.networkEnabled = true
+            $0.networkMode = .bridged
+            $0.macAddress = "aa:bb:cc:dd:ee:0f"
+        }
+        viewModel.updateConfiguration(of: instance) {
+            $0.networkMode = .shared
+            $0.macAddress = nil
+        }
+
+        #expect(vmnet.reservedMACs.isEmpty)
     }
 
     // MARK: - trySave / tryForceStop

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -30,7 +30,8 @@ struct VMLibraryViewModelTests {
         downloadsDirectory: URL? = FileManager.default.urls(
             for: .downloadsDirectory, in: .userDomainMask
         ).first,
-        vmnetNetworks: MockVmnetNetworkProvider = MockVmnetNetworkProvider()
+        vmnetNetworks: MockVmnetNetworkProvider = MockVmnetNetworkProvider(),
+        isVMNetworkingEntitled: Bool = true
     ) -> (
         VMLibraryViewModel, MockVMStorageService, MockDiskImageService, MockVirtualizationService,
         any USBDeviceProviding
@@ -47,7 +48,8 @@ struct VMLibraryViewModelTests {
             fileSystem: fileSystem,
             downloadsDirectory: downloadsDirectory,
             preferences: preferences,
-            vmnetNetworks: vmnetNetworks
+            vmnetNetworks: vmnetNetworks,
+            isVMNetworkingEntitled: isVMNetworkingEntitled
         )
         vm.presenter = presenter
         return (vm, storageService, diskImageService, virtualizationService, usbDeviceService)

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -822,7 +822,8 @@ struct VMSettingsViewControllerTests {
         interfaces: MockBridgedInterfaceProvider = MockBridgedInterfaceProvider(),
         entitled: Bool = true,
         isReadOnly: Bool = false,
-        status: VMStatus = .stopped
+        status: VMStatus = .stopped,
+        vmnetNetworks: MockVmnetNetworkProvider = MockVmnetNetworkProvider()
     ) -> (VMSettingsViewController, VMInstance) {
         let config = VMConfiguration(
             name: "Test VM", guestOS: .linux, bootMode: .efi,
@@ -836,10 +837,73 @@ struct VMSettingsViewControllerTests {
             bridgedInterfaces: interfaces,
             entitlements: EntitlementService(
                 reader: MockEntitlementReader(
-                    granted: entitled ? ["com.apple.vm.networking"] : [])))
+                    granted: entitled ? ["com.apple.vm.networking"] : [])),
+            vmnetNetworks: vmnetNetworks)
         vc.loadViewIfNeeded()
         vc.viewDidAppear()
         return (vc, instance)
+    }
+
+    // MARK: - IP Address row
+
+    @Test("An entitled Shared VM shows its reserved address and takes a reservation slot")
+    func entitledSharedVMShowsReservedAddress() throws {
+        let vmnet = MockVmnetNetworkProvider()
+        vmnet.scriptedAddresses = ["aa:bb:cc:dd:ee:ff": "192.168.64.10"]
+        let (vc, _) = makeNetworkController(vmnetNetworks: vmnet)
+
+        #expect(visibleLabel("IP Address", in: vc.view))
+        #expect(visibleLabel("192.168.64.10", in: vc.view))
+        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:ff"])
+        #expect(vmnet.reservedMACs.map(\.kind) == [.shared])
+    }
+
+    @Test("An entitled Host Only VM's row reserves on the Host Only network")
+    func entitledHostOnlyVMReservesOnItsNetwork() throws {
+        let vmnet = MockVmnetNetworkProvider()
+        vmnet.scriptedAddresses = ["aa:bb:cc:dd:ee:ff": "192.168.128.5"]
+        let (vc, _) = makeNetworkController(mode: .hostOnly, vmnetNetworks: vmnet)
+
+        #expect(visibleLabel("192.168.128.5", in: vc.view))
+        #expect(vmnet.reservedMACs.map(\.kind) == [.hostOnly])
+    }
+
+    @Test("A not-yet-derivable address renders as a placeholder, then fills in after materialization")
+    func pendingAddressShowsPlaceholderAndMaterializes() async throws {
+        let vmnet = MockVmnetNetworkProvider()
+        let (vc, _) = makeNetworkController(vmnetNetworks: vmnet)
+
+        #expect(visibleLabel("—", in: vc.view))
+        // The address becomes derivable once the network materializes — which
+        // the row kicked off itself.
+        vmnet.scriptedAddresses = ["aa:bb:cc:dd:ee:ff": "192.168.64.9"]
+        await vc.ipAddressMaterializeTaskForTesting?.value
+
+        #expect(vmnet.materializeCount == 1)
+        #expect(visibleLabel("192.168.64.9", in: vc.view))
+    }
+
+    @Test("A bridged VM's row reads Assigned by your network")
+    func bridgedVMShowsExternalAssignment() throws {
+        let (vc, _) = makeNetworkController(
+            mode: .bridged, bridgedInterfaceIdentifier: "en0",
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi], primary: "en0"))
+
+        #expect(visibleLabel("Assigned by your network", in: vc.view))
+    }
+
+    @Test("An unentitled build shows no IP Address row")
+    func unentitledBuildHidesTheIPAddressRow() throws {
+        let (vc, _) = makeNetworkController(entitled: false)
+
+        #expect(!visibleLabel("IP Address", in: vc.view))
+    }
+
+    @Test("Mode None hides the IP Address row with the rest of the card")
+    func noneModeHidesTheIPAddressRow() throws {
+        let (vc, _) = makeNetworkController(networkEnabled: false)
+
+        #expect(!visibleLabel("IP Address", in: vc.view))
     }
 
     @Test("The Mode picker replaces the networking switch and offers Shared Network and None")

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -883,6 +883,18 @@ struct VMSettingsViewControllerTests {
         #expect(visibleLabel("192.168.64.9", in: vc.view))
     }
 
+    @Test("A failed materialization leaves the placeholder without spinning the refresh loop")
+    func failedMaterializationLeavesPlaceholder() async throws {
+        let vmnet = MockVmnetNetworkProvider()
+        vmnet.materializeFails = true
+        let (vc, _) = makeNetworkController(vmnetNetworks: vmnet)
+
+        await vc.ipAddressMaterializeTaskForTesting?.value
+
+        #expect(visibleLabel("—", in: vc.view))
+        #expect(vmnet.materializeCount == 1)
+    }
+
     @Test("A bridged VM's row reads Assigned by your network")
     func bridgedVMShowsExternalAssignment() throws {
         let (vc, _) = makeNetworkController(

--- a/KernovaTests/VmnetNetworkServiceTests.swift
+++ b/KernovaTests/VmnetNetworkServiceTests.swift
@@ -341,6 +341,93 @@ struct VmnetNetworkServiceTests {
         #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:02", kind: .shared) == nil)
     }
 
+    // MARK: - Installed vs pending reservations
+
+    @Test("A slot assigned while its network is materialized reads as pending, then resolves after rematerialization")
+    func slotAssignedAfterMaterializationIsPending() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        _ = try service.network(for: .shared)
+
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+
+        // The live network was created before the second slot existed, so its
+        // address is pending — showing it would display an address the guest
+        // never receives.
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:01", kind: .shared) == "192.168.213.2")
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:02", kind: .shared) == nil)
+
+        service.invalidateNetwork(for: .shared)
+        // No network is materialized now, so the durable assignment shows.
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:02", kind: .shared) == "192.168.213.3")
+        _ = try service.network(for: .shared)
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:02", kind: .shared) == "192.168.213.3")
+    }
+
+    @Test("System-adjusted pinned addressing leaves every reservation pending until rematerialization")
+    func adjustedPinnedAddressingLeavesReservationsPending() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        try seed(
+            [
+                .shared: VmnetNetworkRecord(
+                    addressing: Self.storedAddressing, reservedMACs: ["aa:bb:cc:dd:ee:01"])
+            ], at: location.storeURL)
+        let operations = MockVmnetNetworkOperator()
+        operations.reservedAddressingOverride = operations.freshAddressing
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        _ = try service.network(for: .shared)
+
+        // The installed reservations were derived from the old addressing, so
+        // none of them holds on the adjusted network.
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:01", kind: .shared) == nil)
+    }
+
+    @Test("An unparseable MAC is refused a reservation slot")
+    func unparseableMACIsRefusedASlot() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let service = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+
+        service.reserveAddressIfNeeded(for: "not-a-mac", kind: .shared)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+
+        let store = try readStore(at: location.storeURL, from: service)
+        #expect(store?[.shared]?.reservedMACs == ["aa:bb:cc:dd:ee:01"])
+    }
+
+    // MARK: - Invalidation stays pinned
+
+    @Test("A recreate after invalidation never drifts to a fresh subnet")
+    func invalidationRecreateNeverDriftsTheSubnet() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+        _ = try service.network(for: .shared)
+
+        service.invalidateNetwork(for: .shared)
+        // A sibling VM's live attachment can keep the old subnet reserved past
+        // our release; a fresh-subnet fallback would shift every VM's address.
+        operations.pinnedCreateError = TestFailure("subnet still held by VZ refs")
+        #expect(throws: TestFailure.self) {
+            try service.network(for: .shared)
+        }
+        let store = try readStore(at: location.storeURL, from: service)
+        #expect(store?[.shared]?.addressing == operations.freshAddressing)
+
+        // Once the old refs drain, the pinned recreate succeeds and the
+        // constraint lifts.
+        operations.pinnedCreateError = nil
+        _ = try service.network(for: .shared)
+        #expect(operations.pinnedAddressings.last == operations.freshAddressing)
+    }
+
     // MARK: - Network identity
 
     @Test("kind(ofNetwork:) answers for held networks only")

--- a/KernovaTests/VmnetNetworkServiceTests.swift
+++ b/KernovaTests/VmnetNetworkServiceTests.swift
@@ -23,17 +23,21 @@ struct VmnetNetworkServiceTests {
     }
 
     /// Writes `store` where the service reads it, creating the directory.
-    private func seed(_ store: [VmnetNetworkKind: VmnetNetworkAddressing], at storeURL: URL) throws {
+    private func seed(_ store: [VmnetNetworkKind: VmnetNetworkRecord], at storeURL: URL) throws {
         try FileManager.default.createDirectory(
             at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try VMConfiguration.makeJSONEncoder().encode(store).write(to: storeURL)
     }
 
-    /// The persisted store, or `nil` when nothing was written.
-    private func readStore(at storeURL: URL) throws -> [VmnetNetworkKind: VmnetNetworkAddressing]? {
+    /// The persisted store after every scheduled write has landed, or `nil`
+    /// when nothing was written.
+    private func readStore(
+        at storeURL: URL, from service: VmnetNetworkService
+    ) throws -> [VmnetNetworkKind: VmnetNetworkRecord]? {
+        service.flushPersistsForTesting()
         guard let data = try? Data(contentsOf: storeURL) else { return nil }
         return try VMConfiguration.makeJSONDecoder()
-            .decode([VmnetNetworkKind: VmnetNetworkAddressing].self, from: data)
+            .decode([VmnetNetworkKind: VmnetNetworkRecord].self, from: data)
     }
 
     // MARK: - First materialization
@@ -49,8 +53,12 @@ struct VmnetNetworkServiceTests {
 
         #expect(operations.createdKinds == [.hostOnly])
         #expect(operations.pinnedAddressings == [nil])
-        let store = try readStore(at: location.storeURL)
-        #expect(store == [.hostOnly: operations.freshAddressing])
+        let store = try readStore(at: location.storeURL, from: service)
+        #expect(
+            store == [
+                .hostOnly: VmnetNetworkRecord(
+                    addressing: operations.freshAddressing, reservedMACs: [])
+            ])
     }
 
     @Test("A second request returns the held network without touching vmnet again")
@@ -75,22 +83,29 @@ struct VmnetNetworkServiceTests {
     func storedAddressingPinsTheRecreatedNetwork() throws {
         let location = makeStoreLocation()
         defer { try? FileManager.default.removeItem(at: location.directory) }
-        try seed([.hostOnly: Self.storedAddressing], at: location.storeURL)
+        try seed(
+            [.hostOnly: VmnetNetworkRecord(addressing: Self.storedAddressing, reservedMACs: [])],
+            at: location.storeURL)
         let operations = MockVmnetNetworkOperator()
         let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
 
         _ = try service.network(for: .hostOnly)
 
         #expect(operations.pinnedAddressings == [Self.storedAddressing])
-        let store = try readStore(at: location.storeURL)
-        #expect(store == [.hostOnly: Self.storedAddressing])
+        let store = try readStore(at: location.storeURL, from: service)
+        #expect(
+            store == [
+                .hostOnly: VmnetNetworkRecord(addressing: Self.storedAddressing, reservedMACs: [])
+            ])
     }
 
     @Test("Unreservable stored addressing falls back to a fresh network and rewrites the store")
     func unreservableStoredAddressingCreatesFresh() throws {
         let location = makeStoreLocation()
         defer { try? FileManager.default.removeItem(at: location.directory) }
-        try seed([.hostOnly: Self.storedAddressing], at: location.storeURL)
+        try seed(
+            [.hostOnly: VmnetNetworkRecord(addressing: Self.storedAddressing, reservedMACs: [])],
+            at: location.storeURL)
         let operations = MockVmnetNetworkOperator()
         operations.pinnedCreateError = TestFailure("subnet taken")
         let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
@@ -98,15 +113,17 @@ struct VmnetNetworkServiceTests {
         _ = try service.network(for: .hostOnly)
 
         #expect(operations.pinnedAddressings == [Self.storedAddressing, nil])
-        let store = try readStore(at: location.storeURL)
-        #expect(store == [.hostOnly: operations.freshAddressing])
+        let store = try readStore(at: location.storeURL, from: service)
+        #expect(store?[.hostOnly]?.addressing == operations.freshAddressing)
     }
 
     @Test("Addressing the system adjusts on a pinned create is what gets persisted")
     func adjustedPinnedAddressingRewritesTheStore() throws {
         let location = makeStoreLocation()
         defer { try? FileManager.default.removeItem(at: location.directory) }
-        try seed([.hostOnly: Self.storedAddressing], at: location.storeURL)
+        try seed(
+            [.hostOnly: VmnetNetworkRecord(addressing: Self.storedAddressing, reservedMACs: [])],
+            at: location.storeURL)
         let operations = MockVmnetNetworkOperator()
         operations.reservedAddressingOverride = operations.freshAddressing
         let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
@@ -115,8 +132,8 @@ struct VmnetNetworkServiceTests {
 
         // The store must follow what the network actually reserved, or every
         // later launch re-pins a value no network carries.
-        let store = try readStore(at: location.storeURL)
-        #expect(store == [.hostOnly: operations.freshAddressing])
+        let store = try readStore(at: location.storeURL, from: service)
+        #expect(store?[.hostOnly]?.addressing == operations.freshAddressing)
     }
 
     @Test("Invalidation releases the network and the next request recreates it pinned")
@@ -149,8 +166,8 @@ struct VmnetNetworkServiceTests {
         _ = try service.network(for: .hostOnly)
 
         #expect(operations.pinnedAddressings == [nil])
-        let store = try readStore(at: location.storeURL)
-        #expect(store == [.hostOnly: operations.freshAddressing])
+        let store = try readStore(at: location.storeURL, from: service)
+        #expect(store?[.hostOnly]?.addressing == operations.freshAddressing)
     }
 
     // MARK: - Failures
@@ -166,7 +183,7 @@ struct VmnetNetworkServiceTests {
         #expect(throws: TestFailure.self) {
             try service.network(for: .hostOnly)
         }
-        let store = try readStore(at: location.storeURL)
+        let store = try readStore(at: location.storeURL, from: service)
         #expect(store == nil)
     }
 
@@ -183,5 +200,162 @@ struct VmnetNetworkServiceTests {
         #expect(first.network == second.network)
         #expect(operations.createdKinds == [.hostOnly])
         #expect(!FileManager.default.fileExists(atPath: location.directory.path(percentEncoded: false)))
+    }
+
+    // MARK: - Reservation slots
+
+    @Test("Slots assign sequential addresses from host 2, keyed case-insensitively")
+    func slotsAssignSequentialAddresses() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        try seed(
+            [.shared: VmnetNetworkRecord(addressing: Self.storedAddressing, reservedMACs: [])],
+            at: location.storeURL)
+        let service = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+
+        service.reserveAddressIfNeeded(for: "AA:BB:CC:DD:EE:01", kind: .shared)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+        // Re-reserving an existing MAC in another case must not take a new slot.
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:01", kind: .shared) == "192.168.77.2")
+        #expect(service.reservedAddress(for: "AA:BB:CC:DD:EE:02", kind: .shared) == "192.168.77.3")
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:03", kind: .shared) == nil)
+    }
+
+    @Test("A reserved address is unknown until the network's addressing exists")
+    func reservedAddressUnknownBeforeFirstMaterialization() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:01", kind: .shared) == nil)
+
+        _ = try service.network(for: .shared)
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:01", kind: .shared) == "192.168.213.2")
+    }
+
+    @Test("Slots persist across service instances")
+    func slotsPersistAcrossInstances() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let first = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+        first.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        first.flushPersistsForTesting()
+
+        let second = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+        second.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+
+        let store = try readStore(at: location.storeURL, from: second)
+        #expect(store?[.shared]?.reservedMACs == ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"])
+    }
+
+    // MARK: - Reservations at materialization
+
+    @Test("First materialization with slots discovers addressing, then recreates pinned with reservations")
+    func firstMaterializationInstallsReservationsViaDiscovery() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+
+        let handle = try service.network(for: .shared)
+
+        // Discovery create (fresh, no reservations), released, then the
+        // pinned create carrying the reservations.
+        #expect(operations.pinnedAddressings == [nil, operations.freshAddressing])
+        #expect(operations.installedReservations.first?.isEmpty == true)
+        #expect(operations.releasedNetworks.count == 1)
+        #expect(operations.releasedNetworks.first != handle.network)
+        let installed = try #require(operations.installedReservations.last)
+        #expect(installed.map(\.mac) == ["aa:bb:cc:dd:ee:01"])
+        #expect(installed.map(\.address) == ["192.168.213.2"])
+    }
+
+    @Test("Stored addressing materializes in one create with the reservations installed")
+    func storedAddressingInstallsReservationsInOneCreate() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        try seed(
+            [
+                .shared: VmnetNetworkRecord(
+                    addressing: Self.storedAddressing,
+                    reservedMACs: ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"])
+            ], at: location.storeURL)
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        _ = try service.network(for: .shared)
+
+        #expect(operations.pinnedAddressings == [Self.storedAddressing])
+        let installed = try #require(operations.installedReservations.first)
+        #expect(installed.map(\.address) == ["192.168.77.2", "192.168.77.3"])
+    }
+
+    @Test("A failed pinned recreate after discovery falls back to a fresh network without reservations")
+    func failedRecreateAfterDiscoveryFallsBackFresh() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        operations.pinnedCreateError = TestFailure("subnet re-grabbed")
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+
+        _ = try service.network(for: .shared)
+
+        // Discovery, failed pinned recreate, then the working fallback — the
+        // mode beats the IP display.
+        #expect(operations.pinnedAddressings == [nil, operations.freshAddressing, nil])
+        #expect(operations.installedReservations.last?.isEmpty == true)
+        let store = try readStore(at: location.storeURL, from: service)
+        #expect(store?[.shared]?.addressing == operations.freshAddressing)
+        #expect(store?[.shared]?.reservedMACs == ["aa:bb:cc:dd:ee:01"])
+    }
+
+    @Test("Slots past the subnet's capacity are dropped from the installed reservations")
+    func slotsPastSubnetCapacityAreDropped() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        // A /30 leaves exactly one usable host past the gateway: host 2.
+        let tiny = VmnetNetworkAddressing(
+            ipv4Subnet: "192.168.77.0", ipv4Mask: "255.255.255.252",
+            ipv6Prefix: "fd00:aaaa:bbbb:cccc::", ipv6PrefixLength: 64)
+        try seed(
+            [
+                .shared: VmnetNetworkRecord(
+                    addressing: tiny, reservedMACs: ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"])
+            ], at: location.storeURL)
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        _ = try service.network(for: .shared)
+
+        let installed = try #require(operations.installedReservations.first)
+        #expect(installed.map(\.address) == ["192.168.77.2"])
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:02", kind: .shared) == nil)
+    }
+
+    // MARK: - Network identity
+
+    @Test("kind(ofNetwork:) answers for held networks only")
+    func kindOfNetworkAnswersForHeldNetworks() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+
+        let hostOnly = try service.network(for: .hostOnly)
+        let shared = try service.network(for: .shared)
+
+        #expect(service.kind(ofNetwork: hostOnly.network) == .hostOnly)
+        #expect(service.kind(ofNetwork: shared.network) == .shared)
+        service.invalidateNetwork(for: .shared)
+        #expect(service.kind(ofNetwork: shared.network) == nil)
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,19 +124,23 @@ substitute mocks. Services split by concurrency: those that touch
 single VZ-facing translation point, covering boot loader, CPU, memory, storage, network, display,
 input, audio, the Linux SPICE console port, and the macOS `VZVirtioSocketDeviceConfiguration`.
 
-The network attachment follows the VM's persisted mode: shared NAT, bridged over a host
-interface resolved through `BridgedInterfaceProviding` — the same seam the settings section's Mode
-picker reads its interface list from — or host-only on the app-managed vmnet network reached
-through `VmnetNetworkProviding`. A bridged VM whose interface cannot resolve, or a host-only
-network that cannot materialize, builds the device detached rather than failing the boot or
-restore.
+The network attachment follows the VM's persisted mode: shared over the app-managed vmnet
+shared network in an entitled build (system NAT otherwise), bridged over a host interface
+resolved through `BridgedInterfaceProviding` — the same seam the settings section's Mode picker
+reads its interface list from — or host-only on the app-managed host-mode network, both reached
+through `VmnetNetworkProviding`. A bridged VM whose interface cannot resolve, or a vmnet network
+that cannot materialize, builds the device detached rather than failing the boot or restore.
 
 `VmnetNetworkService` (lock-guarded `Sendable`, process-wide — it serves `ConfigurationBuilder`'s
-off-main assembly and the main-actor live-switch path) owns the app's managed vmnet networks. It
-materializes each lazily over the `VmnetNetworkOperating` seam and holds the ref until the app
-exits, so every concurrent VM in the mode shares the one network; addressing stays stable across
-launches by persisting each network's addressing to `Application Support/Kernova/networks.json`
-and pinning it onto the recreated network at next use.
+off-main assembly and the main-actor live-switch path) owns the app's managed vmnet networks and
+the per-VM DHCP reservations riding them: each VM holds a slot keyed on its persisted MAC, the
+slot's derived address is what the settings pane's IP Address row shows, and slots are kept in
+step with configurations through `VMLibraryViewModel`'s persistence funnel. The service
+materializes each network lazily over the `VmnetNetworkOperating` seam and holds the ref until
+the app exits, so every concurrent VM in the mode shares the one network; addressing and slots
+stay stable across launches by persisting each network's record to
+`Application Support/Kernova/networks.json` and pinning the addressing onto the recreated
+network at next use.
 
 While a session runs, `NetworkAttachmentCoordinator` (one per session, owned by `VMInstance`,
 activated when the VM reaches `.running`) keeps the live attachment realizing the persisted mode.


### PR DESCRIPTION
Closes #816

## Summary

- **The IP Address row lands in the Network card** (design decision 4 in docs/research/2026-08-12-network-settings-ui.md): Shared and Host Only VMs show their reserved address with a copy affordance — valid while the VM is stopped, since the app assigns it — and Bridged shows "Assigned by your network". Unentitled builds have no reservation machinery behind the row, so it is absent there (decision 9's spirit: absence over a visible-but-empty control), and Shared keeps `VZNATNetworkDeviceAttachment` in those builds.
- **Entitled Shared Network now runs on an app-managed `VMNET_SHARED_MODE` vmnet network** — the #815 backbone extended, exactly as #819 planned — with one DHCP reservation per VM keyed on its persisted MAC (`vmnet_network_configuration_add_dhcp_reservation`). The issue's sanctioned mechanism: assign the address, then display what was assigned.
- **The verify-first open question is answered: observable NAT behavior matches.** Empirically on this host (probe inside the entitled Debug build + a real guest boot):
  - A fresh app-created shared-mode network reserved **the same `192.168.64.0/24` subnet VZNAT uses here** (allocation is sequential from `192.168.64/16`'s pool; a second concurrent network got `.65.0/24`). Existing VMs stay on the subnet they already knew, pinned thereafter via `networks.json`.
  - Gateway and DNS proxy sit at `.1`, mask `/24` — the same shape VZNAT serves. The vmnet header documents shared-mode defaults as NAT44+NAT66, DHCP, DNS proxy, and router advertisement all enabled.
  - End-to-end on a macOS guest: the DHCP ACK carried exactly the displayed reserved address (`yiaddr 192.168.64.18`, infinite lease), `apple.com` resolved through the proxy and pinged with 0% loss, and the host reached the guest at the displayed address.
  - The one caveat worth naming: the subnet value is an allocation, not a constant — if another vmnet consumer holds `.64.0/24` at Kernova's first-ever shared materialization, the app network gets the next free `/24` and keeps it. Same class of variability VZNAT itself has per host.

## Design

- **Reservation slots, not ad-hoc IPs.** Each network's persisted record holds an ordered MAC list; slot *i* reserves host *2 + i* (the gateway holds 1). Slots are assignable before the subnet is known — cheap, non-blocking, main-actor-safe — and the address derives from persisted addressing, so the row fills instantly on later launches without materializing anything.
- **Slot sync rides the existing funnels**: every `VMInstance` construction (`wirePersistence`) and every `updateConfiguration` pass. The whole library gets slots at first launch after this change, before any network materializes.
- **First materialization does a discover→release→recreate-pinned dance**: reservation IPs need the subnet, which only exists once a network does. Later launches create once, pinned with reservations installed. If the pinned recreate loses the subnet race, the fallback is a working network without reservations — the mode beats the IP display — healed at the next materialization.
- **Reservations are immutable while a network is active** (vmnet.h; the config-mutation call "succeeds" but the live network keeps its set). A slot assigned while its network is materialized — a VM created mid-session after another Shared VM booted — takes effect at the next materialization (next launch, or a recovery-driven recreate). Until then that one VM's first session leases dynamically while the row shows its durable assignment. Judged acceptable over a detach-all/recreate/reattach dance across running VMs; disclosed here rather than in UI copy.
- **Recovery**: `NetworkAttachmentPlan.sharedVmnet` joins the plan enum (`.nat` remains, realizing unentitled Shared); the coordinator snapshots the entitlement at init, and the Host Only materialization ladder and once-per-episode invalidation generalize to any vmnet-backed plan. `VZNetworkDeviceHandle` maps a vmnet attachment back to its kind by ref through the new `kind(ofNetwork:)`, replacing the "any vmnet attachment is Host Only" assumption.
- **`networks.json` changes shape** (`{kind: {addressing, reservedMACs}}`). Per the persisted-data rule there is no migration: an old-shape file fails decode, logs, and self-heals fresh — observed live; the recreated networks re-reserved the same subnets on this host, so even addressing survived in practice.
- Entitled Shared materialization failure builds the device detached, mirroring Host Only, and recovery retries — a deliberate uniformity choice over a per-boot VZNAT fallback, which would have added a third Shared variant whose IP display could silently lie.

## Test plan

- [x] `make test` — full suite green (2718 passed); `make lint` clean
- [x] Manual on the entitled Debug build: row shows the reserved address for Shared and Host Only, updates live on mode switch, persists while stopped; guest DHCP ACK matches the row exactly; DNS proxy + NAT44 + host→guest reach verified; graceful shutdown, mode restored
- [x] Old-shape `networks.json` self-heals through the unreadable-store path

## Notes

- **Review round** (`/code-review high`, 26 raw candidates → 13 after dedup → 10 survived adversarial verification; all addressed in the second commit): an invalidation recreate is now pinned-only, so one Shared VM's ladder exhaustion can no longer drift the subnet out from under running siblings (the recreate fails and retries instead of falling back fresh — the original "VZ has already torn down every attachment" invariant was single-VM); the service records each materialized network's installed reservations and the IP row answers only those, so a slot assigned after materialization (mid-session VM creation while another Shared VM runs — the staleness window the Design section discloses) now renders as pending instead of an address the guest never receives, including the adjusted-pin and fresh-fallback paths; a live Shared↔Host Only switch supersedes the in-flight materialization task rather than being swallowed by its single-flight guard; store snapshots enqueue to the persist queue in mutation order; a malformed MAC is refused a slot and skipped in the store rather than aborting every materialization of its kind; the IP row's materialize kick can no longer spin a refresh loop on an underivable address; slot sync is entitlement-gated to match the row; the duplicate IPv4 dotted-quad conversions consolidated onto one helper. Two candidates were dismissed on the PR-argued decisions above (no-migration store shape; detached-over-NAT uniformity), one was refuted in verification, and the append-only-slots debt is filed as #830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToKPURLVdj5371PLTqXRaf
