### PR TITLE
fix: Refuse a MAC address another VM already holds

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -1525,8 +1525,8 @@ final class VMLibraryViewModel {
     }
 
     /// Frees `target`'s reservation slot unless a VM still in the library wants
-    /// the same one — duplicate MACs are possible, so the last claimant is what
-    /// releases the slot.
+    /// the same one — a bundle can arrive carrying an address another VM already
+    /// holds, so the last claimant is what releases the slot.
     private func releaseAddressReservationIfUnused(_ target: (kind: VmnetNetworkKind, mac: String)) {
         guard isVMNetworkingEntitled else { return }
         let stillWanted = instances.contains {
@@ -1554,6 +1554,53 @@ final class VMLibraryViewModel {
     ) {
         guard isVMNetworkingEntitled, let mac = config.macAddress else { return }
         vmnetNetworks.setPortForwardingRules(rules, for: mac, kind: .shared)
+    }
+
+    /// Withdraws the rules `config` declared, unless a VM still in the library
+    /// carries the same MAC — rules are keyed on the address, so a blanket
+    /// withdrawal would disarm that VM's rules too; its own are re-declared
+    /// instead. An address is one VM's alone once it passes
+    /// ``refuseIfDuplicateMACAddress(_:on:)``, so the survivor is a bundle that
+    /// arrived carrying one already in use.
+    private func withdrawPortForwardingRules(for config: VMConfiguration) {
+        guard let mac = config.macAddress?.lowercased() else { return }
+        let survivor = instances.first { $0.configuration.macAddress?.lowercased() == mac }
+        if let survivor {
+            syncPortForwardingRules(for: survivor.configuration)
+        } else {
+            declarePortForwardingRules([], for: config)
+        }
+    }
+
+    /// The VM other than `instance` whose configuration carries `mac`, `nil`
+    /// when no other VM holds it.
+    ///
+    /// Case-insensitive, matching the reservation slots and forwarding rules the
+    /// address keys. A VM with networking off counts: the address persists
+    /// across mode changes, so turning networking back on would re-form the
+    /// collision.
+    private func vmHoldingMACAddress(_ mac: String, otherThan instance: VMInstance) -> VMInstance? {
+        let wanted = mac.lowercased()
+        return instances.first {
+            $0 !== instance && $0.configuration.macAddress?.lowercased() == wanted
+        }
+    }
+
+    /// Refuses a change that would give `instance` a MAC address another VM in
+    /// the library holds, logging the refusal and surfacing the alert.
+    ///
+    /// - Returns: `true` when the caller must abort.
+    private func refuseIfDuplicateMACAddress(_ mac: String, on instance: VMInstance) -> Bool {
+        guard let holder = vmHoldingMACAddress(mac, otherThan: instance) else { return false }
+        Self.logger.notice(
+            "Refused the MAC address \(mac, privacy: .public) for '\(instance.name, privacy: .public)': '\(holder.name, privacy: .public)' already holds it"
+        )
+        surfaceError(
+            "“\(holder.name)” already uses \(mac). "
+                + "Each virtual machine needs its own MAC address. "
+                + "Change or delete “\(holder.name)” first to move this address to “\(instance.name)”.",
+            title: "MAC Address In Use")
+        return true
     }
 
     /// Recreates every app-managed network whose DHCP reservations or
@@ -1591,9 +1638,15 @@ final class VMLibraryViewModel {
     /// Applies the mutation, persists the result, and dispatches the live policy /
     /// removable-media reconcile. No-ops when the mutation produces the same value.
     ///
+    /// A mutation moving the VM onto a MAC address another VM holds is refused
+    /// whole — no field it also sets is applied — so this is the one place every
+    /// writer of an address passes through.
+    ///
     /// - Returns: Whether the new configuration reached disk. A no-op mutation
     ///   returns `true`; a failed write leaves the new value in memory, so a
-    ///   caller that needs memory and disk to agree rolls back on `false`.
+    ///   caller that needs memory and disk to agree rolls back on `false`. A
+    ///   refused mutation also returns `false`, having left the configuration
+    ///   untouched.
     @discardableResult
     func updateConfiguration(
         of instance: VMInstance,
@@ -1603,13 +1656,18 @@ final class VMLibraryViewModel {
         var new = old
         mutate(&new)
         guard new != old else { return true }
+        if let mac = new.macAddress, mac.lowercased() != old.macAddress?.lowercased(),
+            refuseIfDuplicateMACAddress(mac, on: instance)
+        {
+            return false
+        }
         instance.configuration = new
         // An edited MAC leaves its predecessor holding an older — so
         // higher-priority — reservation slot. Left declared there, the retired
         // address keeps claiming the VM's host ports and the rules re-declared
         // under the new one are dropped as duplicates.
         if let retired = old.macAddress, retired != new.macAddress {
-            declarePortForwardingRules([], for: old)
+            withdrawPortForwardingRules(for: old)
         }
         // Released before the new slot is taken, so the freed slot is the
         // lowest one available and an edited MAC normally keeps the VM's
@@ -2615,7 +2673,7 @@ final class VMLibraryViewModel {
         ClipboardIssueCenter.shared.clear(instanceID: instance.instanceID)
         // A VM out of the library stops claiming its host ports and its
         // address, so the next VM created can be handed both.
-        declarePortForwardingRules([], for: instance.configuration)
+        withdrawPortForwardingRules(for: instance.configuration)
         if bundleIsGone, let target = reservationTarget(for: instance.configuration) {
             releaseAddressReservationIfUnused(target)
         }

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -2453,10 +2453,10 @@ extension VMSettingsViewController: NSMenuItemValidation {
     @objc private func generateMACAddressTapped() {
         // Clicking a push button takes no first responder, so an edit open in
         // the field would outlive the write and commit over it on the way out.
-        // Settle it first; the generated address then replaces whatever it left.
-        if macAddressField.currentEditor() != nil {
-            view.window?.makeFirstResponder(nil)
-        }
+        // Discard it rather than settling it: the generated address supersedes
+        // whatever was typed, so committing first would only refuse a typed
+        // duplicate with an alert about an address no longer in play.
+        macAddressField.abortEditing()
         writeConfig { $0.macAddress = VZMACAddress.randomLocallyAdministered().string }
         refreshMACAddressRow()
     }

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -3221,20 +3221,19 @@ extension VMSettingsViewController: NSTextFieldDelegate {
         writeConfig { $0.memorySizeInGB = clamped }
     }
 
-    /// Persists the typed MAC in canonical form. Text naming no address a guest
-    /// can use writes nothing; the field snapping back to the persisted address
-    /// is the rejection, and the field's tooltip names the accepted spelling.
+    /// Persists the typed MAC in canonical form, then shows the address the VM
+    /// ended up with — so text naming no address a guest can use, and an address
+    /// the library refused because another VM holds it, both snap the field back.
+    /// The tooltip names the accepted spelling; the refusal carries its own alert.
     ///
     /// The field is written directly rather than through
     /// `refreshMACAddressRow()`: editing is still ending here, so the editor the
     /// refresh defers to is the very one being reconciled away.
     private func applyMACAddressFieldEdit() {
-        guard let normalized = Self.normalizedMACAddress(macAddressField.stringValue) else {
-            macAddressField.stringValue = instance.configuration.macAddress ?? ""
-            return
+        if let normalized = Self.normalizedMACAddress(macAddressField.stringValue) {
+            writeConfig { $0.macAddress = normalized }
         }
-        writeConfig { $0.macAddress = normalized }
-        macAddressField.stringValue = normalized
+        macAddressField.stringValue = instance.configuration.macAddress ?? ""
     }
 }
 

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -2161,12 +2161,14 @@ struct VMLibraryViewModelTests {
     /// network — the state a load leaves behind, without going through a scan.
     private func makeReservedInstance(
         in viewModel: VMLibraryViewModel, using vmnet: MockVmnetNetworkProvider,
-        mac: String, mode: VMNetworkMode = .shared
+        mac: String, mode: VMNetworkMode = .shared, name: String = "Test VM",
+        rules: [PortForwardingRule] = []
     ) -> VMInstance {
-        let instance = makeInstance()
+        let instance = makeInstance(name: name)
         instance.configuration.networkEnabled = true
         instance.configuration.networkMode = mode
         instance.configuration.macAddress = mac
+        instance.configuration.portForwardingRules = rules
         viewModel.instances.append(instance)
         if let kind = VmnetNetworkKind(mode: mode) {
             vmnet.reserveAddressIfNeeded(for: mac, kind: kind)
@@ -2340,9 +2342,141 @@ struct VMLibraryViewModelTests {
         #expect(vmnet.retainedMACs.isEmpty)
     }
 
+    // MARK: - MAC Address Uniqueness
+
+    /// A library holding one VM on `held` and one on `editing`, both on the
+    /// shared network — the starting point for every uniqueness assertion.
+    private func makeLibrarySharingNoAddress(
+        using vmnet: MockVmnetNetworkProvider, held: String, editing: String,
+        storage: MockVMStorageService = MockVMStorageService()
+    ) -> (VMLibraryViewModel, VMInstance, VMInstance) {
+        let (viewModel, _, _, _, _) = makeViewModel(
+            storageService: storage, vmnetNetworks: vmnet)
+        let holder = makeReservedInstance(in: viewModel, using: vmnet, mac: held, name: "Holder")
+        let editor = makeReservedInstance(
+            in: viewModel, using: vmnet, mac: editing, name: "Editing VM")
+        return (viewModel, holder, editor)
+    }
+
+    @Test("A MAC address another VM holds is refused, changing nothing")
+    func duplicateMACAddressIsRefused() {
+        let vmnet = MockVmnetNetworkProvider()
+        let storage = MockVMStorageService()
+        let (viewModel, _, editor) = makeLibrarySharingNoAddress(
+            using: vmnet, held: "aa:bb:cc:dd:ee:0f", editing: "aa:bb:cc:dd:ee:10",
+            storage: storage)
+
+        let accepted = viewModel.updateConfiguration(of: editor) {
+            $0.macAddress = "aa:bb:cc:dd:ee:0f"
+        }
+
+        #expect(accepted == false)
+        #expect(editor.configuration.macAddress == "aa:bb:cc:dd:ee:10")
+        #expect(storage.saveConfigurationCallCount == 0)
+        #expect(vmnet.releasedMACs.isEmpty)
+        #expect(vmnet.declaredForwardingRules.isEmpty)
+        #expect(presenter.errorTitle == "MAC Address In Use")
+        #expect(presenter.errorMessage?.contains("Holder") == true)
+        #expect(presenter.errorMessage?.contains("aa:bb:cc:dd:ee:0f") == true)
+    }
+
+    @Test("The refusal matches the held address regardless of case")
+    func duplicateMACAddressRefusalIgnoresCase() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, editor) = makeLibrarySharingNoAddress(
+            using: vmnet, held: "AA:BB:CC:DD:EE:0F", editing: "aa:bb:cc:dd:ee:10")
+
+        let accepted = viewModel.updateConfiguration(of: editor) {
+            $0.macAddress = "aa:bb:cc:dd:ee:0f"
+        }
+
+        #expect(accepted == false)
+        #expect(editor.configuration.macAddress == "aa:bb:cc:dd:ee:10")
+    }
+
+    @Test("A VM with networking off still holds its address")
+    func aVMWithNetworkingOffStillHoldsItsAddress() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, holder, editor) = makeLibrarySharingNoAddress(
+            using: vmnet, held: "aa:bb:cc:dd:ee:0f", editing: "aa:bb:cc:dd:ee:10")
+        holder.configuration.networkEnabled = false
+
+        let accepted = viewModel.updateConfiguration(of: editor) {
+            $0.macAddress = "aa:bb:cc:dd:ee:0f"
+        }
+
+        #expect(accepted == false)
+        #expect(editor.configuration.macAddress == "aa:bb:cc:dd:ee:10")
+    }
+
+    @Test("A refused mutation drops the fields it also set")
+    func aRefusedMutationDropsItsOtherFields() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, editor) = makeLibrarySharingNoAddress(
+            using: vmnet, held: "aa:bb:cc:dd:ee:0f", editing: "aa:bb:cc:dd:ee:10")
+
+        let accepted = viewModel.updateConfiguration(of: editor) {
+            $0.name = "Renamed"
+            $0.macAddress = "aa:bb:cc:dd:ee:0f"
+        }
+
+        #expect(accepted == false)
+        #expect(editor.configuration.name == "Editing VM")
+        #expect(editor.configuration.macAddress == "aa:bb:cc:dd:ee:10")
+    }
+
+    @Test("A VM keeping an address that arrived shared still accepts other edits")
+    func aVMSharingAnAddressFromDiskStillAcceptsEdits() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, editor) = makeLibrarySharingNoAddress(
+            using: vmnet, held: "aa:bb:cc:dd:ee:0f", editing: "aa:bb:cc:dd:ee:0f")
+
+        // Only a change of address is refused, so a pair that arrived from disk
+        // sharing one stays editable in every other respect.
+        let accepted = viewModel.updateConfiguration(of: editor) { $0.name = "Renamed" }
+
+        #expect(accepted)
+        #expect(editor.configuration.name == "Renamed")
+        #expect(!presenter.showError)
+    }
+
+    @Test("Moving the holder off an address frees it for another VM")
+    func editingTheHolderFreesItsAddress() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, holder, editor) = makeLibrarySharingNoAddress(
+            using: vmnet, held: "aa:bb:cc:dd:ee:0f", editing: "aa:bb:cc:dd:ee:10")
+
+        viewModel.updateConfiguration(of: holder) { $0.macAddress = "aa:bb:cc:dd:ee:11" }
+        let accepted = viewModel.updateConfiguration(of: editor) {
+            $0.macAddress = "aa:bb:cc:dd:ee:0f"
+        }
+
+        #expect(accepted)
+        #expect(editor.configuration.macAddress == "aa:bb:cc:dd:ee:0f")
+        #expect(!presenter.showError)
+    }
+
+    @Test("Deleting the holder frees its address for another VM")
+    func deletingTheHolderFreesItsAddress() async {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, holder, editor) = makeLibrarySharingNoAddress(
+            using: vmnet, held: "aa:bb:cc:dd:ee:0f", editing: "aa:bb:cc:dd:ee:10")
+
+        for task in viewModel.deleteConfirmed(holder) { await task.value }
+        let accepted = viewModel.updateConfiguration(of: editor) {
+            $0.macAddress = "aa:bb:cc:dd:ee:0f"
+        }
+
+        #expect(accepted)
+        #expect(editor.configuration.macAddress == "aa:bb:cc:dd:ee:0f")
+        #expect(vmnet.reservedMACs.map(\.mac) == ["aa:bb:cc:dd:ee:0f"])
+        #expect(!presenter.showError)
+    }
+
     // MARK: - Port Forwarding Sync
 
     private static let webRule = PortForwardingRule(transport: .tcp, hostPort: 8080, guestPort: 80)
