### PR TITLE
docs: Align VERSION-FLOORS.md input-device row and version-source pointer with the code

### DIFF
--- a/docs/VERSION-FLOORS.md
+++ b/docs/VERSION-FLOORS.md
@@ -11,10 +11,10 @@ Two different questions live here and are easy to conflate. **Guest-side** floor
 | A USB mass storage device binds a driver and mounts | macOS **12.3** | [2026-08-07 note](research/2026-08-07-macos12-usb-mass-storage.md) — below it the device enumerates and nothing claims it, because `IOUSBMassStorageDriver.kext` is not in the guest's boot kernel collection |
 | A virtio block device mounts | none within what Virtualization can install | Same note, probe 6 — a raw GPT/APFS image mounts on 12.0.1 |
 | Guest-initiated virtio-vsock connects to a host listener | none within what Virtualization can install | [2026-07-31 note](research/2026-07-31-macos12-guest-vsock.md) — 12.0.1 and 12.7.6 both complete the handshake |
-| `VZMacTrackpadConfiguration` is used instead of the USB pointing device | macOS **13.0** | `VZMacTrackpadConfiguration.h` discussion; pairing both devices is what makes an older guest work, and `ConfigurationBuilder.configureMacOSDevices` does exactly that |
+| `VZMacTrackpadConfiguration` is used instead of the USB pointing device | macOS **13.0** | `VZMacTrackpadConfiguration.h` discussion; exactly one device pair is attached, chosen by `GuestInputDevices.resolve` — the Mac devices at 13+, the USB pair below |
 | SPICE clipboard | never, at any version | macOS ships no `spice-vdagent` counterpart; macOS guests reach the clipboard over vsock instead (`ConfigurationBuilder.configureClipboardSharing`) |
 
-A guest's version is not a thing Kernova can look up on demand — see `GuestAgentDiskDelivery.effectiveGuestVersion`, which reads the agent's last report and falls back to the image the VM was installed from.
+A guest's version is not a thing Kernova can look up on demand — see `VMConfiguration.effectiveGuestMacOSVersion`, which reads the agent's last report and falls back to the image the VM was installed from.
 
 ## Host-side limits
 


### PR DESCRIPTION
## Summary
- Corrects two places where `docs/VERSION-FLOORS.md` drifted from the code, found while re-verifying open issues against the tree:
  - The `VZMacTrackpadConfiguration` row's evidence cell said pairing **both** input-device pairs is what makes an older guest work and that `configureMacOSDevices` does exactly that — exactly one pair is attached now, chosen by `GuestInputDevices.resolve` (Mac devices at 13+, USB pair below).
  - The guest-version pointer named `GuestAgentDiskDelivery.effectiveGuestVersion`; the resolver is `VMConfiguration.effectiveGuestMacOSVersion` (behavior described — agent report with install-image fallback — verified unchanged).

## Changes
- `docs/VERSION-FLOORS.md`: two-line correction; no floors or evidence changed

## Test plan
- [x] `Tools/check-docs.sh` passes
- [x] Both statements verified against `GuestInputDevices.resolve` and `VMConfiguration.effectiveGuestMacOSVersion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjmoFoe2Ak64DwuRcYSQHy