### PR TITLE
docs: Run long make targets bare in the background

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ The tool-neutral operating guide for this repository. Deep-dive docs are indexed
 
 Xcode project, not SwiftPM. From the terminal go through the `Makefile` (`make help` lists every target) — never hand-write an `xcodebuild` invocation; the flags are not the obvious ones. Fresh-clone setup: [README](README.md#development-setup); machinery: [docs/BUILD.md](docs/BUILD.md).
 
+Run long targets (`build`, `test`, `test-suite`) as bare **background** shell commands — no pipes, no `tail`/`tee`, no watcher loops. The harness keeps the full output in the task's log file and notifies on exit: the exit code is the verdict, and nothing enters context during the run, so output-mangling saves no tokens — it only truncates the log. After exit, grep the log file for just the lines you need.
+
 The app is Apple Silicon-only (`ARCHS = arm64` project-wide), so `#if arch(arm64)` guards are unnecessary.
 
 A new top-level target needing a dynamic build number calls `Tools/set-build-number.sh <app|agent>` from a `Set Build Number from Git` build phase — never patch the built `Info.plist`.


### PR DESCRIPTION
## Summary
- Adds one paragraph to AGENTS.md's Build & Test section: long targets (`build`, `test`, `test-suite`) run as bare **background** shell commands — no pipes, no `tail`/`tee`, no watcher loops. The harness keeps the full output in the task's log file and signals completion via the task's exit, so the exit code is the verdict and the log is grepped only after the fact.
- The rule states explicitly that output-mangling saves no tokens — nothing enters context during a background run — because the observed failure was a misguided token-saving move: `make test` piped through `tail -30` (truncating the log to the last rendered lines), then a second process grep-polling that file with a pattern (`error:`) that didn't match the run's actual ending (`Error 65`), leaving an orphaned watcher spinning long after the run died.

## Changes
- `AGENTS.md` — Build & Test section, +1 paragraph

## Test plan
- [x] Docs-only; `Tools/check-docs.sh` passes

## Notes
- A Makefile change (tee'd log + verdict line) and a run-tests skill were considered and rejected: `make test`'s exit code already is the verdict, the harness already archives full output, and a skill only fires when invoked while this failure happens precisely when nothing is looked up — the rule has to be ambient. The project-agnostic half of the guidance went to user-scope memory, outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6oTjZ98jTfbqWZzpT7Dmv