### PR TITLE
fix: Install a DHCP reservation declared while its network is being created

### DIFF
--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -430,10 +430,18 @@ final class VmnetNetworkService: @unchecked Sendable {
     }
 
     /// How many networks one request may create before publishing whatever the
-    /// last attempt produced: each retry answers a rule declaration that landed
-    /// while the previous create was in flight, and a caller cannot be made to
-    /// wait on an editor that keeps typing.
+    /// last attempt produced: each retry answers a reservation or rule
+    /// declaration that landed while the previous create was in flight, and a
+    /// caller cannot be made to wait on an editor that keeps typing.
     private static let materializeAttemptLimit = 3
+
+    /// Names the declaration kinds a log line is about, for the two that report
+    /// what changed mid-create.
+    private static func declarationNames(reservations: Bool, rules: Bool) -> String {
+        [reservations ? "DHCP reservations" : nil, rules ? "forwarding rules" : nil]
+            .compactMap { $0 }
+            .joined(separator: " and ")
+    }
 
     /// The app-managed network of `kind`, materializing it on first use.
     /// Blocks for the vmnet XPC round-trip — never call on the main actor.
@@ -453,25 +461,29 @@ final class VmnetNetworkService: @unchecked Sendable {
             attempt += 1
             let materialized = try materialize(kind)
             stateLock.lock()
-            // Slots compare by MAC, and rules by MAC-keyed rule, both blind to
-            // the addresses they resolve to: a network that came back on
-            // addressing the record did not ask for re-derives every address
-            // without anyone having declared anything, and reading that as a
-            // mid-create change would recreate on every attempt. It publishes
-            // pending instead, for a later idle rebuild to carry.
-            let reservationsChanged =
-                materialized.submittedReservations.map(\.mac)
-                != installableReservationsLocked(for: kind).map(\.mac)
+            // Both sides are measured against the addressing this attempt
+            // submitted with, so only a changed declaration registers: a
+            // network that came back on addressing the record did not ask for
+            // re-derives every address without anyone having declared
+            // anything, and reading that as a mid-create change would recreate
+            // on every attempt. It publishes pending instead, for a later idle
+            // rebuild to carry.
+            let reservationsChanged = !materialized.submittedReservations.elementsEqual(
+                installableReservationsLocked(
+                    for: kind, addressing: materialized.submittedAddressing),
+                by: { $0 == $1 })
             let rulesChanged =
                 Self.rulesByMAC(materialized.submittedForwardingRules)
                 != installableForwardingRulesLocked(for: kind)
             let stale = reservationsChanged || rulesChanged
+            let changed = Self.declarationNames(
+                reservations: reservationsChanged, rules: rulesChanged)
             if stale, attempt < Self.materializeAttemptLimit {
                 stateLock.unlock()
                 // Never published, so nothing else can hold this network.
                 operations.releaseNetwork(materialized.handle)
                 Self.logger.info(
-                    "DHCP reservations or forwarding rules changed while the \(kind.rawValue, privacy: .public) network was being created — recreating it"
+                    "The \(kind.rawValue, privacy: .public) network's \(changed, privacy: .public) changed while it was being created — recreating it"
                 )
                 continue
             }
@@ -486,7 +498,7 @@ final class VmnetNetworkService: @unchecked Sendable {
                 // Left pending on purpose: the next configuration sync or
                 // session teardown recreates the network at an idle moment.
                 Self.logger.warning(
-                    "Published the \(kind.rawValue, privacy: .public) network without the DHCP reservations and forwarding rules declared during its creation — they take effect at the next recreate"
+                    "Published the \(kind.rawValue, privacy: .public) network without the \(changed, privacy: .public) declared during its creation — they take effect at the next recreate"
                 )
             }
             return materialized.handle
@@ -513,7 +525,8 @@ final class VmnetNetworkService: @unchecked Sendable {
                         "Recreated the \(kind.rawValue, privacy: .public) network with its stored addressing"
                     )
                     return MaterializedNetwork(
-                        handle: handle, reservations: installing, forwardingRules: forwarding)
+                        handle: handle, reservations: installing, forwardingRules: forwarding,
+                        submittedAddressing: stored)
                 }
                 // vmnet accepted the pin but reserved something else; the
                 // store must follow what the network actually is, or every
