### PR TITLE
feat: Port forwarding for shared networking

### DIFF
--- a/Kernova/Models/PortForwardingRule.swift
+++ b/Kernova/Models/PortForwardingRule.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// The transport a forwarding rule covers.
+enum PortForwardingTransport: String, Codable, Sendable, CaseIterable {
+    case tcp
+    case udp
+
+    /// How the transport reads in the UI.
+    var displayName: String { rawValue.uppercased() }
+}
+
+/// One host→guest port mapping on an app-managed network.
+///
+/// The app's single forwarding model (docs/NETWORKING.md): every consumer of
+/// port mappings uses this rule and the enforcement path behind it.
+struct PortForwardingRule: Codable, Sendable, Equatable, Hashable {
+    /// The transport forwarded.
+    var transport: PortForwardingTransport
+    /// The port traffic arrives on, on the host side (vmnet's *external* port).
+    var hostPort: UInt16
+    /// The port traffic is delivered to inside the guest (vmnet's *internal*
+    /// port).
+    var guestPort: UInt16
+
+    /// The ports a rule may carry — port 0 addresses no service.
+    static let portRange: ClosedRange<Int> = 1...65535
+
+    /// What makes this rule collide with another.
+    var hostClaim: PortForwardingHostClaim {
+        PortForwardingHostClaim(transport: transport, hostPort: hostPort)
+    }
+}
+
+/// A claim on one host-side port.
+///
+/// A network carries one rule per (transport, host port): the host port is
+/// claimed network-wide, across every VM joined to it.
+struct PortForwardingHostClaim: Hashable, Sendable {
+    var transport: PortForwardingTransport
+    var hostPort: UInt16
+}

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -450,6 +450,10 @@ struct VMConfiguration: Codable, Sendable, Equatable {
             SharedDirectory(id: UUID(), path: dir.path, readOnly: dir.readOnly, bookmark: dir.bookmark)
         }
 
