### PR TITLE
fix: Recreate a network when its DHCP reservations change

### DIFF
--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -339,10 +339,10 @@ protocol VmnetNetworkProviding: Sendable {
     /// network's next materialization.
     func setPortForwardingRules(_ rules: [PortForwardingRule], for mac: String, kind: VmnetNetworkKind)
     /// Whether the materialized network of `kind` carries a different set of
-    /// forwarding rules than the one that would install right now — so
-    /// recreating it would change what is forwarded. `false` while no network
-    /// of `kind` is materialized.
-    func portForwardingRulesArePending(for kind: VmnetNetworkKind) -> Bool
+    /// DHCP reservations or forwarding rules than the ones that would install
+    /// right now — so recreating it would change what guests get. `false`
+    /// while no network of `kind` is materialized.
+    func networkConfigurationIsPending(for kind: VmnetNetworkKind) -> Bool
     /// The kind whose materialized network `network` is, `nil` for a network
     /// this service does not hold.
     func kind(ofNetwork network: vmnet_network_ref) -> VmnetNetworkKind?
@@ -366,7 +366,7 @@ protocol VmnetNetworkProviding: Sendable {
 /// and rules can only be added to a configuration), so either one declared
 /// while its network is materialized takes effect at the next materialization
 /// — the next app launch, or a recreate driven by recovery or by
-/// ``portForwardingRulesArePending(for:)``.
+/// ``networkConfigurationIsPending(for:)``.
 ///
 /// Lock-guarded `Sendable` rather than `@MainActor`: it never touches
 /// `VZVirtualMachine`, and `ConfigurationBuilder` consumes it during off-main
@@ -625,7 +625,7 @@ final class VmnetNetworkService: @unchecked Sendable {
     /// Resolves every reservation slot in order, without logging — the shared
     /// source of truth for what a network of `addressing` would install, read
     /// both while materializing and while answering
-    /// ``portForwardingRulesArePending(for:)``.
+    /// ``networkConfigurationIsPending(for:)``.
     private static func resolveSlots(
         macs: [String?], addressing: VmnetNetworkAddressing
     ) -> [ResolvedSlot] {
@@ -751,6 +751,20 @@ final class VmnetNetworkService: @unchecked Sendable {
         return desiredForwardingRules[kind] ?? [:]
     }
 
+    /// The MAC → address reservations a network of `kind` created right now
+    /// would install, in slot order — slots that cannot install (past the
+    /// subnet's capacity, or holding a MAC that no longer parses) are not in
+    /// it, so it is directly comparable with `installedAddresses`.
+    ///
+    /// The caller holds `stateLock`.
+    private func installableReservationsLocked(
+        for kind: VmnetNetworkKind
+    ) -> [(mac: String, address: String)] {
+        guard let record = records[kind], let addressing = record.addressing else { return [] }
+        return Self.installablePairs(
+            Self.resolveSlots(macs: record.reservedMACs, addressing: addressing))
+    }
+
     /// The rules a network of `kind` created right now would carry, keyed by
     /// MAC — declarations that cannot install (no reservation slot, a host port
     /// another VM already claims) are not in it, so it is directly comparable
@@ -760,12 +774,10 @@ final class VmnetNetworkService: @unchecked Sendable {
     private func installableForwardingRulesLocked(
         for kind: VmnetNetworkKind
     ) -> [String: [PortForwardingRule]] {
-        guard let record = records[kind], let addressing = record.addressing else { return [:] }
-        let slots = Self.resolveSlots(macs: record.reservedMACs, addressing: addressing)
-        return Self.rulesByMAC(
+        Self.rulesByMAC(
             Self.resolveForwardingRules(
                 desired: desiredForwardingRules[kind] ?? [:],
-                reservations: Self.installablePairs(slots)
+                reservations: installableReservationsLocked(for: kind)
             ).installing)
     }
 
@@ -986,16 +998,27 @@ extension VmnetNetworkService: VmnetNetworkProviding {
         )
     }
 
-    func portForwardingRulesArePending(for kind: VmnetNetworkKind) -> Bool {
+    func networkConfigurationIsPending(for kind: VmnetNetworkKind) -> Bool {
         stateLock.lock()
         defer { stateLock.unlock() }
         // Nothing pends against a network that does not exist yet: its next
         // materialization installs whatever is declared then.
         guard handles[kind] != nil else { return false }
-        // Compared against what would *install*, not against everything
-        // declared: a rule whose VM holds no reservation can never install, and
-        // measuring against it would leave the flag stuck true and drive an
-        // endless recreate.
+        // Both sides are compared as what would *install*, not as everything
+        // declared: a slot past the subnet's capacity, a MAC that no longer
+        // parses, and a rule whose VM holds no reservation can never install,
+        // and measuring against them would leave the flag stuck true and drive
+        // an endless recreate.
+        //
+        // The whole reservation set is compared rather than only its additions,
+        // so a slot released by a departed VM also pends — the live network
+        // honors its reservation until the recreate.
+        let reservations = Dictionary(
+            installableReservationsLocked(for: kind).map { ($0.mac, $0.address) },
+            // Matches how `installedAddresses` is built, so a hand-edited store
+            // holding one MAC in two slots does not read as forever pending.
+            uniquingKeysWith: { first, _ in first })
+        if reservations != (installedAddresses[kind] ?? [:]) { return true }
         return installableForwardingRulesLocked(for: kind) != (installedForwardingRules[kind] ?? [:])
     }
 

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -375,6 +375,9 @@ final class VMLibraryViewModel {
             let macs = Set(targets.filter { $0.kind == kind }.map(\.mac))
             vmnetNetworks.retainAddressReservations(macs, kind: kind)
         }
+        // A reload can run while a network is materialized, so the slots this
+        // just reclaimed only reach guests through a recreate.
+        rebuildNetworksIfIdle()
     }
 
     // MARK: - Create
@@ -1483,13 +1486,17 @@ final class VMLibraryViewModel {
             guard let self, let instance else { return }
             self.unmountGuestAgentInstaller(from: instance)
         }
-        // Forwarding rules are fixed at network creation, so an edit made while
-        // a VM ran waits for the last session on that network to release it.
+        // Reservations and forwarding rules are fixed at network creation, so a
+        // change made while a VM ran waits for the last session on that network
+        // to release it.
         instance.onSessionTornDown = { [weak self] in
-            self?.rebuildSharedNetworkIfIdle()
+            self?.rebuildNetworksIfIdle()
         }
         syncAddressReservation(for: instance.configuration)
         syncPortForwardingRules(for: instance.configuration)
+        // The create/clone/import/load entry point: a VM arriving with a slot
+        // on an already-materialized network is pending until it is recreated.
+        rebuildNetworksIfIdle()
     }
 
     /// The reservation slot `config` wants: the network its mode maps to and
@@ -1538,8 +1545,7 @@ final class VMLibraryViewModel {
         declarePortForwardingRules(forwards ? config.portForwardingRules : [], for: config)
     }
 
-    /// Declares `rules` for the VM `config` identifies, then rebuilds the
-    /// shared network if that changed what it should carry.
+    /// Declares `rules` for the VM `config` identifies.
     ///
     /// Entitlement-gated like the reservation machinery it rides on — an
     /// unentitled build attaches system NAT, which forwards nothing.
@@ -1548,25 +1554,30 @@ final class VMLibraryViewModel {
     ) {
         guard isVMNetworkingEntitled, let mac = config.macAddress else { return }
         vmnetNetworks.setPortForwardingRules(rules, for: mac, kind: .shared)
-        rebuildSharedNetworkIfIdle()
     }
 
-    /// Recreates the shared network when the rules it was created with are no
-    /// longer the ones that should install, and no VM could be attached to it.
+    /// Recreates every app-managed network whose DHCP reservations or
+    /// forwarding rules are no longer the ones that should install, once no VM
+    /// could be attached to it.
     ///
-    /// Rules are fixed at creation, so an edit reaches guests only through a
+    /// Both are fixed at creation, so a change reaches guests only through a
     /// recreate — and only while no session holds an attachment on the network.
     /// The recreate keeps the network's addressing, so no guest's address
     /// moves.
-    private func rebuildSharedNetworkIfIdle() {
-        guard vmnetNetworks.portForwardingRulesArePending(for: .shared) else { return }
+    private func rebuildNetworksIfIdle() {
+        for kind in VmnetNetworkKind.allCases { rebuildNetworkIfIdle(kind) }
+    }
+
+    private func rebuildNetworkIfIdle(_ kind: VmnetNetworkKind) {
+        guard vmnetNetworks.networkConfigurationIsPending(for: kind) else { return }
         let attached = instances.contains {
-            $0.mayHoldAttachment(on: .shared, networks: vmnetNetworks)
+            $0.mayHoldAttachment(on: kind, networks: vmnetNetworks)
         }
         guard !attached else { return }
         Self.logger.notice(
-            "Recreating the shared network so its changed port forwarding rules take effect")
-        vmnetNetworks.invalidateNetwork(for: .shared)
+            "Recreating the \(kind.rawValue, privacy: .public) network so its changed reservations and port forwarding rules take effect"
+        )
+        vmnetNetworks.invalidateNetwork(for: kind)
     }
 
     /// The single entry point for any UI-driven or programmatic mutation of
@@ -1608,10 +1619,11 @@ final class VMLibraryViewModel {
         syncPortForwardingRules(for: new)
         let saved = saveConfiguration(for: instance)
         applyLivePolicy(for: instance, old: old, new: new)
-        // A live switch off the shared network frees it inside `applyLivePolicy`
-        // — the sync above ran while the session still held the attachment, so
-        // re-check now rather than leaving pending rules to an unrelated event.
-        rebuildSharedNetworkIfIdle()
+        // A live switch off a network frees it inside `applyLivePolicy` — the
+        // syncs above ran while the session still held the attachment, so
+        // re-check now rather than leaving the pending change to an unrelated
+        // event.
+        rebuildNetworksIfIdle()
         return saved
     }
 
@@ -2594,10 +2606,10 @@ final class VMLibraryViewModel {
         // A VM out of the library stops claiming its host ports and its
         // address, so the next VM created can be handed both.
         declarePortForwardingRules([], for: instance.configuration)
-        guard bundleIsGone, let target = reservationTarget(for: instance.configuration) else {
-            return
+        if bundleIsGone, let target = reservationTarget(for: instance.configuration) {
+            releaseAddressReservationIfUnused(target)
         }
-        releaseAddressReservationIfUnused(target)
+        rebuildNetworksIfIdle()
     }
 
     // MARK: - Reorder

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -1489,8 +1489,8 @@ final class VMLibraryViewModel {
         // Reservations and forwarding rules are fixed at network creation, so a
         // change made while a VM ran waits for the last session on that network
         // to release it.
-        instance.onSessionTornDown = { [weak self] in
-            self?.rebuildNetworksIfIdle()
+        instance.onSessionTornDown = { [weak self, weak instance] in
+            self?.rebuildNetworksIfIdle(ignoring: instance)
         }
         syncAddressReservation(for: instance.configuration)
         syncPortForwardingRules(for: instance.configuration)
@@ -1564,18 +1564,23 @@ final class VMLibraryViewModel {
     /// recreate — and only while no session holds an attachment on the network.
     /// The recreate keeps the network's addressing, so no guest's address
     /// moves.
-    private func rebuildNetworksIfIdle() {
-        for kind in VmnetNetworkKind.allCases { rebuildNetworkIfIdle(kind) }
+    /// `tornDown` is the instance whose session just ended, excluded from the
+    /// idle scan: `tearDownSession` fires its hook before the caller settles
+    /// the status, so a VM released from a transitioning one (`.saving` on a
+    /// save-suspend, `.installing` on a cancelled guest setup) would otherwise
+    /// read as still holding the network it just let go of.
+    private func rebuildNetworksIfIdle(ignoring tornDown: VMInstance? = nil) {
+        for kind in VmnetNetworkKind.allCases { rebuildNetworkIfIdle(kind, ignoring: tornDown) }
     }
 
-    private func rebuildNetworkIfIdle(_ kind: VmnetNetworkKind) {
+    private func rebuildNetworkIfIdle(_ kind: VmnetNetworkKind, ignoring tornDown: VMInstance?) {
         guard vmnetNetworks.networkConfigurationIsPending(for: kind) else { return }
         let attached = instances.contains {
-            $0.mayHoldAttachment(on: kind, networks: vmnetNetworks)
+            $0 !== tornDown && $0.mayHoldAttachment(on: kind, networks: vmnetNetworks)
         }
         guard !attached else { return }
         Self.logger.notice(
-            "Recreating the \(kind.rawValue, privacy: .public) network so its changed reservations and port forwarding rules take effect"
+            "Recreating the \(kind.rawValue, privacy: .public) network to install its pending changes"
         )
         vmnetNetworks.invalidateNetwork(for: kind)
     }
@@ -1618,9 +1623,14 @@ final class VMLibraryViewModel {
         syncAddressReservation(for: new)
         syncPortForwardingRules(for: new)
         let saved = saveConfiguration(for: instance)
+        // A live session still reads as attached to the network it is *on*, so
+        // the network this VM is switching *to* is idle only until
+        // `applyLivePolicy` attaches it — which it does synchronously. Recreate
+        // it now, or the change this VM just declared waits for a teardown.
+        rebuildNetworksIfIdle()
         applyLivePolicy(for: instance, old: old, new: new)
         // A live switch off a network frees it inside `applyLivePolicy` — the
-        // syncs above ran while the session still held the attachment, so
+        // pass above ran while the session still held that attachment, so
         // re-check now rather than leaving the pending change to an unrelated
         // event.
         rebuildNetworksIfIdle()

--- a/KernovaTests/Mocks/MockVirtualizationService.swift
+++ b/KernovaTests/Mocks/MockVirtualizationService.swift
@@ -88,6 +88,10 @@ final class MockVirtualizationService: VirtualizationProviding {
 
     func save(_ instance: VMInstance) async throws {
         saveCallCount += 1
+        // The real service marks the VM `.saving` before tearing the session
+        // down and settles the resting status after — so the teardown hook
+        // fires while the status still reads as transitioning.
+        instance.status = .saving
         if let error = saveError {
             instance.tearDownSession()
             instance.status = .error

--- a/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
+++ b/KernovaTests/Mocks/MockVmnetNetworkOperator.swift
@@ -85,11 +85,13 @@ final class MockVmnetNetworkOperator: VmnetNetworkOperating, @unchecked Sendable
 /// callers only compare its identity.
 final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable {
     var scriptedAttachment: VZNetworkDeviceAttachment = VZNATNetworkDeviceAttachment()
-    /// Whether the network counts as materialized: `attachmentIfMaterialized`
-    /// answers `nil` while `false`, and `materializeNetwork` flips it `true`
-    /// unless scripted to fail.
-    var isMaterialized = true
-    /// When `true`, `materializeNetwork` fails and leaves `isMaterialized` as is.
+    /// The kinds counting as materialized — held per kind, since one pass of the
+    /// idle rebuild queries every kind and a shared flag would let the first
+    /// invalidation mask the rest. `attachmentIfMaterialized` answers `nil` for
+    /// a kind not in it, `materializeNetwork` inserts, and `invalidateNetwork`
+    /// removes.
+    var materializedKinds: Set<VmnetNetworkKind> = Set(VmnetNetworkKind.allCases)
+    /// When `true`, `materializeNetwork` fails and leaves `materializedKinds` as is.
     var materializeFails = false
 
     // MARK: - Error Injection
@@ -98,7 +100,8 @@ final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable
 
     private(set) var requestedKinds: [VmnetNetworkKind] = []
     private(set) var materializeCount = 0
-    private(set) var materializedKinds: [VmnetNetworkKind] = []
+    /// Every `materializeNetwork` call, in order — failures included.
+    private(set) var materializeRequestedKinds: [VmnetNetworkKind] = []
     private(set) var invalidatedKinds: [VmnetNetworkKind] = []
 
     func attachment(for kind: VmnetNetworkKind) throws -> VZNetworkDeviceAttachment {
@@ -109,21 +112,21 @@ final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable
 
     func attachmentIfMaterialized(for kind: VmnetNetworkKind) -> VZNetworkDeviceAttachment? {
         requestedKinds.append(kind)
-        guard isMaterialized, attachmentError == nil else { return nil }
+        guard materializedKinds.contains(kind), attachmentError == nil else { return nil }
         return scriptedAttachment
     }
 
     func materializeNetwork(for kind: VmnetNetworkKind) async -> Bool {
         materializeCount += 1
-        materializedKinds.append(kind)
+        materializeRequestedKinds.append(kind)
         guard !materializeFails else { return false }
-        isMaterialized = true
+        materializedKinds.insert(kind)
         return true
     }
 
     func invalidateNetwork(for kind: VmnetNetworkKind) {
         invalidatedKinds.append(kind)
-        isMaterialized = false
+        materializedKinds.remove(kind)
     }
 
     // MARK: - Reservations
@@ -167,8 +170,8 @@ final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable
 
     /// The rules last declared per lowercased MAC, in declaration order.
     private(set) var declaredForwardingRules: [(mac: String, rules: [PortForwardingRule])] = []
-    /// Scripted answer for `portForwardingRulesArePending(for:)`.
-    var scriptedPendingForwardingKinds: Set<VmnetNetworkKind> = []
+    /// Scripted answer for `networkConfigurationIsPending(for:)`.
+    var scriptedPendingKinds: Set<VmnetNetworkKind> = []
     private(set) var pendingQueriedKinds: [VmnetNetworkKind] = []
 
     func setPortForwardingRules(
@@ -177,11 +180,11 @@ final class MockVmnetNetworkProvider: VmnetNetworkProviding, @unchecked Sendable
         declaredForwardingRules.append((mac: mac.lowercased(), rules: rules))
     }
 
-    func portForwardingRulesArePending(for kind: VmnetNetworkKind) -> Bool {
+    func networkConfigurationIsPending(for kind: VmnetNetworkKind) -> Bool {
         pendingQueriedKinds.append(kind)
         // Mirrors the service: nothing pends against a network that is not
         // materialized — its next materialization installs what is declared then.
-        return isMaterialized && scriptedPendingForwardingKinds.contains(kind)
+        return materializedKinds.contains(kind) && scriptedPendingKinds.contains(kind)
     }
 
     /// Scripted answer for `kind(ofNetwork:)`.

--- a/KernovaTests/NetworkAttachmentCoordinatorTests.swift
+++ b/KernovaTests/NetworkAttachmentCoordinatorTests.swift
@@ -161,7 +161,7 @@ struct NetworkAttachmentCoordinatorTests {
             choice: NetworkChoice(mode: .hostOnly, bridgedInterfaceIdentifier: nil),
             entitled: true,
             retryDelays: [])
-        h.vmnet.isMaterialized = false
+        h.vmnet.materializedKinds = []
         h.vmnet.materializeFails = true
         h.device.refusedPlans = [.hostOnly, .sharedVmnet]
 
@@ -180,7 +180,7 @@ struct NetworkAttachmentCoordinatorTests {
         h.device.refusedPlans = []
 
         await h.coordinator.vmnetMaterializationTaskForTesting?.value
-        #expect(h.vmnet.materializedKinds.contains(.shared))
+        #expect(h.vmnet.materializeRequestedKinds.contains(.shared))
         #expect(h.device.appliedPlans.last == .sharedVmnet)
         #expect(!h.coordinator.isPending)
         h.coordinator.stop()
@@ -213,7 +213,7 @@ struct NetworkAttachmentCoordinatorTests {
         let h = makeHarness(
             choice: NetworkChoice(mode: .hostOnly, bridgedInterfaceIdentifier: nil),
             retryDelays: [])
-        h.vmnet.isMaterialized = false
+        h.vmnet.materializedKinds = []
         h.device.refusedPlans = [.hostOnly]
 
         h.coordinator.activate()

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2614,6 +2614,30 @@ struct VMLibraryViewModelTests {
         #expect(vmnet.invalidatedKinds == [.shared])
     }
 
+    @Test("A session torn down from a transitioning status still frees the network")
+    func teardownFromATransitioningStatusStillRecreates() async throws {
+        let vmnet = MockVmnetNetworkProvider()
+        let viewModel = await makeSharedNetworkLibrary(
+            named: ["Saving VM", "Edited VM"], vmnet: vmnet)
+        let saving = try #require(viewModel.instances.first { $0.name == "Saving VM" })
+        let edited = try #require(viewModel.instances.first { $0.name == "Edited VM" })
+        saving.hasLiveVirtualMachineOverrideForTesting = true
+        saving.status = .running
+        vmnet.scriptedPendingKinds = [.shared]
+
+        viewModel.updateConfiguration(of: edited) { $0.macAddress = "aa:bb:cc:dd:ee:11" }
+        #expect(vmnet.invalidatedKinds.isEmpty)
+
+        // `tearDownSession` fires its hook before the caller settles the
+        // status, so the VM that just released the network still reads as
+        // transitioning — the scan has to skip it rather than believe it.
+        saving.hasLiveVirtualMachineOverrideForTesting = false
+        saving.status = .saving
+        saving.tearDownSession()
+
+        #expect(vmnet.invalidatedKinds == [.shared])
+    }
+
     // MARK: - trySave / tryForceStop
 
     @Test("trySave throws on failure")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2421,7 +2421,7 @@ struct VMLibraryViewModelTests {
     @Test("A pending rule change recreates the shared network once no VM is on it")
     func pendingRulesRecreateTheNetworkWhenIdle() {
         let vmnet = MockVmnetNetworkProvider()
-        vmnet.scriptedPendingForwardingKinds = [.shared]
+        vmnet.scriptedPendingKinds = [.shared]
         let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
         let instance = makeInstance()
         instance.configuration.networkEnabled = true
@@ -2430,6 +2430,66 @@ struct VMLibraryViewModelTests {
         viewModel.instances = [instance]
 
         viewModel.updateConfiguration(of: instance) { $0.portForwardingRules = [Self.webRule] }
+
+        #expect(vmnet.invalidatedKinds == [.shared])
+    }
+
+    /// A stopped VM on the app-managed network of `mode`, in a library of its own.
+    private func makeNetworkedLibrary(
+        mode: VMNetworkMode, vmnet: MockVmnetNetworkProvider
+    ) -> (VMLibraryViewModel, VMInstance) {
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let instance = makeInstance()
+        instance.configuration.networkEnabled = true
+        instance.configuration.networkMode = mode
+        instance.configuration.macAddress = "aa:bb:cc:dd:ee:0f"
+        viewModel.instances = [instance]
+        return (viewModel, instance)
+    }
+
+    @Test("A changed MAC recreates the shared network once no VM is on it")
+    func macChangeRecreatesTheSharedNetworkWhenIdle() {
+        let vmnet = MockVmnetNetworkProvider()
+        vmnet.scriptedPendingKinds = [.shared]
+        let (viewModel, instance) = makeNetworkedLibrary(mode: .shared, vmnet: vmnet)
+
+        viewModel.updateConfiguration(of: instance) { $0.macAddress = "aa:bb:cc:dd:ee:10" }
+
+        #expect(vmnet.invalidatedKinds == [.shared])
+    }
+
+    @Test("A Host Only VM's changed MAC recreates the Host Only network")
+    func macChangeRecreatesTheHostOnlyNetwork() {
+        let vmnet = MockVmnetNetworkProvider()
+        vmnet.scriptedPendingKinds = [.hostOnly]
+        let (viewModel, instance) = makeNetworkedLibrary(mode: .hostOnly, vmnet: vmnet)
+
+        viewModel.updateConfiguration(of: instance) { $0.macAddress = "aa:bb:cc:dd:ee:10" }
+
+        #expect(vmnet.invalidatedKinds == [.hostOnly])
+    }
+
+    @Test("A mode switch recreates both app-managed networks, each once")
+    func modeSwitchRecreatesBothNetworks() {
+        let vmnet = MockVmnetNetworkProvider()
+        vmnet.scriptedPendingKinds = [.shared, .hostOnly]
+        let (viewModel, instance) = makeNetworkedLibrary(mode: .shared, vmnet: vmnet)
+
+        // The slot moves off one network and onto the other, so both carry a
+        // reservation set the recreate has to install.
+        viewModel.updateConfiguration(of: instance) { $0.networkMode = .hostOnly }
+
+        #expect(Set(vmnet.invalidatedKinds) == [.shared, .hostOnly])
+        #expect(vmnet.invalidatedKinds.count == 2)
+    }
+
+    @Test("Deleting a VM recreates the network its slot was on")
+    func deleteRecreatesTheNetwork() async {
+        let vmnet = MockVmnetNetworkProvider()
+        vmnet.scriptedPendingKinds = [.shared]
+        let (viewModel, instance) = makeNetworkedLibrary(mode: .shared, vmnet: vmnet)
+
+        for task in viewModel.deleteConfirmed(instance) { await task.value }
 
         #expect(vmnet.invalidatedKinds == [.shared])
     }
@@ -2463,7 +2523,7 @@ struct VMLibraryViewModelTests {
         let edited = try #require(viewModel.instances.first { $0.name == "Edited VM" })
         running.hasLiveVirtualMachineOverrideForTesting = true
         running.status = .running
-        vmnet.scriptedPendingForwardingKinds = [.shared]
+        vmnet.scriptedPendingKinds = [.shared]
 
         viewModel.updateConfiguration(of: edited) { $0.portForwardingRules = [Self.webRule] }
         #expect(vmnet.invalidatedKinds.isEmpty)
@@ -2486,7 +2546,7 @@ struct VMLibraryViewModelTests {
         let edited = try #require(viewModel.instances.first { $0.name == "Edited VM" })
         suspending.hasLiveVirtualMachineOverrideForTesting = true
         suspending.status = .running
-        vmnet.scriptedPendingForwardingKinds = [.shared]
+        vmnet.scriptedPendingKinds = [.shared]
 
         viewModel.updateConfiguration(of: edited) { $0.portForwardingRules = [Self.webRule] }
         #expect(vmnet.invalidatedKinds.isEmpty)
@@ -2507,7 +2567,7 @@ struct VMLibraryViewModelTests {
         let running = try #require(viewModel.instances.first)
         running.hasLiveVirtualMachineOverrideForTesting = true
         running.status = .running
-        vmnet.scriptedPendingForwardingKinds = [.shared]
+        vmnet.scriptedPendingKinds = [.shared]
 
         // The rule sync runs while the VM is still on the shared network; only
         // the mode write that follows frees it.
@@ -2517,6 +2577,39 @@ struct VMLibraryViewModelTests {
         #expect(vmnet.invalidatedKinds.isEmpty)
 
         viewModel.updateConfiguration(of: running) { $0.networkMode = .hostOnly }
+
+        #expect(vmnet.invalidatedKinds == [.shared])
+    }
+
+    @Test("A VM arriving from the library load recreates its materialized network once")
+    func loadedVMRecreatesTheMaterializedNetwork() async {
+        let vmnet = MockVmnetNetworkProvider()
+        vmnet.scriptedPendingKinds = [.shared]
+
+        _ = await makeSharedNetworkLibrary(named: ["First VM", "Second VM"], vmnet: vmnet)
+
+        // Each VM's slot is taken as it loads, but the first recreate leaves the
+        // network unmaterialized — nothing pends against one that does not exist.
+        #expect(vmnet.invalidatedKinds == [.shared])
+    }
+
+    @Test("A live VM holds a reservation recreate off until its session is torn down")
+    func liveVMDefersTheReservationRecreate() async throws {
+        let vmnet = MockVmnetNetworkProvider()
+        let viewModel = await makeSharedNetworkLibrary(
+            named: ["Running VM", "Edited VM"], vmnet: vmnet)
+        let running = try #require(viewModel.instances.first { $0.name == "Running VM" })
+        let edited = try #require(viewModel.instances.first { $0.name == "Edited VM" })
+        running.hasLiveVirtualMachineOverrideForTesting = true
+        running.status = .running
+        vmnet.scriptedPendingKinds = [.shared]
+
+        viewModel.updateConfiguration(of: edited) { $0.macAddress = "aa:bb:cc:dd:ee:11" }
+        #expect(vmnet.invalidatedKinds.isEmpty)
+
+        running.hasLiveVirtualMachineOverrideForTesting = false
+        running.tearDownSession()
+        running.status = .stopped
 
         #expect(vmnet.invalidatedKinds == [.shared])
     }

--- a/KernovaTests/VmnetNetworkServiceTests.swift
+++ b/KernovaTests/VmnetNetworkServiceTests.swift
@@ -510,6 +510,92 @@ struct VmnetNetworkServiceTests {
         #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:02", kind: .shared) == "192.168.213.3")
     }
 
+    @Test("A slot taken while its network is materialized pends until the recreate installs it")
+    func newSlotOnAMaterializedNetworkPends() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, _) = try makeSeededSharedService(macs: ["aa:bb:cc:dd:ee:01"], at: location)
+
+        // Nothing is materialized, so the next materialization installs the
+        // slots as they stand — there is nothing to recreate.
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+        #expect(!service.networkConfigurationIsPending(for: .shared))
+
+        _ = try service.network(for: .shared)
+        #expect(!service.networkConfigurationIsPending(for: .shared))
+
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:03", kind: .shared)
+        #expect(service.networkConfigurationIsPending(for: .shared))
+
+        service.invalidateNetwork(for: .shared)
+        _ = try service.network(for: .shared)
+        #expect(!service.networkConfigurationIsPending(for: .shared))
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:03", kind: .shared) == "192.168.77.4")
+    }
+
+    @Test("A released slot leaves the materialized network pending")
+    func releasedSlotLeavesTheNetworkPending() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, _) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"], at: location)
+        _ = try service.network(for: .shared)
+
+        service.releaseAddressReservation(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+
+        // The live network keeps honoring the freed reservation, so what pends
+        // is the whole set differing — not only an addition to it.
+        #expect(service.networkConfigurationIsPending(for: .shared))
+        service.invalidateNetwork(for: .shared)
+        _ = try service.network(for: .shared)
+        #expect(!service.networkConfigurationIsPending(for: .shared))
+    }
+
+    @Test("A refilled slot pends, and rematerializing moves no other VM's address")
+    func refilledSlotPendsAndKeepsEveryOtherAddress() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, _) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "aa:bb:cc:dd:ee:03"], at: location)
+        _ = try service.network(for: .shared)
+
+        service.releaseAddressReservation(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:04", kind: .shared)
+        #expect(service.networkConfigurationIsPending(for: .shared))
+
+        service.invalidateNetwork(for: .shared)
+        _ = try service.network(for: .shared)
+
+        // The freed slot keeps its index, so the newcomer takes the departed
+        // VM's address and the survivors keep theirs.
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:04", kind: .shared) == "192.168.77.2")
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:02", kind: .shared) == "192.168.77.3")
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:03", kind: .shared) == "192.168.77.4")
+        #expect(!service.networkConfigurationIsPending(for: .shared))
+    }
+
+    @Test("A slot past the subnet's capacity never reads as pending")
+    func slotPastSubnetCapacityNeverPends() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        // A /30 leaves exactly one usable host past the gateway: host 2.
+        let tiny = VmnetNetworkAddressing(
+            ipv4Subnet: "192.168.77.0", ipv4Mask: "255.255.255.252",
+            ipv6Prefix: "fd00:aaaa:bbbb:cccc::", ipv6PrefixLength: 64)
+        try seed(
+            [.shared: VmnetNetworkRecord(addressing: tiny, reservedMACs: ["aa:bb:cc:dd:ee:01"])],
+            at: location.storeURL)
+        let service = VmnetNetworkService(
+            operations: MockVmnetNetworkOperator(), storeURL: location.storeURL)
+        _ = try service.network(for: .shared)
+
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+
+        // The slot can never install, so reading it as pending would drive an
+        // endless recreate.
+        #expect(!service.networkConfigurationIsPending(for: .shared))
+    }
+
     @Test("System-adjusted pinned addressing leaves every reservation pending until rematerialization")
     func adjustedPinnedAddressingLeavesReservationsPending() throws {
         let location = makeStoreLocation()
@@ -530,7 +616,7 @@ struct VmnetNetworkServiceTests {
         // none of them holds on the adjusted network — nor do the rules
         // forwarding to them, which is what leaves them pending.
         #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:01", kind: .shared) == nil)
-        #expect(service.portForwardingRulesArePending(for: .shared))
+        #expect(service.networkConfigurationIsPending(for: .shared))
     }
 
     // MARK: - Port forwarding rules
@@ -596,7 +682,7 @@ struct VmnetNetworkServiceTests {
         #expect(operations.installedForwardingRules.first?.isEmpty == true)
         // An uninstallable rule must not read as pending, or it would drive an
         // endless recreate.
-        #expect(!service.portForwardingRulesArePending(for: .shared))
+        #expect(!service.networkConfigurationIsPending(for: .shared))
     }
 
     @Test("A host port claimed twice across VMs installs once, in slot order")
@@ -626,7 +712,7 @@ struct VmnetNetworkServiceTests {
         _ = try service.network(for: .shared)
 
         service.setPortForwardingRules([], for: "aa:bb:cc:dd:ee:01", kind: .shared)
-        #expect(service.portForwardingRulesArePending(for: .shared))
+        #expect(service.networkConfigurationIsPending(for: .shared))
         service.invalidateNetwork(for: .shared)
         _ = try service.network(for: .shared)
 
@@ -644,7 +730,7 @@ struct VmnetNetworkServiceTests {
         _ = try service.network(for: .shared)
 
         #expect(operations.installedForwardingRules.first?.isEmpty == true)
-        #expect(!service.portForwardingRulesArePending(for: .shared))
+        #expect(!service.networkConfigurationIsPending(for: .shared))
     }
 
     @Test("A rule declared while the network is being created lands in the published network")
@@ -667,7 +753,7 @@ struct VmnetNetworkServiceTests {
         #expect(operations.installedForwardingRules.last?.map(\.rule) == [Self.webRule, Self.sshRule])
         #expect(operations.releasedNetworks.count == 1)
         #expect(operations.releasedNetworks.first != handle.network)
-        #expect(!service.portForwardingRulesArePending(for: .shared))
+        #expect(!service.networkConfigurationIsPending(for: .shared))
     }
 
     @Test("Rules that keep changing publish a network anyway, still reading as pending")
@@ -691,7 +777,7 @@ struct VmnetNetworkServiceTests {
         // rest at the next recreate.
         #expect(operations.createdKinds.count == 3)
         #expect(operations.releasedNetworks.count == 2)
-        #expect(service.portForwardingRulesArePending(for: .shared))
+        #expect(service.networkConfigurationIsPending(for: .shared))
     }
 
     @Test("Rules pend only after the network they would change is materialized")
@@ -703,18 +789,18 @@ struct VmnetNetworkServiceTests {
 
         // Nothing is materialized, so the next materialization installs the
         // rules as they stand — there is nothing to recreate.
-        #expect(!service.portForwardingRulesArePending(for: .shared))
+        #expect(!service.networkConfigurationIsPending(for: .shared))
 
         _ = try service.network(for: .shared)
-        #expect(!service.portForwardingRulesArePending(for: .shared))
+        #expect(!service.networkConfigurationIsPending(for: .shared))
 
         service.setPortForwardingRules(
             [Self.webRule, Self.sshRule], for: "aa:bb:cc:dd:ee:01", kind: .shared)
-        #expect(service.portForwardingRulesArePending(for: .shared))
+        #expect(service.networkConfigurationIsPending(for: .shared))
 
         service.invalidateNetwork(for: .shared)
         _ = try service.network(for: .shared)
-        #expect(!service.portForwardingRulesArePending(for: .shared))
+        #expect(!service.networkConfigurationIsPending(for: .shared))
     }
 
     @Test("An unparseable MAC is refused a reservation slot")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,8 +136,9 @@ off-main assembly and the main-actor live-switch path) owns the app's managed vm
 the per-VM DHCP reservations and port-forwarding rules riding them: each VM holds a slot keyed on
 its persisted MAC, the slot's derived address is what the settings pane's IP Address row shows and
 what a Shared Network VM's rules forward to, and both are kept in step with configurations through
-`VMLibraryViewModel`'s persistence funnel — which also recreates the shared network, once no VM is
-attached to it, when the rules it carries no longer match the ones configured. The service
+`VMLibraryViewModel`'s persistence funnel — which also recreates an app-managed network, once no VM
+is attached to it, when the reservations or rules it carries no longer match the ones configured.
+The service
 materializes each network lazily over the `VmnetNetworkOperating` seam and holds the ref until
 the app exits, so every concurrent VM in the mode shares the one network; addressing and slots
 stay stable across launches by persisting each network's record to


### PR DESCRIPTION
## Summary

A MAC added, changed, or freed while its app-managed network was already materialized never reached guests. Reservations are fixed at network creation, so a slot assigned afterwards is pending until the next materialization — but nothing marked a *reservation* change as needing a recreate: the idle rebuild consulted only `portForwardingRulesArePending(for:)`, and it was hardcoded to Shared.

Viewing any Shared or Host Only VM's Network section materializes that network to fill the IP Address row, so the state is easy to reach: after that, editing a MAC (or creating, cloning, or importing a VM) left the row showing `—` for the rest of the app session and handed the guest a dynamic lease instead of its deterministic reservation. Host Only had no idle-recreate path at all.

## Approach

One predicate covers both declaration sets. `portForwardingRulesArePending(for:)` becomes `networkConfigurationIsPending(for:)`, which compares the materialized network's whole reservation set against what would install right now, then its forwarding rules. The sole consumer is the idle recreate, which does not care *which* set differs — a second sibling predicate would make the call site assemble the same disjunction.

Two properties the comparison has to hold:

- **Both sides are the *installable* sets.** A slot past the subnet's capacity, a slot holding a MAC that no longer parses, and a rule whose VM holds no reservation can never install; measuring against them would leave the flag stuck true and drive an endless recreate. A new `installableReservationsLocked(for:)` is the shared slot resolution that the rules derivation now reads too.
- **The whole set, not just its additions.** Since #836 a release is a second reason the materialized network differs from the record, so a departed VM's freed slot also pends — the live network keeps honoring that reservation until the recreate.

On the view model side, `rebuildSharedNetworkIfIdle()` becomes `rebuildNetworksIfIdle()` over every `VmnetNetworkKind`. The rebuild also moves off `declarePortForwardingRules` (now a pure declaration, with no hidden side effect) and onto the batch boundaries — `wirePersistence`, `updateConfiguration`, `evict`, `pruneAddressReservations`, and session teardown — so one pass of the funnel produces at most one recreate per kind. `evict` gained one on both of its paths; it previously returned before any rebuild when the bundle was still on disk.

A recreate only fires when no VM could be attached, and it keeps the network's pinned addressing, so no guest's address moves.

## Test plan

- [x] `make test` — 2809 tests, 0 failures (new test names verified present in the xcresult, not just the `TEST SUCCEEDED` banner)
- [x] `make lint`
- [x] Service tests: a slot taken, released, or refilled while materialized pends and stops after the recreate; a refilled slot takes the departed VM's address while every survivor keeps its own; a beyond-capacity slot never pends; nothing pends before the first materialization
- [x] View model tests: a changed MAC recreates Shared and Host Only, a mode switch recreates both exactly once, delete and library load recreate, and a live VM defers the recreate until its session is torn down

## Notes

Adds no `RATIONALE:` comments.

`MockVmnetNetworkProvider` swapped its single `isMaterialized` flag for per-kind `materializedKinds` state — one rebuild pass now queries every kind, and a shared flag would let the first invalidation mask the rest.

### Deviations from the issue

- The issue proposed exposing reservation-pending state *alongside* the forwarding-rules predicate; this replaces it with one predicate, per the reasoning above.
- The issue's closing paragraph ("`reservedMACs` is append-only and persisted, so a retired MAC keeps its slot forever… decide separately whether a retired MAC's slot can be reused") is stale — #836 already made the list sparse with in-place refill, so no slot-reuse decision remained open.

### Scope

- **#835** (duplicate-MAC collision) is unaffected: the comparison is MAC-keyed and both sides dedupe identically, so a duplicate MAC compares equal rather than pending. Whatever resolves the collision will trigger a recreate through this machinery.
- **#837** (relocating a beyond-capacity MAC into a freed hole) is deliberately *not* absorbed — beyond-capacity slots are excluded from the comparison precisely so they cannot drive a recreate loop, and nothing here moves a slot.

Closes #834