@@ -528,7 +541,8 @@ final class VmnetNetworkService: @unchecked Sendable {
                 )
                 return MaterializedNetwork(
                     handle: handle, reservations: [], forwardingRules: [],
-                    submittedReservations: installing, submittedForwardingRules: forwarding)
+                    submittedReservations: installing, submittedForwardingRules: forwarding,
+                    submittedAddressing: stored)
             } catch {
                 if isPinnedOnly(kind) {
                     // An invalidation recreate racing VZ's own refs on the old
@@ -570,9 +584,9 @@ final class VmnetNetworkService: @unchecked Sendable {
         }
 
         operations.releaseNetwork(probe)
-        let installing = reservations(for: macs, addressing: discovered, kind: kind)
-        let forwarding = forwardingRules(for: installing, kind: kind)
         do {
+            let installing = reservations(for: macs, addressing: discovered, kind: kind)
+            let forwarding = forwardingRules(for: installing, kind: kind)
             let (handle, reserved) = try operations.createNetwork(
                 kind, addressing: discovered, reservations: installing,
                 forwardingRules: Self.operatorRules(forwarding))
@@ -584,7 +598,8 @@ final class VmnetNetworkService: @unchecked Sendable {
             return MaterializedNetwork(
                 handle: handle, reservations: holds ? installing : [],
                 forwardingRules: holds ? forwarding : [],
-                submittedReservations: installing, submittedForwardingRules: forwarding)
+                submittedReservations: installing, submittedForwardingRules: forwarding,
+                submittedAddressing: discovered)
         } catch {
             // The discovered subnet was re-grabbed between release and
             // recreate. Fall back to a working network without reservations —
@@ -596,13 +611,12 @@ final class VmnetNetworkService: @unchecked Sendable {
             let (handle, addressing) = try operations.createNetwork(
                 kind, addressing: nil, reservations: [], forwardingRules: [])
             updateRecord(for: kind) { $0.addressing = addressing }
-            // Submitted as declared, though this network carries none of it:
-            // the create that would have installed it just failed, so retrying
-            // it here would fail the same way. The next materialization brings
-            // them, as the warning above says.
-            return MaterializedNetwork(
-                handle: handle, reservations: [], forwardingRules: [],
-                submittedReservations: installing, submittedForwardingRules: forwarding)
+            // Submitted nothing and carries nothing, which is what it reports:
+            // the retry that answers reads as one more declaration to install,
+            // and it pins the subnet just persisted rather than the one that
+            // was re-grabbed — a create that can succeed where this one could
+            // not.
+            return MaterializedNetwork(handle: handle, reservations: [], forwardingRules: [])
         }
     }
 
@@ -676,7 +690,7 @@ final class VmnetNetworkService: @unchecked Sendable {
     /// What one successful materialization produced: the handle, plus what the
     /// created network actually honors.
     ///
-    /// The `submitted` pair is what this attempt handed to `createNetwork` —
+    /// The `submitted` values are what this attempt handed to `createNetwork` —
     /// the declarations as they stood when it started, which is the same as
     /// what the network honors except where it came back on addressing they
     /// were not resolved against, honoring none of them. Comparing the
@@ -688,19 +702,28 @@ final class VmnetNetworkService: @unchecked Sendable {
         let forwardingRules: [ResolvedForwardingRule]
         let submittedReservations: [(mac: String, address: String)]
         let submittedForwardingRules: [ResolvedForwardingRule]
+        /// The addressing ``submittedReservations`` were resolved against, so
+        /// an equivalent submission made now is measured on the same footing —
+        /// otherwise a network that came back on addressing the record did not
+        /// ask for reads as a declaration change on every attempt. `nil` where
+        /// the attempt submitted no reservations, which measures against
+        /// whatever the record holds now.
+        let submittedAddressing: VmnetNetworkAddressing?
 
         init(
             handle: VmnetNetworkHandle,
             reservations: [(mac: String, address: String)] = [],
             forwardingRules: [ResolvedForwardingRule] = [],
             submittedReservations: [(mac: String, address: String)]? = nil,
-            submittedForwardingRules: [ResolvedForwardingRule]? = nil
+            submittedForwardingRules: [ResolvedForwardingRule]? = nil,
+            submittedAddressing: VmnetNetworkAddressing? = nil
         ) {
             self.handle = handle
             self.reservations = reservations
             self.forwardingRules = forwardingRules
             self.submittedReservations = submittedReservations ?? reservations
             self.submittedForwardingRules = submittedForwardingRules ?? forwardingRules
+            self.submittedAddressing = submittedAddressing
         }
     }
 
@@ -777,13 +800,16 @@ final class VmnetNetworkService: @unchecked Sendable {
     /// The MAC → address reservations a network of `kind` created right now
     /// would install, in slot order — slots that cannot install (past the
     /// subnet's capacity, or holding a MAC that no longer parses) are not in
-    /// it, so it is directly comparable with `installedAddresses`.
+    /// it, so it is directly comparable with `installedAddresses`. Pass
+    /// `addressing` to resolve the slots against something other than what the
+    /// record holds now.
     ///
     /// The caller holds `stateLock`.
     private func installableReservationsLocked(
-        for kind: VmnetNetworkKind
+        for kind: VmnetNetworkKind, addressing override: VmnetNetworkAddressing? = nil
     ) -> [(mac: String, address: String)] {
-        guard let record = records[kind], let addressing = record.addressing else { return [] }
+        guard let record = records[kind], let addressing = override ?? record.addressing
+        else { return [] }
         return Self.installablePairs(
             Self.resolveSlots(macs: record.reservedMACs, addressing: addressing))
     }

--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -438,10 +438,11 @@ final class VmnetNetworkService: @unchecked Sendable {
     /// The app-managed network of `kind`, materializing it on first use.
     /// Blocks for the vmnet XPC round-trip — never call on the main actor.
     ///
-    /// A rule declared during the create is not in the network that comes back,
-    /// and would go unnoticed — nothing was materialized when it arrived, so it
-    /// never read as pending. Such a network is released and recreated before
-    /// anyone can take it, up to ``materializeAttemptLimit`` attempts.
+    /// A reservation slot taken (or freed) and a rule declared during the create
+    /// are not in the network that comes back, and would go unnoticed — nothing
+    /// was materialized when they arrived, so they never read as pending. Such a
+    /// network is released and recreated before anyone can take it, up to
+    /// ``materializeAttemptLimit`` attempts.
     func network(for kind: VmnetNetworkKind) throws -> VmnetNetworkHandle {
         if let handle = cachedHandle(for: kind) { return handle }
         materializeLock.lock()
@@ -452,15 +453,25 @@ final class VmnetNetworkService: @unchecked Sendable {
             attempt += 1
             let materialized = try materialize(kind)
             stateLock.lock()
-            let stale =
+            // Slots compare by MAC, and rules by MAC-keyed rule, both blind to
+            // the addresses they resolve to: a network that came back on
+            // addressing the record did not ask for re-derives every address
+            // without anyone having declared anything, and reading that as a
+            // mid-create change would recreate on every attempt. It publishes
+            // pending instead, for a later idle rebuild to carry.
+            let reservationsChanged =
+                materialized.submittedReservations.map(\.mac)
+                != installableReservationsLocked(for: kind).map(\.mac)
+            let rulesChanged =
                 Self.rulesByMAC(materialized.submittedForwardingRules)
                 != installableForwardingRulesLocked(for: kind)
+            let stale = reservationsChanged || rulesChanged
             if stale, attempt < Self.materializeAttemptLimit {
                 stateLock.unlock()
                 // Never published, so nothing else can hold this network.
                 operations.releaseNetwork(materialized.handle)
                 Self.logger.info(
-                    "Forwarding rules changed while the \(kind.rawValue, privacy: .public) network was being created — recreating it"
+                    "DHCP reservations or forwarding rules changed while the \(kind.rawValue, privacy: .public) network was being created — recreating it"
                 )
                 continue
             }
@@ -472,10 +483,10 @@ final class VmnetNetworkService: @unchecked Sendable {
             pinnedOnlyKinds.remove(kind)
             stateLock.unlock()
             if stale {
-                // Left pending on purpose: the next rule sync or session
-                // teardown recreates the network at an idle moment.
+                // Left pending on purpose: the next configuration sync or
+                // session teardown recreates the network at an idle moment.
                 Self.logger.warning(
-                    "Published the \(kind.rawValue, privacy: .public) network without the forwarding rules declared during its creation — they take effect at the next recreate"
+                    "Published the \(kind.rawValue, privacy: .public) network without the DHCP reservations and forwarding rules declared during its creation — they take effect at the next recreate"
                 )
             }
             return materialized.handle
@@ -516,7 +527,8 @@ final class VmnetNetworkService: @unchecked Sendable {
                     "Pinned \(kind.rawValue, privacy: .public) network addressing was adjusted by the system — persisting the reserved values"
                 )
                 return MaterializedNetwork(
-                    handle: handle, reservations: [], forwardingRules: [], submitted: forwarding)
+                    handle: handle, reservations: [], forwardingRules: [],
+                    submittedReservations: installing, submittedForwardingRules: forwarding)
             } catch {
                 if isPinnedOnly(kind) {
                     // An invalidation recreate racing VZ's own refs on the old
@@ -558,9 +570,9 @@ final class VmnetNetworkService: @unchecked Sendable {
         }
 
         operations.releaseNetwork(probe)
+        let installing = reservations(for: macs, addressing: discovered, kind: kind)
+        let forwarding = forwardingRules(for: installing, kind: kind)
         do {
-            let installing = reservations(for: macs, addressing: discovered, kind: kind)
-            let forwarding = forwardingRules(for: installing, kind: kind)
             let (handle, reserved) = try operations.createNetwork(
                 kind, addressing: discovered, reservations: installing,
                 forwardingRules: Self.operatorRules(forwarding))
@@ -571,7 +583,8 @@ final class VmnetNetworkService: @unchecked Sendable {
             let holds = reserved == discovered
             return MaterializedNetwork(
                 handle: handle, reservations: holds ? installing : [],
-                forwardingRules: holds ? forwarding : [], submitted: forwarding)
+                forwardingRules: holds ? forwarding : [],
+                submittedReservations: installing, submittedForwardingRules: forwarding)
         } catch {
             // The discovered subnet was re-grabbed between release and
             // recreate. Fall back to a working network without reservations —
@@ -583,7 +596,13 @@ final class VmnetNetworkService: @unchecked Sendable {
             let (handle, addressing) = try operations.createNetwork(
                 kind, addressing: nil, reservations: [], forwardingRules: [])
             updateRecord(for: kind) { $0.addressing = addressing }
-            return MaterializedNetwork(handle: handle, reservations: [], forwardingRules: [])
+            // Submitted as declared, though this network carries none of it:
+            // the create that would have installed it just failed, so retrying
+            // it here would fail the same way. The next materialization brings
+            // them, as the warning above says.
+            return MaterializedNetwork(
+                handle: handle, reservations: [], forwardingRules: [],
+                submittedReservations: installing, submittedForwardingRules: forwarding)
         }
     }
 
@@ -656,28 +675,32 @@ final class VmnetNetworkService: @unchecked Sendable {
 
     /// What one successful materialization produced: the handle, plus what the
     /// created network actually honors.
+    ///
+    /// The `submitted` pair is what this attempt handed to `createNetwork` —
+    /// the declarations as they stood when it started, which is the same as
+    /// what the network honors except where it came back on addressing they
+    /// were not resolved against, honoring none of them. Comparing the
+    /// submitted sets against what would install now is what tells a
+    /// declaration that changed mid-create from one that never held.
     private struct MaterializedNetwork {
         let handle: VmnetNetworkHandle
         let reservations: [(mac: String, address: String)]
         let forwardingRules: [ResolvedForwardingRule]
-        /// The rules handed to `createNetwork`, which is what the declarations
-        /// looked like when this attempt started — the same set as
-        /// ``forwardingRules`` except where the network came back on addressing
-        /// the rules were not resolved against, which honors none of them.
-        /// Comparing it against what would install now is what tells a
-        /// declaration that changed mid-create from one that never held.
+        let submittedReservations: [(mac: String, address: String)]
         let submittedForwardingRules: [ResolvedForwardingRule]
 
         init(
             handle: VmnetNetworkHandle,
             reservations: [(mac: String, address: String)] = [],
             forwardingRules: [ResolvedForwardingRule] = [],
-            submitted: [ResolvedForwardingRule]? = nil
+            submittedReservations: [(mac: String, address: String)]? = nil,
+            submittedForwardingRules: [ResolvedForwardingRule]? = nil
         ) {
             self.handle = handle
             self.reservations = reservations
             self.forwardingRules = forwardingRules
-            self.submittedForwardingRules = submitted ?? forwardingRules
+            self.submittedReservations = submittedReservations ?? reservations
+            self.submittedForwardingRules = submittedForwardingRules ?? forwardingRules
         }
     }
 

--- a/KernovaTests/VmnetNetworkServiceTests.swift
+++ b/KernovaTests/VmnetNetworkServiceTests.swift
@@ -484,6 +484,96 @@ struct VmnetNetworkServiceTests {
         #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:02", kind: .shared) == nil)
     }
 
+    // MARK: - Reservations declared while a network is being created
+
+    @Test("A reservation declared while the network is being created lands in the published network")
+    func reservationDeclaredMidCreateIsInstalled() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, operations) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01"], at: location)
+        operations.duringCreateNetwork = { [weak service] call in
+            guard call == 1 else { return }
+            service?.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+        }
+
+        let handle = try service.network(for: .shared)
+
+        // The first network never became visible to anyone, so it is released
+        // and recreated rather than published without the late slot.
+        let installed = try #require(operations.installedReservations.last)
+        #expect(installed.map(\.mac) == ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"])
+        #expect(installed.map(\.address) == ["192.168.77.2", "192.168.77.3"])
+        #expect(operations.releasedNetworks.count == 1)
+        #expect(operations.releasedNetworks.first != handle.network)
+        // The guest takes its deterministic reservation, and the address shows
+        // rather than reading as pending.
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:02", kind: .shared) == "192.168.77.3")
+        #expect(!service.networkConfigurationIsPending(for: .shared))
+    }
+
+    @Test("A slot freed while the network is being created is gone from the published network")
+    func reservationReleasedMidCreateIsDropped() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, operations) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"], at: location)
+        operations.duringCreateNetwork = { [weak service] call in
+            guard call == 1 else { return }
+            service?.releaseAddressReservation(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+        }
+
+        _ = try service.network(for: .shared)
+
+        #expect(operations.installedReservations.last?.map(\.mac) == ["aa:bb:cc:dd:ee:01"])
+        #expect(operations.releasedNetworks.count == 1)
+        #expect(!service.networkConfigurationIsPending(for: .shared))
+    }
+
+    @Test("A reservation declared during the discovery create is installed before the network publishes")
+    func reservationDeclaredDuringDiscoveryIsInstalled() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        // Call 2 is the pinned recreate that carries the reservations; the
+        // addressing it pins is only known once the discovery create returns.
+        operations.duringCreateNetwork = { [weak service] call in
+            guard call == 2 else { return }
+            service?.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+        }
+
+        _ = try service.network(for: .shared)
+
+        #expect(operations.createdKinds.count == 3)
+        #expect(operations.releasedNetworks.count == 2)
+        let installed = try #require(operations.installedReservations.last)
+        #expect(installed.map(\.mac) == ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"])
+        #expect(installed.map(\.address) == ["192.168.213.2", "192.168.213.3"])
+        #expect(!service.networkConfigurationIsPending(for: .shared))
+    }
+
+    @Test("Reservations that keep changing publish a network anyway, still reading as pending")
+    func endlessReservationChangesPublishAndStayPending() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let (service, operations) = try makeSeededSharedService(
+            macs: ["aa:bb:cc:dd:ee:01"], at: location)
+        operations.duringCreateNetwork = { [weak service] call in
+            service?.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:0\(call + 1)", kind: .shared)
+        }
+
+        _ = try service.network(for: .shared)
+
+        // Three attempts, two of them released — the caller is never made to
+        // wait on a library that keeps declaring, and the pending flag brings
+        // the rest at the next recreate.
+        #expect(operations.createdKinds.count == 3)
+        #expect(operations.releasedNetworks.count == 2)
+        #expect(service.networkConfigurationIsPending(for: .shared))
+    }
+
     // MARK: - Installed vs pending reservations
 
     @Test("A slot assigned while its network is materialized reads as pending, then resolves after rematerialization")
@@ -617,6 +707,10 @@ struct VmnetNetworkServiceTests {
         // forwarding to them, which is what leaves them pending.
         #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:01", kind: .shared) == nil)
         #expect(service.networkConfigurationIsPending(for: .shared))
+        // Nothing was declared during the create, so the rewritten addressing
+        // alone must not read as a mid-create change and recreate the network.
+        #expect(operations.createdKinds.count == 1)
+        #expect(operations.releasedNetworks.isEmpty)
     }
 
     // MARK: - Port forwarding rules

--- a/KernovaTests/VmnetNetworkServiceTests.swift
+++ b/KernovaTests/VmnetNetworkServiceTests.swift
@@ -452,13 +452,44 @@ struct VmnetNetworkServiceTests {
 
         _ = try service.network(for: .shared)
 
-        // Discovery, failed pinned recreate, then the working fallback — the
-        // mode beats the IP display.
-        #expect(operations.pinnedAddressings == [nil, operations.freshAddressing, nil])
+        // The fallback carries no reservation, so it reads as one still to
+        // install and the bounded loop retries — but every pinned create
+        // fails, so it runs to the attempt limit and publishes the working
+        // fresh network without reservations. The mode beats the IP display.
+        #expect(try #require(operations.pinnedAddressings.last) == nil)
         #expect(operations.installedReservations.last?.isEmpty == true)
+        #expect(service.networkConfigurationIsPending(for: .shared))
+        // Three attempts of discovery, failed pinned recreate and fallback,
+        // plus the failed pinned create opening attempts two and three.
+        #expect(operations.createdKinds.count == 11)
         let store = try readStore(at: location.storeURL, from: service)
         #expect(store?[.shared]?.addressing == operations.freshAddressing)
         #expect(store?[.shared]?.reservedMACs == ["aa:bb:cc:dd:ee:01"])
+    }
+
+    @Test("A transiently failed pinned recreate installs its reservations on the retry")
+    func transientlyFailedRecreateInstallsReservationsOnRetry() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        let operations = MockVmnetNetworkOperator()
+        operations.pinnedCreateError = TestFailure("subnet re-grabbed")
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+        service.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:01", kind: .shared)
+        // Call 3 is the fresh fallback, by which point the re-grab has passed —
+        // the retry's pinned create reserves the addressing that one persisted.
+        operations.duringCreateNetwork = { [weak operations] call in
+            guard call == 3 else { return }
+            operations?.pinnedCreateError = nil
+        }
+
+        _ = try service.network(for: .shared)
+
+        #expect(operations.createdKinds.count == 4)
+        let installed = try #require(operations.installedReservations.last)
+        #expect(installed.map(\.mac) == ["aa:bb:cc:dd:ee:01"])
+        #expect(installed.map(\.address) == ["192.168.213.2"])
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:01", kind: .shared) == "192.168.213.2")
+        #expect(!service.networkConfigurationIsPending(for: .shared))
     }
 
     @Test("Slots past the subnet's capacity are dropped from the installed reservations")
@@ -527,6 +558,35 @@ struct VmnetNetworkServiceTests {
 
         #expect(operations.installedReservations.last?.map(\.mac) == ["aa:bb:cc:dd:ee:01"])
         #expect(operations.releasedNetworks.count == 1)
+        #expect(!service.networkConfigurationIsPending(for: .shared))
+    }
+
+    @Test("A slot that moves while the network is being created publishes at its new address")
+    func relocatedSlotMidCreateIsInstalledAtItsNewAddress() throws {
+        let location = makeStoreLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        // A free slot ahead of the only reservation, so releasing and
+        // re-reserving that MAC refills the hole and moves its address while
+        // leaving the set of reserved MACs identical.
+        try seed(
+            [
+                .shared: VmnetNetworkRecord(
+                    addressing: Self.storedAddressing, reservedMACs: [nil, "aa:bb:cc:dd:ee:02"])
+            ], at: location.storeURL)
+        let operations = MockVmnetNetworkOperator()
+        let service = VmnetNetworkService(operations: operations, storeURL: location.storeURL)
+        operations.duringCreateNetwork = { [weak service] call in
+            guard call == 1 else { return }
+            service?.releaseAddressReservation(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+            service?.reserveAddressIfNeeded(for: "aa:bb:cc:dd:ee:02", kind: .shared)
+        }
+
+        _ = try service.network(for: .shared)
+
+        #expect(operations.installedReservations.first?.map(\.address) == ["192.168.77.3"])
+        #expect(operations.installedReservations.last?.map(\.address) == ["192.168.77.2"])
+        #expect(operations.releasedNetworks.count == 1)
+        #expect(service.reservedAddress(for: "aa:bb:cc:dd:ee:02", kind: .shared) == "192.168.77.2")
         #expect(!service.networkConfigurationIsPending(for: .shared))
     }
 


### PR DESCRIPTION
Closes #839.

## Summary

`VmnetNetworkService.network(for:)` re-checks its declarations before publishing a freshly created network, so a declaration that landed during the vmnet create round-trip is not silently lost. That check covered forwarding rules only. A reservation slot taken (or freed) mid-create is not in the network that comes back, and the publish path installs `installedAddresses[kind]` from what the create actually carried — so the slot goes unnoticed.

`networkConfigurationIsPending(for:)` answers `false` while nothing is published, so the rebuild pass that runs when the slot is taken finds nothing to do; once the network publishes the slot does read as pending, but nothing re-checks at that moment. Until an unrelated trigger recreates the network, the VM's IP Address row shows `—`, its guest takes a dynamic lease instead of its deterministic reservation, and any forwarding rules riding that reservation are dropped as unreserved.

The pre-publish check now covers reservations as well, releasing and recreating the not-yet-published network exactly as a changed rule already does (bounded by the existing `materializeAttemptLimit`).

## Changes

- `MaterializedNetwork` carries `submittedReservations` and the `submittedAddressing` they were resolved against, alongside `submittedForwardingRules`; every construction site reports what that attempt handed to `createNetwork`.
- `network(for:)` compares both submitted sets against what would install now; either difference releases and recreates. The publish-time logs name only the declaration kinds that actually differed.
- `installableReservationsLocked` takes an optional addressing override, so the comparison resolves the record's slots against the addressing the attempt submitted with.

## The adjusted-addressing interaction

The issue flagged that the system-adjusted-addressing path deliberately publishes with `reservations: []` after rewriting the record's addressing, and that a naive comparison would read that as stale on every attempt.

No exclusion is needed. Both sides of the comparison are resolved against the addressing *that attempt* submitted with, so a rewritten addressing — which re-derives every slot's address without anyone having declared anything — compares equal, while every real declaration change still registers: an added slot, a freed slot, and a slot that moved index. `adjustedPinnedAddressingLeavesReservationsPending` passes untouched and gains a guard asserting that path still creates exactly one network.

An earlier revision of this PR compared MAC lists instead. Three review passes independently caught the same hole: with a free slot ahead of a reservation, releasing and re-reserving that MAC mid-create refills the hole and moves its address while the MAC list stays byte-identical — the network published at the old address and the slot stayed pending. Comparing whole pairs against the attempt's own addressing closes that and makes the pre-publish check exactly as strong as `networkConfigurationIsPending`.

## Deviations from the issue

- The issue proposed folding a submitted-reservations counterpart into the same check, then excluding or reconciling the adjusted-addressing path. The counterpart is adopted; the exclusion turned out to be unnecessary, per above.
- One change the issue does not mention: the `materializeFresh` catch fallback publishes a network carrying no reservations after a pinned create failed, and now reads as stale so the bounded loop retries. That retry pins the subnet the fallback just persisted rather than the one that was re-grabbed, so a transient conflict ends with the reservations installed rather than pending until an unrelated recreate. It also restores the rules-driven retry that path already had.
- No `VMLibraryViewModel` change. Making the rebuild pass re-check at publish time would not work: `rebuildNetworkIfIdle` refuses while any instance `mayHoldAttachment(on:)`, and the VM that drove the materialization is about to attach. Absorbing the declaration inside `network(for:)`, while nobody can hold the network, is the same reasoning that already justifies the loop for rules.

Scoped to #839 — #837 (relocating an over-capacity slot) and #841 (import/load admitting a duplicate MAC) are unaffected: #837's value appears on both sides of the new comparison, and #841 is confined to `VMLibraryViewModel`. Filed #843 for the convergence gap this does not close: a network published while its configuration reads pending still has no trigger to reconcile it.

## Test plan

- [x] `make test` — 2827 tests pass (6 new)
- [x] Every new test verified to fail without its fix
- [x] `make lint`