+        // A host port is claimed once network-wide, so carried-over rules would
+        // collide with the source's the moment both VMs share a network.
+        clone.portForwardingRules = []
+
         // The clone copies the source bundle's post-install artifacts, so
         // preserving either install context would falsely mark it as awaiting
         // an initial boot.

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -78,6 +78,13 @@ struct VMConfiguration: Codable, Sendable, Equatable {
 
     var macAddress: String?
 
+    /// Host→guest port mappings for a Shared Network VM, installed on the
+    /// app-managed network when it is created.
+    ///
+    /// Ignored in every other mode: Bridged guests are reached at their own
+    /// address, Host Only ones only from this Mac.
+    var portForwardingRules: [PortForwardingRule]
+
     // MARK: - Clipboard Sharing
 
     /// When `true`, a SPICE agent console port is configured to enable clipboard
@@ -239,6 +246,7 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         networkMode: VMNetworkMode = .shared,
         bridgedInterfaceIdentifier: String? = nil,
         macAddress: String? = nil,
+        portForwardingRules: [PortForwardingRule] = [],
         clipboardSharingEnabled: Bool = false,
         clipboardPassthroughEnabled: Bool = false,
         serialSocketRelayEnabled: Bool = false,
@@ -283,6 +291,7 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         self.networkMode = networkMode
         self.bridgedInterfaceIdentifier = bridgedInterfaceIdentifier
         self.macAddress = macAddress
+        self.portForwardingRules = portForwardingRules
         self.clipboardSharingEnabled = clipboardSharingEnabled
         self.clipboardPassthroughEnabled = clipboardPassthroughEnabled
         self.serialSocketRelayEnabled = serialSocketRelayEnabled
@@ -338,6 +347,8 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         self.bridgedInterfaceIdentifier = try c.decodeIfPresent(
             String.self, forKey: .bridgedInterfaceIdentifier)
         self.macAddress = try c.decodeIfPresent(String.self, forKey: .macAddress)
+        self.portForwardingRules =
+            try c.decodeIfPresent([PortForwardingRule].self, forKey: .portForwardingRules) ?? []
         self.clipboardSharingEnabled = try c.decode(Bool.self, forKey: .clipboardSharingEnabled)
         self.clipboardPassthroughEnabled =
             try c.decodeIfPresent(Bool.self, forKey: .clipboardPassthroughEnabled) ?? false

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -33,7 +33,12 @@ final class VMInstance {
 
     let instanceID: UUID
     var configuration: VMConfiguration
-    var status: VMStatus
+    var status: VMStatus {
+        didSet {
+            guard status != oldValue, status.isResting else { return }
+            onSessionEnded?()
+        }
+    }
     var virtualMachine: VZVirtualMachine?
     let bundleURL: URL
 
@@ -192,6 +197,13 @@ final class VMInstance {
     ///
     /// The host uses it to auto-eject the guest-agent installer disk.
     @ObservationIgnored var onAgentBecameCurrent: (@MainActor () -> Void)?
+
+    /// Fired when this VM settles into a resting status, so no session of its
+    /// own is live any more.
+    ///
+    /// Wired by `VMLibraryViewModel.wirePersistence(for:)`; the library uses it
+    /// for work that can only run while no VM holds the resource it touches.
+    @ObservationIgnored var onSessionEnded: (@MainActor () -> Void)?
 
     /// Applies a configuration mutation, routing it through the persistence
     /// pipeline when `onUpdateConfiguration` is wired.

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -33,12 +33,7 @@ final class VMInstance {
 
     let instanceID: UUID
     var configuration: VMConfiguration
-    var status: VMStatus {
-        didSet {
-            guard status != oldValue, status.isResting else { return }
-            onSessionEnded?()
-        }
-    }
+    var status: VMStatus
     var virtualMachine: VZVirtualMachine?
     let bundleURL: URL
 
@@ -198,12 +193,13 @@ final class VMInstance {
     /// The host uses it to auto-eject the guest-agent installer disk.
     @ObservationIgnored var onAgentBecameCurrent: (@MainActor () -> Void)?
 
-    /// Fired when this VM settles into a resting status, so no session of its
-    /// own is live any more.
+    /// Fired at the end of ``tearDownSession()``, once this VM's
+    /// `VZVirtualMachine` and everything riding it are released — a stop, a
+    /// force stop, an error, or a completed save-suspend alike.
     ///
     /// Wired by `VMLibraryViewModel.wirePersistence(for:)`; the library uses it
     /// for work that can only run while no VM holds the resource it touches.
-    @ObservationIgnored var onSessionEnded: (@MainActor () -> Void)?
+    @ObservationIgnored var onSessionTornDown: (@MainActor () -> Void)?
 
     /// Applies a configuration mutation, routing it through the persistence
     /// pipeline when `onUpdateConfiguration` is wired.
@@ -377,6 +373,33 @@ final class VMInstance {
         canAttachUSBDevices && configuration.guestOS == .macOS
     }
 
+    /// Whether this VM may be holding — or be about to take — an attachment on
+    /// the app-managed network of `kind`, so recreating that network would pull
+    /// it out from under a session.
+    ///
+    /// A live session answers from the attachment it is *on*, not from the
+    /// configuration: the two disagree from a live mode switch until the swap
+    /// lands, in both directions. With no live `VZVirtualMachine` there is
+    /// nothing to read, so the configuration decides — and only while a session
+    /// could be forming or settling, since off-main configuration assembly can
+    /// already hold a handle this VM has not been given yet.
+    func mayHoldAttachment(
+        on kind: VmnetNetworkKind, networks: any VmnetNetworkProviding
+    ) -> Bool {
+        if let virtualMachine {
+            return virtualMachine.networkDevices.contains { device in
+                guard let vmnet = device.attachment as? VZVmnetNetworkDeviceAttachment else {
+                    return false
+                }
+                return networks.kind(ofNetwork: vmnet.network) == kind
+            }
+        }
+        guard configuration.networkEnabled,
+            VmnetNetworkKind(mode: configuration.networkMode) == kind
+        else { return false }
+        return status.isTransitioning || hasLiveVirtualMachine
+    }
+
     /// `true` when the VM is paused-to-disk but has no live `VZVirtualMachine` in memory.
     var isColdPaused: Bool {
         status == .paused && !hasLiveVirtualMachine
@@ -482,6 +505,7 @@ final class VMInstance {
         // `.hidden` (headless) has no window to do so — reset here so it
         // can't leak into the next session.
         displayMode = .inline
+        onSessionTornDown?()
     }
 
     func resetToStopped() {

--- a/Kernova/Models/VMStatus.swift
+++ b/Kernova/Models/VMStatus.swift
@@ -43,22 +43,6 @@ enum VMStatus: Sendable {
         }
     }
 
-    /// Whether no VZ session is live in this state, so work that cannot run
-    /// alongside one — recreating a network a session would be attached to —
-    /// may proceed.
-    ///
-    /// `.paused` counts as live: it covers a live-paused VM, which still holds
-    /// its attachments. Exhaustive rather than `default`, so a new state has to
-    /// choose a side.
-    var isResting: Bool {
-        switch self {
-        case .stopped, .error, .initialBoot:
-            true
-        case .starting, .running, .paused, .saving, .restoring, .installing:
-            false
-        }
-    }
-
     /// Whether terminating during this state would leave a half-written file
     /// where a complete one belongs, so a quit must wait the operation out
     /// instead of exiting through it.

--- a/Kernova/Models/VMStatus.swift
+++ b/Kernova/Models/VMStatus.swift
@@ -43,6 +43,22 @@ enum VMStatus: Sendable {
         }
     }
 
+    /// Whether no VZ session is live in this state, so work that cannot run
+    /// alongside one — recreating a network a session would be attached to —
+    /// may proceed.
+    ///
+    /// `.paused` counts as live: it covers a live-paused VM, which still holds
+    /// its attachments. Exhaustive rather than `default`, so a new state has to
+    /// choose a side.
+    var isResting: Bool {
+        switch self {
+        case .stopped, .error, .initialBoot:
+            true
+        case .starting, .running, .paused, .saving, .restoring, .installing:
+            false
+        }
+    }
+
     /// Whether terminating during this state would leave a half-written file
     /// where a complete one belongs, so a quit must wait the operation out
     /// instead of exiting through it.

--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -102,12 +102,15 @@ struct VmnetNetworkHandle: @unchecked Sendable {
 protocol VmnetNetworkOperating: Sendable {
     /// Creates a network of `kind` — reserving `addressing` when given, the
     /// system's choice when `nil` — installing the given MAC → IPv4 DHCP
-    /// reservations, and returns the handle plus the addressing the network
-    /// actually reserved. Reservations are fixed for the life of the network.
+    /// reservations and port-forwarding rules, and returns the handle plus the
+    /// addressing the network actually reserved. Both are fixed for the life of
+    /// the network; `forwardingRules` arrives already deduped, each rule paired
+    /// with the guest address it forwards to.
     func createNetwork(
         _ kind: VmnetNetworkKind,
         addressing: VmnetNetworkAddressing?,
-        reservations: [(mac: String, address: String)]
+        reservations: [(mac: String, address: String)],
+        forwardingRules: [(rule: PortForwardingRule, internalAddress: String)]
     ) throws -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing)
     /// Releases `handle`'s network ref, ending its subnet reservation.
     func releaseNetwork(_ handle: VmnetNetworkHandle)
@@ -118,6 +121,16 @@ protocol VmnetNetworkOperating: Sendable {
 /// `CFRelease` on an unmanaged import, so route through `Unmanaged`.
 func releaseVmnetRef(_ ref: OpaquePointer) {
     Unmanaged<AnyObject>.fromOpaque(UnsafeRawPointer(ref)).release()
+}
+
+extension PortForwardingTransport {
+    /// The `IPPROTO_*` value vmnet takes for this transport.
+    fileprivate var ipProtocol: UInt8 {
+        switch self {
+        case .tcp: UInt8(IPPROTO_TCP)
+        case .udp: UInt8(IPPROTO_UDP)
+        }
+    }
 }
 
 /// A vmnet call that failed.
@@ -141,7 +154,8 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
     func createNetwork(
         _ kind: VmnetNetworkKind,
         addressing: VmnetNetworkAddressing?,
-        reservations: [(mac: String, address: String)]
+        reservations: [(mac: String, address: String)],
+        forwardingRules: [(rule: PortForwardingRule, internalAddress: String)]
     ) throws -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing) {
         var status = vmnet_return_t.VMNET_SUCCESS
         guard let configuration = vmnet_network_configuration_create(mode(for: kind), &status) else {
@@ -152,13 +166,14 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
             try pin(addressing, onto: configuration)
         }
         try install(reservations, onto: configuration)
+        try install(forwarding: forwardingRules, onto: configuration)
         guard let network = vmnet_network_create(configuration, &status) else {
             throw VmnetOperationError(operation: "vmnet_network_create", status: status)
         }
 
         let reserved = Self.reservedAddressing(of: network)
         Self.logger.notice(
-            "Created \(kind.rawValue, privacy: .public) network (\(addressing == nil ? "fresh" : "pinned", privacy: .public), \(reservations.count, privacy: .public) reservations): \(reserved.ipv4Subnet, privacy: .public) mask \(reserved.ipv4Mask, privacy: .public), \(reserved.ipv6Prefix, privacy: .public)/\(reserved.ipv6PrefixLength, privacy: .public)"
+            "Created \(kind.rawValue, privacy: .public) network (\(addressing == nil ? "fresh" : "pinned", privacy: .public), \(reservations.count, privacy: .public) reservations, \(forwardingRules.count, privacy: .public) forwarding rules): \(reserved.ipv4Subnet, privacy: .public) mask \(reserved.ipv4Mask, privacy: .public), \(reserved.ipv6Prefix, privacy: .public)/\(reserved.ipv6PrefixLength, privacy: .public)"
         )
         return (VmnetNetworkHandle(network: network), reserved)
     }
@@ -191,6 +206,29 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
             guard status == .VMNET_SUCCESS else {
                 throw VmnetOperationError(
                     operation: "vmnet_network_configuration_add_dhcp_reservation", status: status)
+            }
+        }
+    }
+
+    private func install(
+        forwarding rules: [(rule: PortForwardingRule, internalAddress: String)],
+        onto configuration: vmnet_network_configuration_ref
+    ) throws {
+        for entry in rules {
+            guard let addressValue = IPv4Value.parse(entry.internalAddress) else {
+                throw VmnetOperationError(
+                    operation: "parsing a port forwarding rule's guest address", status: nil)
+            }
+            var address = in_addr(s_addr: addressValue.bigEndian)
+            // Argument order follows the signature, which takes the internal
+            // (guest) port before the external (host) one — vmnet.h's own
+            // `@param` block for this function lists them the other way round.
+            let status = vmnet_network_configuration_add_port_forwarding_rule(
+                configuration, entry.rule.transport.ipProtocol, sa_family_t(AF_INET),
+                entry.rule.guestPort, entry.rule.hostPort, &address)
+            guard status == .VMNET_SUCCESS else {
+                throw VmnetOperationError(
+                    operation: "vmnet_network_configuration_add_port_forwarding_rule", status: status)
             }
         }
     }
@@ -273,13 +311,26 @@ protocol VmnetNetworkProviding: Sendable {
     /// while `mac` holds no slot or the network has never materialized (its
     /// addressing is not yet known).
     func reservedAddress(for mac: String, kind: VmnetNetworkKind) -> String?
+    /// Records `rules` as what the VM at `mac` forwards on the network of
+    /// `kind`, replacing whatever it declared before; an empty array declares
+    /// none. Cheap and non-blocking — safe from the main actor.
+    ///
+    /// Rules are fixed at network creation, so a change reaches guests at the
+    /// network's next materialization.
+    func setPortForwardingRules(_ rules: [PortForwardingRule], for mac: String, kind: VmnetNetworkKind)
+    /// Whether the materialized network of `kind` carries a different set of
+    /// forwarding rules than the one that would install right now — so
+    /// recreating it would change what is forwarded. `false` while no network
+    /// of `kind` is materialized.
+    func portForwardingRulesArePending(for kind: VmnetNetworkKind) -> Bool
     /// The kind whose materialized network `network` is, `nil` for a network
     /// this service does not hold.
     func kind(ofNetwork network: vmnet_network_ref) -> VmnetNetworkKind?
 }
 
 /// Owns the app's managed vmnet networks — the Host Only network and the
-/// Shared Network network — and the per-VM DHCP reservations riding them.
+/// Shared Network network — and the per-VM DHCP reservations and
+/// port-forwarding rules riding them.
 ///
 /// vmnet networks do not survive the process, so each network's record —
 /// addressing plus reservation slots — is persisted to
@@ -290,10 +341,12 @@ protocol VmnetNetworkProviding: Sendable {
 /// subnet reservation lives as long as the ref, and every concurrent VM in
 /// the mode shares the one network.
 ///
-/// Reservations are fixed at network creation (vmnet.h: modifying them is not
-/// allowed while a network is active), so a slot assigned while its network
-/// is materialized takes effect at the next materialization — the next app
-/// launch, or a recovery-driven recreate.
+/// Reservations and forwarding rules are both fixed at network creation
+/// (vmnet.h: modifying reservations is not allowed while a network is active,
+/// and rules can only be added to a configuration), so either one declared
+/// while its network is materialized takes effect at the next materialization
+/// — the next app launch, or a recreate driven by recovery or by
+/// ``portForwardingRulesArePending(for:)``.
 ///
 /// Lock-guarded `Sendable` rather than `@MainActor`: it never touches
 /// `VZVirtualMachine`, and `ConfigurationBuilder` consumes it during off-main
@@ -318,6 +371,16 @@ final class VmnetNetworkService: @unchecked Sendable {
     /// a slot assigned after materialization reads as pending rather than as
     /// an address the guest never receives.
     private var installedAddresses: [VmnetNetworkKind: [String: String]] = [:]
+    /// The forwarding rules each VM declares on a network, keyed by lowercased
+    /// MAC.
+    ///
+    /// In-memory only: each VM's `config.json` owns its rules, and the library
+    /// re-declares every VM's at load, before anything materializes.
+    private var desiredForwardingRules: [VmnetNetworkKind: [String: [PortForwardingRule]]] = [:]
+    /// The forwarding rules each materialized network was created with, keyed
+    /// by lowercased MAC — the counterpart of `installedAddresses`, and the only
+    /// set the live network honors.
+    private var installedForwardingRules: [VmnetNetworkKind: [String: [PortForwardingRule]]] = [:]
     /// Kinds whose next materialization must reserve the stored addressing or
     /// fail. Set by invalidation: its recreate races VZ still holding the old
     /// network's refs (a sibling VM's live attachment keeps the subnet
@@ -353,14 +416,16 @@ final class VmnetNetworkService: @unchecked Sendable {
         materializeLock.lock()
         defer { materializeLock.unlock() }
         if let handle = cachedHandle(for: kind) { return handle }
-        let (handle, installed) = try materialize(kind)
+        let materialized = try materialize(kind)
         stateLock.lock()
-        handles[kind] = handle
+        handles[kind] = materialized.handle
         installedAddresses[kind] = Dictionary(
-            installed.map { ($0.mac, $0.address) }, uniquingKeysWith: { first, _ in first })
+            materialized.reservations.map { ($0.mac, $0.address) },
+            uniquingKeysWith: { first, _ in first })
+        installedForwardingRules[kind] = Self.rulesByMAC(materialized.forwardingRules)
         pinnedOnlyKinds.remove(kind)
         stateLock.unlock()
-        return handle
+        return materialized.handle
     }
 
     private func cachedHandle(for kind: VmnetNetworkKind) -> VmnetNetworkHandle? {
@@ -369,31 +434,34 @@ final class VmnetNetworkService: @unchecked Sendable {
         return handles[kind]
     }
 
-    private func materialize(_ kind: VmnetNetworkKind) throws
-        -> (handle: VmnetNetworkHandle, installed: [(mac: String, address: String)])
-    {
+    private func materialize(_ kind: VmnetNetworkKind) throws -> MaterializedNetwork {
         let record = currentRecord(for: kind)
         if let stored = record.addressing {
             do {
                 let installing = reservations(for: record.reservedMACs, addressing: stored, kind: kind)
+                let forwarding = forwardingRules(for: installing, kind: kind)
                 let (handle, reserved) = try operations.createNetwork(
-                    kind, addressing: stored, reservations: installing)
+                    kind, addressing: stored, reservations: installing,
+                    forwardingRules: Self.operatorRules(forwarding))
                 if reserved == stored {
                     Self.logger.info(
                         "Recreated the \(kind.rawValue, privacy: .public) network with its stored addressing"
                     )
-                    return (handle, installing)
+                    return MaterializedNetwork(
+                        handle: handle, reservations: installing, forwardingRules: forwarding)
                 }
                 // vmnet accepted the pin but reserved something else; the
                 // store must follow what the network actually is, or every
                 // later launch re-pins a value no network carries. The
                 // installed reservations were derived from the old addressing,
-                // so none of them holds on this network — report none.
+                // so none of them — nor the rules forwarding to them — holds on
+                // this network; report none, and let the pending rule set drive
+                // a later recreate.
                 updateRecord(for: kind) { $0.addressing = reserved }
                 Self.logger.warning(
                     "Pinned \(kind.rawValue, privacy: .public) network addressing was adjusted by the system — persisting the reserved values"
                 )
-                return (handle, [])
+                return MaterializedNetwork(handle: handle, reservations: [], forwardingRules: [])
             } catch {
                 if isPinnedOnly(kind) {
                     // An invalidation recreate racing VZ's own refs on the old
@@ -423,28 +491,31 @@ final class VmnetNetworkService: @unchecked Sendable {
     /// depend on the subnet, which is only known once a network exists — so
     /// create fresh to discover the addressing, then release and recreate
     /// pinned to it with the reservations installed.
-    private func materializeFresh(_ kind: VmnetNetworkKind) throws
-        -> (handle: VmnetNetworkHandle, installed: [(mac: String, address: String)])
-    {
+    private func materializeFresh(_ kind: VmnetNetworkKind) throws -> MaterializedNetwork {
         let (probe, discovered) = try operations.createNetwork(
-            kind, addressing: nil, reservations: [])
+            kind, addressing: nil, reservations: [], forwardingRules: [])
         let macs = currentRecord(for: kind).reservedMACs
         guard !macs.isEmpty else {
             updateRecord(for: kind) { $0.addressing = discovered }
             Self.logger.notice("Created and persisted the \(kind.rawValue, privacy: .public) network")
-            return (probe, [])
+            return MaterializedNetwork(handle: probe, reservations: [], forwardingRules: [])
         }
 
         operations.releaseNetwork(probe)
         do {
             let installing = reservations(for: macs, addressing: discovered, kind: kind)
+            let forwarding = forwardingRules(for: installing, kind: kind)
             let (handle, reserved) = try operations.createNetwork(
-                kind, addressing: discovered, reservations: installing)
+                kind, addressing: discovered, reservations: installing,
+                forwardingRules: Self.operatorRules(forwarding))
             updateRecord(for: kind) { $0.addressing = reserved }
             Self.logger.notice(
                 "Created and persisted the \(kind.rawValue, privacy: .public) network with \(macs.count, privacy: .public) reservation slots"
             )
-            return (handle, reserved == discovered ? installing : [])
+            let holds = reserved == discovered
+            return MaterializedNetwork(
+                handle: handle, reservations: holds ? installing : [],
+                forwardingRules: holds ? forwarding : [])
         } catch {
             // The discovered subnet was re-grabbed between release and
             // recreate. Fall back to a working network without reservations —
@@ -454,9 +525,9 @@ final class VmnetNetworkService: @unchecked Sendable {
                 "Recreating the \(kind.rawValue, privacy: .public) network with reservations failed — falling back to a fresh network without them: \(error.localizedDescription, privacy: .public)"
             )
             let (handle, addressing) = try operations.createNetwork(
-                kind, addressing: nil, reservations: [])
+                kind, addressing: nil, reservations: [], forwardingRules: [])
             updateRecord(for: kind) { $0.addressing = addressing }
-            return (handle, [])
+            return MaterializedNetwork(handle: handle, reservations: [], forwardingRules: [])
         }
     }
 
@@ -466,21 +537,140 @@ final class VmnetNetworkService: @unchecked Sendable {
     private func reservations(
         for macs: [String], addressing: VmnetNetworkAddressing, kind: VmnetNetworkKind
     ) -> [(mac: String, address: String)] {
-        macs.enumerated().compactMap { index, mac in
-            guard VZMACAddress(string: mac) != nil else {
+        let slots = Self.resolveSlots(macs: macs, addressing: addressing)
+        for (index, slot) in slots.enumerated() {
+            switch slot {
+            case .installable:
+                continue
+            case .unparseableMAC:
                 Self.logger.warning(
                     "Skipping unparseable MAC in \(kind.rawValue, privacy: .public) reservation slot \(index, privacy: .public)"
                 )
-                return nil
-            }
-            guard let address = addressing.reservedAddress(slot: index) else {
+            case .noAddressLeft:
                 Self.logger.warning(
                     "No address left in the \(kind.rawValue, privacy: .public) subnet for reservation slot \(index, privacy: .public)"
                 )
-                return nil
             }
+        }
+        return Self.installablePairs(slots)
+    }
+
+    /// What one reservation slot resolves to against a network's addressing.
+    private enum ResolvedSlot {
+        case installable(mac: String, address: String)
+        /// The slot's MAC no longer parses (a hand-edited store).
+        case unparseableMAC
+        /// The subnet has no address left at this slot's index.
+        case noAddressLeft
+    }
+
+    /// Resolves every reservation slot in order, without logging — the shared
+    /// source of truth for what a network of `addressing` would install, read
+    /// both while materializing and while answering
+    /// ``portForwardingRulesArePending(for:)``.
+    private static func resolveSlots(
+        macs: [String], addressing: VmnetNetworkAddressing
+    ) -> [ResolvedSlot] {
+        macs.enumerated().map { index, mac in
+            guard VZMACAddress(string: mac) != nil else { return .unparseableMAC }
+            guard let address = addressing.reservedAddress(slot: index) else { return .noAddressLeft }
+            return .installable(mac: mac, address: address)
+        }
+    }
+
+    private static func installablePairs(_ slots: [ResolvedSlot]) -> [(mac: String, address: String)] {
+        slots.compactMap { slot in
+            guard case .installable(let mac, let address) = slot else { return nil }
             return (mac: mac, address: address)
         }
+    }
+
+    // MARK: - Port forwarding
+
+    /// One declared rule resolved against the reservation carrying it.
+    private struct ResolvedForwardingRule: Equatable {
+        let mac: String
+        let rule: PortForwardingRule
+        /// The guest's reserved IPv4 address — the rule's internal address.
+        let address: String
+    }
+
+    /// What one successful materialization produced: the handle, plus what the
+    /// created network actually honors.
+    private struct MaterializedNetwork {
+        let handle: VmnetNetworkHandle
+        let reservations: [(mac: String, address: String)]
+        let forwardingRules: [ResolvedForwardingRule]
+    }
+
+    /// The declared rules a network carrying `reservations` can install,
+    /// logging every drop.
+    private func forwardingRules(
+        for reservations: [(mac: String, address: String)], kind: VmnetNetworkKind
+    ) -> [ResolvedForwardingRule] {
+        let desired = currentDesiredForwardingRules(for: kind)
+        guard !desired.isEmpty else { return [] }
+        let resolution = Self.resolveForwardingRules(desired: desired, reservations: reservations)
+        for duplicate in resolution.duplicates {
+            Self.logger.warning(
+                "Dropping a \(kind.rawValue, privacy: .public) forwarding rule: \(duplicate.rule.transport.displayName, privacy: .public) host port \(duplicate.rule.hostPort, privacy: .public) is already forwarded on that network"
+            )
+        }
+        for mac in resolution.unreservedMACs {
+            Self.logger.warning(
+                "Dropping \(desired[mac]?.count ?? 0, privacy: .public) \(kind.rawValue, privacy: .public) forwarding rules for a VM holding no address reservation on that network"
+            )
+        }
+        return resolution.installing
+    }
+
+    /// Pairs each declared rule with the address of the reservation carrying
+    /// it, in reservation-slot order and each MAC's own rule order — so the
+    /// same library always yields the same rule set — and drops every later
+    /// claimant of a (transport, host port) pair.
+    private static func resolveForwardingRules(
+        desired: [String: [PortForwardingRule]],
+        reservations: [(mac: String, address: String)]
+    ) -> (
+        installing: [ResolvedForwardingRule], duplicates: [ResolvedForwardingRule],
+        unreservedMACs: [String]
+    ) {
+        var installing: [ResolvedForwardingRule] = []
+        var duplicates: [ResolvedForwardingRule] = []
+        var claimed: Set<PortForwardingHostClaim> = []
+        for entry in reservations {
+            for rule in desired[entry.mac] ?? [] {
+                let resolved = ResolvedForwardingRule(
+                    mac: entry.mac, rule: rule, address: entry.address)
+                if claimed.insert(rule.hostClaim).inserted {
+                    installing.append(resolved)
+                } else {
+                    duplicates.append(resolved)
+                }
+            }
+        }
+        let reserved = Set(reservations.map(\.mac))
+        return (installing, duplicates, desired.keys.filter { !reserved.contains($0) }.sorted())
+    }
+
+    private static func operatorRules(
+        _ resolved: [ResolvedForwardingRule]
+    ) -> [(rule: PortForwardingRule, internalAddress: String)] {
+        resolved.map { (rule: $0.rule, internalAddress: $0.address) }
+    }
+
+    private static func rulesByMAC(
+        _ resolved: [ResolvedForwardingRule]
+    ) -> [String: [PortForwardingRule]] {
+        Dictionary(grouping: resolved, by: \.mac).mapValues { $0.map(\.rule) }
+    }
+
+    private func currentDesiredForwardingRules(
+        for kind: VmnetNetworkKind
+    ) -> [String: [PortForwardingRule]] {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return desiredForwardingRules[kind] ?? [:]
     }
 
     // MARK: - Records
@@ -579,6 +769,7 @@ extension VmnetNetworkService: VmnetNetworkProviding {
         stateLock.lock()
         let dropped = handles.removeValue(forKey: kind)
         installedAddresses[kind] = nil
+        installedForwardingRules[kind] = nil
         // A sibling VM's live attachment may still hold the old network (VZ
         // retains its own ref), keeping the subnet reserved past our release —
         // so the recreate must reserve the stored addressing or fail, never
@@ -630,6 +821,52 @@ extension VmnetNetworkService: VmnetNetworkProviding {
             return nil
         }
         return derived
+    }
+
+    func setPortForwardingRules(
+        _ rules: [PortForwardingRule], for mac: String, kind: VmnetNetworkKind
+    ) {
+        let normalized = mac.lowercased()
+        guard VZMACAddress(string: normalized) != nil else {
+            // A malformed MAC (hand-edited config) resolves to no reservation,
+            // so its rules could never install — refuse them instead.
+            Self.logger.warning(
+                "Refusing \(kind.rawValue, privacy: .public) port forwarding rules for an unparseable MAC"
+            )
+            return
+        }
+        stateLock.lock()
+        let previous = desiredForwardingRules[kind]?[normalized] ?? []
+        if rules.isEmpty {
+            desiredForwardingRules[kind]?[normalized] = nil
+        } else {
+            desiredForwardingRules[kind, default: [:]][normalized] = rules
+        }
+        stateLock.unlock()
+        guard previous != rules else { return }
+        Self.logger.info(
+            "A VM now declares \(rules.count, privacy: .public) \(kind.rawValue, privacy: .public) forwarding rules"
+        )
+    }
+
+    func portForwardingRulesArePending(for kind: VmnetNetworkKind) -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        // Nothing pends against a network that does not exist yet: its next
+        // materialization installs whatever is declared then.
+        guard handles[kind] != nil else { return false }
+        guard let addressing = records[kind]?.addressing else { return false }
+        // Compared against what would *install*, not against everything
+        // declared: a rule whose VM holds no reservation can never install, and
+        // measuring against it would leave the flag stuck true and drive an
+        // endless recreate.
+        let slots = Self.resolveSlots(
+            macs: records[kind]?.reservedMACs ?? [], addressing: addressing)
+        let installable = Self.resolveForwardingRules(
+            desired: desiredForwardingRules[kind] ?? [:],
+            reservations: Self.installablePairs(slots)
+        ).installing
+        return Self.rulesByMAC(installable) != (installedForwardingRules[kind] ?? [:])
     }
 
     func kind(ofNetwork network: vmnet_network_ref) -> VmnetNetworkKind? {

--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -409,23 +409,57 @@ final class VmnetNetworkService: @unchecked Sendable {
             .appendingPathComponent("networks.json", isDirectory: false)
     }
 
+    /// How many networks one request may create before publishing whatever the
+    /// last attempt produced: each retry answers a rule declaration that landed
+    /// while the previous create was in flight, and a caller cannot be made to
+    /// wait on an editor that keeps typing.
+    private static let materializeAttemptLimit = 3
+
     /// The app-managed network of `kind`, materializing it on first use.
     /// Blocks for the vmnet XPC round-trip — never call on the main actor.
+    ///
+    /// A rule declared during the create is not in the network that comes back,
+    /// and would go unnoticed — nothing was materialized when it arrived, so it
+    /// never read as pending. Such a network is released and recreated before
+    /// anyone can take it, up to ``materializeAttemptLimit`` attempts.
     func network(for kind: VmnetNetworkKind) throws -> VmnetNetworkHandle {
         if let handle = cachedHandle(for: kind) { return handle }
         materializeLock.lock()
         defer { materializeLock.unlock() }
         if let handle = cachedHandle(for: kind) { return handle }
-        let materialized = try materialize(kind)
-        stateLock.lock()
-        handles[kind] = materialized.handle
-        installedAddresses[kind] = Dictionary(
-            materialized.reservations.map { ($0.mac, $0.address) },
-            uniquingKeysWith: { first, _ in first })
-        installedForwardingRules[kind] = Self.rulesByMAC(materialized.forwardingRules)
-        pinnedOnlyKinds.remove(kind)
-        stateLock.unlock()
-        return materialized.handle
+        var attempt = 0
+        while true {
+            attempt += 1
+            let materialized = try materialize(kind)
+            stateLock.lock()
+            let stale =
+                Self.rulesByMAC(materialized.submittedForwardingRules)
+                != installableForwardingRulesLocked(for: kind)
+            if stale, attempt < Self.materializeAttemptLimit {
+                stateLock.unlock()
+                // Never published, so nothing else can hold this network.
+                operations.releaseNetwork(materialized.handle)
+                Self.logger.info(
+                    "Forwarding rules changed while the \(kind.rawValue, privacy: .public) network was being created — recreating it"
+                )
+                continue
+            }
+            handles[kind] = materialized.handle
+            installedAddresses[kind] = Dictionary(
+                materialized.reservations.map { ($0.mac, $0.address) },
+                uniquingKeysWith: { first, _ in first })
+            installedForwardingRules[kind] = Self.rulesByMAC(materialized.forwardingRules)
+            pinnedOnlyKinds.remove(kind)
+            stateLock.unlock()
+            if stale {
+                // Left pending on purpose: the next rule sync or session
+                // teardown recreates the network at an idle moment.
+                Self.logger.warning(
+                    "Published the \(kind.rawValue, privacy: .public) network without the forwarding rules declared during its creation — they take effect at the next recreate"
+                )
+            }
+            return materialized.handle
+        }
     }
 
     private func cachedHandle(for kind: VmnetNetworkKind) -> VmnetNetworkHandle? {
@@ -461,7 +495,8 @@ final class VmnetNetworkService: @unchecked Sendable {
                 Self.logger.warning(
                     "Pinned \(kind.rawValue, privacy: .public) network addressing was adjusted by the system — persisting the reserved values"
                 )
-                return MaterializedNetwork(handle: handle, reservations: [], forwardingRules: [])
+                return MaterializedNetwork(
+                    handle: handle, reservations: [], forwardingRules: [], submitted: forwarding)
             } catch {
                 if isPinnedOnly(kind) {
                     // An invalidation recreate racing VZ's own refs on the old
@@ -515,7 +550,7 @@ final class VmnetNetworkService: @unchecked Sendable {
             let holds = reserved == discovered
             return MaterializedNetwork(
                 handle: handle, reservations: holds ? installing : [],
-                forwardingRules: holds ? forwarding : [])
+                forwardingRules: holds ? forwarding : [], submitted: forwarding)
         } catch {
             // The discovered subnet was re-grabbed between release and
             // recreate. Fall back to a working network without reservations —
@@ -601,6 +636,25 @@ final class VmnetNetworkService: @unchecked Sendable {
         let handle: VmnetNetworkHandle
         let reservations: [(mac: String, address: String)]
         let forwardingRules: [ResolvedForwardingRule]
+        /// The rules handed to `createNetwork`, which is what the declarations
+        /// looked like when this attempt started — the same set as
+        /// ``forwardingRules`` except where the network came back on addressing
+        /// the rules were not resolved against, which honors none of them.
+        /// Comparing it against what would install now is what tells a
+        /// declaration that changed mid-create from one that never held.
+        let submittedForwardingRules: [ResolvedForwardingRule]
+
+        init(
+            handle: VmnetNetworkHandle,
+            reservations: [(mac: String, address: String)] = [],
+            forwardingRules: [ResolvedForwardingRule] = [],
+            submitted: [ResolvedForwardingRule]? = nil
+        ) {
+            self.handle = handle
+            self.reservations = reservations
+            self.forwardingRules = forwardingRules
+            self.submittedForwardingRules = submitted ?? forwardingRules
+        }
     }
 
     /// The declared rules a network carrying `reservations` can install,
@@ -671,6 +725,24 @@ final class VmnetNetworkService: @unchecked Sendable {
         stateLock.lock()
         defer { stateLock.unlock() }
         return desiredForwardingRules[kind] ?? [:]
+    }
+
+    /// The rules a network of `kind` created right now would carry, keyed by
+    /// MAC — declarations that cannot install (no reservation slot, a host port
+    /// another VM already claims) are not in it, so it is directly comparable
+    /// with `installedForwardingRules`.
+    ///
+    /// The caller holds `stateLock`.
+    private func installableForwardingRulesLocked(
+        for kind: VmnetNetworkKind
+    ) -> [String: [PortForwardingRule]] {
+        guard let record = records[kind], let addressing = record.addressing else { return [:] }
+        let slots = Self.resolveSlots(macs: record.reservedMACs, addressing: addressing)
+        return Self.rulesByMAC(
+            Self.resolveForwardingRules(
+                desired: desiredForwardingRules[kind] ?? [:],
+                reservations: Self.installablePairs(slots)
+            ).installing)
     }
 
     // MARK: - Records
@@ -855,18 +927,11 @@ extension VmnetNetworkService: VmnetNetworkProviding {
         // Nothing pends against a network that does not exist yet: its next
         // materialization installs whatever is declared then.
         guard handles[kind] != nil else { return false }
-        guard let addressing = records[kind]?.addressing else { return false }
         // Compared against what would *install*, not against everything
         // declared: a rule whose VM holds no reservation can never install, and
         // measuring against it would leave the flag stuck true and drive an
         // endless recreate.
-        let slots = Self.resolveSlots(
-            macs: records[kind]?.reservedMACs ?? [], addressing: addressing)
-        let installable = Self.resolveForwardingRules(
-            desired: desiredForwardingRules[kind] ?? [:],
-            reservations: Self.installablePairs(slots)
-        ).installing
-        return Self.rulesByMAC(installable) != (installedForwardingRules[kind] ?? [:])
+        return installableForwardingRulesLocked(for: kind) != (installedForwardingRules[kind] ?? [:])
     }
 
     func kind(ofNetwork network: vmnet_network_ref) -> VmnetNetworkKind? {

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -1464,7 +1464,13 @@ final class VMLibraryViewModel {
             guard let self, let instance else { return }
             self.unmountGuestAgentInstaller(from: instance)
         }
+        // Forwarding rules are fixed at network creation, so an edit made while
+        // a VM ran waits for the last session on that network to end.
+        instance.onSessionEnded = { [weak self] in
+            self?.rebuildSharedNetworkIfIdle()
+        }
         syncAddressReservation(for: instance.configuration)
+        syncPortForwardingRules(for: instance.configuration)
     }
 
     /// Keeps the VM's DHCP reservation slot in step with its configuration:
@@ -1479,6 +1485,46 @@ final class VMLibraryViewModel {
             let kind = VmnetNetworkKind(mode: config.networkMode)
         else { return }
         vmnetNetworks.reserveAddressIfNeeded(for: mac, kind: kind)
+    }
+
+    /// Keeps the VM's port-forwarding rules in step with its configuration: a
+    /// Shared Network VM declares its rules on that network, a VM in any other
+    /// mode declares none. Runs wherever ``syncAddressReservation(for:)`` does.
+    private func syncPortForwardingRules(for config: VMConfiguration) {
+        let forwards = config.networkEnabled && config.networkMode == .shared
+        declarePortForwardingRules(forwards ? config.portForwardingRules : [], for: config)
+    }
+
+    /// Declares `rules` for the VM `config` identifies, then rebuilds the
+    /// shared network if that changed what it should carry.
+    ///
+    /// Entitlement-gated like the reservation machinery it rides on — an
+    /// unentitled build attaches system NAT, which forwards nothing.
+    private func declarePortForwardingRules(
+        _ rules: [PortForwardingRule], for config: VMConfiguration
+    ) {
+        guard isVMNetworkingEntitled, let mac = config.macAddress else { return }
+        vmnetNetworks.setPortForwardingRules(rules, for: mac, kind: .shared)
+        rebuildSharedNetworkIfIdle()
+    }
+
+    /// Recreates the shared network when the rules it was created with are no
+    /// longer the ones that should install, and no VM could be attached to it.
+    ///
+    /// Rules are fixed at creation, so an edit reaches guests only through a
+    /// recreate — and only while no session holds an attachment on the network.
+    /// The recreate keeps the network's addressing, so no guest's address
+    /// moves.
+    private func rebuildSharedNetworkIfIdle() {
+        guard vmnetNetworks.portForwardingRulesArePending(for: .shared) else { return }
+        let attached = instances.contains { instance in
+            instance.configuration.networkEnabled && instance.configuration.networkMode == .shared
+                && !instance.status.isResting
+        }
+        guard !attached else { return }
+        Self.logger.notice(
+            "Recreating the shared network so its changed port forwarding rules take effect")
+        vmnetNetworks.invalidateNetwork(for: .shared)
     }
 
     /// The single entry point for any UI-driven or programmatic mutation of
@@ -1501,6 +1547,7 @@ final class VMLibraryViewModel {
         guard new != old else { return true }
         instance.configuration = new
         syncAddressReservation(for: new)
+        syncPortForwardingRules(for: new)
         let saved = saveConfiguration(for: instance)
         applyLivePolicy(for: instance, old: old, new: new)
         return saved
@@ -2473,6 +2520,8 @@ final class VMLibraryViewModel {
             selectedID = instances.first?.id
         }
         ClipboardIssueCenter.shared.clear(instanceID: instance.instanceID)
+        // A VM out of the library stops claiming its host ports.
+        declarePortForwardingRules([], for: instance.configuration)
     }
 
     // MARK: - Reorder

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -1465,8 +1465,8 @@ final class VMLibraryViewModel {
             self.unmountGuestAgentInstaller(from: instance)
         }
         // Forwarding rules are fixed at network creation, so an edit made while
-        // a VM ran waits for the last session on that network to end.
-        instance.onSessionEnded = { [weak self] in
+        // a VM ran waits for the last session on that network to release it.
+        instance.onSessionTornDown = { [weak self] in
             self?.rebuildSharedNetworkIfIdle()
         }
         syncAddressReservation(for: instance.configuration)
@@ -1517,9 +1517,8 @@ final class VMLibraryViewModel {
     /// moves.
     private func rebuildSharedNetworkIfIdle() {
         guard vmnetNetworks.portForwardingRulesArePending(for: .shared) else { return }
-        let attached = instances.contains { instance in
-            instance.configuration.networkEnabled && instance.configuration.networkMode == .shared
-                && !instance.status.isResting
+        let attached = instances.contains {
+            $0.mayHoldAttachment(on: .shared, networks: vmnetNetworks)
         }
         guard !attached else { return }
         Self.logger.notice(
@@ -1550,6 +1549,10 @@ final class VMLibraryViewModel {
         syncPortForwardingRules(for: new)
         let saved = saveConfiguration(for: instance)
         applyLivePolicy(for: instance, old: old, new: new)
+        // A live switch off the shared network frees it inside `applyLivePolicy`
+        // — the sync above ran while the session still held the attachment, so
+        // re-check now rather than leaving pending rules to an unrelated event.
+        rebuildSharedNetworkIfIdle()
         return saved
     }
 

--- a/Kernova/Views/Detail/PortForwardingRuleSheetContentViewController.swift
+++ b/Kernova/Views/Detail/PortForwardingRuleSheetContentViewController.swift
@@ -1,0 +1,346 @@
+import AppKit
+
+/// Delegate for ``PortForwardingRuleSheetContentViewController``.
+@MainActor
+protocol PortForwardingRuleSheetContentViewControllerDelegate: AnyObject {
+    /// The user accepted a rule the sheet already validated.
+    func portForwardingRuleSheet(
+        _ vc: PortForwardingRuleSheetContentViewController,
+        didAdd rule: PortForwardingRule
+    )
+
+    /// The user dismissed without adding one.
+    func portForwardingRuleSheetDidCancel(
+        _ vc: PortForwardingRuleSheetContentViewController
+    )
+}
+
+/// Sheet that composes one port-forwarding rule: protocol, host port, guest
+/// port.
+///
+/// **Add** stays disabled until the fields describe a rule the network can
+/// carry — both ports in range, and the host port not already claimed
+/// (docs/NETWORKING.md: a rule that cannot take effect is refused when the user
+/// enters it, never accepted and left to fail at VM start).
+@MainActor
+final class PortForwardingRuleSheetContentViewController: NSViewController {
+    weak var delegate: PortForwardingRuleSheetContentViewControllerDelegate?
+
+    /// The (transport, host port) pairs already forwarded on the network — every
+    /// Shared Network VM's, since the host port is claimed network-wide.
+    private let takenHostClaims: Set<PortForwardingHostClaim>
+
+    private let transportPopUp = NSPopUpButton()
+    private let hostPortField = NSTextField()
+    private let guestPortField = NSTextField()
+    private let addButton = NSButton()
+    private let noteLabel = NSTextField(wrappingLabelWithString: "")
+
+    /// `true` while the host port field is only mirroring the guest port, so
+    /// further typing on the guest side keeps it in step; cleared the moment the
+    /// user types a host port of their own.
+    private var hostPortMirrorsGuestPort = true
+
+    // MARK: - Layout constants
+
+    private static let sheetWidth: CGFloat = 420
+    private static let sheetHeight: CGFloat = 268
+    private static let padding: CGFloat = 16
+    private static let fieldWidth: CGFloat = 96
+    private static let labelWidth: CGFloat = 92
+
+    /// Identifiers on the two port fields, so tests (and this controller's own
+    /// delegate callbacks) can tell them apart.
+    nonisolated static let hostPortFieldIdentifier = NSUserInterfaceItemIdentifier(
+        "portForwardingHostPort")
+    nonisolated static let guestPortFieldIdentifier = NSUserInterfaceItemIdentifier(
+        "portForwardingGuestPort")
+
+    init(takenHostClaims: Set<PortForwardingHostClaim>) {
+        self.takenHostClaims = takenHostClaims
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("PortForwardingRuleSheetContentViewController does not support NSCoder")
+    }
+
+    override func loadView() {
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let header = makeHeader()
+        let divider1 = makeHorizontalSeparator()
+        let body = makeBody()
+        let divider2 = makeHorizontalSeparator()
+        let footer = makeFooter()
+
+        for subview in [header, divider1, body, divider2, footer] {
+            subview.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview(subview)
+        }
+
+        NSLayoutConstraint.activate([
+            container.widthAnchor.constraint(equalToConstant: Self.sheetWidth),
+            container.heightAnchor.constraint(equalToConstant: Self.sheetHeight),
+
+            header.topAnchor.constraint(equalTo: container.topAnchor),
+            header.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            divider1.topAnchor.constraint(equalTo: header.bottomAnchor),
+            divider1.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            divider1.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            body.topAnchor.constraint(equalTo: divider1.bottomAnchor),
+            body.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            body.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            divider2.topAnchor.constraint(equalTo: body.bottomAnchor),
+            divider2.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            divider2.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            footer.topAnchor.constraint(equalTo: divider2.bottomAnchor),
+            footer.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            footer.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            footer.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+
+        view = container
+        updateControls()
+    }
+
+    // MARK: - Header
+
+    private func makeHeader() -> NSView {
+        let container = NSView()
+
+        let title = NSTextField(labelWithString: "Add Port Forwarding Rule")
+        title.font = .preferredFont(forTextStyle: .headline)
+        title.isSelectable = false
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let stack = NSStackView(views: [title, spacer])
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = Spacing.small
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.padding),
+            stack.trailingAnchor.constraint(
+                equalTo: container.trailingAnchor, constant: -Self.padding),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Self.padding),
+        ])
+        return container
+    }
+
+    // MARK: - Body
+
+    private func makeBody() -> NSView {
+        let container = NSView()
+
+        transportPopUp.controlSize = .small
+        transportPopUp.target = self
+        transportPopUp.action = #selector(transportChanged)
+        for transport in PortForwardingTransport.allCases {
+            let item = NSMenuItem(title: transport.displayName, action: nil, keyEquivalent: "")
+            item.representedObject = transport.rawValue
+            transportPopUp.menu?.addItem(item)
+        }
+
+        configure(hostPortField, identifier: Self.hostPortFieldIdentifier)
+        configure(guestPortField, identifier: Self.guestPortFieldIdentifier)
+
+        noteLabel.font = .preferredFont(forTextStyle: .caption1)
+        noteLabel.textColor = .secondaryLabelColor
+        noteLabel.maximumNumberOfLines = 2
+        noteLabel.isSelectable = false
+
+        let stack = NSStackView(views: [
+            makeFieldRow("Protocol", control: transportPopUp),
+            makeFieldRow("Host Port", control: hostPortField),
+            makeFieldRow("Guest Port", control: guestPortField),
+            noteLabel,
+        ])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = Spacing.small
+        stack.setCustomSpacing(Spacing.medium, after: stack.arrangedSubviews[2])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.padding),
+            stack.trailingAnchor.constraint(
+                equalTo: container.trailingAnchor, constant: -Self.padding),
+            stack.bottomAnchor.constraint(
+                lessThanOrEqualTo: container.bottomAnchor, constant: -Self.padding),
+            noteLabel.widthAnchor.constraint(equalTo: stack.widthAnchor),
+        ])
+        return container
+    }
+
+    /// Deliberately without a target/action of its own: Return then reaches the
+    /// default button, which is the only thing that composes a rule — a field
+    /// action would run alongside it and add the same rule twice.
+    private func configure(_ field: NSTextField, identifier: NSUserInterfaceItemIdentifier) {
+        field.identifier = identifier
+        field.alignment = .right
+        field.delegate = self
+        field.widthAnchor.constraint(equalToConstant: Self.fieldWidth).isActive = true
+    }
+
+    private func makeFieldRow(_ title: String, control: NSView) -> NSView {
+        let label = NSTextField(labelWithString: title)
+        label.font = Typography.body
+        label.alignment = .right
+        label.isSelectable = false
+        label.widthAnchor.constraint(equalToConstant: Self.labelWidth).isActive = true
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let row = NSStackView(views: [label, control, spacer])
+        row.orientation = .horizontal
+        row.alignment = .firstBaseline
+        row.spacing = Spacing.standard
+        return row
+    }
+
+    // MARK: - Footer
+
+    private func makeFooter() -> NSView {
+        let container = NSView()
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelTapped))
+        cancel.bezelStyle = .push
+        cancel.keyEquivalent = "\u{1b}"  // Escape
+
+        addButton.title = "Add"
+        addButton.target = self
+        addButton.action = #selector(addTapped)
+        addButton.bezelStyle = .push
+        addButton.keyEquivalent = "\r"  // Return = default action
+
+        let stack = NSStackView(views: [spacer, cancel, addButton])
+        stack.orientation = .horizontal
+        stack.spacing = Spacing.standard
+        stack.alignment = .centerY
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: Self.padding),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.padding),
+            stack.trailingAnchor.constraint(
+                equalTo: container.trailingAnchor, constant: -Self.padding),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Self.padding),
+        ])
+        return container
+    }
+
+    // MARK: - Composition & validation
+
+    /// The transport the popup currently selects.
+    var selectedTransport: PortForwardingTransport {
+        guard let raw = transportPopUp.selectedItem?.representedObject as? String,
+            let transport = PortForwardingTransport(rawValue: raw)
+        else { return .tcp }
+        return transport
+    }
+
+    /// The rule the fields describe, `nil` while they describe none the network
+    /// can carry: a port empty, non-numeric or outside 1–65535, or a
+    /// (transport, host port) pair already forwarded.
+    var composedRule: PortForwardingRule? {
+        guard let hostPort = Self.port(from: hostPortField.stringValue),
+            let guestPort = Self.port(from: guestPortField.stringValue)
+        else { return nil }
+        let rule = PortForwardingRule(
+            transport: selectedTransport, hostPort: hostPort, guestPort: guestPort)
+        guard !takenHostClaims.contains(rule.hostClaim) else { return nil }
+        return rule
+    }
+
+    /// The port `text` names, `nil` when it names none.
+    private static func port(from text: String) -> UInt16? {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        guard let value = Int(trimmed), PortForwardingRule.portRange.contains(value) else {
+            return nil
+        }
+        return UInt16(value)
+    }
+
+    /// What the sheet says about the entered host port, `nil` when there is
+    /// nothing to say.
+    private var hostPortNote: String? {
+        guard let hostPort = Self.port(from: hostPortField.stringValue) else { return nil }
+        let claim = PortForwardingHostClaim(transport: selectedTransport, hostPort: hostPort)
+        if takenHostClaims.contains(claim) {
+            return
+                "\(selectedTransport.displayName) host port \(hostPort) is already forwarded to a virtual machine on this network."
+        }
+        if hostPort < 1024 {
+            return "Ports below 1024 are conventionally reserved for system services."
+        }
+        return nil
+    }
+
+    private func updateControls() {
+        addButton.isEnabled = composedRule != nil
+        noteLabel.stringValue = hostPortNote ?? ""
+    }
+
+    // MARK: - Actions
+
+    @objc private func transportChanged() {
+        updateControls()
+    }
+
+    @objc private func cancelTapped() {
+        delegate?.portForwardingRuleSheetDidCancel(self)
+    }
+
+    @objc private func addTapped() {
+        guard let rule = composedRule else { return }
+        delegate?.portForwardingRuleSheet(self, didAdd: rule)
+    }
+
+    // MARK: - Helpers
+
+    private func makeHorizontalSeparator() -> NSBox {
+        let box = NSBox()
+        box.boxType = .separator
+        return box
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+
+extension PortForwardingRuleSheetContentViewController: NSTextFieldDelegate {
+    /// Keeps the host port mirroring the guest port until the user gives it a
+    /// value of its own — the symmetric default every comparable rules table
+    /// offers — and re-validates on every keystroke.
+    func controlTextDidChange(_ obj: Notification) {
+        let edited = (obj.object as? NSTextField)?.identifier
+        if edited == Self.hostPortFieldIdentifier {
+            hostPortMirrorsGuestPort = hostPortField.stringValue.isEmpty
+        } else if edited == Self.guestPortFieldIdentifier, hostPortMirrorsGuestPort {
+            hostPortField.stringValue = guestPortField.stringValue
+        }
+        updateControls()
+    }
+}

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -48,6 +48,7 @@ final class VMSettingsViewController: NSViewController {
     // MARK: - Presenters & coordinators
 
     private let reorderSheetPresenter = SheetPresenter()
+    private let portForwardingSheetPresenter = SheetPresenter()
     private let micPermissionPresenter = PopoverPresenter()
     private let attachmentInfoPresenter = PopoverPresenter()
     private lazy var storageDiskCoordinator = DiskSizePopoverCoordinator(
@@ -178,6 +179,11 @@ final class VMSettingsViewController: NSViewController {
     /// row shows anything else.
     private var ipAddressCopyValue: String?
     private var ipAddressMaterializeTask: Task<Void, Never>?
+    /// The Port Forwarding block — the rule rows and the Add Rule row — hidden
+    /// wherever forwarding cannot apply.
+    private var portForwardingRow: GroupedFormCollapsibleRow?
+    /// Holds the rule rows and the trailing Add Rule row, rebuilt on change.
+    private var portForwardingListStack = NSStackView()
     /// Stands in for the card's rows while the mode is None.
     private var networkNoDeviceCaption = NSTextField()
 
@@ -222,6 +228,11 @@ final class VMSettingsViewController: NSViewController {
         let readOnly: Bool
         let controlsEnabled: Bool
     }
+    /// Value snapshot of the Port Forwarding rows' rendered appearance.
+    private struct RenderedPortForwardingRows: Equatable {
+        let rules: [PortForwardingRule]
+        let controlsEnabled: Bool
+    }
     private var renderedStorageRows: [RenderedRow]?
     private var renderedRemovableRows: [RenderedRow]?
     private var renderedSharedRows: [RenderedRow]?
@@ -230,6 +241,9 @@ final class VMSettingsViewController: NSViewController {
     /// nothing about networking skips a rebuild — which enumerates the host's
     /// bridgeable interfaces and queries the process signature.
     private var renderedNetworkChoice: NetworkModeChoice?
+    /// The rules (and lock state) the Port Forwarding rows were last built for,
+    /// so a rebuild happens exactly when one of them changed.
+    private var renderedPortForwardingRows: RenderedPortForwardingRows?
     /// The live-switch state the Mode menu was last built for; a change rebuilds
     /// so the None entry's enablement tracks it.
     private var renderedNetworkLiveSwitchable = false
@@ -381,6 +395,7 @@ final class VMSettingsViewController: NSViewController {
         NotificationCenter.default.removeObserver(
             self, name: NSApplication.didBecomeActiveNotification, object: nil)
         if reorderSheetPresenter.isShown { reorderSheetPresenter.close() }
+        if portForwardingSheetPresenter.isShown { portForwardingSheetPresenter.close() }
         if micPermissionPresenter.isShown { micPermissionPresenter.close() }
         if attachmentInfoPresenter.isShown { attachmentInfoPresenter.close() }
         // Drop any in-flight inline rename so the flag can't pin a list in a
@@ -486,6 +501,7 @@ extension VMSettingsViewController {
         renderedSharedRows = nil
         renderedAudioWarning = nil
         renderedNetworkChoice = nil
+        renderedPortForwardingRows = nil
 
         displayResolutionIsCustom = false
 
@@ -951,14 +967,16 @@ extension VMSettingsViewController {
         } else {
             macAddressRow = nil
         }
+        rows.append(makePortForwardingRow())
         networkNoDeviceCaption = makeGroupedFormCaption("This virtual machine has no network device.")
 
         // With the entitlement, Shared and Host Only assign each guest a
-        // deterministic address the IP Address row shows; without it there is
-        // no row, so the copy concedes the gap instead.
+        // deterministic address the IP Address row shows, and Shared can forward
+        // host ports to it; without it there is neither, so the copy concedes
+        // the gap instead.
         let sharedReachClause =
             entitlements.hasVMNetworking
-            ? "there is no port forwarding from host to guest — this Mac reaches it at the address in the IP Address row"
+            ? "other machines on your network reach it only on the ports you forward, and this Mac reaches it at the address in the IP Address row"
             : "there is no port forwarding from host to guest — incoming connections require knowing the guest's IP"
         var paragraphs: [InfoPopoverParagraph] = [
             .body(
@@ -968,6 +986,18 @@ extension VMSettingsViewController {
                 "Bridged traffic bypasses a VPN running on the host. Bridging over Wi-Fi is best-effort — the Wi-Fi standard does not bridge additional stations and there is no client-side fix, so prefer a wired interface."
             ),
         ]
+        if entitlements.hasVMNetworking {
+            paragraphs.append(
+                .body(
+                    "A forwarded port is reachable from other devices on your network. Rule changes take effect the next time a Shared Network virtual machine starts."
+                ))
+            if #unavailable(macOS 27) {
+                paragraphs.append(
+                    .body(
+                        "On this version of macOS a forwarded port is not reachable from this Mac itself through localhost. Apple documents this as a known limitation of vmnet."
+                    ))
+            }
+        }
         if instance.configuration.guestOS == .linux {
             paragraphs.append(
                 .body(
@@ -1078,6 +1108,134 @@ extension VMSettingsViewController {
     @objc private func copyIPAddressTapped() {
         guard let value = ipAddressCopyValue else { return }
         copyToPasteboard(value)
+    }
+
+    // MARK: Port Forwarding
+
+    /// The Port Forwarding block: a title, one row per rule, and the trailing
+    /// Add Rule row. `refreshPortForwardingRows()` owns its contents;
+    /// `refreshNetwork()` owns its visibility.
+    private func makePortForwardingRow() -> GroupedFormCollapsibleRow {
+        let title = NSTextField(labelWithString: "Port Forwarding")
+        title.font = Typography.body
+        title.isSelectable = false
+
+        portForwardingListStack = makeListStack()
+        portForwardingListStack.spacing = Spacing.small
+
+        let content = NSStackView(views: [title, portForwardingListStack])
+        content.orientation = .vertical
+        content.alignment = .leading
+        content.spacing = Spacing.small
+        content.translatesAutoresizingMaskIntoConstraints = false
+        portForwardingListStack.widthAnchor.constraint(equalTo: content.widthAnchor).isActive = true
+
+        let row = GroupedFormCollapsibleRow(row: content)
+        portForwardingRow = row
+        return row
+    }
+
+    /// Rebuilds the rule rows when the rules — or the lock state their controls
+    /// carry — changed.
+    private func refreshPortForwardingRows() {
+        let rendered = RenderedPortForwardingRows(
+            rules: instance.configuration.portForwardingRules, controlsEnabled: !isReadOnly)
+        guard rendered != renderedPortForwardingRows else { return }
+        renderedPortForwardingRows = rendered
+        clear(portForwardingListStack)
+        for (index, rule) in rendered.rules.enumerated() {
+            addFullWidth(
+                makePortForwardingRuleRow(rule, index: index, enabled: rendered.controlsEnabled),
+                to: portForwardingListStack)
+        }
+        addFullWidth(
+            makeAddPortForwardingRuleRow(enabled: rendered.controlsEnabled),
+            to: portForwardingListStack)
+    }
+
+    /// How one rule's ports read in the card — the guest side of the arrow is
+    /// where traffic lands.
+    private static func portForwardingRuleText(_ rule: PortForwardingRule) -> String {
+        "Host \(rule.hostPort) → Guest \(rule.guestPort)"
+    }
+
+    private func makePortForwardingRuleRow(
+        _ rule: PortForwardingRule, index: Int, enabled: Bool
+    ) -> NSView {
+        let transport = NSTextField(labelWithString: rule.transport.displayName)
+        transport.font = Typography.body
+        transport.textColor = .secondaryLabelColor
+        transport.isSelectable = false
+        transport.setContentHuggingPriority(.required, for: .horizontal)
+        transport.widthAnchor.constraint(equalToConstant: 38).isActive = true
+
+        let ports = NSTextField(labelWithString: Self.portForwardingRuleText(rule))
+        ports.font = Typography.body
+        ports.isSelectable = false
+        ports.lineBreakMode = .byTruncatingTail
+
+        let remove = NSButton()
+        remove.image = .systemSymbol("minus.circle", accessibilityDescription: "Remove Rule")
+        remove.imagePosition = .imageOnly
+        remove.isBordered = false
+        remove.contentTintColor = .secondaryLabelColor
+        remove.toolTip = "Remove Rule"
+        remove.isEnabled = enabled
+        remove.tag = index
+        remove.target = self
+        remove.action = #selector(removePortForwardingRuleTapped)
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let row = NSStackView(views: [transport, ports, spacer, remove])
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = Spacing.standard
+        return row
+    }
+
+    private func makeAddPortForwardingRuleRow(enabled: Bool) -> NSView {
+        let add = NSButton(
+            title: "Add Rule…", target: self, action: #selector(addPortForwardingRuleTapped))
+        add.image = .systemSymbol("plus.circle", accessibilityDescription: "")
+        add.imagePosition = .imageLeading
+        add.isBordered = false
+        add.bezelStyle = .badge
+        add.contentTintColor = .controlAccentColor
+        add.isEnabled = enabled
+        add.setContentHuggingPriority(.required, for: .horizontal)
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let row = NSStackView(views: [add, spacer])
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = Spacing.standard
+        return row
+    }
+
+    /// Every (transport, host port) pair already forwarded on the shared
+    /// network: the host port is claimed network-wide, so a new rule collides
+    /// with any Shared Network VM's, not just this one's.
+    private func takenHostPortClaims() -> Set<PortForwardingHostClaim> {
+        var claims = Set(instance.configuration.portForwardingRules.map(\.hostClaim))
+        for other in viewModel.instances where other.id != instance.id {
+            let config = other.configuration
+            guard config.networkEnabled, config.networkMode == .shared else { continue }
+            claims.formUnion(config.portForwardingRules.map(\.hostClaim))
+        }
+        return claims
+    }
+
+    private func writePortForwardingRules(_ rules: [PortForwardingRule]) {
+        viewModel.updateConfiguration(of: instance) { $0.portForwardingRules = rules }
+        // The rows are built from the configuration, so re-render with the
+        // write rather than waiting for the model-observation pass.
+        refreshPortForwardingRows()
     }
 
     /// While the pane is read-only, whether the Mode picker stays live as the
@@ -1770,6 +1928,15 @@ extension VMSettingsViewController {
         macAddressRow?.isHidden = !hasDevice
         networkNoDeviceCaption.isHidden = hasDevice
         refreshIPAddressRow()
+        // Rules ride the app-managed shared network, and reach the guest at the
+        // address its MAC reserves: an unentitled build attaches system NAT,
+        // which forwards nothing, the other modes carry no forwarding at all,
+        // and without a MAC there is no reservation to forward to.
+        let forwards =
+            hasDevice && instance.configuration.networkMode == .shared
+            && entitlements.hasVMNetworking && instance.configuration.macAddress != nil
+        portForwardingRow?.isHidden = !forwards
+        if forwards { refreshPortForwardingRows() }
     }
 
     private func refreshAudio() {
@@ -2367,6 +2534,24 @@ extension VMSettingsViewController: NSMenuItemValidation {
         reorderSheetPresenter.show(content: sheet, in: window)
     }
 
+    @objc private func addPortForwardingRuleTapped() {
+        guard !isReadOnly, let window = view.window, !portForwardingSheetPresenter.isShown else {
+            return
+        }
+        let sheet = PortForwardingRuleSheetContentViewController(
+            takenHostClaims: takenHostPortClaims())
+        sheet.delegate = self
+        portForwardingSheetPresenter.show(content: sheet, in: window)
+    }
+
+    @objc private func removePortForwardingRuleTapped(_ sender: NSButton) {
+        guard !isReadOnly else { return }
+        var rules = instance.configuration.portForwardingRules
+        guard rules.indices.contains(sender.tag) else { return }
+        rules.remove(at: sender.tag)
+        writePortForwardingRules(rules)
+    }
+
     @objc private func storageReadOnlyToggled(_ sender: NSSwitch) {
         guard let id = uuid(from: sender) else { return }
         setStorageReadOnly(sender.state == .on, forDiskID: id)
@@ -2912,5 +3097,20 @@ extension VMSettingsViewController: StorageDiskReorderSheetContentViewController
 
     func storageDiskReorderSheetDidDismiss(_ vc: StorageDiskReorderSheetContentViewController) {
         reorderSheetPresenter.close()
+    }
+}
+
+// MARK: - PortForwardingRuleSheetContentViewControllerDelegate
+
+extension VMSettingsViewController: PortForwardingRuleSheetContentViewControllerDelegate {
+    func portForwardingRuleSheet(
+        _ vc: PortForwardingRuleSheetContentViewController, didAdd rule: PortForwardingRule
+    ) {
+        portForwardingSheetPresenter.close()
+        writePortForwardingRules(instance.configuration.portForwardingRules + [rule])
+    }
+
+    func portForwardingRuleSheetDidCancel(_ vc: PortForwardingRuleSheetContentViewController) {
+        portForwardingSheetPresenter.close()
     }
 }

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -1218,18 +1218,24 @@ extension VMSettingsViewController {
         return row
     }
 
-    /// Every (transport, host port) pair already forwarded on the shared
-    /// network: the host port is claimed network-wide, so a new rule collides
-    /// with any Shared Network VM's, not just this one's.
+    /// Every (transport, host port) pair any VM in the library claims.
+    ///
+    /// The claim is held by the persisted configuration, not by the mode: a rule
+    /// survives a switch away from Shared Network and takes its host port back
+    /// on the way in, so a VM in another mode counts too — otherwise two VMs end
+    /// up holding the same port and one of them silently stops forwarding.
     private func takenHostPortClaims() -> Set<PortForwardingHostClaim> {
         var claims = Set(instance.configuration.portForwardingRules.map(\.hostClaim))
         for other in viewModel.instances where other.id != instance.id {
-            let config = other.configuration
-            guard config.networkEnabled, config.networkMode == .shared else { continue }
-            claims.formUnion(config.portForwardingRules.map(\.hostClaim))
+            claims.formUnion(other.configuration.portForwardingRules.map(\.hostClaim))
         }
         return claims
     }
+
+    #if DEBUG
+    /// The claim set the Add Rule sheet is built with, for tests.
+    var takenHostPortClaimsForTesting: Set<PortForwardingHostClaim> { takenHostPortClaims() }
+    #endif
 
     private func writePortForwardingRules(_ rules: [PortForwardingRule]) {
         viewModel.updateConfiguration(of: instance) { $0.portForwardingRules = rules }

--- a/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
+++ b/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
@@ -11,6 +11,9 @@ import vmnet
 /// Every handle wraps a fabricated pointer, distinct per call so a test can
 /// tell a cached handle from a freshly materialized one.
 final class MockVmnetNetworkOperator: VmnetNetworkOperating, @unchecked Sendable {
+    /// One create call's forwarding-rule argument.
+    typealias RecordedForwardingRules = [(rule: PortForwardingRule, internalAddress: String)]
+
     /// The addressing a fresh (unpinned) create reserves.
     var freshAddressing = VmnetNetworkAddressing(
         ipv4Subnet: "192.168.213.0", ipv4Mask: "255.255.255.0",
@@ -33,6 +36,8 @@ final class MockVmnetNetworkOperator: VmnetNetworkOperating, @unchecked Sendable
     private(set) var createdKinds: [VmnetNetworkKind] = []
     private(set) var pinnedAddressings: [VmnetNetworkAddressing?] = []
     private(set) var installedReservations: [[(mac: String, address: String)]] = []
+    /// The forwarding rules each create was handed, in call order.
+    private(set) var installedForwardingRules: [RecordedForwardingRules] = []
     private(set) var releasedNetworks: [OpaquePointer] = []
 
     private var fabricatedNetworks: [UnsafeMutableRawPointer] = []
@@ -42,11 +47,13 @@ final class MockVmnetNetworkOperator: VmnetNetworkOperating, @unchecked Sendable
     func createNetwork(
         _ kind: VmnetNetworkKind,
         addressing: VmnetNetworkAddressing?,
-        reservations: [(mac: String, address: String)]
+        reservations: [(mac: String, address: String)],
+        forwardingRules: [(rule: PortForwardingRule, internalAddress: String)]
     ) throws -> (handle: VmnetNetworkHandle, addressing: VmnetNetworkAddressing) {
         createdKinds.append(kind)
         pinnedAddressings.append(addressing)
         installedReservations.append(reservations)
+        installedForwardingRules.append(forwardingRules)
         if let createNetworkError { throw createNetworkError }
         if addressing != nil, let pinnedCreateError { throw pinnedCreateError }
         return (makeHandle(), reservedAddressingOverride ?? addressing ?? freshAddressing)
@@ -129,6 +136,25 @@ final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable
 
     func reservedAddress(for mac: String, kind: VmnetNetworkKind) -> String? {
         scriptedAddresses[mac.lowercased()]
+    }
+
+    // MARK: - Port forwarding
+
+    /// The rules last declared per lowercased MAC, in declaration order.
+    private(set) var declaredForwardingRules: [(mac: String, rules: [PortForwardingRule])] = []
+    /// Scripted answer for `portForwardingRulesArePending(for:)`.
+    var scriptedPendingForwardingKinds: Set<VmnetNetworkKind> = []
+    private(set) var pendingQueriedKinds: [VmnetNetworkKind] = []
+
+    func setPortForwardingRules(
+        _ rules: [PortForwardingRule], for mac: String, kind: VmnetNetworkKind
+    ) {
+        declaredForwardingRules.append((mac: mac.lowercased(), rules: rules))
+    }
+
+    func portForwardingRulesArePending(for kind: VmnetNetworkKind) -> Bool {
+        pendingQueriedKinds.append(kind)
+        return scriptedPendingForwardingKinds.contains(kind)
     }
 
     /// Scripted answer for `kind(ofNetwork:)`.

--- a/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
+++ b/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
@@ -40,6 +40,11 @@ final class MockVmnetNetworkOperator: VmnetNetworkOperating, @unchecked Sendable
     private(set) var installedForwardingRules: [RecordedForwardingRules] = []
     private(set) var releasedNetworks: [OpaquePointer] = []
 
+    /// Runs inside each create, before it returns, with the 1-based number of
+    /// the call — the seam for a test that has to change service state while a
+    /// create is in flight.
+    var duringCreateNetwork: ((Int) -> Void)?
+
     private var fabricatedNetworks: [UnsafeMutableRawPointer] = []
 
     deinit { fabricatedNetworks.forEach { $0.deallocate() } }
@@ -54,6 +59,7 @@ final class MockVmnetNetworkOperator: VmnetNetworkOperating, @unchecked Sendable
         pinnedAddressings.append(addressing)
         installedReservations.append(reservations)
         installedForwardingRules.append(forwardingRules)
+        duringCreateNetwork?(createdKinds.count)
         if let createNetworkError { throw createNetworkError }
         if addressing != nil, let pinnedCreateError { throw pinnedCreateError }
         return (makeHandle(), reservedAddressingOverride ?? addressing ?? freshAddressing)
@@ -154,7 +160,9 @@ final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable
 
     func portForwardingRulesArePending(for kind: VmnetNetworkKind) -> Bool {
         pendingQueriedKinds.append(kind)
-        return scriptedPendingForwardingKinds.contains(kind)
+        // Mirrors the service: nothing pends against a network that is not
+        // materialized — its next materialization installs what is declared then.
+        return isMaterialized && scriptedPendingForwardingKinds.contains(kind)
     }
 
     /// Scripted answer for `kind(ofNetwork:)`.

--- a/KernovaTests/PortForwardingRuleSheetContentViewControllerTests.swift
+++ b/KernovaTests/PortForwardingRuleSheetContentViewControllerTests.swift
@@ -1,0 +1,177 @@
+import AppKit
+import Testing
+
+@testable import Kernova
+
+@Suite("PortForwardingRuleSheetContentViewController Tests")
+@MainActor
+struct PortForwardingRuleSheetContentViewControllerTests {
+    private func makeSheet(
+        taken: Set<PortForwardingHostClaim> = []
+    ) -> PortForwardingRuleSheetContentViewController {
+        let vc = PortForwardingRuleSheetContentViewController(takenHostClaims: taken)
+        vc.loadViewIfNeeded()
+        return vc
+    }
+
+    private func field(
+        _ identifier: NSUserInterfaceItemIdentifier,
+        in vc: PortForwardingRuleSheetContentViewController
+    ) -> NSTextField? {
+        firstSubview(NSTextField.self, in: vc.view) { $0.identifier == identifier }
+    }
+
+    /// Types `text` into a field the way the user does — value plus the change
+    /// notification the controller validates on.
+    private func type(
+        _ text: String, into identifier: NSUserInterfaceItemIdentifier,
+        of vc: PortForwardingRuleSheetContentViewController
+    ) throws {
+        let field = try #require(self.field(identifier, in: vc))
+        field.stringValue = text
+        vc.controlTextDidChange(
+            Notification(name: NSControl.textDidChangeNotification, object: field))
+    }
+
+    private func addButton(in vc: PortForwardingRuleSheetContentViewController) -> NSButton? {
+        findButton(titled: "Add", in: vc.view)
+    }
+
+    private func hostField(_ vc: PortForwardingRuleSheetContentViewController) -> NSTextField? {
+        field(PortForwardingRuleSheetContentViewController.hostPortFieldIdentifier, in: vc)
+    }
+
+    @Test("Add is disabled until both ports are entered")
+    func addDisabledUntilBothPorts() throws {
+        let vc = makeSheet()
+        #expect(addButton(in: vc)?.isEnabled == false)
+
+        try type("80", into: .guestPort, of: vc)
+
+        #expect(addButton(in: vc)?.isEnabled == true)
+        #expect(vc.composedRule == PortForwardingRule(transport: .tcp, hostPort: 80, guestPort: 80))
+    }
+
+    @Test("The host port mirrors the guest port until the user gives it one")
+    func hostPortMirrorsGuestPort() throws {
+        let vc = makeSheet()
+
+        try type("8", into: .guestPort, of: vc)
+        try type("80", into: .guestPort, of: vc)
+        #expect(hostField(vc)?.stringValue == "80")
+
+        // Typing a host port of their own stops the mirroring.
+        try type("8080", into: .hostPort, of: vc)
+        try type("8080", into: .guestPort, of: vc)
+        #expect(hostField(vc)?.stringValue == "8080")
+        #expect(
+            vc.composedRule == PortForwardingRule(transport: .tcp, hostPort: 8080, guestPort: 8080))
+    }
+
+    @Test("Zero, out-of-range, and non-numeric ports compose no rule")
+    func invalidPortsComposeNoRule() throws {
+        let vc = makeSheet()
+        try type("80", into: .guestPort, of: vc)
+
+        for text in ["0", "65536", "eighty", "-1", " "] {
+            try type(text, into: .hostPort, of: vc)
+            #expect(vc.composedRule == nil, "\(text) should compose no rule")
+            #expect(addButton(in: vc)?.isEnabled == false)
+        }
+
+        try type("65535", into: .hostPort, of: vc)
+        #expect(vc.composedRule?.hostPort == 65535)
+    }
+
+    @Test("A host port already forwarded is refused, and said so")
+    func takenHostPortIsRefused() throws {
+        let vc = makeSheet(taken: [PortForwardingHostClaim(transport: .tcp, hostPort: 8080)])
+
+        try type("80", into: .guestPort, of: vc)
+        try type("8080", into: .hostPort, of: vc)
+
+        #expect(vc.composedRule == nil)
+        #expect(addButton(in: vc)?.isEnabled == false)
+        #expect(findLabel(containing: "already forwarded", in: vc.view) != nil)
+    }
+
+    @Test("The same host port on the other transport is free")
+    func otherTransportIsNotACollision() throws {
+        let vc = makeSheet(taken: [PortForwardingHostClaim(transport: .tcp, hostPort: 8080)])
+        let popUp = try #require(firstSubview(NSPopUpButton.self, in: vc.view))
+
+        try type("80", into: .guestPort, of: vc)
+        try type("8080", into: .hostPort, of: vc)
+        popUp.selectItem(withTitle: "UDP")
+        popUp.sendAction(popUp.action, to: popUp.target)
+
+        #expect(
+            vc.composedRule == PortForwardingRule(transport: .udp, hostPort: 8080, guestPort: 80))
+        #expect(addButton(in: vc)?.isEnabled == true)
+    }
+
+    @Test("A privileged host port is noted, not refused")
+    func privilegedHostPortIsNoted() throws {
+        let vc = makeSheet()
+
+        try type("80", into: .guestPort, of: vc)
+        try type("443", into: .hostPort, of: vc)
+
+        #expect(addButton(in: vc)?.isEnabled == true)
+        #expect(findLabel(containing: "reserved for system services", in: vc.view) != nil)
+
+        try type("8443", into: .hostPort, of: vc)
+        #expect(findLabel(containing: "reserved for system services", in: vc.view) == nil)
+    }
+
+    @Test("Add hands the composed rule to the delegate")
+    func addReportsTheRule() throws {
+        let vc = makeSheet()
+        let delegate = MockPortForwardingRuleSheetDelegate()
+        vc.delegate = delegate
+
+        try type("22", into: .guestPort, of: vc)
+        try type("2222", into: .hostPort, of: vc)
+        addButton(in: vc)?.performClick(nil)
+
+        #expect(delegate.added == [PortForwardingRule(transport: .tcp, hostPort: 2222, guestPort: 22)])
+        #expect(delegate.cancelCount == 0)
+    }
+
+    @Test("Cancel reports a dismissal and no rule")
+    func cancelReportsDismissal() {
+        let vc = makeSheet()
+        let delegate = MockPortForwardingRuleSheetDelegate()
+        vc.delegate = delegate
+
+        findButton(titled: "Cancel", in: vc.view)?.performClick(nil)
+
+        #expect(delegate.added.isEmpty)
+        #expect(delegate.cancelCount == 1)
+    }
+}
+
+extension NSUserInterfaceItemIdentifier {
+    fileprivate static let hostPort =
+        PortForwardingRuleSheetContentViewController.hostPortFieldIdentifier
+    fileprivate static let guestPort =
+        PortForwardingRuleSheetContentViewController.guestPortFieldIdentifier
+}
+
+@MainActor
+private final class MockPortForwardingRuleSheetDelegate:
+    PortForwardingRuleSheetContentViewControllerDelegate
+{
+    private(set) var added: [PortForwardingRule] = []
+    private(set) var cancelCount = 0
+
+    func portForwardingRuleSheet(
+        _ vc: PortForwardingRuleSheetContentViewController, didAdd rule: PortForwardingRule
+    ) {
+        added.append(rule)
+    }
+
+    func portForwardingRuleSheetDidCancel(_ vc: PortForwardingRuleSheetContentViewController) {
+        cancelCount += 1
+    }
+}

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -360,6 +360,42 @@ struct VMConfigurationTests {
         #expect(config.serialSocketRelayEnabled == false)
     }
 
+    // MARK: - Port Forwarding
+
+    @Test("Port forwarding rules round-trip through JSON")
+    func portForwardingRulesRoundTrip() throws {
+        var original = VMConfiguration(name: "Forwarding VM", guestOS: .linux, bootMode: .efi)
+        original.portForwardingRules = [
+            PortForwardingRule(transport: .tcp, hostPort: 8080, guestPort: 80),
+            PortForwardingRule(transport: .udp, hostPort: 5353, guestPort: 53),
+        ]
+
+        let decoded = try VMConfiguration.makeJSONDecoder()
+            .decode(VMConfiguration.self, from: VMConfiguration.makeJSONEncoder().encode(original))
+
+        #expect(decoded.portForwardingRules == original.portForwardingRules)
+    }
+
+    @Test("Missing portForwardingRules decodes as none")
+    func missingPortForwardingRulesDefaultsEmpty() throws {
+        let config = try VMConfiguration.makeJSONDecoder()
+            .decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
+
+        #expect(config.portForwardingRules.isEmpty)
+    }
+
+    @Test("A clone keeps the source VM's forwarding rules")
+    func cloneKeepsPortForwardingRules() {
+        var config = VMConfiguration(name: "Forwarding VM", guestOS: .linux, bootMode: .efi)
+        config.portForwardingRules = [
+            PortForwardingRule(transport: .tcp, hostPort: 2222, guestPort: 22)
+        ]
+
+        let clone = config.clonedForNewInstance(existingNames: [])
+
+        #expect(clone.portForwardingRules == config.portForwardingRules)
+    }
+
     @Test("Unknown JSON keys are silently ignored")
     func unknownKeysIgnored() throws {
         let json = Self.makeBaseJSON(

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -384,8 +384,8 @@ struct VMConfigurationTests {
         #expect(config.portForwardingRules.isEmpty)
     }
 
-    @Test("A clone keeps the source VM's forwarding rules")
-    func cloneKeepsPortForwardingRules() {
+    @Test("A clone starts with no forwarding rules of its own")
+    func cloneDropsPortForwardingRules() {
         var config = VMConfiguration(name: "Forwarding VM", guestOS: .linux, bootMode: .efi)
         config.portForwardingRules = [
             PortForwardingRule(transport: .tcp, hostPort: 2222, guestPort: 22)
@@ -393,7 +393,10 @@ struct VMConfigurationTests {
 
         let clone = config.clonedForNewInstance(existingNames: [])
 
-        #expect(clone.portForwardingRules == config.portForwardingRules)
+        // Carried over, the clone's rules would claim host ports the source
+        // already holds on the same network.
+        #expect(clone.portForwardingRules.isEmpty)
+        #expect(config.portForwardingRules.count == 1)
     }
 
     @Test("Unknown JSON keys are silently ignored")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2225,10 +2225,13 @@ struct VMLibraryViewModelTests {
         #expect(vmnet.invalidatedKinds == [.shared])
     }
 
-    @Test("A live shared-network VM holds the recreate off until its session ends")
-    func liveSharedVMDefersTheRecreate() async throws {
+    /// A library holding one shared-network VM per name, wired through the real
+    /// load path so each instance carries its persistence hooks.
+    private func makeSharedNetworkLibrary(
+        named names: [String], vmnet: MockVmnetNetworkProvider
+    ) async -> VMLibraryViewModel {
         let storage = MockVMStorageService()
-        for name in ["Running VM", "Edited VM"] {
+        for name in names {
             var config = VMConfiguration(name: name, guestOS: .linux, bootMode: .efi)
             config.networkMode = .shared
             config.macAddress = VZMACAddress.randomLocallyAdministered().string
@@ -2237,19 +2240,75 @@ struct VMLibraryViewModelTests {
                     .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
             ] = config
         }
-        let vmnet = MockVmnetNetworkProvider()
         let (viewModel, _, _, _, _) = makeViewModel(storageService: storage, vmnetNetworks: vmnet)
         await viewModel.loadVMs()
+        return viewModel
+    }
+
+    @Test("A live shared-network VM holds the recreate off until its session is torn down")
+    func liveSharedVMDefersTheRecreate() async throws {
+        let vmnet = MockVmnetNetworkProvider()
+        let viewModel = await makeSharedNetworkLibrary(
+            named: ["Running VM", "Edited VM"], vmnet: vmnet)
         let running = try #require(viewModel.instances.first { $0.name == "Running VM" })
         let edited = try #require(viewModel.instances.first { $0.name == "Edited VM" })
+        running.hasLiveVirtualMachineOverrideForTesting = true
         running.status = .running
         vmnet.scriptedPendingForwardingKinds = [.shared]
 
         viewModel.updateConfiguration(of: edited) { $0.portForwardingRules = [Self.webRule] }
         #expect(vmnet.invalidatedKinds.isEmpty)
 
-        // The session ending is what makes the recreate safe.
+        // Releasing the session's virtual machine is what makes the recreate
+        // safe; the override stands in for the `VZVirtualMachine` teardown nils.
+        running.hasLiveVirtualMachineOverrideForTesting = false
+        running.tearDownSession()
         running.status = .stopped
+
+        #expect(vmnet.invalidatedKinds == [.shared])
+    }
+
+    @Test("A save-suspended VM releases the shared network for a pending rule change")
+    func saveSuspendReleasesTheSharedNetwork() async throws {
+        let vmnet = MockVmnetNetworkProvider()
+        let viewModel = await makeSharedNetworkLibrary(
+            named: ["Suspending VM", "Edited VM"], vmnet: vmnet)
+        let suspending = try #require(viewModel.instances.first { $0.name == "Suspending VM" })
+        let edited = try #require(viewModel.instances.first { $0.name == "Edited VM" })
+        suspending.hasLiveVirtualMachineOverrideForTesting = true
+        suspending.status = .running
+        vmnet.scriptedPendingForwardingKinds = [.shared]
+
+        viewModel.updateConfiguration(of: edited) { $0.portForwardingRules = [Self.webRule] }
+        #expect(vmnet.invalidatedKinds.isEmpty)
+
+        // A save-suspend rests at `.paused` with nothing live, so the rebuild
+        // rides the session teardown rather than any status.
+        suspending.hasLiveVirtualMachineOverrideForTesting = false
+        await viewModel.save(suspending)
+
+        #expect(suspending.status == .paused)
+        #expect(vmnet.invalidatedKinds == [.shared])
+    }
+
+    @Test("A live switch out of Shared Network frees the network for the pending rebuild")
+    func liveSwitchOutOfSharedFreesTheNetwork() async throws {
+        let vmnet = MockVmnetNetworkProvider()
+        let viewModel = await makeSharedNetworkLibrary(named: ["Running VM"], vmnet: vmnet)
+        let running = try #require(viewModel.instances.first)
+        running.hasLiveVirtualMachineOverrideForTesting = true
+        running.status = .running
+        vmnet.scriptedPendingForwardingKinds = [.shared]
+
+        // The rule sync runs while the VM is still on the shared network; only
+        // the mode write that follows frees it.
+        viewModel.updateConfiguration(of: running) {
+            $0.portForwardingRules = [Self.webRule]
+        }
+        #expect(vmnet.invalidatedKinds.isEmpty)
+
+        viewModel.updateConfiguration(of: running) { $0.networkMode = .hostOnly }
+
         #expect(vmnet.invalidatedKinds == [.shared])
     }
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2155,6 +2155,104 @@ struct VMLibraryViewModelTests {
         #expect(vmnet.reservedMACs.isEmpty)
     }
 
+    // MARK: - Port Forwarding Sync
+
+    private static let webRule = PortForwardingRule(transport: .tcp, hostPort: 8080, guestPort: 80)
+
+    @Test("A configuration change declares a shared VM's forwarding rules")
+    func updateConfigurationDeclaresForwardingRules() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeInstance()
+
+        viewModel.updateConfiguration(of: instance) {
+            $0.networkEnabled = true
+            $0.networkMode = .shared
+            $0.macAddress = "AA:BB:CC:DD:EE:0F"
+            $0.portForwardingRules = [Self.webRule]
+        }
+
+        #expect(vmnet.declaredForwardingRules.last?.mac == "aa:bb:cc:dd:ee:0f")
+        #expect(vmnet.declaredForwardingRules.last?.rules == [Self.webRule])
+    }
+
+    @Test("Switching away from Shared Network withdraws the VM's forwarding rules")
+    func modeSwitchWithdrawsForwardingRules() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeInstance()
+        viewModel.updateConfiguration(of: instance) {
+            $0.networkEnabled = true
+            $0.networkMode = .shared
+            $0.macAddress = "aa:bb:cc:dd:ee:0f"
+            $0.portForwardingRules = [Self.webRule]
+        }
+
+        viewModel.updateConfiguration(of: instance) { $0.networkMode = .hostOnly }
+
+        #expect(vmnet.declaredForwardingRules.last?.rules.isEmpty == true)
+    }
+
+    @Test("Deleting a VM withdraws its forwarding rules")
+    func deleteWithdrawsForwardingRules() async {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeInstance()
+        instance.configuration.networkEnabled = true
+        instance.configuration.networkMode = .shared
+        instance.configuration.macAddress = "aa:bb:cc:dd:ee:0f"
+        instance.configuration.portForwardingRules = [Self.webRule]
+        viewModel.instances = [instance]
+
+        for task in viewModel.deleteConfirmed(instance) { await task.value }
+
+        #expect(vmnet.declaredForwardingRules.last?.rules.isEmpty == true)
+    }
+
+    @Test("A pending rule change recreates the shared network once no VM is on it")
+    func pendingRulesRecreateTheNetworkWhenIdle() {
+        let vmnet = MockVmnetNetworkProvider()
+        vmnet.scriptedPendingForwardingKinds = [.shared]
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeInstance()
+        instance.configuration.networkEnabled = true
+        instance.configuration.networkMode = .shared
+        instance.configuration.macAddress = "aa:bb:cc:dd:ee:0f"
+        viewModel.instances = [instance]
+
+        viewModel.updateConfiguration(of: instance) { $0.portForwardingRules = [Self.webRule] }
+
+        #expect(vmnet.invalidatedKinds == [.shared])
+    }
+
+    @Test("A live shared-network VM holds the recreate off until its session ends")
+    func liveSharedVMDefersTheRecreate() async throws {
+        let storage = MockVMStorageService()
+        for name in ["Running VM", "Edited VM"] {
+            var config = VMConfiguration(name: name, guestOS: .linux, bootMode: .efi)
+            config.networkMode = .shared
+            config.macAddress = VZMACAddress.randomLocallyAdministered().string
+            storage.bundles[
+                FileManager.default.temporaryDirectory
+                    .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+            ] = config
+        }
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage, vmnetNetworks: vmnet)
+        await viewModel.loadVMs()
+        let running = try #require(viewModel.instances.first { $0.name == "Running VM" })
+        let edited = try #require(viewModel.instances.first { $0.name == "Edited VM" })
+        running.status = .running
+        vmnet.scriptedPendingForwardingKinds = [.shared]
+
+        viewModel.updateConfiguration(of: edited) { $0.portForwardingRules = [Self.webRule] }
+        #expect(vmnet.invalidatedKinds.isEmpty)
+
+        // The session ending is what makes the recreate safe.
+        running.status = .stopped
+        #expect(vmnet.invalidatedKinds == [.shared])
+    }
+
     // MARK: - trySave / tryForceStop
 
     @Test("trySave throws on failure")

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -824,7 +824,8 @@ struct VMSettingsViewControllerTests {
         entitled: Bool = true,
         isReadOnly: Bool = false,
         status: VMStatus = .stopped,
-        vmnetNetworks: MockVmnetNetworkProvider = MockVmnetNetworkProvider()
+        vmnetNetworks: MockVmnetNetworkProvider = MockVmnetNetworkProvider(),
+        viewModel: VMLibraryViewModel? = nil
     ) -> (VMSettingsViewController, VMInstance) {
         let config = VMConfiguration(
             name: "Test VM", guestOS: .linux, bootMode: .efi,
@@ -835,7 +836,7 @@ struct VMSettingsViewControllerTests {
             .appendingPathComponent(config.id.uuidString, isDirectory: true)
         let instance = VMInstance(configuration: config, bundleURL: bundleURL, status: status)
         let vc = VMSettingsViewController(
-            instance: instance, viewModel: makeViewModel(), isReadOnly: isReadOnly,
+            instance: instance, viewModel: viewModel ?? makeViewModel(), isReadOnly: isReadOnly,
             bridgedInterfaces: interfaces,
             entitlements: EntitlementService(
                 reader: MockEntitlementReader(
@@ -1306,6 +1307,31 @@ struct VMSettingsViewControllerTests {
 
         #expect(findButton(titled: "Add Rule…", in: vc.view)?.isEnabled == true)
         #expect(removeRuleButtons(in: vc.view).allSatisfy { $0.isEnabled })
+    }
+
+    @Test("Host port claims cover every VM's rules, whatever mode each VM is in")
+    func hostPortClaimsSpanEveryMode() {
+        let viewModel = makeViewModel()
+        // A rule persists across a mode switch and takes its host port back on
+        // the way in, so a Host Only VM still holds the claim.
+        let hostOnly = makeInstance(guestOS: .linux)
+        hostOnly.configuration.networkMode = .hostOnly
+        hostOnly.configuration.portForwardingRules = [Self.sshRule]
+        let disabled = makeInstance(guestOS: .linux)
+        disabled.configuration.networkEnabled = false
+        disabled.configuration.portForwardingRules = [
+            PortForwardingRule(transport: .udp, hostPort: 5353, guestPort: 53)
+        ]
+        viewModel.instances = [hostOnly, disabled]
+
+        let (vc, _) = makeNetworkController(
+            portForwardingRules: [Self.webRule], viewModel: viewModel)
+
+        #expect(
+            vc.takenHostPortClaimsForTesting == [
+                Self.webRule.hostClaim, Self.sshRule.hostClaim,
+                PortForwardingHostClaim(transport: .udp, hostPort: 5353),
+            ])
     }
 
     private func removeRuleButtons(in view: NSView) -> [NSButton] {

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -819,6 +819,7 @@ struct VMSettingsViewControllerTests {
         mode: VMNetworkMode = .shared,
         bridgedInterfaceIdentifier: String? = nil,
         macAddress: String? = "aa:bb:cc:dd:ee:ff",
+        portForwardingRules: [PortForwardingRule] = [],
         interfaces: MockBridgedInterfaceProvider = MockBridgedInterfaceProvider(),
         entitled: Bool = true,
         isReadOnly: Bool = false,
@@ -828,7 +829,8 @@ struct VMSettingsViewControllerTests {
         let config = VMConfiguration(
             name: "Test VM", guestOS: .linux, bootMode: .efi,
             networkEnabled: networkEnabled, networkMode: mode,
-            bridgedInterfaceIdentifier: bridgedInterfaceIdentifier, macAddress: macAddress)
+            bridgedInterfaceIdentifier: bridgedInterfaceIdentifier, macAddress: macAddress,
+            portForwardingRules: portForwardingRules)
         let bundleURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(config.id.uuidString, isDirectory: true)
         let instance = VMInstance(configuration: config, bundleURL: bundleURL, status: status)
@@ -1229,6 +1231,85 @@ struct VMSettingsViewControllerTests {
         let popUp = try #require(networkModePopUp(in: vc.view))
         #expect(popUp.isEnabled)
         #expect(popUp.menu?.items.first { $0.title == "None" }?.isEnabled == true)
+    }
+
+    // MARK: - Port Forwarding
+
+    private static let webRule = PortForwardingRule(transport: .tcp, hostPort: 8080, guestPort: 80)
+    private static let sshRule = PortForwardingRule(transport: .tcp, hostPort: 2222, guestPort: 22)
+
+    @Test("An entitled Shared VM lists its forwarding rules and the Add Rule row")
+    func sharedVMListsForwardingRules() {
+        let (vc, _) = makeNetworkController(portForwardingRules: [Self.webRule, Self.sshRule])
+
+        #expect(visibleLabel("Port Forwarding", in: vc.view))
+        #expect(visibleLabel("TCP", in: vc.view))
+        #expect(visibleLabel("Host 8080 → Guest 80", in: vc.view))
+        #expect(visibleLabel("Host 2222 → Guest 22", in: vc.view))
+        #expect(findButton(titled: "Add Rule…", in: vc.view) != nil)
+    }
+
+    @Test("A VM with no rules still offers Add Rule")
+    func sharedVMWithoutRulesOffersAddRule() {
+        let (vc, _) = makeNetworkController()
+
+        #expect(visibleLabel("Port Forwarding", in: vc.view))
+        #expect(findButton(titled: "Add Rule…", in: vc.view)?.isEnabled == true)
+    }
+
+    @Test("Modes and builds that cannot forward show no Port Forwarding rows")
+    func nonForwardingModesHideTheRows() {
+        // Host Only reaches only this Mac, None has no device, and an
+        // unentitled build attaches system NAT — none of them forwards.
+        let (hostOnly, _) = makeNetworkController(
+            mode: .hostOnly, portForwardingRules: [Self.webRule])
+        #expect(!visibleLabel("Port Forwarding", in: hostOnly.view))
+
+        let (none, _) = makeNetworkController(
+            networkEnabled: false, portForwardingRules: [Self.webRule])
+        #expect(!visibleLabel("Port Forwarding", in: none.view))
+
+        let (unentitled, _) = makeNetworkController(
+            portForwardingRules: [Self.webRule], entitled: false)
+        #expect(!visibleLabel("Port Forwarding", in: unentitled.view))
+    }
+
+    @Test("Removing a rule writes the configuration without it")
+    func removingARuleWritesTheRemainder() throws {
+        let (vc, instance) = makeNetworkController(
+            portForwardingRules: [Self.webRule, Self.sshRule])
+        let remove = try #require(removeRuleButtons(in: vc.view).first)
+
+        remove.performClick(nil)
+
+        #expect(instance.configuration.portForwardingRules == [Self.sshRule])
+        #expect(!visibleLabel("Host 8080 → Guest 80", in: vc.view))
+        #expect(visibleLabel("Host 2222 → Guest 22", in: vc.view))
+    }
+
+    @Test("A running VM's rule controls are locked")
+    func runningVMLocksTheRuleControls() {
+        let (vc, _) = makeNetworkController(
+            portForwardingRules: [Self.webRule], isReadOnly: true, status: .running)
+
+        #expect(removeRuleButtons(in: vc.view).allSatisfy { !$0.isEnabled })
+        #expect(findButton(titled: "Add Rule…", in: vc.view)?.isEnabled == false)
+    }
+
+    @Test("Unlocking after a session re-enables the rule controls")
+    func unlockingReenablesTheRuleControls() {
+        let (vc, instance) = makeNetworkController(
+            portForwardingRules: [Self.webRule], isReadOnly: true, status: .running)
+        #expect(findButton(titled: "Add Rule…", in: vc.view)?.isEnabled == false)
+
+        vc.reconfigure(instance: instance, viewModel: makeViewModel(), isReadOnly: false)
+
+        #expect(findButton(titled: "Add Rule…", in: vc.view)?.isEnabled == true)
+        #expect(removeRuleButtons(in: vc.view).allSatisfy { $0.isEnabled })
+    }
+
+    private func removeRuleButtons(in view: NSView) -> [NSButton] {
+        allSubviews(NSButton.self, in: view) { $0.toolTip == "Remove Rule" }
     }
 
     // MARK: - Helpers (view-tree introspection)

--- a/KernovaTests/VmnetNetworkServiceTests.swift
+++ b/KernovaTests/VmnetNetworkServiceTests.swift
@@ -504,6 +504,53 @@ struct VmnetNetworkServiceTests {
         #expect(!service.portForwardingRulesArePending(for: .shared))
     }
 
+    @Test("A rule declared while the network is being created lands in the published network")
+    func rulesDeclaredMidCreateAreInstalled() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, operations) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01"], at: location)
+        service.setPortForwardingRules([Self.webRule], for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        operations.duringCreateNetwork = { [weak service] call in
+            guard call == 1 else { return }
+            service?.setPortForwardingRules(
+                [Self.webRule, Self.sshRule], for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        }
+
+        let handle = try service.network(for: .shared)
+
+        // The first network never became visible to anyone, so it is released
+        // and recreated rather than published without the late rule.
+        #expect(operations.installedForwardingRules.last?.map(\.rule) == [Self.webRule, Self.sshRule])
+        #expect(operations.releasedNetworks.count == 1)
+        #expect(operations.releasedNetworks.first != handle.network)
+        #expect(!service.portForwardingRulesArePending(for: .shared))
+    }
+
+    @Test("Rules that keep changing publish a network anyway, still reading as pending")
+    func endlessRuleChangesPublishAndStayPending() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, operations) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01"], at: location)
+        var rules = [Self.webRule]
+        operations.duringCreateNetwork = { [weak service] _ in
+            rules.append(
+                PortForwardingRule(
+                    transport: .tcp, hostPort: UInt16(9000 + rules.count), guestPort: 80))
+            service?.setPortForwardingRules(rules, for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        }
+
+        _ = try service.network(for: .shared)
+
+        // Three attempts, two of them released — the caller is never made to
+        // wait on an editor that keeps typing, and the pending flag brings the
+        // rest at the next recreate.
+        #expect(operations.createdKinds.count == 3)
+        #expect(operations.releasedNetworks.count == 2)
+        #expect(service.portForwardingRulesArePending(for: .shared))
+    }
+
     @Test("Rules pend only after the network they would change is materialized")
     func pendingTracksTheMaterializedRuleSet() throws {
         let location = makeStoreLocation()

--- a/KernovaTests/VmnetNetworkServiceTests.swift
+++ b/KernovaTests/VmnetNetworkServiceTests.swift
@@ -379,12 +379,152 @@ struct VmnetNetworkServiceTests {
         let operations = MockVmnetNetworkOperator()
         operations.reservedAddressingOverride = operations.freshAddressing
         let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+        service.setPortForwardingRules([Self.webRule], for: "aa:bb:cc:dd:ee:01", kind: .shared)
 
         _ = try service.network(for: .shared)
 
         // The installed reservations were derived from the old addressing, so
-        // none of them holds on the adjusted network.
+        // none of them holds on the adjusted network — nor do the rules
+        // forwarding to them, which is what leaves them pending.
         #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:01", kind: .shared) == nil)
+        #expect(service.portForwardingRulesArePending(for: .shared))
+    }
+
+    // MARK: - Port forwarding rules
+
+    private static let webRule = PortForwardingRule(transport: .tcp, hostPort: 8080, guestPort: 80)
+    private static let sshRule = PortForwardingRule(transport: .tcp, hostPort: 2222, guestPort: 22)
+
+    /// A service over a store already holding `macs` as reservation slots on
+    /// the shared network, so materialization is a single pinned create.
+    private func makeSeededSharedService(
+        macs: [String], at location: (directory: URL, storeURL: URL)
+    ) throws -> (VmnetNetworkService, MockVmnetNetworkOperator) {
+        try seed(
+            [.shared: VmnetNetworkRecord(addressing: Self.storedAddressing, reservedMACs: macs)],
+            at: location.storeURL)
+        let operations = MockVmnetNetworkOperator()
+        return (
+            VmnetNetworkService(operations: operations, storeURL: location.storeURL), operations
+        )
+    }
+
+    @Test("Rules install at materialization, forwarding to the MAC's reserved address")
+    func rulesInstallWithTheSlotDerivedAddress() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, operations) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01"], at: location)
+        service.setPortForwardingRules(
+            [Self.webRule, Self.sshRule], for: "AA:BB:CC:DD:EE:01", kind: .shared)
+
+        _ = try service.network(for: .shared)
+
+        let installed = try #require(operations.installedForwardingRules.first)
+        #expect(installed.map(\.rule) == [Self.webRule, Self.sshRule])
+        #expect(installed.map(\.internalAddress) == ["192.168.77.2", "192.168.77.2"])
+    }
+
+    @Test("TCP and UDP on the same host port both install")
+    func sameHostPortOnBothTransportsInstalls() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, operations) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01"], at: location)
+        let tcp = PortForwardingRule(transport: .tcp, hostPort: 5000, guestPort: 5000)
+        let udp = PortForwardingRule(transport: .udp, hostPort: 5000, guestPort: 5000)
+        service.setPortForwardingRules([tcp, udp], for: "aa:bb:cc:dd:ee:01", kind: .shared)
+
+        _ = try service.network(for: .shared)
+
+        #expect(operations.installedForwardingRules.first?.map(\.rule) == [tcp, udp])
+    }
+
+    @Test("Rules for a MAC holding no reservation slot are dropped")
+    func rulesWithoutAReservationAreDropped() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, operations) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01"], at: location)
+        service.setPortForwardingRules([Self.webRule], for: "aa:bb:cc:dd:ee:09", kind: .shared)
+
+        _ = try service.network(for: .shared)
+
+        #expect(operations.installedForwardingRules.first?.isEmpty == true)
+        // An uninstallable rule must not read as pending, or it would drive an
+        // endless recreate.
+        #expect(!service.portForwardingRulesArePending(for: .shared))
+    }
+
+    @Test("A host port claimed twice across VMs installs once, in slot order")
+    func duplicateHostPortAcrossVMsInstallsFirstSlotOnly() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, operations) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"], at: location)
+        let second = PortForwardingRule(transport: .tcp, hostPort: 8080, guestPort: 8080)
+        service.setPortForwardingRules([Self.webRule], for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        service.setPortForwardingRules([second], for: "aa:bb:cc:dd:ee:02", kind: .shared)
+
+        _ = try service.network(for: .shared)
+
+        let installed = try #require(operations.installedForwardingRules.first)
+        #expect(installed.map(\.rule) == [Self.webRule])
+        #expect(installed.map(\.internalAddress) == ["192.168.77.2"])
+    }
+
+    @Test("Clearing a VM's rules frees its host port for the next materialization")
+    func clearingRulesReleasesTheHostPort() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, operations) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01"], at: location)
+        service.setPortForwardingRules([Self.webRule], for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        _ = try service.network(for: .shared)
+
+        service.setPortForwardingRules([], for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        #expect(service.portForwardingRulesArePending(for: .shared))
+        service.invalidateNetwork(for: .shared)
+        _ = try service.network(for: .shared)
+
+        #expect(operations.installedForwardingRules.last?.isEmpty == true)
+    }
+
+    @Test("Rules declared for an unparseable MAC are refused")
+    func unparseableMACIsRefusedForwardingRules() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, operations) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01"], at: location)
+
+        service.setPortForwardingRules([Self.webRule], for: "not-a-mac", kind: .shared)
+        _ = try service.network(for: .shared)
+
+        #expect(operations.installedForwardingRules.first?.isEmpty == true)
+        #expect(!service.portForwardingRulesArePending(for: .shared))
+    }
+
+    @Test("Rules pend only after the network they would change is materialized")
+    func pendingTracksTheMaterializedRuleSet() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, _) = try makeSeededSharedService(macs: ["aa:bb:cc:dd:ee:01"], at: location)
+        service.setPortForwardingRules([Self.webRule], for: "aa:bb:cc:dd:ee:01", kind: .shared)
+
+        // Nothing is materialized, so the next materialization installs the
+        // rules as they stand — there is nothing to recreate.
+        #expect(!service.portForwardingRulesArePending(for: .shared))
+
+        _ = try service.network(for: .shared)
+        #expect(!service.portForwardingRulesArePending(for: .shared))
+
+        service.setPortForwardingRules(
+            [Self.webRule, Self.sshRule], for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        #expect(service.portForwardingRulesArePending(for: .shared))
+
+        service.invalidateNetwork(for: .shared)
+        _ = try service.network(for: .shared)
+        #expect(!service.portForwardingRulesArePending(for: .shared))
     }
 
     @Test("An unparseable MAC is refused a reservation slot")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,9 +133,11 @@ that cannot materialize, builds the device detached rather than failing the boot
 
 `VmnetNetworkService` (lock-guarded `Sendable`, process-wide — it serves `ConfigurationBuilder`'s
 off-main assembly and the main-actor live-switch path) owns the app's managed vmnet networks and
-the per-VM DHCP reservations riding them: each VM holds a slot keyed on its persisted MAC, the
-slot's derived address is what the settings pane's IP Address row shows, and slots are kept in
-step with configurations through `VMLibraryViewModel`'s persistence funnel. The service
+the per-VM DHCP reservations and port-forwarding rules riding them: each VM holds a slot keyed on
+its persisted MAC, the slot's derived address is what the settings pane's IP Address row shows and
+what a Shared Network VM's rules forward to, and both are kept in step with configurations through
+`VMLibraryViewModel`'s persistence funnel — which also recreates the shared network, once no VM is
+attached to it, when the rules it carries no longer match the ones configured. The service
 materializes each network lazily over the `VmnetNetworkOperating` seam and holds the ref until
 the app exits, so every concurrent VM in the mode shares the one network; addressing and slots
 stay stable across launches by persisting each network's record to


### PR DESCRIPTION
Closes #817

## Summary

Per-VM port-forwarding rules for Shared Network VMs: a guest service becomes reachable from other machines on the host's network without bridged mode. Rules are installed on the app-managed vmnet shared network at creation, forwarding to each VM's reserved (deterministic) address — the same machinery that carries DHCP reservations (#815/#816).

The spike the issue asked for is recorded in [this comment](https://github.com/nicholas-lonsinger/kernova/issues/817#issuecomment-5288071006): rules are **strictly config-time** through the VZ attachment path — every runtime mutation API needs an `interface_ref` the attachment never exposes. That decided the design:

- **Rules table is stopped-only** (the section's existing lock behavior).
- The service tracks *desired* vs *installed* rules and exposes `portForwardingRulesArePending(for:)`; the library recreates the shared network whenever rules pend and no live session could be attached to it (rule edits, session teardown). The recreate rides the existing pinned-addressing machinery, so no guest's address moves — and an edited rule takes effect at the next VM start without an app relaunch, even though the IP-address row materializes the network early.
- Each VM's `config.json` is the single source of truth (`portForwardingRules` on `VMConfiguration`). The service's per-MAC declarations are in-memory only, re-declared at library load — deliberately *not* persisted to `networks.json`, which would be a second source of truth (reservation slots are persisted there only because slot *order* is genuinely owned state).
- One forwarding model (`PortForwardingRule` / `PortForwardingTransport` / `PortForwardingHostClaim`), per docs/NETWORKING.md principle 4 — #85's container mappings should reuse it.
- A host port is claimed network-wide, so the Add Rule sheet validates collisions across **all** Shared Network VMs' rules, not just the edited VM's; the service additionally dedupes deterministically (reservation-slot order, first wins, logged) so a duplicate can never reach vmnet and fail network creation for every VM on it.
- The vmnet call follows the SDK **signature** — internal (guest) port before external (host) port — against the header's contradictory `@param` order; commented at the call site.

UI per docs/research/2026-08-12-network-settings-ui.md decision 6: rule rows inside the Network card beneath MAC (`TCP  Host 8080 → Guest 80`, borderless remove), a trailing `Add Rule…` row opening a compact sheet (Protocol, Host Port, Guest Port; Add disabled while a port is empty/zero/out-of-range or the host port is taken; sub-1024 inline note; host port mirrors the guest port until edited). Rows show only for entitled Shared Network VMs. The macOS 26 loopback limitation is disclosed in the section's info popover.

## Deviations from the design doc (stated per its own rule)

- **Rule rows render as the mock does** — indented lines under a "Port Forwarding" title with no hairline between rules — rather than the prose's "one hairline row per rule". The mock and prose disagree; the mock's rendering keeps the card's major-row hairlines meaningful.
- **Rows additionally require a MAC address** (matching the IP row's gating): without a MAC there is no reservation to forward to, so the control would be visible but dead.
- **The popover's entitled-build clause was reworded, not just appended**: it asserted "there is no port forwarding from host to guest", which this feature makes false.
- **NETWORKING.md principle 3's "narrowest useful listener" cannot be implemented**: `vmnet_network_configuration_add_port_forwarding_rule` has no bind-address/listener parameter — the listener scope is fixed by vmnet (reachable from the external network; on macOS 26, *not* from the host's own localhost). The popover discloses the actual reach instead.

## Changes

- `Kernova/Models/PortForwardingRule.swift` (new) — the forwarding model
- `Kernova/Models/VMConfiguration.swift` — `portForwardingRules` (`decodeIfPresent ?? []`)
- `Kernova/Models/VMStatus.swift` — `isResting`; `Kernova/Models/VMInstance.swift` — `onSessionEnded`, fired when a VM settles into a resting status
- `Kernova/Services/VmnetNetworkService.swift` — rule install at `createNetwork`, desired/installed rule state, `setPortForwardingRules`, `portForwardingRulesArePending`; slot resolution factored into one shared path
- `Kernova/ViewModels/VMLibraryViewModel.swift` — `syncPortForwardingRules` beside the reservation sync (update funnel + instance construction), eviction cleanup, `rebuildSharedNetworkIfIdle`
- `Kernova/Views/Detail/VMSettingsViewController.swift` — Port Forwarding rows, popover copy; `PortForwardingRuleSheetContentViewController.swift` (new) — the Add Rule sheet
- Tests: `VmnetNetworkServiceTests`, `VMConfigurationTests`, `VMLibraryViewModelTests`, `VMSettingsViewControllerTests`, new `PortForwardingRuleSheetContentViewControllerTests`, mock extensions
- `docs/ARCHITECTURE.md` — one clause on the `VmnetNetworkService` paragraph

## Test plan

- [x] Full suite green (2593 test cases, 0 failures)
- [x] Service: install with slot-derived internal address, cross-VM dedupe, MAC-without-slot drop, pending-flag semantics (installable vs installed, so an uninstallable rule can't wedge it), invalidate clears installed rules
- [x] Model: Codable round-trip, absent-key default, clone carries rules
- [x] View model: sync on update/construction, clear on mode switch and evict, idle rebuild fires only when pending and no shared VM is live
- [x] UI: row rendering/gating (mode, entitlement, MAC), remove writes config, read-only lock; sheet validation matrix incl. collision note and guest→host prefill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVhaNysNERLWKNJRE9ECkR
