### PR TITLE
fix: Cap serial.log size with single-generation rotation

### DIFF
--- a/Kernova/Models/VMBundleLayout.swift
+++ b/Kernova/Models/VMBundleLayout.swift
@@ -40,6 +40,11 @@ struct VMBundleLayout: Sendable {
         bundleURL.appendingPathComponent("serial.log")
     }
 
+    /// The rotated previous generation of `serialLogURL` (see `SerialLogWriter`).
+    var serialLogRotatedURL: URL {
+        bundleURL.appendingPathComponent("serial.log.1")
+    }
+
     var additionalDisksDirectoryURL: URL {
         bundleURL.appendingPathComponent("AdditionalDisks")
     }

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -575,7 +575,9 @@ final class VMInstance {
 
         // Created once per session so the readability handler can capture them
         // as `Sendable` locals — the handler must never touch `self` off-actor.
-        let writer = SerialLogWriter(logURL: serialLogURL, label: name)
+        let writer = SerialLogWriter(
+            logURL: bundleLayout.serialLogURL, rotatedURL: bundleLayout.serialLogRotatedURL,
+            label: name)
         serialLogWriter = writer
         let relay = makeSerialRelay()
 

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -238,7 +238,7 @@ final class VMInstance {
     var serialInputPipe: Pipe?
     var serialOutputPipe: Pipe?
 
-    private var serialLogFileHandle: FileHandle?
+    private var serialLogWriter: SerialLogWriter?
 
     /// Host-side AF_UNIX relay exposing the serial port to an external terminal.
     ///
@@ -568,46 +568,22 @@ final class VMInstance {
 
     /// Begins reading from the serial output pipe.
     ///
-    /// Output is written to the on-disk `serial.log` and tee'd to the
-    /// `SerialSocketRelay` when enabled.
+    /// Output is written to the on-disk `serial.log` (size-capped by
+    /// `SerialLogWriter`) and tee'd to the `SerialSocketRelay` when enabled.
     func startSerialReading() {
         guard let outputPipe = serialOutputPipe else { return }
 
-        let logURL = serialLogURL
-        if !FileManager.default.fileExists(atPath: logURL.path(percentEncoded: false)) {
-            FileManager.default.createFile(atPath: logURL.path(percentEncoded: false), contents: nil)
-        }
-        do {
-            let handle = try FileHandle(forWritingTo: logURL)
-            do { _ = try handle.seekToEnd() } catch {
-                Self.logger.warning(
-                    "Could not seek to end of serial log: \(error.localizedDescription, privacy: .public)")
-            }
-            serialLogFileHandle = handle
-        } catch {
-            Self.logger.warning(
-                "Could not open serial log for writing: \(error.localizedDescription, privacy: .public)")
-        }
-
-        // Created once per session so the readability handler can capture it as
-        // a `Sendable` local — the handler must never touch `self` off-actor.
+        // Created once per session so the readability handler can capture them
+        // as `Sendable` locals — the handler must never touch `self` off-actor.
+        let writer = SerialLogWriter(logURL: serialLogURL, label: name)
+        serialLogWriter = writer
         let relay = makeSerialRelay()
-
-        // Captured for the readability handler, which runs on a background GCD queue.
-        let logFileHandle = serialLogFileHandle
-        let logger = Self.logger
 
         outputPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
             guard !data.isEmpty else { return }
 
-            // Background-safe: FileHandle is thread-safe for sequential writes.
-            do {
-                try logFileHandle?.write(contentsOf: data)
-            } catch {
-                logger.error("Failed to write to serial log: \(error.localizedDescription, privacy: .public)")
-            }
-
+            writer.write(data)
             relay?.forwardOutput(data)
         }
 
@@ -645,14 +621,8 @@ final class VMInstance {
         serialOutputPipe?.fileHandleForReading.readabilityHandler = nil
         serialSocketRelay?.stop()
         serialSocketRelay = nil
-        do {
-            try serialLogFileHandle?.close()
-        } catch {
-            Self.logger.warning(
-                "Failed to close serial log file for VM '\(self.name, privacy: .public)': \(error.localizedDescription, privacy: .public)"
-            )
-        }
-        serialLogFileHandle = nil
+        serialLogWriter?.close()
+        serialLogWriter = nil
     }
 
     // MARK: - Clipboard Service Lifecycle

--- a/Kernova/Services/SerialLogWriter.swift
+++ b/Kernova/Services/SerialLogWriter.swift
@@ -3,9 +3,10 @@ import os
 
 /// Appending writer for a VM's on-disk `serial.log` that bounds its size with
 /// single-generation rotation: when the file reaches `maxFileSize` it is
-/// renamed to `serial.log.1` (replacing any earlier generation) and a fresh
-/// `serial.log` is started, so a bundle never holds more than roughly twice
-/// `maxFileSize` of serial history.
+/// renamed to `rotatedURL` (replacing any earlier generation) and a fresh log
+/// is started, so a bundle never holds more than roughly twice `maxFileSize`
+/// of serial history. A pre-existing log already at the cap is cleared at
+/// open rather than archived, so the bound holds from the first write.
 ///
 /// All file state is guarded by one `NSLock`, so `write(_:)` is safe to call
 /// from the background queue that drives serial output. After `close()` or a
@@ -31,24 +32,40 @@ final class SerialLogWriter: @unchecked Sendable {
 
     private static let logger = Logger(subsystem: "app.kernova", category: "SerialLogWriter")
 
-    init(logURL: URL, label: String, maxFileSize: Int = SerialLogWriter.defaultMaxFileSize) {
+    init(
+        logURL: URL, rotatedURL: URL, label: String,
+        maxFileSize: Int = SerialLogWriter.defaultMaxFileSize
+    ) {
         self.logURL = logURL
-        self.rotatedURL = logURL.appendingPathExtension("1")
+        self.rotatedURL = rotatedURL
         self.maxFileSize = maxFileSize
         self.label = label
 
         lock.lock()
         defer { lock.unlock() }
         openLocked()
+
+        // A pre-existing log at or over the cap (from a build without one, or
+        // a run whose rotation was disabled) is cleared, not archived: rotating
+        // it whole would carry an arbitrarily large file as `serial.log.1`,
+        // breaking the twice-the-cap bound exactly when it matters most.
         if fileSize >= maxFileSize {
-            rotateLocked()
+            do {
+                try handle?.truncate(atOffset: 0)
+                fileSize = 0
+            } catch {
+                Self.logger.warning(
+                    "Could not clear oversized serial log for '\(self.label, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+                )
+            }
         }
     }
 
     /// Appends `data` to the log, rotating once the file reaches `maxFileSize`.
     ///
-    /// Safe to call from any thread. A dropped chunk (closed writer, failed
-    /// open, or write error) is logged and never blocks the serial reader.
+    /// Safe to call from any thread and never blocks the serial reader. A
+    /// write error is logged and the chunk dropped; writes after `close()` or
+    /// a failed open are dropped silently.
     func write(_ data: Data) {
         guard !data.isEmpty else { return }
         lock.lock()

--- a/Kernova/Services/SerialLogWriter.swift
+++ b/Kernova/Services/SerialLogWriter.swift
@@ -1,0 +1,140 @@
+import Foundation
+import os
+
+/// Appending writer for a VM's on-disk `serial.log` that bounds its size with
+/// single-generation rotation: when the file reaches `maxFileSize` it is
+/// renamed to `serial.log.1` (replacing any earlier generation) and a fresh
+/// `serial.log` is started, so a bundle never holds more than roughly twice
+/// `maxFileSize` of serial history.
+///
+/// All file state is guarded by one `NSLock`, so `write(_:)` is safe to call
+/// from the background queue that drives serial output. After `close()` or a
+/// failed open, writes are dropped.
+final class SerialLogWriter: @unchecked Sendable {
+    /// Rotation threshold. 10 MB retains dozens of Linux boots' console output
+    /// while keeping the worst-case bundle overhead (live file plus one rotated
+    /// generation) negligible next to a disk image.
+    static let defaultMaxFileSize = 10 * 1024 * 1024
+
+    private let logURL: URL
+    private let rotatedURL: URL
+    private let maxFileSize: Int
+    private let label: String
+
+    private let lock = NSLock()
+
+    // Guarded by `lock`.
+    private var handle: FileHandle?
+    private var fileSize = 0
+    /// Set after a failed rotation so the failure logs once, not per chunk.
+    private var rotationDisabled = false
+
+    private static let logger = Logger(subsystem: "app.kernova", category: "SerialLogWriter")
+
+    init(logURL: URL, label: String, maxFileSize: Int = SerialLogWriter.defaultMaxFileSize) {
+        self.logURL = logURL
+        self.rotatedURL = logURL.appendingPathExtension("1")
+        self.maxFileSize = maxFileSize
+        self.label = label
+
+        lock.lock()
+        defer { lock.unlock() }
+        openLocked()
+        if fileSize >= maxFileSize {
+            rotateLocked()
+        }
+    }
+
+    /// Appends `data` to the log, rotating once the file reaches `maxFileSize`.
+    ///
+    /// Safe to call from any thread. A dropped chunk (closed writer, failed
+    /// open, or write error) is logged and never blocks the serial reader.
+    func write(_ data: Data) {
+        guard !data.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        guard let handle else { return }
+
+        do {
+            try handle.write(contentsOf: data)
+            fileSize += data.count
+        } catch {
+            Self.logger.error(
+                "Failed to write to serial log for '\(self.label, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+            return
+        }
+
+        if fileSize >= maxFileSize {
+            rotateLocked()
+        }
+    }
+
+    /// Closes the log file. Subsequent writes are dropped. Idempotent.
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        closeLocked()
+    }
+
+    // MARK: - Locked helpers
+
+    private func openLocked() {
+        let path = logURL.path(percentEncoded: false)
+        if !FileManager.default.fileExists(atPath: path) {
+            FileManager.default.createFile(atPath: path, contents: nil)
+        }
+        do {
+            let newHandle = try FileHandle(forWritingTo: logURL)
+            do {
+                fileSize = Int(try newHandle.seekToEnd())
+            } catch {
+                Self.logger.warning(
+                    "Could not seek to end of serial log for '\(self.label, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+                )
+                fileSize = 0
+            }
+            handle = newHandle
+        } catch {
+            Self.logger.warning(
+                "Could not open serial log for writing for '\(self.label, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+            handle = nil
+            fileSize = 0
+        }
+    }
+
+    private func closeLocked() {
+        do {
+            try handle?.close()
+        } catch {
+            Self.logger.warning(
+                "Failed to close serial log file for '\(self.label, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+        }
+        handle = nil
+    }
+
+    /// Moves `serial.log` to `serial.log.1` and reopens a fresh live file. On
+    /// failure, keeps appending to the oversized file — losing output would be
+    /// worse — and disables further rotation attempts for this writer.
+    private func rotateLocked() {
+        guard !rotationDisabled else { return }
+        closeLocked()
+
+        do {
+            let fileManager = FileManager.default
+            if fileManager.fileExists(atPath: rotatedURL.path(percentEncoded: false)) {
+                try fileManager.removeItem(at: rotatedURL)
+            }
+            try fileManager.moveItem(at: logURL, to: rotatedURL)
+        } catch {
+            rotationDisabled = true
+            Self.logger.error(
+                "Serial log rotation failed for '\(self.label, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+        }
+
+        openLocked()
+    }
+}

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -1626,7 +1626,7 @@ extension VMSettingsViewController {
                 "Expose Serial Socket", control: serialRelaySwitch,
                 paragraphs: [
                     .body(
-                        "Exposes the running VM's serial port over a local UNIX socket so an external terminal can attach. Output is always captured to `serial.log` regardless of this setting."
+                        "Exposes the running VM's serial port over a local UNIX socket so an external terminal can attach. Output is always captured to `serial.log` regardless of this setting; when it grows large it rolls to `serial.log.1` alongside."
                     ),
                     .body(
                         "While the VM is running, connect with `socat` (best for full-screen apps; `brew install socat`):"

--- a/KernovaTests/SerialLogWriterTests.swift
+++ b/KernovaTests/SerialLogWriterTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Testing
+
+@testable import Kernova
+
+@Suite("SerialLogWriter")
+struct SerialLogWriterTests {
+    private func makeTempDir() throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        return tempDir
+    }
+
+    private func contents(of url: URL) -> String? {
+        guard let data = FileManager.default.contents(atPath: url.path(percentEncoded: false))
+        else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    @Test("Writes append to the log file")
+    func writesAppend() throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let logURL = tempDir.appendingPathComponent("serial.log")
+
+        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        writer.write(Data("hello ".utf8))
+        writer.write(Data("world".utf8))
+        writer.close()
+
+        #expect(contents(of: logURL) == "hello world")
+    }
+
+    @Test("A new writer appends to an existing log")
+    func newWriterAppends() throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let logURL = tempDir.appendingPathComponent("serial.log")
+
+        let first = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        first.write(Data("run1\n".utf8))
+        first.close()
+
+        let second = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        second.write(Data("run2\n".utf8))
+        second.close()
+
+        #expect(contents(of: logURL) == "run1\nrun2\n")
+    }
+
+    @Test("Reaching the cap rotates the log to serial.log.1 and starts fresh")
+    func rotationAtCap() throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let logURL = tempDir.appendingPathComponent("serial.log")
+        let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
+
+        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 8)
+        writer.write(Data("0123456789".utf8))  // 10 bytes ≥ cap → rotates
+        writer.write(Data("after".utf8))
+        writer.close()
+
+        #expect(contents(of: rotatedURL) == "0123456789")
+        #expect(contents(of: logURL) == "after")
+    }
+
+    @Test("A second rotation replaces the previous serial.log.1")
+    func secondRotationReplacesPrevious() throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let logURL = tempDir.appendingPathComponent("serial.log")
+        let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
+
+        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 8)
+        writer.write(Data("first-gen".utf8))  // rotation 1
+        writer.write(Data("second-gen".utf8))  // rotation 2
+        writer.write(Data("live".utf8))
+        writer.close()
+
+        #expect(contents(of: rotatedURL) == "second-gen")
+        #expect(contents(of: logURL) == "live")
+    }
+
+    @Test("An oversized pre-existing log rotates on open")
+    func oversizedExistingLogRotatesOnOpen() throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let logURL = tempDir.appendingPathComponent("serial.log")
+        let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
+        try Data("stale-history".utf8).write(to: logURL)
+
+        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 8)
+        writer.write(Data("fresh".utf8))
+        writer.close()
+
+        #expect(contents(of: rotatedURL) == "stale-history")
+        #expect(contents(of: logURL) == "fresh")
+    }
+
+    @Test("An under-cap pre-existing log is kept and appended to")
+    func underCapExistingLogIsKept() throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let logURL = tempDir.appendingPathComponent("serial.log")
+        let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
+        try Data("old\n".utf8).write(to: logURL)
+
+        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        writer.write(Data("new\n".utf8))
+        writer.close()
+
+        #expect(contents(of: logURL) == "old\nnew\n")
+        #expect(!FileManager.default.fileExists(atPath: rotatedURL.path(percentEncoded: false)))
+    }
+
+    @Test("Writes after close are dropped without error")
+    func writeAfterCloseIsDropped() throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let logURL = tempDir.appendingPathComponent("serial.log")
+
+        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        writer.write(Data("kept".utf8))
+        writer.close()
+        writer.write(Data("dropped".utf8))
+        writer.close()
+
+        #expect(contents(of: logURL) == "kept")
+    }
+
+    @Test("A failed open drops writes without crashing")
+    func failedOpenDropsWrites() {
+        let missingDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let logURL = missingDir.appendingPathComponent("serial.log")
+
+        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        writer.write(Data("dropped".utf8))
+        writer.close()
+
+        #expect(!FileManager.default.fileExists(atPath: logURL.path(percentEncoded: false)))
+    }
+
+    @Test("Empty writes never trigger rotation")
+    func emptyWriteIsIgnored() throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let logURL = tempDir.appendingPathComponent("serial.log")
+        let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
+
+        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 4)
+        writer.write(Data("full".utf8))  // exactly at cap → rotates
+        writer.write(Data())  // must not rotate the now-empty live file again
+        writer.close()
+
+        #expect(contents(of: rotatedURL) == "full")
+        #expect(contents(of: logURL) == "")
+    }
+}

--- a/KernovaTests/SerialLogWriterTests.swift
+++ b/KernovaTests/SerialLogWriterTests.swift
@@ -23,8 +23,9 @@ struct SerialLogWriterTests {
         let tempDir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: tempDir) }
         let logURL = tempDir.appendingPathComponent("serial.log")
+        let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
 
-        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        let writer = SerialLogWriter(logURL: logURL, rotatedURL: rotatedURL, label: "test", maxFileSize: 1024)
         writer.write(Data("hello ".utf8))
         writer.write(Data("world".utf8))
         writer.close()
@@ -37,12 +38,13 @@ struct SerialLogWriterTests {
         let tempDir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: tempDir) }
         let logURL = tempDir.appendingPathComponent("serial.log")
+        let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
 
-        let first = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        let first = SerialLogWriter(logURL: logURL, rotatedURL: rotatedURL, label: "test", maxFileSize: 1024)
         first.write(Data("run1\n".utf8))
         first.close()
 
-        let second = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        let second = SerialLogWriter(logURL: logURL, rotatedURL: rotatedURL, label: "test", maxFileSize: 1024)
         second.write(Data("run2\n".utf8))
         second.close()
 
@@ -56,7 +58,7 @@ struct SerialLogWriterTests {
         let logURL = tempDir.appendingPathComponent("serial.log")
         let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
 
-        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 8)
+        let writer = SerialLogWriter(logURL: logURL, rotatedURL: rotatedURL, label: "test", maxFileSize: 8)
         writer.write(Data("0123456789".utf8))  // 10 bytes ≥ cap → rotates
         writer.write(Data("after".utf8))
         writer.close()
@@ -72,7 +74,7 @@ struct SerialLogWriterTests {
         let logURL = tempDir.appendingPathComponent("serial.log")
         let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
 
-        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 8)
+        let writer = SerialLogWriter(logURL: logURL, rotatedURL: rotatedURL, label: "test", maxFileSize: 8)
         writer.write(Data("first-gen".utf8))  // rotation 1
         writer.write(Data("second-gen".utf8))  // rotation 2
         writer.write(Data("live".utf8))
@@ -82,20 +84,21 @@ struct SerialLogWriterTests {
         #expect(contents(of: logURL) == "live")
     }
 
-    @Test("An oversized pre-existing log rotates on open")
-    func oversizedExistingLogRotatesOnOpen() throws {
+    @Test("An oversized pre-existing log is cleared on open, not archived")
+    func oversizedExistingLogIsClearedOnOpen() throws {
         let tempDir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: tempDir) }
         let logURL = tempDir.appendingPathComponent("serial.log")
         let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
         try Data("stale-history".utf8).write(to: logURL)
+        try Data("prior-generation".utf8).write(to: rotatedURL)
 
-        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 8)
+        let writer = SerialLogWriter(logURL: logURL, rotatedURL: rotatedURL, label: "test", maxFileSize: 8)
         writer.write(Data("fresh".utf8))
         writer.close()
 
-        #expect(contents(of: rotatedURL) == "stale-history")
         #expect(contents(of: logURL) == "fresh")
+        #expect(contents(of: rotatedURL) == "prior-generation")
     }
 
     @Test("An under-cap pre-existing log is kept and appended to")