+    private static let sshRule = PortForwardingRule(transport: .tcp, hostPort: 2222, guestPort: 22)
 
     @Test("A configuration change declares a shared VM's forwarding rules")
     func updateConfigurationDeclaresForwardingRules() {
@@ -2636,6 +2770,45 @@ struct VMLibraryViewModelTests {
         saving.tearDownSession()
 
         #expect(vmnet.invalidatedKinds == [.shared])
+    }
+
+    @Test("Deleting a VM leaves the rules of one sharing its address declared")
+    func deleteKeepsADuplicateMACsForwardingRules() async {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let deleted = makeReservedInstance(
+            in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f", name: "Deleted",
+            rules: [Self.webRule])
+        _ = makeReservedInstance(
+            in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f", name: "Survivor",
+            rules: [Self.sshRule])
+
+        for task in viewModel.deleteConfirmed(deleted) { await task.value }
+
+        // Rules are keyed on the address, so withdrawing the deleted VM's would
+        // disarm the survivor's through the same key.
+        #expect(vmnet.declaredForwardingRules.last?.mac == "aa:bb:cc:dd:ee:0f")
+        #expect(vmnet.declaredForwardingRules.last?.rules == [Self.sshRule])
+    }
+
+    @Test("Editing a MAC leaves the rules of a VM sharing the retired address declared")
+    func macAddressChangeKeepsADuplicateMACsForwardingRules() {
+        let vmnet = MockVmnetNetworkProvider()
+        let (viewModel, _, _, _, _) = makeViewModel(vmnetNetworks: vmnet)
+        let edited = makeReservedInstance(
+            in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f", name: "Edited",
+            rules: [Self.webRule])
+        _ = makeReservedInstance(
+            in: viewModel, using: vmnet, mac: "aa:bb:cc:dd:ee:0f", name: "Survivor",
+            rules: [Self.sshRule])
+
+        viewModel.updateConfiguration(of: edited) { $0.macAddress = "aa:bb:cc:dd:ee:10" }
+
+        #expect(
+            vmnet.declaredForwardingRules.suffix(2).map(\.mac)
+                == ["aa:bb:cc:dd:ee:0f", "aa:bb:cc:dd:ee:10"])
+        #expect(vmnet.declaredForwardingRules.dropLast().last?.rules == [Self.sshRule])
+        #expect(vmnet.declaredForwardingRules.last?.rules == [Self.webRule])
     }
 
     // MARK: - trySave / tryForceStop

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -1208,12 +1208,23 @@ struct VMSettingsViewControllerTests {
         }
     }
 
