### PR TITLE
fix: Reclaim DHCP reservation slots when a VM or its MAC goes away

### DIFF
--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -9,7 +9,7 @@ import vmnet
 /// (docs/NETWORKING.md).
 // `CodingKeyRepresentable` so a `[VmnetNetworkKind: …]` store encodes as a
 // JSON object keyed by kind, not Codable's array-of-pairs fallback.
-enum VmnetNetworkKind: String, Codable, CodingKeyRepresentable, Sendable {
+enum VmnetNetworkKind: String, Codable, CodingKeyRepresentable, CaseIterable, Sendable {
     /// The Host Only network: guests on it reach the host and each other,
     /// never the LAN or the internet.
     case hostOnly
@@ -71,14 +71,18 @@ enum IPv4Value {
 }
 
 /// What one app-managed network persists across launches: its addressing once
-/// first reserved, and the ordered MACs holding DHCP reservation slots —
-/// slot order is the address assignment, so the list only ever appends.
+/// first reserved, and the ordered MACs holding DHCP reservation slots.
+///
+/// Slot position *is* the address (``VmnetNetworkAddressing/reservedAddress(slot:)``),
+/// so a slot is released by emptying it in place — a `nil` element is a free
+/// slot the next MAC needing one refills, leaving every surviving VM's address
+/// where it was. Trailing free slots are trimmed.
 struct VmnetNetworkRecord: Codable, Sendable, Equatable {
     /// `nil` until the network first materializes.
     var addressing: VmnetNetworkAddressing?
-    var reservedMACs: [String]
+    var reservedMACs: [String?]
 
-    init(addressing: VmnetNetworkAddressing? = nil, reservedMACs: [String] = []) {
+    init(addressing: VmnetNetworkAddressing? = nil, reservedMACs: [String?] = []) {
         self.addressing = addressing
         self.reservedMACs = reservedMACs
     }
@@ -307,6 +311,22 @@ protocol VmnetNetworkProviding: Sendable {
     /// Cheap and non-blocking — safe from the main actor; the reservation is
     /// installed at the network's next materialization.
     func reserveAddressIfNeeded(for mac: String, kind: VmnetNetworkKind)
+    /// Frees the DHCP reservation slot `mac` holds on the network of `kind`,
+    /// so a later MAC can take it; a no-op when it holds none. Cheap and
+    /// non-blocking — safe from the main actor.
+    ///
+    /// The slot is emptied in place, so no surviving VM's reserved address
+    /// moves. The live network keeps honoring the freed reservation until its
+    /// next materialization.
+    func releaseAddressReservation(for mac: String, kind: VmnetNetworkKind)
+    /// Frees every DHCP reservation slot on the network of `kind` whose MAC is
+    /// not in `macs` — the reclaim for slots orphaned while the app was not
+    /// running. Same in-place semantics as
+    /// ``releaseAddressReservation(for:kind:)``.
+    ///
+    /// Callers pass the complete set of MACs wanting a slot on that network;
+    /// an incomplete set frees slots that are still in use.
+    func retainAddressReservations(_ macs: Set<String>, kind: VmnetNetworkKind)
     /// The IPv4 address reserved for `mac` on the network of `kind`; `nil`
     /// while `mac` holds no slot or the network has never materialized (its
     /// addressing is not yet known).
@@ -530,7 +550,8 @@ final class VmnetNetworkService: @unchecked Sendable {
         let (probe, discovered) = try operations.createNetwork(
             kind, addressing: nil, reservations: [], forwardingRules: [])
         let macs = currentRecord(for: kind).reservedMACs
-        guard !macs.isEmpty else {
+        let slotCount = macs.count(where: { $0 != nil })
+        guard slotCount > 0 else {
             updateRecord(for: kind) { $0.addressing = discovered }
             Self.logger.notice("Created and persisted the \(kind.rawValue, privacy: .public) network")
             return MaterializedNetwork(handle: probe, reservations: [], forwardingRules: [])
@@ -545,7 +566,7 @@ final class VmnetNetworkService: @unchecked Sendable {
                 forwardingRules: Self.operatorRules(forwarding))
             updateRecord(for: kind) { $0.addressing = reserved }
             Self.logger.notice(
-                "Created and persisted the \(kind.rawValue, privacy: .public) network with \(macs.count, privacy: .public) reservation slots"
+                "Created and persisted the \(kind.rawValue, privacy: .public) network with \(slotCount, privacy: .public) reservation slots"
             )
             let holds = reserved == discovered
             return MaterializedNetwork(
@@ -570,12 +591,12 @@ final class VmnetNetworkService: @unchecked Sendable {
     /// `addressing`, in slot order; slots past the subnet's capacity and MACs
     /// that no longer parse (a hand-edited store) are dropped with a warning.
     private func reservations(
-        for macs: [String], addressing: VmnetNetworkAddressing, kind: VmnetNetworkKind
+        for macs: [String?], addressing: VmnetNetworkAddressing, kind: VmnetNetworkKind
     ) -> [(mac: String, address: String)] {
         let slots = Self.resolveSlots(macs: macs, addressing: addressing)
         for (index, slot) in slots.enumerated() {
             switch slot {
-            case .installable:
+            case .installable, .free:
                 continue
             case .unparseableMAC:
                 Self.logger.warning(
@@ -593,6 +614,8 @@ final class VmnetNetworkService: @unchecked Sendable {
     /// What one reservation slot resolves to against a network's addressing.
     private enum ResolvedSlot {
         case installable(mac: String, address: String)
+        /// The slot holds no MAC — released, and waiting to be refilled.
+        case free
         /// The slot's MAC no longer parses (a hand-edited store).
         case unparseableMAC
         /// The subnet has no address left at this slot's index.
@@ -604,9 +627,10 @@ final class VmnetNetworkService: @unchecked Sendable {
     /// both while materializing and while answering
     /// ``portForwardingRulesArePending(for:)``.
     private static func resolveSlots(
-        macs: [String], addressing: VmnetNetworkAddressing
+        macs: [String?], addressing: VmnetNetworkAddressing
     ) -> [ResolvedSlot] {
         macs.enumerated().map { index, mac in
+            guard let mac else { return .free }
             guard VZMACAddress(string: mac) != nil else { return .unparseableMAC }
             guard let address = addressing.reservedAddress(slot: index) else { return .noAddressLeft }
             return .installable(mac: mac, address: address)
@@ -868,12 +892,53 @@ extension VmnetNetworkService: VmnetNetworkProviding {
         }
         updateRecord(for: kind) { record in
             guard !record.reservedMACs.contains(normalized) else { return }
-            record.reservedMACs.append(normalized)
-            let slot = record.reservedMACs.count - 1
+            // A slot freed by an earlier release is refilled before the table
+            // grows, so reclaimed addresses are the ones handed out next.
+            let slot = record.reservedMACs.firstIndex(where: { $0 == nil }) ?? record.reservedMACs.count
+            if slot == record.reservedMACs.count {
+                record.reservedMACs.append(normalized)
+            } else {
+                record.reservedMACs[slot] = normalized
+            }
             Self.logger.info(
                 "Reserved \(kind.rawValue, privacy: .public) address slot \(slot, privacy: .public)"
             )
         }
+    }
+
+    func releaseAddressReservation(for mac: String, kind: VmnetNetworkKind) {
+        let normalized = mac.lowercased()
+        updateRecord(for: kind) { record in
+            guard let slot = record.reservedMACs.firstIndex(of: normalized) else { return }
+            record.reservedMACs[slot] = nil
+            Self.trimFreeTail(&record.reservedMACs)
+            Self.logger.info(
+                "Released \(kind.rawValue, privacy: .public) address slot \(slot, privacy: .public)"
+            )
+        }
+    }
+
+    func retainAddressReservations(_ macs: Set<String>, kind: VmnetNetworkKind) {
+        let retained = Set(macs.map { $0.lowercased() })
+        updateRecord(for: kind) { record in
+            var freed = 0
+            for (slot, mac) in record.reservedMACs.enumerated() {
+                guard let mac, !retained.contains(mac) else { continue }
+                record.reservedMACs[slot] = nil
+                freed += 1
+            }
+            guard freed > 0 else { return }
+            Self.trimFreeTail(&record.reservedMACs)
+            Self.logger.info(
+                "Released \(freed, privacy: .public) \(kind.rawValue, privacy: .public) address slots no VM claims"
+            )
+        }
+    }
+
+    /// Drops trailing free slots, so an emptied table reads as empty and the
+    /// store never accumulates a tail of `null`s.
+    private static func trimFreeTail(_ macs: inout [String?]) {
+        while let last = macs.last, last == nil { macs.removeLast() }
     }
 
     func reservedAddress(for mac: String, kind: VmnetNetworkKind) -> String? {

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -2458,6 +2458,9 @@ final class VMLibraryViewModel {
 
             var diskConfigs: [(VMConfiguration, URL)] = []
             var failedBundles: [String] = []
+            // Bundles present on disk but unreadable: their VMs still exist, so
+            // eviction must not reclaim what is keyed on them.
+            var failedBundleURLs: Set<URL> = []
             for bundleURL in diskBundles {
                 let bundleName = bundleURL.deletingPathExtension().lastPathComponent
                 do {
@@ -2469,6 +2472,7 @@ final class VMLibraryViewModel {
                         "Failed to load config from \(bundleURL.lastPathComponent, privacy: .public) during reconciliation: \(error.localizedDescription, privacy: .public)"
                     )
                     failedBundles.append(bundleName)
+                    failedBundleURLs.insert(bundleURL)
                 }
             }
             let diskIDs = Set(diskConfigs.map(\.0.id))
@@ -2502,7 +2506,7 @@ final class VMLibraryViewModel {
                 // Cancel any in-flight setup task before evicting — otherwise it keeps
                 // mutating an orphan instance the view model no longer knows about.
                 instance.setupTask?.cancel()
-                evict(instance)
+                evict(instance, bundleIsGone: !failedBundleURLs.contains(instance.bundleURL))
                 Self.logger.info("VM '\(instance.name, privacy: .public)' no longer on disk — removed from library")
                 didChange = true
             }
@@ -2576,7 +2580,12 @@ final class VMLibraryViewModel {
     ///
     /// The single removal path: a clipboard problem left in the issue center
     /// would otherwise keep drawing a menu line for a VM that no longer exists.
-    private func evict(_ instance: VMInstance) {
+    ///
+    /// `bundleIsGone: false` drops the row but keeps the VM's DHCP reservation
+    /// slot, for a bundle still on disk whose configuration could not be read —
+    /// that VM still exists, so handing its address to somebody else would move
+    /// it once the configuration is readable again.
+    private func evict(_ instance: VMInstance, bundleIsGone: Bool = true) {
         instances.removeAll { $0.id == instance.id }
         if selectedID == instance.id {
             selectedID = instances.first?.id
@@ -2585,9 +2594,10 @@ final class VMLibraryViewModel {
         // A VM out of the library stops claiming its host ports and its
         // address, so the next VM created can be handed both.
         declarePortForwardingRules([], for: instance.configuration)
-        if let target = reservationTarget(for: instance.configuration) {
-            releaseAddressReservationIfUnused(target)
+        guard bundleIsGone, let target = reservationTarget(for: instance.configuration) else {
+            return
         }
+        releaseAddressReservationIfUnused(target)
     }
 
     // MARK: - Reorder

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -355,7 +355,26 @@ final class VMLibraryViewModel {
                 selectedID = instances.first?.id
             }
         }
+        pruneAddressReservations(scanWasComplete: scan.failedBundleNames.isEmpty)
         Self.logger.notice("Loaded \(self.instances.count, privacy: .public) VMs")
+    }
+
+    /// Frees every reservation slot no VM in the library claims — the reclaim
+    /// for slots orphaned while the app was not running (a bundle trashed in
+    /// Finder), which no in-session release can catch.
+    ///
+    /// Runs only over a complete library: a bundle whose configuration failed
+    /// to parse is absent from `instances` while its VM still exists, so its
+    /// slot must not be handed to somebody else. Entitlement-gated like the
+    /// rest of the reservation machinery — an unentitled build never reserves,
+    /// so pruning there would empty a store the entitled build owns.
+    private func pruneAddressReservations(scanWasComplete: Bool) {
+        guard isVMNetworkingEntitled, scanWasComplete else { return }
+        let targets = instances.compactMap { reservationTarget(for: $0.configuration) }
+        for kind in VmnetNetworkKind.allCases {
+            let macs = Set(targets.filter { $0.kind == kind }.map(\.mac))
+            vmnetNetworks.retainAddressReservations(macs, kind: kind)
+        }
     }
 
     // MARK: - Create
@@ -1473,6 +1492,19 @@ final class VMLibraryViewModel {
         syncPortForwardingRules(for: instance.configuration)
     }
 
+    /// The reservation slot `config` wants: the network its mode maps to and
+    /// the lowercased MAC keying the slot, `nil` for a VM that can join no
+    /// app-managed network (networking off, or Bridged, where external DHCP
+    /// owns addressing).
+    private func reservationTarget(
+        for config: VMConfiguration
+    ) -> (kind: VmnetNetworkKind, mac: String)? {
+        guard config.networkEnabled, let mac = config.macAddress,
+            let kind = VmnetNetworkKind(mode: config.networkMode)
+        else { return nil }
+        return (kind: kind, mac: mac.lowercased())
+    }
+
     /// Keeps the VM's DHCP reservation slot in step with its configuration:
     /// any VM that can join an app-managed network holds a slot keyed on its
     /// persisted MAC, so its address is assigned before the network next
@@ -1481,10 +1513,21 @@ final class VMLibraryViewModel {
     /// consumer of the reservation machinery — an unentitled build never
     /// materializes a network, so slots taken there would be dead weight.
     private func syncAddressReservation(for config: VMConfiguration) {
-        guard isVMNetworkingEntitled, config.networkEnabled, let mac = config.macAddress,
-            let kind = VmnetNetworkKind(mode: config.networkMode)
-        else { return }
-        vmnetNetworks.reserveAddressIfNeeded(for: mac, kind: kind)
+        guard isVMNetworkingEntitled, let target = reservationTarget(for: config) else { return }
+        vmnetNetworks.reserveAddressIfNeeded(for: target.mac, kind: target.kind)
+    }
+
+    /// Frees `target`'s reservation slot unless a VM still in the library wants
+    /// the same one — duplicate MACs are possible, so the last claimant is what
+    /// releases the slot.
+    private func releaseAddressReservationIfUnused(_ target: (kind: VmnetNetworkKind, mac: String)) {
+        guard isVMNetworkingEntitled else { return }
+        let stillWanted = instances.contains {
+            let other = reservationTarget(for: $0.configuration)
+            return other?.kind == target.kind && other?.mac == target.mac
+        }
+        guard !stillWanted else { return }
+        vmnetNetworks.releaseAddressReservation(for: target.mac, kind: target.kind)
     }
 
     /// Keeps the VM's port-forwarding rules in step with its configuration: a
@@ -1551,6 +1594,15 @@ final class VMLibraryViewModel {
         // under the new one are dropped as duplicates.
         if let retired = old.macAddress, retired != new.macAddress {
             declarePortForwardingRules([], for: old)
+        }
+        // Released before the new slot is taken, so the freed slot is the
+        // lowest one available and an edited MAC normally keeps the VM's
+        // address. Covers a MAC change, a mode switch, and networking off.
+        if let retired = reservationTarget(for: old) {
+            let kept = reservationTarget(for: new)
+            if kept?.kind != retired.kind || kept?.mac != retired.mac {
+                releaseAddressReservationIfUnused(retired)
+            }
         }
         syncAddressReservation(for: new)
         syncPortForwardingRules(for: new)
@@ -2530,8 +2582,12 @@ final class VMLibraryViewModel {
             selectedID = instances.first?.id
         }
         ClipboardIssueCenter.shared.clear(instanceID: instance.instanceID)
-        // A VM out of the library stops claiming its host ports.
+        // A VM out of the library stops claiming its host ports and its
+        // address, so the next VM created can be handed both.
         declarePortForwardingRules([], for: instance.configuration)
+        if let target = reservationTarget(for: instance.configuration) {
+            releaseAddressReservationIfUnused(target)
+        }
     }
 
     // MARK: - Reorder

--- a/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
+++ b/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
@@ -130,7 +130,14 @@ final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable
 
     /// Scripted answer for `reservedAddress(for:kind:)`, keyed by lowercased MAC.
     var scriptedAddresses: [String: String] = [:]
+    /// The slots currently held, so a test reads the live set rather than a
+    /// call log — mirroring the service, where a release frees the slot.
     private(set) var reservedMACs: [(mac: String, kind: VmnetNetworkKind)] = []
+    /// Every release, in call order — kept alongside `reservedMACs` so a test
+    /// can assert a release happened, and that it preceded a reserve.
+    private(set) var releasedMACs: [(mac: String, kind: VmnetNetworkKind)] = []
+    /// Every retain set, in call order.
+    private(set) var retainedMACs: [(macs: Set<String>, kind: VmnetNetworkKind)] = []
 
     func reserveAddressIfNeeded(for mac: String, kind: VmnetNetworkKind) {
         let normalized = mac.lowercased()
@@ -138,6 +145,18 @@ final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable
             return
         }
         reservedMACs.append((mac: normalized, kind: kind))
+    }
+
+    func releaseAddressReservation(for mac: String, kind: VmnetNetworkKind) {
+        let normalized = mac.lowercased()
+        releasedMACs.append((mac: normalized, kind: kind))
+        reservedMACs.removeAll { $0.mac == normalized && $0.kind == kind }
+    }
+
+    func retainAddressReservations(_ macs: Set<String>, kind: VmnetNetworkKind) {
+        let retained = Set(macs.map { $0.lowercased() })
+        retainedMACs.append((macs: retained, kind: kind))
+        reservedMACs.removeAll { $0.kind == kind && !retained.contains($0.mac) }
     }
 
     func reservedAddress(for mac: String, kind: VmnetNetworkKind) -> String? {

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2155,6 +2155,160 @@ struct VMLibraryViewModelTests {
         #expect(vmnet.reservedMACs.isEmpty)
     }
 
+    // MARK: - Address Reservation Release
+
+    /// A VM in the library already holding a reservation slot on its mode's
+    /// network — the state a load leaves behind, without going through a scan.
+    private func makeReservedInstance(
+        in viewModel: VMLibraryViewModel, using vmnet: MockVmnetNetworkProvider,
+        mac: String, mode: VMNetworkMode = .shared
+    ) -> VMInstance {
+        let instance = makeInstance()
+        instance.configuration.networkEnabled = true
+        instance.configuration.networkMode = mode
+        instance.configuration.macAddress = mac
+        viewModel.instances.append(instance)
+        if let kind = VmnetNetworkKind(mode: mode) {
+            vmnet.reserveAddressIfNeeded(for: mac, kind: kind)
+        }
+        return instance
+    }
+
+    @Test("Deleting a VM releases its DHCP reservation slot")
+    func deleteReleasesAddressReservation() async {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeReservedInstance(in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f")
+
+        for task in viewModel.deleteConfirmed(instance) { await task.value }
+
+        #expect(vmnet.releasedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f"])
+        #expect(vmnet.reservedMACs.isEmpty)
+    }
+
+    @Test("A slot another VM still wants survives a delete")
+    func deleteKeepsASlotADuplicateMACStillWants() async {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let first = makeReservedInstance(in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f")
+        _ = makeReservedInstance(in: viewModel, using: vmnet, mac: "AA:BB:CC:DD:EE:0F")
+
+        for task in viewModel.deleteConfirmed(first) { await task.value }
+
+        #expect(vmnet.releasedMACs.isEmpty)
+        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f"])
+    }
+
+    @Test("Editing the MAC releases the retired slot before the new MAC takes one")
+    func macAddressChangeReleasesTheRetiredSlotFirst() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeReservedInstance(in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f")
+
+        viewModel.updateConfiguration(of: instance) { $0.macAddress = "aa:bb:cc:dd:ee:10" }
+
+        // Release first, so the freed slot is the lowest one available and the
+        // VM's reserved address does not move.
+        #expect(vmnet.releasedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f"])
+        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:10"])
+    }
+
+    @Test("Switching network mode releases the slot on the old kind")
+    func modeSwitchReleasesTheOldKindsSlot() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeReservedInstance(in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f")
+
+        viewModel.updateConfiguration(of: instance) { $0.networkMode = .hostOnly }
+
+        #expect(vmnet.releasedMACs.map(\.kind) == [.shared])
+        #expect(vmnet.reservedMACs.map(\.kind) == [.hostOnly])
+    }
+
+    @Test("Disabling networking releases the slot")
+    func disablingNetworkingReleasesTheSlot() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeReservedInstance(in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f")
+
+        viewModel.updateConfiguration(of: instance) { $0.networkEnabled = false }
+
+        #expect(vmnet.releasedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f"])
+        #expect(vmnet.reservedMACs.isEmpty)
+    }
+
+    @Test("An unrelated configuration change releases nothing")
+    func unrelatedChangeReleasesNothing() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeReservedInstance(in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f")
+
+        viewModel.updateConfiguration(of: instance) { $0.name = "Renamed" }
+
+        #expect(vmnet.releasedMACs.isEmpty)
+        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f"])
+    }
+
+    @Test("Loading the library frees slots no VM claims")
+    func loadFreesSlotsNoVMClaims() async {
+        let vmnet = MockVmnetNetworkProvider()
+        let storage = MockVMStorageService()
+        var config = VMConfiguration(name: "Kept", guestOS: .linux, bootMode: .efi)
+        config.networkEnabled = true
+        config.networkMode = .shared
+        config.macAddress = "aa:bb:cc:dd:ee:0f"
+        storage.bundles[
+            FileManager.default.temporaryDirectory
+                .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+        ] = config
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage, vmnetNetworks: vmnet)
+        // A slot left behind by a VM trashed while the app was not running.
+        vmnet.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:99", kind: .shared)
+
+        await viewModel.loadVMs()
+
+        #expect(vmnet.retainedMACs.first(where: { $0.kind == .shared })?.macs == ["aa:bb:cc:dd:ee:0f"])
+        #expect(vmnet.retainedMACs.first(where: { $0.kind == .hostOnly })?.macs == [])
+        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f"])
+    }
+
+    @Test("A library that failed to read a bundle frees no slot")
+    func loadWithAFailedBundleFreesNothing() async {
+        let vmnet = MockVmnetNetworkProvider()
+        let storage = MockVMStorageService()
+        let config = VMConfiguration(name: "Unreadable", guestOS: .linux, bootMode: .efi)
+        let failing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+        storage.bundles[failing] = config
+        storage.loadConfigurationFailURLs = [failing]
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage, vmnetNetworks: vmnet)
+        vmnet.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:99", kind: .shared)
+
+        await viewModel.loadVMs()
+
+        // The failed bundle's VM still exists, so its slot must not be reclaimed.
+        #expect(vmnet.retainedMACs.isEmpty)
+        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:99"])
+    }
+
+    @Test("An unentitled build neither releases nor prunes")
+    func unentitledBuildLeavesReservationsAlone() async {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(
+            vmnetNetworks: vmnet, isVMNetworkingEntitled: false)
+        let instance = makeInstance()
+        instance.configuration.networkEnabled = true
+        instance.configuration.networkMode = .shared
+        instance.configuration.macAddress = "aa:bb:cc:dd:ee:0f"
+        viewModel.instances = [instance]
+
+        viewModel.updateConfiguration(of: instance) { $0.macAddress = "aa:bb:cc:dd:ee:10" }
+        await viewModel.loadVMs()
+
+        #expect(vmnet.releasedMACs.isEmpty)
+        #expect(vmnet.retainedMACs.isEmpty)
+    }
+
     // MARK: - Port Forwarding Sync
 
     private static let webRule = PortForwardingRule(transport: .tcp, hostPort: 8080, guestPort: 80)
@@ -2214,7 +2368,7 @@ struct VMLibraryViewModelTests {
                 == ["aa:bb:cc:dd:ee:0f", "aa:bb:cc:dd:ee:10"])
         #expect(vmnet.declaredForwardingRules.dropLast().last?.rules.isEmpty == true)
         #expect(vmnet.declaredForwardingRules.last?.rules == [Self.webRule])
-        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f", "aa:bb:cc:dd:ee:10"])
+        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:10"])
     }
 
     @Test("Deleting a VM withdraws its forwarding rules")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2291,6 +2291,37 @@ struct VMLibraryViewModelTests {
         #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:99"])
     }
 
+    @Test("A reconcile keeps the slot of a VM whose bundle is on disk but unreadable")
+    func reconcileKeepsTheSlotOfAnUnreadableBundle() {
+        let vmnet = MockVmnetNetworkProvider()
+        let storage = MockVMStorageService()
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage, vmnetNetworks: vmnet)
+        let instance = makeReservedInstance(in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f")
+        // The bundle is still on disk; only its configuration stopped parsing,
+        // so the VM leaves the library but has not gone away.
+        storage.bundles[instance.bundleURL] = instance.configuration
+        storage.loadConfigurationFailURLs = [instance.bundleURL]
+
+        viewModel.reconcileWithDisk()
+
+        #expect(viewModel.instances.isEmpty)
+        #expect(vmnet.releasedMACs.isEmpty)
+        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f"])
+    }
+
+    @Test("A reconcile releases the slot of a VM whose bundle is gone")
+    func reconcileReleasesTheSlotOfADeletedBundle() {
+        let vmnet = MockVmnetNetworkProvider()
+        let storage = MockVMStorageService()
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage, vmnetNetworks: vmnet)
+        _ = makeReservedInstance(in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f")
+
+        viewModel.reconcileWithDisk()
+
+        #expect(viewModel.instances.isEmpty)
+        #expect(vmnet.releasedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f"])
+    }
+
     @Test("An unentitled build neither releases nor prunes")
     func unentitledBuildLeavesReservationsAlone() async {
         let vmnet = MockVmnetNetworkProvider()

--- a/KernovaTests/VmnetNetworkServiceTests.swift
+++ b/KernovaTests/VmnetNetworkServiceTests.swift
@@ -255,6 +255,149 @@ struct VmnetNetworkServiceTests {
         #expect(store?[.shared]?.reservedMACs == ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"])
     }
 
+    // MARK: - Releasing reservation slots
+
+    @Test("A released slot is handed to the next MAC, leaving every other address put")
+    func releasedSlotIsReusedWithoutMovingOthers() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        try seed(
+            [.shared: VmnetNetworkRecord(addressing: Self.storedAddressing, reservedMACs: [])],
+            at: location.storeURL)
+        let service = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+        for suffix in ["01", "02", "03"] {
+            service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:\(suffix)", kind: .shared)
+        }
+
+        service.releaseAddressReservation(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:04", kind: .shared)
+
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:02", kind: .shared) == nil)
+        // The freed slot is refilled in place, so the newcomer takes the
+        // reclaimed address and the two survivors keep theirs.
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:04", kind: .shared) == "192.168.77.3")
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:01", kind: .shared) == "192.168.77.2")
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:03", kind: .shared) == "192.168.77.4")
+    }
+
+    @Test("A release is keyed case-insensitively")
+    func releaseIsCaseInsensitive() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let service = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+
+        service.releaseAddressReservation(for: "AA:BB:CC:DD:EE:01", kind: .shared)
+
+        let store = try readStore(at: location.storeURL, from: service)
+        #expect(store?[.shared]?.reservedMACs == [nil, "aa:bb:cc:dd:ee:02"])
+    }
+
+    @Test("Releasing a MAC that holds no slot writes nothing")
+    func releasingAnUnreservedMACWritesNothing() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let service = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+
+        service.releaseAddressReservation(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+
+        #expect(try readStore(at: location.storeURL, from: service) == nil)
+    }
+
+    @Test("A released trailing slot is trimmed rather than persisted as a hole")
+    func releasedTrailingSlotIsTrimmed() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let service = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+
+        service.releaseAddressReservation(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+
+        let store = try readStore(at: location.storeURL, from: service)
+        #expect(store?[.shared]?.reservedMACs == ["aa:bb:cc:dd:ee:01"])
+    }
+
+    @Test("A released slot survives a relaunch as a free slot")
+    func releasedSlotPersistsAsFreeAcrossInstances() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let first = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+        first.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        first.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+        first.releaseAddressReservation(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        first.flushPersistsForTesting()
+
+        let second = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+        second.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:03", kind: .shared)
+
+        let store = try readStore(at: location.storeURL, from: second)
+        #expect(store?[.shared]?.reservedMACs == ["aa:bb:cc:dd:ee:03", "aa:bb:cc:dd:ee:02"])
+    }
+
+    @Test("Retaining a set of MACs frees every slot outside it")
+    func retainFreesUnclaimedSlots() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let service = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+        for suffix in ["01", "02", "03"] {
+            service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:\(suffix)", kind: .shared)
+        }
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:04", kind: .hostOnly)
+
+        service.retainAddressReservations(["AA:BB:CC:DD:EE:03"], kind: .shared)
+
+        let store = try readStore(at: location.storeURL, from: service)
+        #expect(store?[.shared]?.reservedMACs == [nil, nil, "aa:bb:cc:dd:ee:03"])
+        // Retaining on one network never touches the other's slots.
+        #expect(store?[.hostOnly]?.reservedMACs == ["aa:bb:cc:dd:ee:04"])
+    }
+
+    @Test("Retaining nothing empties the table")
+    func retainNothingEmptiesTheTable() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let service = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+
+        service.retainAddressReservations([], kind: .shared)
+
+        #expect(try readStore(at: location.storeURL, from: service)?[.shared]?.reservedMACs == [])
+    }
+
+    @Test("A reused slot is installed for its new owner at the next materialization")
+    func reusedSlotInstallsForItsNewOwner() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        try seed(
+            [
+                .shared: VmnetNetworkRecord(
+                    addressing: Self.storedAddressing,
+                    reservedMACs: ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"])
+            ], at: location.storeURL)
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+        _ = try service.network(for: .shared)
+
+        service.releaseAddressReservation(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:03", kind: .shared)
+        service.invalidateNetwork(for: .shared)
+        _ = try service.network(for: .shared)
+
+        let installed = try #require(operations.installedReservations.last)
+        #expect(installed.map(\.mac) == ["aa:bb:cc:dd:ee:03", "aa:bb:cc:dd:ee:02"])
+        #expect(installed.map(\.address) == ["192.168.77.2", "192.168.77.3"])
+    }
+
     // MARK: - Reservations at materialization
 
     @Test("First materialization with slots discovers addressing, then recreates pinned with reservations")


### PR DESCRIPTION
Closes #830.

## Summary

`VmnetNetworkService`'s per-network reservation table was append-only — `reserveAddressIfNeeded` was its only mutator. Nothing freed a slot when a VM was deleted, when its MAC was edited or regenerated (#833's Generate flow makes that unbounded rather than one-per-VM), or when its mode switched away from an app-managed network. Slot position *is* the address (`host 2 + index`), so each dead slot permanently costs the network an address its DHCP can no longer hand out dynamically — 253 of them on the /24 vmnet reserves.

Slots are now released **in place**: `VmnetNetworkRecord.reservedMACs` holds `[String?]`, where a `nil` element is a free slot the next MAC needing one refills. That reclaims the address without moving any surviving VM's, and needs no compaction. Trailing free slots are trimmed so an emptied table reads as empty.

Three release points:

| Trigger | Where |
|---|---|
| VM leaves the library (delete, external deletion, phantom cleanup) | `VMLibraryViewModel.evict` — the single removal path |
| MAC edited/regenerated, mode switched, networking turned off | `updateConfiguration`'s retirement block, beside the existing forwarding-rule withdrawal |
| Slots orphaned while the app was not running, and those already accumulated | `pruneAddressReservations` at load |

A release is guarded by a library-wide survivor check: duplicate MACs are legal today (#835), so only the last claimant frees the slot. The retirement release runs **before** `syncAddressReservation(for: new)`, mirroring the existing withdraw-then-declare order for rules — the freed slot is then the lowest one available, so an edited MAC normally keeps the VM's address.

## Deviations from the issue's suggested fix

The issue proposed replacing the positional list with a persisted MAC → address map. A sparse list was chosen instead:

- **A map breaks the persisted shape.** Under AGENTS.md's no-migration rule the old key would simply be ignored, so every existing install would lose `reservedMACs` and re-reserve in library order — reshuffling every guest's IP address once, which is exactly the stability the issue wanted to protect. `Optional<String>` decodes from a plain JSON string, so an existing `networks.json` reads unchanged and nothing migrates.
- **A map needs a reassignment path that does not exist.** `materialize` persists system-adjusted addressing, which would strand every stored address outside the new subnet.
- A `nil` hole reclaims the slot just as completely and leaves the positional derivation, capacity handling, and slot-ordered forwarding-rule dedupe exactly as they are.

Two additions beyond the issue: the survivor check (needed while duplicate MACs are legal) and the load-time prune (without it, slots already accumulated — the issue's headline complaint — are never reclaimed).

## Scope

Kept to #830. #834 (a reservation-pending network never rematerializing) and #835 (duplicate MACs) are untouched — no pending flag, no validation, no UI. Two notes for whoever takes them:

- **#834** — a release is now a second reason a materialized network's reservations differ from the record, so its pending comparison must be written against the whole reservation set, not just additions. Its deferred question ("can a retired MAC's slot be reused without moving any other VM's address?") is answered *yes* here: a freed slot keeps its index.
- **#835** — the survivor check is correct while duplicates are legal and stays correct once they are forbidden.

The issue carries `Type: Refactor`, but this changes behavior (slots are now freed and reused), so the commit uses the `fix` prefix.

## Test plan

- [x] `make test` — full suite green, including 17 new cases
- [x] `make lint`

New coverage: slot reuse without moving other addresses, case-insensitive release, a no-op release writing nothing, trailing-slot trimming, a free slot surviving a relaunch, retain semantics (including cross-network isolation), a reused slot installing for its new owner at the next materialization, and the view model's delete / MAC-edit ordering / mode-switch / networking-off / duplicate-MAC-survivor / load-prune / failed-bundle / unentitled paths.

### Maintenance Notes

- ✅ **docs/ARCHITECTURE.md** — skipped, no component boundary changed. Its description ("each VM holds a slot keyed on its persisted MAC … kept in step with configurations through `VMLibraryViewModel`'s persistence funnel") stays true; `VmnetNetworkProviding` gained two methods on an existing seam.
- ✅ **Tests** — 17 new cases across `VmnetNetworkServiceTests` and `VMLibraryViewModelTests`; `MockVmnetNetworkProvider` extended.
- ✅ **AGENTS.md** — skipped, no rule stated there changed.
- ✅ **RATIONALE:** — none added, so no `## Notes` disclosure beyond the commit's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)