@@ -106,7 +109,7 @@ struct SerialLogWriterTests {
         let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
         try Data("old\n".utf8).write(to: logURL)
 
-        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        let writer = SerialLogWriter(logURL: logURL, rotatedURL: rotatedURL, label: "test", maxFileSize: 1024)
         writer.write(Data("new\n".utf8))
         writer.close()
 
@@ -119,8 +122,9 @@ struct SerialLogWriterTests {
         let tempDir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: tempDir) }
         let logURL = tempDir.appendingPathComponent("serial.log")
+        let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
 
-        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        let writer = SerialLogWriter(logURL: logURL, rotatedURL: rotatedURL, label: "test", maxFileSize: 1024)
         writer.write(Data("kept".utf8))
         writer.close()
         writer.write(Data("dropped".utf8))
@@ -134,8 +138,9 @@ struct SerialLogWriterTests {
         let missingDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         let logURL = missingDir.appendingPathComponent("serial.log")
+        let rotatedURL = missingDir.appendingPathComponent("serial.log.1")
 
-        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 1024)
+        let writer = SerialLogWriter(logURL: logURL, rotatedURL: rotatedURL, label: "test", maxFileSize: 1024)
         writer.write(Data("dropped".utf8))
         writer.close()
 
@@ -149,7 +154,7 @@ struct SerialLogWriterTests {
         let logURL = tempDir.appendingPathComponent("serial.log")
         let rotatedURL = tempDir.appendingPathComponent("serial.log.1")
 
-        let writer = SerialLogWriter(logURL: logURL, label: "test", maxFileSize: 4)
+        let writer = SerialLogWriter(logURL: logURL, rotatedURL: rotatedURL, label: "test", maxFileSize: 4)
         writer.write(Data("full".utf8))  // exactly at cap → rotates
         writer.write(Data())  // must not rotate the now-empty live file again
         writer.close()

--- a/KernovaTests/VMBundleLayoutTests.swift
+++ b/KernovaTests/VMBundleLayoutTests.swift
@@ -57,6 +57,13 @@ struct VMBundleLayoutTests {
         #expect(layout.serialLogURL.deletingLastPathComponent() == bundleURL)
     }
 
+    @Test("serialLogRotatedURL appends serial.log.1 to bundle path")
+    func serialLogRotatedURL() {
+        let layout = VMBundleLayout(bundleURL: bundleURL)
+        #expect(layout.serialLogRotatedURL.lastPathComponent == "serial.log.1")
+        #expect(layout.serialLogRotatedURL.deletingLastPathComponent() == bundleURL)
+    }
+
     @Test("additionalDisksDirectoryURL appends AdditionalDisks to bundle path")
     func additionalDisksDirectoryURL() {
         let layout = VMBundleLayout(bundleURL: bundleURL)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Requires macOS 26 (Tahoe) or later on Apple Silicon to run the app. macOS guests
 - **Input** — Mac or USB keyboard-and-pointer devices, chosen automatically by guest macOS version with a per-VM override
 - **Audio** — guest audio routed to the host, on by default; host microphone passthrough opt-in per VM, off by default for privacy
 - **Network** — per-VM modes: Shared Network (default; private outbound through the host, with port-forwarding rules), Bridged onto a chosen host interface or Automatic, Host Only (guests reach the host and each other, nothing wider), or None — plus a live IP address readout and a persistent, editable MAC address with one-click regeneration
-- **Serial** — output persisted to `serial.log` in the bundle, plus an opt-in AF_UNIX socket relay for external tools (`socat`, `nc -U`), hot-toggleable while running
+- **Serial** — output persisted to a size-capped `serial.log` in the bundle, plus an opt-in AF_UNIX socket relay for external tools (`socat`, `nc -U`), hot-toggleable while running
 
 <p align="center">
   <picture>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -298,9 +298,8 @@ VMCreationWizardViewController (modal sheet, presented by DetailContainerViewCon
 ```
 
 **Serial console.** `VMInstance.startSerialReading` is the guest output pipe's single reader; it
-fans out to `serial.log` (authoritative, always on, size-capped by `SerialLogWriter`'s
-single-generation rotation to `serial.log.1`) and to `SerialSocketRelay` (best-effort tee,
-gated on `serialSocketRelayEnabled`). The relay's `AF_UNIX` socket is the sole host-side writer of
+fans out to `serial.log` (authoritative, always on, size-capped by `SerialLogWriter`) and to
+`SerialSocketRelay` (best-effort tee, gated on `serialSocketRelayEnabled`). The relay's `AF_UNIX` socket is the sole host-side writer of
 serial input. There is no in-app terminal emulator — emulation is delegated to the user's terminal.
 
 ### Data Flow

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -298,7 +298,8 @@ VMCreationWizardViewController (modal sheet, presented by DetailContainerViewCon
 ```
 
 **Serial console.** `VMInstance.startSerialReading` is the guest output pipe's single reader; it
-fans out to `serial.log` (authoritative, always on) and to `SerialSocketRelay` (best-effort tee,
+fans out to `serial.log` (authoritative, always on, size-capped by `SerialLogWriter`'s
+single-generation rotation to `serial.log.1`) and to `SerialSocketRelay` (best-effort tee,
 gated on `serialSocketRelayEnabled`). The relay's `AF_UNIX` socket is the sole host-side writer of
 serial input. There is no in-app terminal emulator — emulation is delegated to the user's terminal.
 


### PR DESCRIPTION
## Summary
- `serial.log` was opened with `seekToEnd` and appended forever — no cap, no rotation — so a chatty Linux guest's console output grew the VM bundle without bound, both across boots and within a single long run. (macOS guests never write to the virtio console port, so in practice only Linux guests feed this file — but the within-run case made it worth bounding.)
- A new `SerialLogWriter` owns the append path: at 10 MB the live file rolls to `serial.log.1`, replacing the previous generation, bounding a bundle's serial history at ~20 MB while still retaining dozens of boots of Linux console output. A pre-existing log already at or over the cap (from a build without one) is cleared at open rather than archived, so the bound holds from the first write. `VMBundleLayout` owns both in-bundle paths.
- A failed rotation logs once, disables further attempts for the session, and keeps appending — an oversized log beats losing output, and per-chunk retry would spam the log; the next start's clear-at-open reclaims the space.

A fixed cap, deliberately not user-configurable: nobody can pick a meaningful value for "how many MB of console output to retain", the worst case is already negligible next to a disk image, and anyone needing complete capture can attach to the serial socket relay and `tee` outside the bundle. Time-based rotation was rejected because growth tracks output volume, not wall-clock. Truncate-on-start was rejected because it erases last-boot output exactly when you reboot to investigate, and doesn't bound within-run growth at all.

Reviewed with `/code-review medium`: 8 candidates, 5 confirmed and fixed (oversized legacy log handling, rotated-path ownership, settings/README copy, `write(_:)` doc accuracy, ARCHITECTURE.md layering), 3 dismissed (double-start corruption refuted — fresh pipes every start; delete-before-move ordering and main-thread lock stall unreachable/negligible — bundles only live in the app container on local APFS).

Closes #275

## Changes
- `Kernova/Services/SerialLogWriter.swift` — new lock-guarded `@unchecked Sendable` appending writer with size-capped single-generation rotation
- `Kernova/Models/VMInstance.swift` — `startSerialReading`/`stopSerialReading` use `SerialLogWriter` instead of a raw `FileHandle`
- `Kernova/Models/VMBundleLayout.swift` — `serialLogRotatedURL`
- `Kernova/Views/Detail/VMSettingsViewController.swift`, `README.md` — copy mentions the cap/rotation
- `KernovaTests/SerialLogWriterTests.swift`, `KernovaTests/VMBundleLayoutTests.swift` — append, reopen-append, rotation, generation replacement, oversized-cleared-on-open, under-cap-kept, write-after-close, failed-open, empty-write, and path cases
- `docs/ARCHITECTURE.md` — serial-console paragraph notes the size cap

## Test plan
- [x] `make test-suite SUITE=KernovaTests/SerialLogWriterTests` — 9 passed
- [x] `make test` — full suite, 2836 test cases passed
- [x] `make lint` (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgmJ4bHshrgzeuLESsGw3t