-    @Test("A MAC address another VM holds is refused and the field reverts")
-    func macAddressHeldByAnotherVMIsRefused() throws {
+    /// A library already holding `mac`, wired to a presenter so the refusal's
+    /// alert is observable rather than buffered.
+    private func makeLibraryHolding(
+        _ mac: String, presenter: MockVMLibraryPresenting
+    ) -> VMLibraryViewModel {
         let viewModel = makeViewModel()
         let holder = makeInstance(guestOS: .linux)
-        holder.configuration.macAddress = "aa:bb:cc:dd:ee:0f"
+        holder.configuration.macAddress = mac
         viewModel.instances = [holder]
+        viewModel.presenter = presenter
+        return viewModel
+    }
+
+    @Test("A MAC address another VM holds is refused and the field reverts")
+    func macAddressHeldByAnotherVMIsRefused() throws {
+        let presenter = MockVMLibraryPresenting()
+        let viewModel = makeLibraryHolding("aa:bb:cc:dd:ee:0f", presenter: presenter)
         let (vc, instance) = makeNetworkController(viewModel: viewModel)
         let field = try #require(editableField("MAC Address", in: vc.view))
 
@@ -1222,6 +1233,29 @@ struct VMSettingsViewControllerTests {
 
         #expect(instance.configuration.macAddress == "aa:bb:cc:dd:ee:ff")
         #expect(field.stringValue == "aa:bb:cc:dd:ee:ff")
+        #expect(presenter.errorTitle == "MAC Address In Use")
+    }
+
+    @Test("Generate discards a typed duplicate instead of refusing it")
+    func generateDiscardsATypedDuplicate() throws {
+        let presenter = MockVMLibraryPresenting()
+        let viewModel = makeLibraryHolding("aa:bb:cc:dd:ee:0f", presenter: presenter)
+        let (vc, instance) = makeNetworkController(viewModel: viewModel)
+        let window = makeTestWindow(styleMask: [.titled])
+        window.contentView = vc.view
+        let field = try #require(editableField("MAC Address", in: vc.view))
+        #expect(window.makeFirstResponder(field))
+        try #require(field.currentEditor()).string = "aa:bb:cc:dd:ee:0f"
+        let generate = try #require(findButton(titled: "Generate", in: vc.view))
+
+        generate.sendAction(generate.action, to: generate.target)
+
+        // The generated address supersedes the typed one, so the duplicate is
+        // never committed and its refusal never reaches the user.
+        let mac = try #require(instance.configuration.macAddress)
+        #expect(mac != "aa:bb:cc:dd:ee:0f")
+        #expect(field.stringValue == mac)
+        #expect(!presenter.showError)
     }
 
     @Test("Text a real edit session rejects reverts in the field")

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -1208,6 +1208,22 @@ struct VMSettingsViewControllerTests {
         }
     }
 
+    @Test("A MAC address another VM holds is refused and the field reverts")
+    func macAddressHeldByAnotherVMIsRefused() throws {
+        let viewModel = makeViewModel()
+        let holder = makeInstance(guestOS: .linux)
+        holder.configuration.macAddress = "aa:bb:cc:dd:ee:0f"
+        viewModel.instances = [holder]
+        let (vc, instance) = makeNetworkController(viewModel: viewModel)
+        let field = try #require(editableField("MAC Address", in: vc.view))
+
+        field.stringValue = "AA:BB:CC:DD:EE:0F"
+        commitEdit(field, on: vc)
+
+        #expect(instance.configuration.macAddress == "aa:bb:cc:dd:ee:ff")
+        #expect(field.stringValue == "aa:bb:cc:dd:ee:ff")
+    }
+
     @Test("Text a real edit session rejects reverts in the field")
     func rejectedEditRevertsThroughTheFieldEditor() throws {
         let (vc, instance) = makeNetworkController()

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -88,7 +88,7 @@ never a visible-but-broken control.
 second holder** — the DHCP reservation slot and the forwarding rules are both keyed
 on the address, so two holders share one slot and one rule set. Enforcement sits at
 the single configuration funnel, not at each surface that can write an address, and
-the user moves an address by clearing or deleting the VM holding it first. An
+the user moves an address by changing or deleting the VM holding it first. An
 address a bundle arrives with is never silently rewritten: the guest can pin it, and
 under Bridged the LAN's DHCP server may hold a reservation for it.
 

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -82,7 +82,17 @@ omits Bridged and Host Only rather than presenting entries that would fail; the 
 the build can deliver keep working unchanged. Absence is the honest degraded state —
 never a visible-but-broken control.
 
-### 9. Guest-to-guest reach is network membership
+### 9. A MAC address belongs to one virtual machine
+
+**An address identifies exactly one VM in the library, and the library refuses a
+second holder** — the DHCP reservation slot and the forwarding rules are both keyed
+on the address, so two holders share one slot and one rule set. Enforcement sits at
+the single configuration funnel, not at each surface that can write an address, and
+the user moves an address by clearing or deleting the VM holding it first. An
+address a bundle arrives with is never silently rewritten: the guest can pin it, and
+under Bridged the LAN's DHCP server may hold a reservation for it.
+
+### 10. Guest-to-guest reach is network membership
 
 **A guest reaches another guest exactly when the user placed both on the same
 app-managed network.** Host Only is one such network: every guest the user puts in that


### PR DESCRIPTION
Closes #835

## Summary

Nothing checked a MAC address against the rest of the library, so two VMs could hold the same one and collide on both things keyed on it: the DHCP reservation slot (a single slot, both guests promised one address) and `desiredForwardingRules[kind][mac]` (last writer wins, and either VM's withdrawal disarmed the other's rules until something re-declared them).

The app now refuses the second holder. Enforcement sits at `updateConfiguration(of:mutate:)` — the single configuration funnel — so the MAC field, Generate, and any future writer are covered rather than one surface at a time. A refusal logs at `.notice`, surfaces an alert naming the VM that holds the address, and leaves the mutation entirely unapplied (including any other field the same closure set). The MAC field then shows the address the VM actually ended up with, so a refused address snaps back exactly like a malformed one, with the alert supplying the reason the snap-back alone never could.

Carrying an address across from a VM being replaced stays reachable, and the alert says how: change or delete the VM holding it first.

## The route taken

- **Refuse rather than re-key.** The alternative was re-keying the reservation table and `desiredForwardingRules` on VM identity so duplicates stop colliding. Rejected: two stations sharing an L2 identity on one segment is broken regardless of what the app does, so re-keying would make the app carefully support a configuration that cannot work — and it is a far wider change to a subsystem #836 and #838 both landed in this week. Refusing is what makes the MAC a legitimate key.
- **The surface is `surfaceError`, not an inline caption.** This matches `refuseIfDuplicateMachineIDConflict`, the repo's existing duplicate-identity refusal, and puts the reason at the same choke point as the enforcement — so every writer inherits it instead of each re-implementing one. No new view state or refresh lifecycle.
- **"Held" means any VM carrying the address**, including one with networking off. The address persists across mode changes, so a narrower test would let a VM with networking off keep a colliding address and re-form the collision the moment networking came back on.
- **`evict` and the MAC-retirement block no longer clear the shared key.** Both pushed `[]` through `desiredForwardingRules[.shared][mac]`; with a duplicate pair that silently disarmed the other VM's forwarding. `withdrawPortForwardingRules(for:)` re-declares a same-MAC survivor's own rules instead. This is the finding #836 dismissed into this issue's territory, and it is the pattern already used for reservations (`releaseAddressReservationIfUnused`) — leaving one of the two MAC-keyed teardowns unguarded would have been divergence.

## Duplicates already on disk

No load-time dedupe, no regeneration, no rejection at load — deliberately, and not only because of the no-migration rule. Rewriting a guest's MAC behind the user's back is a silent edit to something the guest can see and pin in its own network configuration, and which under Bridged the LAN's DHCP server may hold a reservation for; NETWORKING.md's north star points away from it. A pre-existing duplicate keeps behaving exactly as it does today, the survivor guard removes its only destructive edge, and the user repairs it by editing either VM onto a free address — which this change explicitly permits, since only a *change* of address is checked.

Import is untouched for the same reason, and is the remaining way a duplicate can enter the library (alongside a hand-edited `config.json`); the UUID short-circuit in `reserveAndImport` already catches re-importing the same VM.

## Queued issues

No material effect on #837 (relocating a beyond-capacity MAC into a freed hole) — that touches slot assignment, which this does not; it only reduces how many MACs can share a slot. None on #839 either, which compares forwarding rules only.

## Changes

- `VMLibraryViewModel`: `vmHoldingMACAddress(_:otherThan:)`, `refuseIfDuplicateMACAddress(_:on:)`, `withdrawPortForwardingRules(for:)`; the refusal wired into `updateConfiguration`, and both MAC-keyed teardowns routed through the survivor-guarded withdrawal.
- `VMSettingsViewController.applyMACAddressFieldEdit()`: the field follows the model after the write.
- `docs/NETWORKING.md`: new principle 9, "A MAC address belongs to one virtual machine" (the former 9 becomes 10).
- Tests: a `MAC Address Uniqueness` section (refusal, case-insensitivity, networking-off holder, whole-mutation drop, pre-existing duplicate still editable, both escape hatches), two survivor cases in `Port Forwarding Sync`, and a field-revert case in `VMSettingsViewControllerTests`.

## Test plan

- [x] `make test` — 2820 tests, 0 failures, totals read from the xcresult
- [x] `make lint`

### Maintenance Notes

- ✅ ARCHITECTURE.md — skipped: no component boundary, data flow, or actor isolation changed.
- ✅ Tests — 10 new cases covering the refusal, its escape hatches, and the survivor-guarded withdrawal.
- ✅ AGENTS.md — skipped: no rule stated there changed. The new rule constrains future networking decisions, so it lives in docs/NETWORKING.md.