### PR TITLE
fix: Disclose a MAC address two VMs hold, and refuse the second start

### DIFF
--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -540,6 +540,13 @@ final class VMLibraryViewModel {
     }
 
     func start(_ instance: VMInstance, bootIntoRecovery: Bool = false) async {
+        // Ahead of the setup dispatch: guest setup builds and runs a
+        // `VZVirtualMachine` carrying the configured machine identity and MAC
+        // address, so a conflicting one must be refused before it reaches the
+        // installer, not only on the auto-boot that follows.
+        if refuseIfDuplicateMachineIDConflict(instance) { return }
+        if refuseIfDuplicateMACAddressConflict(instance, joining: instance.configuration) { return }
+
         // Dispatch on the surviving setup context, not status, so `.error`
         // retries route through the same pipeline too.
         if instance.configuration.installContext != nil {
@@ -550,9 +557,6 @@ final class VMLibraryViewModel {
             downloadAndAutoBoot(instance)
             return
         }
-
-        if refuseIfDuplicateMachineIDConflict(instance) { return }
-        if refuseIfDuplicateMACAddressConflict(instance) { return }
 
         surfaceDisplay(for: instance)
         applyMatchWindowBootResolution(to: instance)
@@ -627,14 +631,20 @@ final class VMLibraryViewModel {
     /// Refuses an operation that would put a second guest on one MAC address on
     /// one network, logging the refusal and surfacing the alert.
     ///
+    /// `config` is the configuration the VM would run under — its own at start,
+    /// the prospective one for a live mode switch, which moves an unchanged
+    /// address onto a different network.
+    ///
     /// ``refuseIfDuplicateMACAddress(_:on:)`` keeps the library unique for every
     /// address the app writes; this covers the pair a bundle arrived carrying,
     /// which passed through no writer.
     ///
     /// - Returns: `true` when the caller must abort.
-    private func refuseIfDuplicateMACAddressConflict(_ instance: VMInstance) -> Bool {
-        guard let conflict = liveMACAddressConflict(for: instance),
-            let mac = instance.configuration.macAddress
+    private func refuseIfDuplicateMACAddressConflict(
+        _ instance: VMInstance, joining config: VMConfiguration
+    ) -> Bool {
+        guard let conflict = liveMACAddressConflict(for: config, excluding: instance),
+            let mac = config.macAddress
         else { return false }
         Self.logger.notice(
             "Refused to run '\(instance.name, privacy: .public)': shares the MAC address \(mac, privacy: .public) with active VM '\(conflict.name, privacy: .public)'"
@@ -647,8 +657,8 @@ final class VMLibraryViewModel {
         return true
     }
 
-    /// The first live VM sharing `instance`'s MAC address on the network it
-    /// would join, if any.
+    /// The first live VM sharing `config`'s MAC address on the network `config`
+    /// joins, if any.
     ///
     /// Live means VZ holds the attachment, as it does for the machine identity.
     /// The mode names the network, so two holders collide only where both
@@ -656,15 +666,14 @@ final class VMLibraryViewModel {
     /// Host Only and Bridged are separate networks. Two bridged VMs compare as
     /// one network whatever interface each names — Automatic resolves at start,
     /// so which link they land on is not knowable in advance.
-    private func liveMACAddressConflict(for instance: VMInstance) -> VMInstance? {
-        let config = instance.configuration
-        guard config.networkEnabled, let mac = config.macAddress?.lowercased() else { return nil }
-        return instances.first { other in
-            other !== instance
-                && (other.status.isActive || other.isLivePaused)
+    private func liveMACAddressConflict(
+        for config: VMConfiguration, excluding instance: VMInstance
+    ) -> VMInstance? {
+        guard config.networkEnabled, let mac = config.macAddress else { return nil }
+        return vmsHoldingMACAddress(mac, otherThan: instance).first { other in
+            (other.status.isActive || other.isLivePaused)
                 && other.configuration.networkEnabled
                 && other.configuration.networkMode == config.networkMode
-                && other.configuration.macAddress?.lowercased() == mac
         }
     }
 
@@ -897,7 +906,9 @@ final class VMLibraryViewModel {
         // holds both, and refusing would be refusing a VM its own identity.
         if instance.isColdPaused {
             if refuseIfDuplicateMachineIDConflict(instance) { return }
-            if refuseIfDuplicateMACAddressConflict(instance) { return }
+            if refuseIfDuplicateMACAddressConflict(instance, joining: instance.configuration) {
+                return
+            }
         }
 
         surfaceDisplay(for: instance)
@@ -1622,41 +1633,34 @@ final class VMLibraryViewModel {
         }
     }
 
-    /// The VM other than `instance` whose configuration carries `mac`, `nil`
-    /// when no other VM holds it.
+    /// The VMs other than `instance` whose configuration carries `mac`, in
+    /// library order — the one lookup every duplicate-address question derives
+    /// from.
     ///
     /// Case-insensitive, matching the reservation slots and forwarding rules the
     /// address keys. A VM with networking off counts: the address persists
     /// across mode changes, so turning networking back on would re-form the
     /// collision.
-    private func vmHoldingMACAddress(_ mac: String, otherThan instance: VMInstance) -> VMInstance? {
+    private func vmsHoldingMACAddress(_ mac: String, otherThan instance: VMInstance) -> [VMInstance] {
         let wanted = mac.lowercased()
-        return instances.first {
+        return instances.filter {
             $0 !== instance && $0.configuration.macAddress?.lowercased() == wanted
         }
     }
 
     /// Names of the other VMs in the library carrying `instance`'s MAC address,
     /// in library order — empty when the address is this VM's alone.
-    ///
-    /// Case-insensitive, matching the reservation slots and forwarding rules the
-    /// address keys. A VM with networking off counts: it still holds the
-    /// address, and turning networking back on would form the collision.
     func vmNamesSharingMACAddress(with instance: VMInstance) -> [String] {
-        guard let wanted = instance.configuration.macAddress?.lowercased() else { return [] }
-        return instances.compactMap { other in
-            guard other !== instance, other.configuration.macAddress?.lowercased() == wanted else {
-                return nil
-            }
-            return other.name
-        }
+        guard let mac = instance.configuration.macAddress else { return [] }
+        return vmsHoldingMACAddress(mac, otherThan: instance).map(\.name)
     }
 
     /// Records every MAC address two or more VMs in the library hold.
     ///
     /// Import, load and reconcile admit whatever address a bundle arrives
     /// carrying, so this is where a pair the app never authored becomes
-    /// traceable. Runs wherever library membership changes.
+    /// traceable. Runs on each of those three, which are the paths a VM the app
+    /// did not author an address for enters by.
     private func logDuplicateMACAddressHolders() {
         let holders = Dictionary(grouping: instances) { $0.configuration.macAddress?.lowercased() }
         for (mac, vms) in holders where mac != nil && vms.count > 1 {
@@ -1671,7 +1675,7 @@ final class VMLibraryViewModel {
     ///
     /// - Returns: `true` when the caller must abort.
     private func refuseIfDuplicateMACAddress(_ mac: String, on instance: VMInstance) -> Bool {
-        guard let holder = vmHoldingMACAddress(mac, otherThan: instance) else { return false }
+        guard let holder = vmsHoldingMACAddress(mac, otherThan: instance).first else { return false }
         Self.logger.notice(
             "Refused the MAC address \(mac, privacy: .public) for '\(instance.name, privacy: .public)': '\(holder.name, privacy: .public)' already holds it"
         )
@@ -1738,6 +1742,18 @@ final class VMLibraryViewModel {
         guard new != old else { return true }
         if let mac = new.macAddress, mac.lowercased() != old.macAddress?.lowercased(),
             refuseIfDuplicateMACAddress(mac, on: instance)
+        {
+            return false
+        }
+        // A live VM's Mode picker stays enabled, and a mode change hot-swaps the
+        // attachment: the address is unchanged, so the refusal above never sees
+        // it, and the network it lands on is not the one `start` checked. Only a
+        // VM already running can form the collision this way, and only a
+        // configuration not already in one is refused — a VM that reached a
+        // collision by some other route has to stay editable to leave it.
+        if instance.status.isActive || instance.isLivePaused,
+            liveMACAddressConflict(for: old, excluding: instance) == nil,
+            refuseIfDuplicateMACAddressConflict(instance, joining: new)
         {
             return false
         }

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -330,6 +330,7 @@ final class VMLibraryViewModel {
                 wirePersistence(for: instance)
                 return instance
             } + addedDuringRead
+        logDuplicateMACAddressHolders()
 
         if !scan.failedBundleNames.isEmpty {
             reportedFailedBundles.formUnion(scan.failedBundleNames)
@@ -551,6 +552,7 @@ final class VMLibraryViewModel {
         }
 
         if refuseIfDuplicateMachineIDConflict(instance) { return }
+        if refuseIfDuplicateMACAddressConflict(instance) { return }
 
         surfaceDisplay(for: instance)
         applyMatchWindowBootResolution(to: instance)
@@ -620,6 +622,50 @@ final class VMLibraryViewModel {
             return true
         }
         return false
+    }
+
+    /// Refuses an operation that would put a second guest on one MAC address on
+    /// one network, logging the refusal and surfacing the alert.
+    ///
+    /// ``refuseIfDuplicateMACAddress(_:on:)`` keeps the library unique for every
+    /// address the app writes; this covers the pair a bundle arrived carrying,
+    /// which passed through no writer.
+    ///
+    /// - Returns: `true` when the caller must abort.
+    private func refuseIfDuplicateMACAddressConflict(_ instance: VMInstance) -> Bool {
+        guard let conflict = liveMACAddressConflict(for: instance),
+            let mac = instance.configuration.macAddress
+        else { return false }
+        Self.logger.notice(
+            "Refused to run '\(instance.name, privacy: .public)': shares the MAC address \(mac, privacy: .public) with active VM '\(conflict.name, privacy: .public)'"
+        )
+        surfaceError(
+            "“\(instance.name)” has the same MAC address as “\(conflict.name)”, which is active. "
+                + "Two virtual machines with the same MAC address must not run on the same network at once. "
+                + "Stop “\(conflict.name)” first, or give one of them a new address in Network settings.",
+            title: "Duplicate MAC Address")
+        return true
+    }
+
+    /// The first live VM sharing `instance`'s MAC address on the network it
+    /// would join, if any.
+    ///
+    /// Live means VZ holds the attachment, as it does for the machine identity.
+    /// The mode names the network, so two holders collide only where both
+    /// guests attach: networking off puts no address on a wire, and Shared,
+    /// Host Only and Bridged are separate networks. Two bridged VMs compare as
+    /// one network whatever interface each names — Automatic resolves at start,
+    /// so which link they land on is not knowable in advance.
+    private func liveMACAddressConflict(for instance: VMInstance) -> VMInstance? {
+        let config = instance.configuration
+        guard config.networkEnabled, let mac = config.macAddress?.lowercased() else { return nil }
+        return instances.first { other in
+            other !== instance
+                && (other.status.isActive || other.isLivePaused)
+                && other.configuration.networkEnabled
+                && other.configuration.networkMode == config.networkMode
+                && other.configuration.macAddress?.lowercased() == mac
+        }
     }
 
     /// Resizes a cold-booting VM's display to the surface it is about to appear
@@ -846,10 +892,13 @@ final class VMLibraryViewModel {
 
     func resume(_ instance: VMInstance) async {
         // A cold resume builds a fresh VZVirtualMachine from the save file, so it
-        // claims the machine identity just as a cold boot does. A hot resume's
-        // live object already holds it, and refusing would be refusing a VM its
-        // own identity.
-        if instance.isColdPaused, refuseIfDuplicateMachineIDConflict(instance) { return }
+        // claims the machine identity — and puts its MAC address back on a
+        // network — just as a cold boot does. A hot resume's live object already
+        // holds both, and refusing would be refusing a VM its own identity.
+        if instance.isColdPaused {
+            if refuseIfDuplicateMachineIDConflict(instance) { return }
+            if refuseIfDuplicateMACAddressConflict(instance) { return }
+        }
 
         surfaceDisplay(for: instance)
         do {
@@ -1194,6 +1243,7 @@ final class VMLibraryViewModel {
         instances.append(phantom)
         sortInstances()
         persistOrder()
+        logDuplicateMACAddressHolders()
         if selectedInstance?.isPreparing != true {
             selectedID = phantom.id
         }
@@ -1583,6 +1633,36 @@ final class VMLibraryViewModel {
         let wanted = mac.lowercased()
         return instances.first {
             $0 !== instance && $0.configuration.macAddress?.lowercased() == wanted
+        }
+    }
+
+    /// Names of the other VMs in the library carrying `instance`'s MAC address,
+    /// in library order — empty when the address is this VM's alone.
+    ///
+    /// Case-insensitive, matching the reservation slots and forwarding rules the
+    /// address keys. A VM with networking off counts: it still holds the
+    /// address, and turning networking back on would form the collision.
+    func vmNamesSharingMACAddress(with instance: VMInstance) -> [String] {
+        guard let wanted = instance.configuration.macAddress?.lowercased() else { return [] }
+        return instances.compactMap { other in
+            guard other !== instance, other.configuration.macAddress?.lowercased() == wanted else {
+                return nil
+            }
+            return other.name
+        }
+    }
+
+    /// Records every MAC address two or more VMs in the library hold.
+    ///
+    /// Import, load and reconcile admit whatever address a bundle arrives
+    /// carrying, so this is where a pair the app never authored becomes
+    /// traceable. Runs wherever library membership changes.
+    private func logDuplicateMACAddressHolders() {
+        let holders = Dictionary(grouping: instances) { $0.configuration.macAddress?.lowercased() }
+        for (mac, vms) in holders where mac != nil && vms.count > 1 {
+            let names = vms.map { "'\($0.name)'" }.joined(separator: ", ")
+            Self.logger.warning(
+                "MAC address \(mac ?? "", privacy: .public) is held by \(names, privacy: .public)")
         }
     }
 
@@ -2594,6 +2674,7 @@ final class VMLibraryViewModel {
             if didChange {
                 sortInstances()
                 persistOrder()
+                logDuplicateMACAddressHolders()
             }
 
             let newFailures = failedBundles.filter { !reportedFailedBundles.contains($0) }

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -487,7 +487,10 @@ final class VMSettingsViewController: NSViewController {
         }
     }
 
-    private func writeConfig(_ mutate: (inout VMConfiguration) -> Void) {
+    /// - Returns: Whether the mutation was applied, so a caller whose control
+    ///   already moved can put it back when the view model refused.
+    @discardableResult
+    private func writeConfig(_ mutate: (inout VMConfiguration) -> Void) -> Bool {
         viewModel.updateConfiguration(of: instance, mutate: mutate)
     }
 }
@@ -2509,31 +2512,36 @@ extension VMSettingsViewController: NSMenuItemValidation {
     @objc private func networkModeChanged() {
         guard let choice = networkModePopUp.selectedItem?.representedObject as? NetworkModeChoice
         else { return }
+        let accepted: Bool
         switch choice {
         case .shared:
             // `bridgedInterfaceIdentifier` is left alone so switching back to
             // Bridged remembers the interface.
-            writeConfig {
+            accepted = writeConfig {
                 $0.networkEnabled = true
                 $0.networkMode = .shared
                 Self.mintMACAddressIfNeeded(&$0)
             }
         case .hostOnly:
-            writeConfig {
+            accepted = writeConfig {
                 $0.networkEnabled = true
                 $0.networkMode = .hostOnly
                 Self.mintMACAddressIfNeeded(&$0)
             }
         case .none:
-            writeConfig { $0.networkEnabled = false }
+            accepted = writeConfig { $0.networkEnabled = false }
         case .bridged(let identifier):
-            writeConfig {
+            accepted = writeConfig {
                 $0.networkEnabled = true
                 $0.networkMode = .bridged
                 $0.bridgedInterfaceIdentifier = identifier
                 Self.mintMACAddressIfNeeded(&$0)
             }
         }
+        // A refused switch leaves the configuration untouched, so nothing marks
+        // the menu stale and the picker would go on showing a mode the VM is not
+        // on. Rebuilding re-selects the configured one.
+        if !accepted { rebuildNetworkModeMenu() }
         // The write flips the card's row visibility; refresh in case the value was
         // already what the model held.
         refreshNetwork()

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -187,6 +187,8 @@ final class VMSettingsViewController: NSViewController {
     private var portForwardingListStack = NSStackView()
     /// Stands in for the card's rows while the mode is None.
     private var networkNoDeviceCaption = NSTextField()
+    /// Holds the banner naming the other VMs sharing this one's MAC address.
+    private var networkWarningContainer = NSStackView()
 
     // Audio
     private var audioInputSwitch = NSSwitch()
@@ -241,6 +243,9 @@ final class VMSettingsViewController: NSViewController {
     private var renderedRemovableRows: [RenderedRow]?
     private var renderedSharedRows: [RenderedRow]?
     private var renderedAudioWarning: MicWarningState?
+    /// The duplicate-MAC banner's rendered message, `nil` when no banner is
+    /// shown, so a pass that changed nothing about it skips the rebuild.
+    private var renderedNetworkMACWarning: String?
     /// The Mode menu's rendered selection, so an `apply()` pass that changed
     /// nothing about networking skips a rebuild — which enumerates the host's
     /// bridgeable interfaces and queries the process signature.
@@ -379,6 +384,10 @@ final class VMSettingsViewController: NSViewController {
                 _ = self.instance.status
                 _ = self.viewModel.activeRename
                 _ = self.viewModel.agentInstallPromptDisabled
+                // Registers every instance's configuration, so the
+                // duplicate-MAC banner follows a change made on the *other*
+                // holder, and library membership changing under it.
+                _ = self.viewModel.vmNamesSharingMACAddress(with: self.instance)
             },
             apply: { [weak self] in self?.apply() }
         )
@@ -504,6 +513,7 @@ extension VMSettingsViewController {
         renderedRemovableRows = nil
         renderedSharedRows = nil
         renderedAudioWarning = nil
+        renderedNetworkMACWarning = nil
         renderedNetworkChoice = nil
         renderedPortForwardingRows = nil
 
@@ -969,6 +979,11 @@ extension VMSettingsViewController {
         rows.append(makeMACAddressRow())
         rows.append(makePortForwardingRow())
         networkNoDeviceCaption = makeGroupedFormCaption("This virtual machine has no network device.")
+        networkWarningContainer = NSStackView()
+        networkWarningContainer.orientation = .vertical
+        networkWarningContainer.alignment = .leading
+        networkWarningContainer.spacing = Spacing.small
+        networkWarningContainer.translatesAutoresizingMaskIntoConstraints = false
 
         // With the entitlement, Shared and Host Only assign each guest a
         // deterministic address the IP Address row shows, and Shared can forward
@@ -1010,6 +1025,7 @@ extension VMSettingsViewController {
         return makeSection([
             header,
             makeGroupedFormCard(rows: rows),
+            networkWarningContainer,
             networkNoDeviceCaption,
         ])
     }
@@ -2021,6 +2037,7 @@ extension VMSettingsViewController {
         // to a caption saying so.
         let hasDevice = instance.configuration.networkEnabled
         refreshMACAddressRow()
+        refreshMACAddressWarning(hasDevice: hasDevice)
         networkNoDeviceCaption.isHidden = hasDevice
         refreshIPAddressRow()
         // Rules ride the app-managed shared network, and reach the guest at the
@@ -2032,6 +2049,34 @@ extension VMSettingsViewController {
             && entitlements.hasVMNetworking && instance.configuration.macAddress != nil
         portForwardingRow?.isHidden = !forwards
         if forwards { refreshPortForwardingRows() }
+    }
+
+    /// Discloses that another VM in the library carries this one's MAC address.
+    ///
+    /// Import, load and reconcile admit a bundle whatever address it arrives
+    /// with, so the pair is visible here rather than refused at the door — the
+    /// address stays editable, and Generate above the banner moves this VM off
+    /// it. Shown wherever the MAC row is: an address is held while networking
+    /// is off, but nothing shows it there to contradict.
+    private func refreshMACAddressWarning(hasDevice: Bool) {
+        let message: String?
+        if hasDevice, instance.configuration.macAddress != nil {
+            let names = viewModel.vmNamesSharingMACAddress(with: instance)
+            message =
+                names.isEmpty
+                ? nil
+                : "This MAC address is also used by \(names.map { "“\($0)”" }.joined(separator: ", ")). "
+                    + "Each virtual machine needs its own."
+        } else {
+            message = nil
+        }
+        guard message != renderedNetworkMACWarning else { return }
+        renderedNetworkMACWarning = message
+        networkWarningContainer.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        guard let message else { return }
+        let banner = makeGroupedFormBanner(
+            symbolName: "exclamationmark.triangle.fill", tint: .systemYellow, message: message)
+        addFullWidth(banner, to: networkWarningContainer)
     }
 
     private func refreshAudio() {

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -1541,6 +1541,256 @@ struct VMLibraryViewModelTests {
         #expect(presenter.errorTitle == "Duplicate Machine ID")
     }
 
+    // MARK: - Duplicate MAC Address Boot Guard
+
+    /// Two VMs carrying the given MAC addresses and network modes, both appended
+    /// to `viewModel`.
+    ///
+    /// `other` is the one the tests park in a live status; `starting` is the one
+    /// they try to boot.
+    private func appendMACAddressPair(
+        to viewModel: VMLibraryViewModel,
+        mac: String = "aa:bb:cc:dd:ee:01",
+        otherMAC: String = "aa:bb:cc:dd:ee:01",
+        mode: VMNetworkMode = .shared,
+        otherMode: VMNetworkMode = .shared
+    ) -> (starting: VMInstance, other: VMInstance) {
+        let starting = makeInstance(name: "Starting")
+        let other = makeInstance(name: "Twin")
+        starting.configuration.macAddress = mac
+        starting.configuration.networkMode = mode
+        other.configuration.macAddress = otherMAC
+        other.configuration.networkMode = otherMode
+        viewModel.instances.append(contentsOf: [starting, other])
+        return (starting, other)
+    }
+
+    @Test("start is refused while another VM with the same MAC address is running")
+    func startBlockedByRunningMACAddressTwin() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMACAddressPair(to: viewModel)
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 0)
+        #expect(presenter.errorTitle == "Duplicate MAC Address")
+        #expect(presenter.errorMessage?.contains("Starting") == true)
+        #expect(presenter.errorMessage?.contains("Twin") == true)
+        #expect(starting.status == .stopped)
+    }
+
+    @Test("start is refused while the MAC address twin is live-paused (it still holds the address)")
+    func startBlockedByLivePausedMACAddressTwin() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMACAddressPair(to: viewModel)
+        other.status = .paused
+        other.hasLiveVirtualMachineOverrideForTesting = true
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 0)
+        #expect(presenter.errorTitle == "Duplicate MAC Address")
+    }
+
+    @Test("start proceeds when the MAC address twin is stopped")
+    func startProceedsWhenMACAddressTwinIsStopped() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMACAddressPair(to: viewModel)
+        other.status = .stopped
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 1)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("start proceeds when the MAC address twin runs on a different network mode")
+    func startProceedsWhenMACAddressTwinIsOnAnotherMode() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMACAddressPair(
+            to: viewModel, mode: .shared, otherMode: .hostOnly)
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 1)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("start is refused for two bridged VMs whichever interface each names")
+    func startBlockedByBridgedMACAddressTwinOnAnotherInterface() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMACAddressPair(
+            to: viewModel, mode: .bridged, otherMode: .bridged)
+        starting.configuration.bridgedInterfaceIdentifier = "en0"
+        other.configuration.bridgedInterfaceIdentifier = "en1"
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 0)
+        #expect(presenter.errorTitle == "Duplicate MAC Address")
+    }
+
+    @Test("start proceeds when the starting VM has networking off")
+    func startProceedsWhenStartingVMHasNetworkingOff() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMACAddressPair(to: viewModel)
+        starting.configuration.networkEnabled = false
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 1)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("start proceeds when the running MAC address twin has networking off")
+    func startProceedsWhenMACAddressTwinHasNetworkingOff() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMACAddressPair(to: viewModel)
+        other.configuration.networkEnabled = false
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 1)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("start proceeds when the running VM's MAC address differs")
+    func startProceedsWhenMACAddressesDiffer() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMACAddressPair(
+            to: viewModel, otherMAC: "aa:bb:cc:dd:ee:02")
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 1)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("the boot refusal matches the held MAC address regardless of case")
+    func startRefusalIgnoresMACAddressCase() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMACAddressPair(
+            to: viewModel, mac: "aa:bb:cc:dd:ee:01", otherMAC: "AA:BB:CC:DD:EE:01")
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        #expect(virtService.startCallCount == 0)
+        #expect(presenter.errorTitle == "Duplicate MAC Address")
+    }
+
+    @Test("a cold resume is refused while a MAC address twin is running")
+    func coldResumeBlockedByRunningMACAddressTwin() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (resuming, other) = appendMACAddressPair(to: viewModel)
+        resuming.status = .paused
+        other.status = .running
+
+        await viewModel.resume(resuming)
+
+        #expect(virtService.resumeCallCount == 0)
+        #expect(presenter.errorTitle == "Duplicate MAC Address")
+        #expect(resuming.status == .paused)
+    }
+
+    @Test("a hot resume is never refused — the live VM already holds the address")
+    func hotResumeIsNotBlockedByMACAddressTwin() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (resuming, other) = appendMACAddressPair(to: viewModel)
+        resuming.status = .paused
+        resuming.hasLiveVirtualMachineOverrideForTesting = true
+        other.status = .running
+
+        await viewModel.resume(resuming)
+
+        #expect(virtService.resumeCallCount == 1)
+        #expect(presenter.showError == false)
+    }
+
+    // MARK: - Duplicate MAC Address Admission
+
+    /// Two on-disk bundles carrying `mac`, in a storage mock — the hand-copied
+    /// pair every admission path has to take.
+    private func makeStorageWithMACAddressPair(mac: String = "aa:bb:cc:dd:ee:01")
+        -> MockVMStorageService
+    {
+        let storage = MockVMStorageService()
+        for name in ["First VM", "Second VM"] {
+            var config = VMConfiguration(name: name, guestOS: .linux, bootMode: .efi)
+            config.macAddress = mac
+            let bundleURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("\(config.id.uuidString).kernova", isDirectory: true)
+            storage.bundles[bundleURL] = config
+        }
+        return storage
+    }
+
+    @Test("loadVMs admits both bundles sharing a MAC address, without an error")
+    func loadAdmitsBundlesSharingAMACAddress() async {
+        let storage = makeStorageWithMACAddressPair()
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+
+        await viewModel.loadVMs()
+
+        #expect(viewModel.instances.count == 2)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("reconcileWithDisk admits a discovered bundle whose MAC address is already held")
+    func reconcileAdmitsABundleSharingAMACAddress() {
+        let storage = makeStorageWithMACAddressPair()
+        let (viewModel, _, _, _, _) = makeViewModel(storageService: storage)
+
+        viewModel.reconcileWithDisk()
+
+        #expect(viewModel.instances.count == 2)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("vmNamesSharingMACAddress names the other holders, regardless of case")
+    func vmNamesSharingMACAddressNamesOtherHolders() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let (starting, _) = appendMACAddressPair(
+            to: viewModel, mac: "aa:bb:cc:dd:ee:01", otherMAC: "AA:BB:CC:DD:EE:01")
+
+        #expect(viewModel.vmNamesSharingMACAddress(with: starting) == ["Twin"])
+    }
+
+    @Test("vmNamesSharingMACAddress is empty when the address is the VM's alone")
+    func vmNamesSharingMACAddressIsEmptyWhenUnique() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let (starting, _) = appendMACAddressPair(
+            to: viewModel, otherMAC: "aa:bb:cc:dd:ee:02")
+
+        #expect(viewModel.vmNamesSharingMACAddress(with: starting).isEmpty)
+    }
+
+    @Test("vmNamesSharingMACAddress counts a holder whose networking is off")
+    func vmNamesSharingMACAddressCountsANetworkingOffHolder() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let (starting, other) = appendMACAddressPair(to: viewModel)
+        other.configuration.networkEnabled = false
+
+        #expect(viewModel.vmNamesSharingMACAddress(with: starting) == ["Twin"])
+    }
+
     // MARK: - Match-Window Boot Resolution
 
     /// Hands `start` a fixed surface, standing in for the window/screen geometry

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -1724,6 +1724,70 @@ struct VMLibraryViewModelTests {
         #expect(presenter.showError == false)
     }
 
+    @Test("a start that dispatches to macOS guest setup is refused before the installer runs")
+    func macOSSetupStartBlockedByRunningMACAddressTwin() async {
+        let virtService = MockVirtualizationService()
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let (starting, other) = appendMACAddressPair(to: viewModel)
+        starting.configuration.installContext = MacOSInstallContext(
+            source: .localFile, localIPSWPath: "/tmp/foo.ipsw")
+        starting.status = .initialBoot
+        other.status = .running
+
+        await viewModel.start(starting)
+
+        // The installer builds and runs its own VZ virtual machine, so the
+        // refusal has to land before guest setup is dispatched at all.
+        #expect(starting.setupTask == nil)
+        #expect(virtService.startCallCount == 0)
+        #expect(presenter.errorTitle == "Duplicate MAC Address")
+    }
+
+    @Test("a live mode switch onto a MAC address twin's network is refused, changing nothing")
+    func liveModeSwitchOntoAMACAddressTwinIsRefused() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let (switching, other) = appendMACAddressPair(
+            to: viewModel, mode: .hostOnly, otherMode: .shared)
+        // Both run: the start guard allowed it, the modes being different.
+        switching.status = .running
+        other.status = .running
+
+        let accepted = viewModel.updateConfiguration(of: switching) { $0.networkMode = .shared }
+
+        #expect(accepted == false)
+        #expect(switching.configuration.networkMode == .hostOnly)
+        #expect(presenter.errorTitle == "Duplicate MAC Address")
+    }
+
+    @Test("a stopped VM may take the mode a live MAC address twin is on — its start is the guard")
+    func stoppedVMMayTakeALiveMACAddressTwinsMode() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let (switching, other) = appendMACAddressPair(
+            to: viewModel, mode: .hostOnly, otherMode: .shared)
+        switching.status = .stopped
+        other.status = .running
+
+        let accepted = viewModel.updateConfiguration(of: switching) { $0.networkMode = .shared }
+
+        #expect(accepted)
+        #expect(switching.configuration.networkMode == .shared)
+        #expect(presenter.showError == false)
+    }
+
+    @Test("a live VM already sharing a network with its twin stays editable")
+    func aVMAlreadyInAMACAddressCollisionStaysEditable() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let (switching, other) = appendMACAddressPair(to: viewModel)
+        switching.status = .running
+        other.status = .running
+
+        let accepted = viewModel.updateConfiguration(of: switching) { $0.memorySizeInGB = 6 }
+
+        #expect(accepted)
+        #expect(switching.configuration.memorySizeInGB == 6)
+        #expect(presenter.showError == false)
+    }
+
     // MARK: - Duplicate MAC Address Admission
 
     /// Two on-disk bundles carrying `mac`, in a storage mock — the hand-copied

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -1208,16 +1208,18 @@ struct VMSettingsViewControllerTests {
         }
     }
 
-    /// A library already holding `mac`, wired to a presenter so the refusal's
-    /// alert is observable rather than buffered.
+    /// A library whose single member, named "Holder", already holds `mac` —
+    /// named so a banner reporting it is unambiguous, and wired to a presenter
+    /// so a refusal's alert is observable rather than buffered.
     private func makeLibraryHolding(
-        _ mac: String, presenter: MockVMLibraryPresenting
+        _ mac: String, presenter: MockVMLibraryPresenting? = nil
     ) -> VMLibraryViewModel {
         let viewModel = makeViewModel()
         let holder = makeInstance(guestOS: .linux)
+        holder.configuration.name = "Holder"
         holder.configuration.macAddress = mac
         viewModel.instances = [holder]
-        viewModel.presenter = presenter
+        if let presenter { viewModel.presenter = presenter }
         return viewModel
     }
 
@@ -1234,6 +1236,33 @@ struct VMSettingsViewControllerTests {
         #expect(instance.configuration.macAddress == "aa:bb:cc:dd:ee:ff")
         #expect(field.stringValue == "aa:bb:cc:dd:ee:ff")
         #expect(presenter.errorTitle == "MAC Address In Use")
+    }
+
+    private static let duplicateMACBanner =
+        "This MAC address is also used by “Holder”. Each virtual machine needs its own."
+
+    @Test("The Network section names another VM holding this VM's MAC address")
+    func networkSectionDisclosesADuplicateMACAddress() {
+        let viewModel = makeLibraryHolding("aa:bb:cc:dd:ee:ff")
+        let (vc, _) = makeNetworkController(viewModel: viewModel)
+
+        #expect(visibleLabel(Self.duplicateMACBanner, in: vc.view))
+    }
+
+    @Test("No duplicate-MAC banner when the address is this VM's alone")
+    func networkSectionHasNoBannerForAUniqueMACAddress() {
+        let viewModel = makeLibraryHolding("aa:bb:cc:dd:ee:0f")
+        let (vc, _) = makeNetworkController(viewModel: viewModel)
+
+        #expect(!containsLabel(Self.duplicateMACBanner, in: vc.view))
+    }
+
+    @Test("No duplicate-MAC banner while this VM has no network device")
+    func networkSectionHasNoBannerWithNetworkingOff() {
+        let viewModel = makeLibraryHolding("aa:bb:cc:dd:ee:ff")
+        let (vc, _) = makeNetworkController(networkEnabled: false, viewModel: viewModel)
+
+        #expect(!containsLabel(Self.duplicateMACBanner, in: vc.view))
     }
 
     @Test("Generate discards a typed duplicate instead of refusing it")

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -1265,6 +1265,27 @@ struct VMSettingsViewControllerTests {
         #expect(!containsLabel(Self.duplicateMACBanner, in: vc.view))
     }
 
+    @Test("A refused live mode switch puts the Mode picker back on the VM's mode")
+    func refusedLiveModeSwitchRevertsThePicker() throws {
+        let presenter = MockVMLibraryPresenting()
+        let viewModel = makeLibraryHolding("aa:bb:cc:dd:ee:ff", presenter: presenter)
+        // The holder is live on Shared; this VM shares its address on Host Only,
+        // which the start guard permits — the two are on different networks.
+        let holder = try #require(viewModel.instances.first)
+        holder.status = .running
+        let (vc, instance) = makeNetworkController(
+            mode: .hostOnly, isReadOnly: true, status: .running, viewModel: viewModel)
+        let popUp = try #require(networkModePopUp(in: vc.view))
+        let shared = try #require(popUp.itemArray.first { $0.title == "Shared Network" })
+
+        popUp.select(shared)
+        popUp.sendAction(popUp.action, to: popUp.target)
+
+        #expect(instance.configuration.networkMode == .hostOnly)
+        #expect(presenter.errorTitle == "Duplicate MAC Address")
+        #expect(popUp.titleOfSelectedItem == "Host Only")
+    }
+
     @Test("Generate discards a typed duplicate instead of refusing it")
     func generateDiscardsATypedDuplicate() throws {
         let presenter = MockVMLibraryPresenting()

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -84,13 +84,16 @@ never a visible-but-broken control.
 
 ### 9. A MAC address belongs to one virtual machine
 
-**An address identifies exactly one VM in the library, and the library refuses a
-second holder** — the DHCP reservation slot and the forwarding rules are both keyed
-on the address, so two holders share one slot and one rule set. Enforcement sits at
-the single configuration funnel, not at each surface that can write an address, and
-the user moves an address by changing or deleting the VM holding it first. An
-address a bundle arrives with is never silently rewritten: the guest can pin it, and
-under Bridged the LAN's DHCP server may hold a reservation for it.
+**An address identifies exactly one VM in the library** — the DHCP reservation slot
+and the forwarding rules are both keyed on it, so two holders share one slot and one
+rule set. The app never writes a second holder: enforcement sits at the single
+configuration funnel, not at each surface that can write an address, and the user
+moves an address by changing or deleting the VM holding it first. An address a
+bundle arrives with is neither rewritten nor grounds to keep the bundle out — the
+guest can pin it, and under Bridged the LAN's DHCP server may hold a reservation for
+it — so import, load and reconcile admit it, and the VM's Network section names the
+other holder while the address stays editable. Two holders never run on one network
+at once: the second to start is refused.
 
 ### 10. Guest-to-guest reach is network membership
 


### PR DESCRIPTION
## Summary

`reserveAndImport`, `loadVMs` and `reconcileWithDisk` admit whatever MAC address a bundle arrives carrying — their only duplicate check is by VM UUID. Two VMs then share the single DHCP reservation slot and the single `desiredForwardingRules` entry the address keys, and the IP Address row shows one address as fact for both. #840's funnel refusal covers every address the app itself writes, and deliberately did not reach these paths.

This takes the shape **admit, disclose, refuse the second start**:

- **Admission stays permissive** on all three paths. Refusing at the door leaves no in-app remedy — the MAC field cannot repair a bundle that was never admitted — and at load/reconcile it would hide a VM the user can see on disk. Tests pin this so it is not "fixed" back.
- **Disclosure** is a warning banner in the VM's Network section naming the other holder(s). Being a function of library state, it covers import, load and reconcile identically, with no launch-time modal. The Generate button directly above it is the one-click remedy.
- **Enforcement** sits where the collision actually bites: `start` and a cold `resume` refuse when a live VM shares the address *on the same network mode*, mirroring `refuseIfDuplicateMachineIDConflict`. A hot resume is not guarded — the live VM already holds its own address.
- **Diagnostics**: `logDuplicateMACAddressHolders()` records the pair at `.warning` wherever library membership changes, so a duplicate that arrived from disk is traceable.

The address is never silently regenerated (#840's reasoning stands: the guest can pin it, and under Bridged the LAN's DHCP server may hold a reservation for it).

`docs/NETWORKING.md` principle 9 claimed "the library refuses a second holder", which was only ever true of addresses the app authors; it now states the admitted-and-disclosed end state.

## Deviations from the issue

- **The issue's `## Location` named `reserveAndImport`, `loadVMs`, `reconcileWithDisk` as where enforcement would go; none of them gained a refusal** — only the diagnostic log — for the remedy reason above.
- **No `blockDuplicateMACBoot` preference**, deviating from the machine-ID precedent's other half. That toggle exists because *its* remedy is dangerous (regenerating a machine ID can stop a macOS 12 guest booting). The MAC remedy is one click on either VM, and #840 already refuses a duplicate address with no override — an escape hatch only at boot would make one invariant negotiable in one place and absolute in the other.
- **Refusal is narrowed to the same `networkMode`**, where the machine-ID guard needs no narrowing: a Shared VM and a Host Only VM sharing an address are on different networks and different reservation slots. Two bridged VMs are refused whatever interface each names — Automatic resolves at start, so which link they land on is not knowable in advance.
- **No alert on import.** A multi-bundle drop would alert per bundle, and the identical state arriving via load or reconcile cannot be alerted without a launch-time modal — so the banner was needed regardless. The machine-ID case is likewise silent at import and walls the user at start.

## Test plan

- [x] `make test` — 2846 tests, 0 failures, verified from the xcresult (`totalTestCount` 2846 / `failedTests` 0); 16 new cases
- [x] `make lint`

## Notes

- No `RATIONALE:` comments added.
- No overlap with the concurrent #837 work: nothing here touches `VmnetNetworkService`, and no new call into `VmnetNetworkProviding` is added — the guard and the banner read `instances` only.

Closes #841