### PR TITLE
feat: Edit and regenerate a VM's MAC address

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -1545,6 +1545,13 @@ final class VMLibraryViewModel {
         mutate(&new)
         guard new != old else { return true }
         instance.configuration = new
+        // An edited MAC leaves its predecessor holding an older — so
+        // higher-priority — reservation slot. Left declared there, the retired
+        // address keeps claiming the VM's host ports and the rules re-declared
+        // under the new one are dropped as duplicates.
+        if let retired = old.macAddress, retired != new.macAddress {
+            declarePortForwardingRules([], for: old)
+        }
         syncAddressReservation(for: new)
         syncPortForwardingRules(for: new)
         let saved = saveConfiguration(for: instance)

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -1133,13 +1133,20 @@ extension VMSettingsViewController {
     }
 
     private func refreshMACAddressRow() {
-        let mac = instance.configuration.macAddress
-        macAddressRow?.isHidden = !instance.configuration.networkEnabled || mac == nil
+        let config = instance.configuration
+        let hidden = !config.networkEnabled || config.macAddress == nil
+        // End an open editor before the row goes: AppKit doesn't resign a
+        // hidden field, so the mode picker — which takes no first responder of
+        // its own — would leave it focused and invisible, swallowing keystrokes.
+        if hidden, macAddressField.currentEditor() != nil {
+            view.window?.makeFirstResponder(nil)
+        }
+        macAddressRow?.isHidden = hidden
         // A field with an open editor is mid-edit: any refresh — a status change
         // started from the toolbar, say — would otherwise discard the keystrokes
         // typed so far.
         if macAddressField.currentEditor() == nil {
-            macAddressField.stringValue = mac ?? ""
+            macAddressField.stringValue = instance.configuration.macAddress ?? ""
         }
     }
 
@@ -2381,6 +2388,12 @@ extension VMSettingsViewController: NSMenuItemValidation {
     private static let unspecifiedMACAddress = "00:00:00:00:00:00"
 
     @objc private func generateMACAddressTapped() {
+        // Clicking a push button takes no first responder, so an edit open in
+        // the field would outlive the write and commit over it on the way out.
+        // Settle it first; the generated address then replaces whatever it left.
+        if macAddressField.currentEditor() != nil {
+            view.window?.makeFirstResponder(nil)
+        }
         writeConfig { $0.macAddress = VZMACAddress.randomLocallyAdministered().string }
         refreshMACAddressRow()
     }
@@ -3137,15 +3150,17 @@ extension VMSettingsViewController: NSTextFieldDelegate {
     /// Persists the typed MAC in canonical form. Text naming no address a guest
     /// can use writes nothing; the field snapping back to the persisted address
     /// is the rejection, and the field's tooltip names the accepted spelling.
+    ///
+    /// The field is written directly rather than through
+    /// `refreshMACAddressRow()`: editing is still ending here, so the editor the
+    /// refresh defers to is the very one being reconciled away.
     private func applyMACAddressFieldEdit() {
         guard let normalized = Self.normalizedMACAddress(macAddressField.stringValue) else {
-            refreshMACAddressRow()
+            macAddressField.stringValue = instance.configuration.macAddress ?? ""
             return
         }
         writeConfig { $0.macAddress = normalized }
-        // Retyping the persisted address in another case writes nothing, so the
-        // field is reconciled here rather than by the configuration observation.
-        refreshMACAddressRow()
+        macAddressField.stringValue = normalized
     }
 }
 

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -8,8 +8,8 @@ import os
 /// viewing a running VM's configuration in read-only mode.
 ///
 /// Structure that depends on the *instance* (guest-agent section visibility,
-/// MAC-address row, OS-specific help text) is fixed per instance and built in
-/// ``buildForm()``; switching VMs rebuilds the form. ``apply()`` only updates
+/// OS-specific help text) is fixed per instance and built in ``buildForm()``;
+/// switching VMs rebuilds the form. ``apply()`` only updates
 /// mutable state: control values, lock/enabled state, the dynamic attachment
 /// lists, and the microphone permission warning.
 @MainActor
@@ -169,9 +169,10 @@ final class VMSettingsViewController: NSViewController {
     /// The Network header's lock icon, hidden — unlike its `lockIcons` peers —
     /// while the picker is the live-switch surface.
     private var networkLockIcon: NSImageView?
-    /// The MAC Address row, hidden while the VM has no network device; `nil` for a
-    /// VM carrying no MAC address, whose row is never built.
+    /// The MAC Address row, hidden while the VM has no network device or has
+    /// yet to be given an address.
     private var macAddressRow: GroupedFormCollapsibleRow?
+    private var macAddressField = NSTextField()
     private var ipAddressRow: GroupedFormCollapsibleRow?
     private var ipAddressValueLabel: NSTextField?
     private var ipAddressCopyButton: NSButton?
@@ -959,14 +960,7 @@ extension VMSettingsViewController {
 
         var rows: [NSView] = [makeGroupedFormCardRow("Mode", control: networkModePopUp)]
         rows.append(makeIPAddressRow())
-        if let mac = instance.configuration.macAddress {
-            let row = GroupedFormCollapsibleRow(
-                row: makeGroupedFormCardRow("MAC Address", control: makeGroupedFormValueLabel(mac)))
-            macAddressRow = row
-            rows.append(row)
-        } else {
-            macAddressRow = nil
-        }
+        rows.append(makeMACAddressRow())
         rows.append(makePortForwardingRow())
         networkNoDeviceCaption = makeGroupedFormCaption("This virtual machine has no network device.")
 
@@ -1108,6 +1102,45 @@ extension VMSettingsViewController {
     @objc private func copyIPAddressTapped() {
         guard let value = ipAddressCopyValue else { return }
         copyToPasteboard(value)
+    }
+
+    // MARK: MAC Address
+
+    /// The MAC Address row: an editable, VZ-validated field and a Generate
+    /// button. `refreshMACAddressRow()` owns its content and visibility.
+    private func makeMACAddressRow() -> GroupedFormCollapsibleRow {
+        macAddressField = NSTextField()
+        macAddressField.alignment = .right
+        macAddressField.delegate = self
+        macAddressField.toolTip =
+            "Six pairs of hexadecimal digits separated by colons, for example 3a:5f:20:11:88:c4."
+        macAddressField.widthAnchor.constraint(equalToConstant: 140).isActive = true
+
+        let generate = makePushButton("Generate", action: #selector(generateMACAddressTapped))
+        generate.controlSize = .small
+        // Unlike the Mode picker above it, the address is read once at start and
+        // fixed for the session, so both controls lock with the section.
+        persistentLockableControls += [macAddressField, generate]
+
+        let control = NSStackView(views: [macAddressField, generate])
+        control.orientation = .horizontal
+        control.alignment = .centerY
+        control.spacing = Spacing.tight
+        let row = GroupedFormCollapsibleRow(
+            row: makeGroupedFormCardRow("MAC Address", control: control))
+        macAddressRow = row
+        return row
+    }
+
+    private func refreshMACAddressRow() {
+        let mac = instance.configuration.macAddress
+        macAddressRow?.isHidden = !instance.configuration.networkEnabled || mac == nil
+        // A field with an open editor is mid-edit: any refresh — a status change
+        // started from the toolbar, say — would otherwise discard the keystrokes
+        // typed so far.
+        if macAddressField.currentEditor() == nil {
+            macAddressField.stringValue = mac ?? ""
+        }
     }
 
     // MARK: Port Forwarding
@@ -1931,7 +1964,7 @@ extension VMSettingsViewController {
         // None leaves no device to describe, so the card's remaining rows give way
         // to a caption saying so.
         let hasDevice = instance.configuration.networkEnabled
-        macAddressRow?.isHidden = !hasDevice
+        refreshMACAddressRow()
         networkNoDeviceCaption.isHidden = hasDevice
         refreshIPAddressRow()
         // Rules ride the app-managed shared network, and reach the guest at the
@@ -2322,6 +2355,34 @@ extension VMSettingsViewController: NSMenuItemValidation {
     private static func mintMACAddressIfNeeded(_ config: inout VMConfiguration) {
         guard config.macAddress == nil else { return }
         config.macAddress = VZMACAddress.randomLocallyAdministered().string
+    }
+
+    /// The canonical form of the MAC address `text` names — lowercase,
+    /// colon-separated — or `nil` when it names none a guest can use.
+    ///
+    /// `VZMACAddress(string:)` takes six colon-separated hex pairs in either
+    /// case and rejects every other spelling, so case is the only thing left to
+    /// normalize. It also accepts the all-zero address and multicast/broadcast
+    /// addresses, none of which a station can send from: a guest configured
+    /// with one gets no link, and the app would key its reservation and
+    /// forwarding rules on an address no frame can source
+    /// (docs/NETWORKING.md principle 3 — refuse at entry what cannot take
+    /// effect).
+    static func normalizedMACAddress(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let address = VZMACAddress(string: trimmed), address.isUnicastAddress,
+            address.string != Self.unspecifiedMACAddress
+        else { return nil }
+        return address.string
+    }
+
+    /// The all-zero address, which parses and reads as unicast but addresses
+    /// nothing.
+    private static let unspecifiedMACAddress = "00:00:00:00:00:00"
+
+    @objc private func generateMACAddressTapped() {
+        writeConfig { $0.macAddress = VZMACAddress.randomLocallyAdministered().string }
+        refreshMACAddressRow()
     }
 
     @objc private func networkModeChanged() {
@@ -3029,6 +3090,8 @@ extension VMSettingsViewController: NSTextFieldDelegate {
             applyMemoryFieldEdit()
         case displayWidthField, displayHeightField:
             applyDisplaySizeFieldEdit()
+        case macAddressField:
+            applyMACAddressFieldEdit()
         default:
             break
         }
@@ -3069,6 +3132,20 @@ extension VMSettingsViewController: NSTextFieldDelegate {
         memoryField.integerValue = clamped
         memoryStepper.integerValue = clamped
         writeConfig { $0.memorySizeInGB = clamped }
+    }
+
+    /// Persists the typed MAC in canonical form. Text naming no address a guest
+    /// can use writes nothing; the field snapping back to the persisted address
+    /// is the rejection, and the field's tooltip names the accepted spelling.
+    private func applyMACAddressFieldEdit() {
+        guard let normalized = Self.normalizedMACAddress(macAddressField.stringValue) else {
+            refreshMACAddressRow()
+            return
+        }
+        writeConfig { $0.macAddress = normalized }
+        // Retyping the persisted address in another case writes nothing, so the
+        // field is reconciled here rather than by the configuration observation.
+        refreshMACAddressRow()
     }
 }
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2193,6 +2193,30 @@ struct VMLibraryViewModelTests {
         #expect(vmnet.declaredForwardingRules.last?.rules.isEmpty == true)
     }
 
+    @Test("Editing the MAC address moves the rules to it and withdraws the old ones")
+    func macAddressChangeMovesForwardingRules() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeInstance()
+        viewModel.updateConfiguration(of: instance) {
+            $0.networkEnabled = true
+            $0.networkMode = .shared
+            $0.macAddress = "aa:bb:cc:dd:ee:0f"
+            $0.portForwardingRules = [Self.webRule]
+        }
+
+        viewModel.updateConfiguration(of: instance) { $0.macAddress = "aa:bb:cc:dd:ee:10" }
+
+        // The retired address gives up its claim on the host port before the new
+        // one declares the same rules, so nothing is dropped as a duplicate.
+        #expect(
+            vmnet.declaredForwardingRules.suffix(2).map(\.mac)
+                == ["aa:bb:cc:dd:ee:0f", "aa:bb:cc:dd:ee:10"])
+        #expect(vmnet.declaredForwardingRules.dropLast().last?.rules.isEmpty == true)
+        #expect(vmnet.declaredForwardingRules.last?.rules == [Self.webRule])
+        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f", "aa:bb:cc:dd:ee:10"])
+    }
+
     @Test("Deleting a VM withdraws its forwarding rules")
     func deleteWithdrawsForwardingRules() async {
         let vmnet = MockVmnetNetworkProvider()

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -1208,6 +1208,75 @@ struct VMSettingsViewControllerTests {
         }
     }
 
+    @Test("Text a real edit session rejects reverts in the field")
+    func rejectedEditRevertsThroughTheFieldEditor() throws {
+        let (vc, instance) = makeNetworkController()
+        let window = makeTestWindow(styleMask: [.titled])
+        window.contentView = vc.view
+        let field = try #require(editableField("MAC Address", in: vc.view))
+        #expect(window.makeFirstResponder(field))
+        try #require(field.currentEditor()).string = "nonsense"
+
+        #expect(window.makeFirstResponder(nil))
+
+        #expect(instance.configuration.macAddress == "aa:bb:cc:dd:ee:ff")
+        #expect(field.stringValue == "aa:bb:cc:dd:ee:ff")
+    }
+
+    @Test("Text a real edit session accepts lands canonically in the field")
+    func acceptedEditCanonicalizesThroughTheFieldEditor() throws {
+        let (vc, instance) = makeNetworkController()
+        let window = makeTestWindow(styleMask: [.titled])
+        window.contentView = vc.view
+        let field = try #require(editableField("MAC Address", in: vc.view))
+        #expect(window.makeFirstResponder(field))
+        try #require(field.currentEditor()).string = "AA:BB:CC:DD:EE:0F"
+
+        #expect(window.makeFirstResponder(nil))
+
+        #expect(instance.configuration.macAddress == "aa:bb:cc:dd:ee:0f")
+        #expect(field.stringValue == "aa:bb:cc:dd:ee:0f")
+    }
+
+    @Test("Choosing None settles an open MAC edit instead of hiding a focused field")
+    func hidingTheRowEndsAnOpenMACEdit() throws {
+        let (vc, instance) = makeNetworkController()
+        let window = makeTestWindow(styleMask: [.titled])
+        window.contentView = vc.view
+        let field = try #require(editableField("MAC Address", in: vc.view))
+        #expect(window.makeFirstResponder(field))
+        try #require(field.currentEditor()).string = "aa:bb:cc:dd:ee:01"
+        let popUp = try #require(networkModePopUp(in: vc.view))
+
+        popUp.selectItem(withTitle: "None")
+        popUp.sendAction(popUp.action, to: popUp.target)
+
+        #expect(instance.configuration.networkEnabled == false)
+        #expect(!visibleLabel("MAC Address", in: vc.view))
+        #expect(field.currentEditor() == nil)
+    }
+
+    @Test("Generate overrides an edit still open in the field")
+    func generateOverridesAnOpenEdit() throws {
+        let (vc, instance) = makeNetworkController()
+        let window = makeTestWindow(styleMask: [.titled])
+        window.contentView = vc.view
+        let field = try #require(editableField("MAC Address", in: vc.view))
+        #expect(window.makeFirstResponder(field))
+        try #require(field.currentEditor()).string = "aa:bb:cc:dd:ee:01"
+        let generate = try #require(findButton(titled: "Generate", in: vc.view))
+
+        generate.sendAction(generate.action, to: generate.target)
+
+        // Clicking a push button leaves the field first responder, so the
+        // generated address has to survive the edit it interrupts.
+        let mac = try #require(instance.configuration.macAddress)
+        #expect(mac != "aa:bb:cc:dd:ee:01")
+        #expect(field.stringValue == mac)
+        #expect(window.makeFirstResponder(nil))
+        #expect(instance.configuration.macAddress == mac)
+    }
+
     @Test("Generate mints a fresh locally administered address and shows it")
     func generateMintsALocallyAdministeredAddress() throws {
         let (vc, instance) = makeNetworkController()

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -562,7 +562,7 @@ struct VMSettingsViewControllerTests {
 
         #expect(instance.configuration.displaySizesToWindow == true)
         #expect(!popUp.isEnabled)
-        #expect(sizeField("Width", in: vc.view)?.isEnabled == false)
+        #expect(editableField("Width", in: vc.view)?.isEnabled == false)
         // Neither HiDPI nor auto-resize is a size control, so match mode leaves
         // both usable.
         #expect(firstSwitch(action: "displayHiDPIToggled", in: vc.view)?.isEnabled == true)
@@ -574,8 +574,8 @@ struct VMSettingsViewControllerTests {
         let (vc, _) = makeDisplayController(sizesToWindow: true)
 
         #expect(firstPopUp(in: vc.view)?.isEnabled == false)
-        #expect(sizeField("Width", in: vc.view)?.isEnabled == false)
-        #expect(sizeField("Height", in: vc.view)?.isEnabled == false)
+        #expect(editableField("Width", in: vc.view)?.isEnabled == false)
+        #expect(editableField("Height", in: vc.view)?.isEnabled == false)
         // HiDPI picks the scale the computed size is measured at, so it stays
         // usable — as does the mode switch, so the user can turn match off.
         #expect(firstSwitch(action: "displayHiDPIToggled", in: vc.view)?.isEnabled == true)
@@ -594,15 +594,15 @@ struct VMSettingsViewControllerTests {
 
         #expect(instance.configuration.displayWidth == 1440)
         #expect(instance.configuration.displayHeight == 900)
-        #expect(sizeField("Width", in: vc.view)?.integerValue == 1440)
-        #expect(sizeField("Height", in: vc.view)?.integerValue == 900)
+        #expect(editableField("Width", in: vc.view)?.integerValue == 1440)
+        #expect(editableField("Height", in: vc.view)?.integerValue == 900)
     }
 
     @Test("A typed size below the floor clamps and flips the popup to Custom")
     func typedSizeClampsAndSelectsCustom() {
         let (vc, instance) = makeDisplayController()
-        guard let width = sizeField("Width", in: vc.view),
-            let height = sizeField("Height", in: vc.view),
+        guard let width = editableField("Width", in: vc.view),
+            let height = editableField("Height", in: vc.view),
             let popUp = firstPopUp(in: vc.view)
         else {
             Issue.record("Expected the width, height, and resolution controls")
@@ -634,7 +634,7 @@ struct VMSettingsViewControllerTests {
         #expect(instance.configuration.displayHeight == 1600)
         #expect(instance.configuration.displayPPI == DisplayBootSizing.hiDPIPixelsPerInch)
         // The fields keep showing the "looks like" size.
-        #expect(sizeField("Width", in: vc.view)?.integerValue == 1280)
+        #expect(editableField("Width", in: vc.view)?.integerValue == 1280)
 
         hiDPI.state = .off
         hiDPI.sendAction(hiDPI.action, to: hiDPI.target)
@@ -669,18 +669,18 @@ struct VMSettingsViewControllerTests {
         let (retinaVC, _) = makeDisplayController(width: 2560, height: 1600, ppi: 220)
         #expect(firstSwitch(action: "displayHiDPIToggled", in: retinaVC.view)?.state == .on)
         // The fields show the halved "looks like" size.
-        #expect(sizeField("Width", in: retinaVC.view)?.integerValue == 1280)
+        #expect(editableField("Width", in: retinaVC.view)?.integerValue == 1280)
 
         let (standardVC, _) = makeDisplayController(width: 1920, height: 1200, ppi: 144)
         #expect(firstSwitch(action: "displayHiDPIToggled", in: standardVC.view)?.state == .off)
-        #expect(sizeField("Width", in: standardVC.view)?.integerValue == 1920)
+        #expect(editableField("Width", in: standardVC.view)?.integerValue == 1920)
 
         // Match mode on a 1× host: the intent is on while the trio it last
         // booted at is not, and each control shows its own.
         let (divergentVC, _) = makeDisplayController(
             sizesToWindow: true, width: 1400, height: 880, ppi: 144, hiDPI: true)
         #expect(firstSwitch(action: "displayHiDPIToggled", in: divergentVC.view)?.state == .on)
-        #expect(sizeField("Width", in: divergentVC.view)?.integerValue == 1400)
+        #expect(editableField("Width", in: divergentVC.view)?.integerValue == 1400)
     }
 
     @Test("Turning match-window off reconciles the trio to the HiDPI intent")
@@ -700,7 +700,7 @@ struct VMSettingsViewControllerTests {
         #expect(instance.configuration.displayWidth == 2800)
         #expect(instance.configuration.displayHeight == 1760)
         #expect(instance.configuration.displayPPI == DisplayBootSizing.hiDPIPixelsPerInch)
-        #expect(sizeField("Width", in: vc.view)?.integerValue == 1400)
+        #expect(editableField("Width", in: vc.view)?.integerValue == 1400)
     }
 
     @Test("Turning match-window off leaves an already-matching trio alone")
@@ -747,7 +747,7 @@ struct VMSettingsViewControllerTests {
             #expect(
                 firstSwitch(action: "displayMatchWindowToggled", in: vc.view)?.isEnabled == false)
             #expect(firstPopUp(in: vc.view)?.isEnabled == false)
-            #expect(sizeField("Width", in: vc.view)?.isEnabled == false)
+            #expect(editableField("Width", in: vc.view)?.isEnabled == false)
             #expect(firstSwitch(action: "displayAutoResizeToggled", in: vc.view)?.isEnabled == true)
             if guestOS == .macOS {
                 #expect(firstSwitch(action: "displayHiDPIToggled", in: vc.view)?.isEnabled == false)
@@ -777,7 +777,7 @@ struct VMSettingsViewControllerTests {
         let (vc, _) = makeDisplayController(width: 1920, height: 1200)
         let window = makeTestWindow(styleMask: [.titled])
         window.contentView = vc.view
-        guard let width = sizeField("Width", in: vc.view) else {
+        guard let width = editableField("Width", in: vc.view) else {
             Issue.record("Expected the width field")
             return
         }
@@ -794,7 +794,7 @@ struct VMSettingsViewControllerTests {
 
         #expect(width.currentEditor()?.string == "1600")
         // The committed value is untouched: only the editor holds the edit.
-        #expect(sizeField("Height", in: vc.view)?.integerValue == 1200)
+        #expect(editableField("Height", in: vc.view)?.integerValue == 1200)
     }
 
     @Test("The restart caption shows only while read-only")
@@ -1160,6 +1160,124 @@ struct VMSettingsViewControllerTests {
         #expect(instance.configuration.macAddress == "aa:bb:cc:dd:ee:ff")
     }
 
+    // MARK: - MAC Address row
+
+    /// Ends editing the way a click outside the field does.
+    private func commitEdit(_ field: NSTextField, on vc: VMSettingsViewController) {
+        vc.controlTextDidEndEditing(Notification(name: .init("test"), object: field))
+    }
+
+    @Test("The MAC Address row offers the persisted address in an editable field")
+    func macAddressRowIsEditable() throws {
+        let (vc, _) = makeNetworkController()
+
+        let field = try #require(editableField("MAC Address", in: vc.view))
+        #expect(field.stringValue == "aa:bb:cc:dd:ee:ff")
+        #expect(findButton(titled: "Generate", in: vc.view) != nil)
+    }
+
+    @Test("A typed MAC address is persisted in canonical form")
+    func typedMACAddressIsPersistedCanonically() throws {
+        let (vc, instance) = makeNetworkController()
+        let field = try #require(editableField("MAC Address", in: vc.view))
+
+        field.stringValue = " AA:BB:CC:DD:EE:0F "
+        commitEdit(field, on: vc)
+
+        #expect(instance.configuration.macAddress == "aa:bb:cc:dd:ee:0f")
+        #expect(field.stringValue == "aa:bb:cc:dd:ee:0f")
+    }
+
+    @Test("A MAC address no guest can use is refused and the field reverts")
+    func unusableMACAddressIsRefused() throws {
+        // Malformed spellings, then the three that parse but address no
+        // station: all-zero, broadcast, and multicast.
+        let refused = [
+            "aa-bb-cc-dd-ee-ff", "aabbccddeeff", "a:b:c:d:e:f", "aa:bb:cc:dd:ee:fg", "",
+            "00:00:00:00:00:00", "ff:ff:ff:ff:ff:ff", "01:00:5e:00:00:01",
+        ]
+        for text in refused {
+            let (vc, instance) = makeNetworkController()
+            let field = try #require(editableField("MAC Address", in: vc.view))
+
+            field.stringValue = text
+            commitEdit(field, on: vc)
+
+            #expect(instance.configuration.macAddress == "aa:bb:cc:dd:ee:ff")
+            #expect(field.stringValue == "aa:bb:cc:dd:ee:ff")
+        }
+    }
+
+    @Test("Generate mints a fresh locally administered address and shows it")
+    func generateMintsALocallyAdministeredAddress() throws {
+        let (vc, instance) = makeNetworkController()
+        let generate = try #require(findButton(titled: "Generate", in: vc.view))
+
+        generate.sendAction(generate.action, to: generate.target)
+
+        let mac = try #require(instance.configuration.macAddress)
+        #expect(mac != "aa:bb:cc:dd:ee:ff")
+        let address = try #require(VZMACAddress(string: mac))
+        #expect(address.isUnicastAddress)
+        #expect(address.isLocallyAdministeredAddress)
+        #expect(editableField("MAC Address", in: vc.view)?.stringValue == mac)
+    }
+
+    @Test("A running VM locks the MAC controls while the picker stays live")
+    func runningVMLocksTheMACControls() throws {
+        let (vc, _) = makeNetworkController(
+            interfaces: MockBridgedInterfaceProvider(available: [Self.wiFi], primary: "en0"),
+            isReadOnly: true, status: .running)
+
+        #expect(editableField("MAC Address", in: vc.view)?.isEnabled == false)
+        #expect(findButton(titled: "Generate", in: vc.view)?.isEnabled == false)
+        #expect(networkModePopUp(in: vc.view)?.isEnabled == true)
+    }
+
+    @Test("A refresh leaves a MAC address the user is still typing in alone")
+    func refreshKeepsAnInProgressMACEdit() throws {
+        let (vc, _) = makeNetworkController()
+        let window = makeTestWindow(styleMask: [.titled])
+        window.contentView = vc.view
+        let field = try #require(editableField("MAC Address", in: vc.view))
+        #expect(window.makeFirstResponder(field))
+        let editor = try #require(field.currentEditor())
+        editor.string = "aa:bb:cc:dd:ee:0"
+
+        // Stands in for any observation pass — starting the VM from the toolbar
+        // mutates status, which refreshes the whole pane.
+        vc.viewDidAppear()
+
+        #expect(field.currentEditor()?.string == "aa:bb:cc:dd:ee:0")
+    }
+
+    @Test("A VM given its first MAC address shows it in the row straight away")
+    func mintedMACAddressAppearsInTheRow() throws {
+        let (vc, instance) = makeNetworkController(networkEnabled: false, macAddress: nil)
+        #expect(!visibleLabel("MAC Address", in: vc.view))
+        let popUp = try #require(networkModePopUp(in: vc.view))
+
+        popUp.selectItem(withTitle: "Shared Network")
+        popUp.sendAction(popUp.action, to: popUp.target)
+
+        #expect(visibleLabel("MAC Address", in: vc.view))
+        #expect(
+            editableField("MAC Address", in: vc.view)?.stringValue
+                == instance.configuration.macAddress)
+    }
+
+    @Test("Only a usable MAC address normalizes")
+    func normalizedMACAddressAcceptsOnlyUsableAddresses() {
+        #expect(VMSettingsViewController.normalizedMACAddress("AA:BB:CC:DD:EE:FF") == "aa:bb:cc:dd:ee:ff")
+        #expect(VMSettingsViewController.normalizedMACAddress(" aa:bb:cc:dd:ee:ff\n") == "aa:bb:cc:dd:ee:ff")
+        for text in [
+            "aa-bb-cc-dd-ee-ff", "aabbccddeeff", "a:b:c:d:e:f", "aa:bb:cc:dd:ee:fg", "",
+            "00:00:00:00:00:00", "ff:ff:ff:ff:ff:ff", "01:00:5e:00:00:01",
+        ] {
+            #expect(VMSettingsViewController.normalizedMACAddress(text) == nil)
+        }
+    }
+
     @Test("While a networked VM runs, the picker stays live with None disabled")
     func runningVMKeepsThePickerLiveWithNoneDisabled() throws {
         let (vc, _) = makeNetworkController(
@@ -1370,11 +1488,13 @@ struct VMSettingsViewControllerTests {
         firstSubview(NSPopUpButton.self, in: view)
     }
 
-    /// The editable field in the grouped-form card row titled `label`.
-    private func sizeField(_ label: String, in view: NSView) -> NSTextField? {
+    /// The editable field in the grouped-form card row titled `label`, however
+    /// deeply the row nests it (the MAC row pairs its field with a button).
+    private func editableField(_ label: String, in view: NSView) -> NSTextField? {
         let row = firstSubview(NSStackView.self, in: view) { stack in
             stack.arrangedSubviews.contains { ($0 as? NSTextField)?.stringValue == label }
         }
-        return row?.arrangedSubviews.compactMap { $0 as? NSTextField }.first { $0.isEditable }
+        guard let row else { return nil }
+        return findEditableField(in: row)
     }
 }


### PR DESCRIPTION
## Summary

The Network section's MAC Address row becomes an editable, `VZMACAddress(string:)`-validated field with a `Generate` button — slice 5 of the end-state design in `docs/research/2026-08-12-network-settings-ui.md`. A VM's address can now be set to one an 802.1X or port-security network expects, instead of only the random locally-administered address minted at creation and clone. Both controls lock with the rest of the section while the VM runs.

Closes #818

## Changes

- **`VMSettingsViewController`** — `makeMACAddressRow()` builds the field plus `Generate`; `refreshMACAddressRow()` owns its content and visibility. `applyMACAddressFieldEdit()` commits through the existing `controlTextDidEndEditing` path, so Return, focus loss, and an outside click all commit once; `generateMACAddressTapped()` writes a fresh `VZMACAddress.randomLocallyAdministered().string`.
- **`normalizedMACAddress(_:)`** — trims surrounding whitespace, parses with `VZMACAddress(string:)`, and persists `address.string`, which is always the lowercase colon-separated form. Text naming no usable address writes nothing; the field snapping back to the persisted value is the rejection, and the field's tooltip names the accepted spelling.
- **Field-editor discipline.** A push button takes no first responder and the Mode picker takes none either, so an open editor can outlive the write that follows a click. `Generate` and the row's own hide both settle an open edit first, and the commit path writes the field directly rather than through the refresh that defers to the editor being reconciled away.
- **The row is built unconditionally.** It was previously built only for a VM that already carried an address, so a VM given its first MAC by turning networking on had no row to show it until the form was rebuilt by switching VMs — which would have shipped a new control that is sometimes invisible for no user-visible reason.
- **`VMLibraryViewModel.updateConfiguration`** withdraws the port-forwarding rules declared under a retired MAC. `VmnetNetworkService`'s reservation list is append-only and `resolveForwardingRules` walks it in slot order, giving the first claimant of a `(transport, host port)` pair the rule; without this, an in-session A→B edit leaves A holding the older slot and the rules re-declared under B are dropped as duplicates, so the guest silently receives nothing until the app restarts.

## Deviations

The research note's preamble asks for deviations to be stated.

- **Validation is `VZMACAddress(string:)` plus a unicast and non-all-zero rule**, where the note says only "`VZMACAddress(string:)`-validated". Measured against the macOS 27 SDK, `VZMACAddress(string:)` is a strict *syntax* check that nonetheless accepts `00:00:00:00:00:00`, `ff:ff:ff:ff:ff:ff`, and multicast addresses like `01:00:5e:00:00:01`. None is a usable station address: the guest gets no link, DHCP never completes, and the app would key a reservation and forwarding rules on an address no frame can source. `docs/NETWORKING.md` principle 3 is the house rule for exactly this — refused when the user enters it, never accepted and left to fail at VM start.
- **Whitespace is trimmed before parsing** (`VZMACAddress` accepts none), matching the URL and port fields elsewhere in the app, so a pasted address with a trailing space isn't silently rejected. Nothing else is normalized: no dashes, no bare hex. Rewriting those would mean inventing a parser wider than VZ's, while the persisted store, `VmnetNetworkService`'s reservation keys, and `ConfigurationBuilder` all assume the canonical form.
- **The button is labeled `Generate`**, per the design note, rather than the issue title's "regenerate". No ellipsis — it gathers no input, and it is not an unconditional destructive command.
- **Two items outside the issue's stated scope are included**: the unconditional row and the retired-MAC rule withdrawal, both described above. The second is a defect this feature would otherwise introduce.
- **The Network section's lock icon still hides while the Mode picker is live**, even though the MAC controls beside it are now disabled. That is #828's deliberate choice for the live-switch surface; the Guest Agent card is the existing precedent for conveying a locked sub-control by graying it rather than by a section lock.

## Deferred

Two review findings are real but need work beyond this slice, and are filed rather than folded in:

- **#834** — a changed or new MAC's DHCP reservation never activates while the network is already materialized. Not introduced here: a newly created or cloned VM lands in the same pending state at the merge base. The fix is reservation-pending state in `VmnetNetworkService` plus a kind-generalized idle recreate.
- **#835** — two VMs can hold the same MAC, colliding on the reservation and forwarding keys. Enforcing uniqueness needs a home (`VMLibraryViewModel`, covering clone and Generate too) and a rejection surface that says why, which this row does not have.

## Test plan

- [x] `make test` — full suite green, including 14 new cases
- [x] `make lint`
- [x] MAC row: editable field carries the persisted address; a typed address persists in canonical form
- [x] Refusal: malformed spellings, empty text, all-zero, broadcast, and multicast each leave the configuration untouched and revert the field
- [x] Through a real field-editor session in a window: accepted text canonicalizes in place, refused text reverts
- [x] `Generate` mints a unicast, locally-administered address, shows it, and survives an edit left open in the field
- [x] Running VM disables the field and `Generate` while the Mode picker stays live
- [x] A refresh mid-typing leaves the open editor alone; choosing None settles it instead of hiding a focused field
- [x] A VM given its first MAC shows it in the row straight away
- [x] Editing the MAC moves the forwarding rules and withdraws the old declarations