### PR TITLE
feat: Start marked VMs automatically when Kernova opens

### DIFF
--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -25,8 +25,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     /// The launch pass that brings up the VMs marked to start automatically.
     ///
     /// Retained so a quit can cancel it: the pass outlives the library read, and
-    /// left running it would keep booting guests behind the termination save
-    /// pass — which would then either chase them or exit through a starting VM.
+    /// left running it would keep starting *further* guests behind the
+    /// termination save pass. Cancelling bounds the pass to the VMs it has
+    /// already reached — the one inside VZ at that moment still finishes, and a
+    /// quit does not wait on a `.starting` VM.
     private var autoStartPass: Task<Void, Never>?
     private var clipboardWindows: [UUID: ClipboardWindowController] = [:]
     private var clipboardObservers: [UUID: Any] = [:]

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -328,10 +328,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
 
     /// Brings up the resident app with its library window on screen.
     ///
-    /// VMs are **not** auto-started — they appear at their last-logout state — and
-    /// idle termination is not armed: while *Continue running in Status Bar* is
-    /// on the app stays resident until an explicit Quit, with any running VMs
-    /// executing headless.
+    /// VMs appear at their last-logout state, except those marked
+    /// `VMConfiguration.startsAutomaticallyOnLaunch`, which come up once the
+    /// library read lands. Idle termination is not armed: while *Continue running
+    /// in Status Bar* is on the app stays resident until an explicit Quit, with
+    /// any running VMs executing headless.
     private func startResidentApp() {
         syncStatusItem()
         observeResidencyPreference()
@@ -359,6 +360,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         Self.logger.notice("Kernova resident app ready — \(provenance, privacy: .public)")
 
         summonUserInterface()
+
+        // After the summon, not before: its deferred window show runs while the
+        // library read is still doing its off-main-actor file I/O, so a VM
+        // booting here finds the measurable surface `applyMatchWindowBootResolution`
+        // needs. The marked VMs only exist in `instances` once that read applies.
+        Task { @MainActor in
+            await self.libraryLoad?.value
+            await self.viewModel.startAutomaticVMsForLaunch()
+        }
     }
 
     /// Builds the menu-bar status item.

--- a/Kernova/App/AppDelegate.swift
+++ b/Kernova/App/AppDelegate.swift
@@ -22,6 +22,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
     /// Retained so `application(_:open:)` can wait for it: a Finder open that
     /// launched the app is delivered while the read is still in flight.
     private var libraryLoad: Task<Void, Never>?
+    /// The launch pass that brings up the VMs marked to start automatically.
+    ///
+    /// Retained so a quit can cancel it: the pass outlives the library read, and
+    /// left running it would keep booting guests behind the termination save
+    /// pass — which would then either chase them or exit through a starting VM.
+    private var autoStartPass: Task<Void, Never>?
     private var clipboardWindows: [UUID: ClipboardWindowController] = [:]
     private var clipboardObservers: [UUID: Any] = [:]
     private var displayWindows: [UUID: VMDisplayWindowController] = [:]
@@ -365,7 +371,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
         // library read is still doing its off-main-actor file I/O, so a VM
         // booting here finds the measurable surface `applyMatchWindowBootResolution`
         // needs. The marked VMs only exist in `instances` once that read applies.
-        Task { @MainActor in
+        autoStartPass = Task { @MainActor in
             await self.libraryLoad?.value
             await self.viewModel.startAutomaticVMsForLaunch()
         }
@@ -923,10 +929,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, 
             return .terminateLater
 
         case .terminateNow:
+            autoStartPass?.cancel()
             cancelAndCleanupPreparingInstances()
             return .terminateNow
 
         case .saveThenTerminate:
+            // Before the save pass, so it never has to chase a guest the launch
+            // pass brings up behind it.
+            autoStartPass?.cancel()
             cancelAndCleanupPreparingInstances()
             // macOS quits and relaunches the app when a TCC permission is revoked, and
             // its built-in relaunch times out while VMs are saving. Mark for relaunch

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -39,6 +39,15 @@ struct VMConfiguration: Codable, Sendable, Equatable {
     var guestOS: VMGuestOS
     var bootMode: VMBootMode
 
+    // MARK: - Startup
+
+    /// When `true`, Kernova starts this VM as part of coming up — resuming it
+    /// from saved state when one exists, cold-booting it otherwise.
+    ///
+    /// A VM still awaiting its initial boot is left alone: its start runs an
+    /// install or an image download, which never begins unattended.
+    var startsAutomaticallyOnLaunch: Bool
+
     // MARK: - Resources
 
     var cpuCount: Int
@@ -252,6 +261,7 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         name: String,
         guestOS: VMGuestOS,
         bootMode: VMBootMode,
+        startsAutomaticallyOnLaunch: Bool = false,
         cpuCount: Int? = nil,
         memorySizeInGB: Int? = nil,
         diskSizeInGB: Int? = nil,
@@ -298,6 +308,7 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         self.name = name
         self.guestOS = guestOS
         self.bootMode = bootMode
+        self.startsAutomaticallyOnLaunch = startsAutomaticallyOnLaunch
         self.cpuCount = cpuCount ?? guestOS.defaultCPUCount
         self.memorySizeInGB = memorySizeInGB ?? guestOS.defaultMemoryInGB
         self.diskSizeInGB = diskSizeInGB ?? VMGuestOS.defaultDiskSizeInGB
@@ -354,6 +365,8 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         self.name = try c.decode(String.self, forKey: .name)
         self.guestOS = try c.decode(VMGuestOS.self, forKey: .guestOS)
         self.bootMode = try c.decode(VMBootMode.self, forKey: .bootMode)
+        self.startsAutomaticallyOnLaunch =
+            try c.decodeIfPresent(Bool.self, forKey: .startsAutomaticallyOnLaunch) ?? false
         self.cpuCount = try c.decode(Int.self, forKey: .cpuCount)
         self.memorySizeInGB = try c.decode(Int.self, forKey: .memorySizeInGB)
         self.diskSizeInGB = try c.decode(Int.self, forKey: .diskSizeInGB)
@@ -488,6 +501,11 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         // A clone's guest-agent state hasn't been evaluated by the user, so let
         // the install nudge surface again rather than inheriting the dismissal.
         clone.agentInstallNudgeDismissed = false
+
+        // Duplicating a VM asks for a copy, not for a second guest booting at
+        // every launch — and a clone keeping the source's machine ID would be
+        // refused by the duplicate-identity guard every time.
+        clone.startsAutomaticallyOnLaunch = false
 
         return clone
     }

--- a/Kernova/Models/VMConfiguration.swift
+++ b/Kernova/Models/VMConfiguration.swift
@@ -521,6 +521,16 @@ struct VMConfiguration: Codable, Sendable, Equatable {
         UInt64(memorySizeInGB) * 1024 * 1024 * 1024
     }
 
+    /// Whether this VM has yet to complete its initial boot — a surviving
+    /// install context of either guest's kind.
+    ///
+    /// The canonical signal, and the one ``VMStatus/initialBoot`` is derived
+    /// from: a start here runs the macOS install or the Linux image download
+    /// rather than booting the guest.
+    var hasPendingSetup: Bool {
+        installContext != nil || linuxInstallContext != nil
+    }
+
     /// The stored `displayWidth`/`displayHeight`/`displayPPI` trio as one value.
     var displayResolution: DisplayBootSizing.Resolution {
         get {

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -1379,7 +1379,14 @@ final class VMLibraryViewModel {
     private func reserveAndImport(from sourceURL: URL) {
         do {
             let vmsDir = try storageService.vmsDirectory
-            let config = try storageService.loadConfiguration(from: sourceURL)
+            var config = try storageService.loadConfiguration(from: sourceURL)
+
+            // Auto-start is the one setting that runs a guest with no user
+            // action, so it is local intent rather than something a bundle
+            // carries in: a VM arriving pre-marked would boot on the next
+            // launch without ever being asked for. The local user marks it.
+            let arrivedMarkedForAutoStart = config.startsAutomaticallyOnLaunch
+            config.startsAutomaticallyOnLaunch = false
 
             // Already in the library by UUID (including a source already inside the VMs
             // directory) — select it rather than re-importing.
@@ -1399,11 +1406,18 @@ final class VMLibraryViewModel {
                 configuration: config, bundleURL: destinationURL, status: initialStatus,
                 preferences: preferences)
 
+            let storage = storageService
+            let sanitizedConfig = config
             prepareBundle(
                 phantom, operation: .importing,
                 copyWork: {
                     try await Self.runBoundedCopy {
                         try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+                    }
+                    // The copy reproduces the source `config.json` verbatim, so
+                    // the cleared flag only reaches disk by writing it back.
+                    if arrivedMarkedForAutoStart {
+                        try storage.saveConfiguration(sanitizedConfig, to: destinationURL)
                     }
                 },
                 onSuccess: {
@@ -2557,6 +2571,9 @@ final class VMLibraryViewModel {
     ///
     /// Per-VM failures are logged and surfaced by those two methods; the pass
     /// carries on to the next VM either way.
+    ///
+    /// Cancelling stops it between VMs — a start already inside VZ is left to
+    /// finish, since abandoning one mid-flight is worse than completing it.
     func startAutomaticVMsForLaunch() async {
         let marked = instances.filter { $0.configuration.startsAutomaticallyOnLaunch }
         guard !marked.isEmpty else {
@@ -2570,6 +2587,22 @@ final class VMLibraryViewModel {
         var skippedCount = 0
         var failedCount = 0
         for instance in marked {
+            // A quit cancels the pass; anything left is the terminating app's
+            // business, not this one's.
+            if Task.isCancelled {
+                Self.logger.notice("Launch auto-start cancelled — the app is terminating")
+                break
+            }
+            // A boot takes long enough for the user to delete or evict a later
+            // VM meanwhile, and `marked` still holds that instance. Starting it
+            // would open a display window over a bundle no longer in the library.
+            guard instances.contains(where: { $0 === instance }) else {
+                Self.logger.debug(
+                    "Launch auto-start: '\(instance.name, privacy: .public)' left the library before its turn"
+                )
+                skippedCount += 1
+                continue
+            }
             // Re-read at the moment of acting rather than trusting the snapshot:
             // the user can start a VM by hand while this pass runs, and the
             // previous iteration's boot is what can make the next one a

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -2539,6 +2539,20 @@ final class VMLibraryViewModel {
 
     // MARK: - Launch Auto-Start
 
+    /// Names of the macOS VMs marked to start automatically, in library order —
+    /// which is the order ``startAutomaticVMsForLaunch()`` reaches them in.
+    ///
+    /// Feeds the Startup section's capacity warning: macOS caps how many macOS
+    /// guests run at once, so a longer list than that cap cannot come up whole.
+    var macOSVMNamesMarkedForAutoStart: [String] {
+        instances
+            .filter {
+                $0.configuration.guestOS == .macOS
+                    && $0.configuration.startsAutomaticallyOnLaunch
+            }
+            .map(\.name)
+    }
+
     /// What the launch auto-start pass does with one VM.
     enum AutoStartStep: Equatable {
         case start

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -234,7 +234,7 @@ final class VMLibraryViewModel {
     /// that the VM has never completed its initial boot, so it outranks
     /// `.paused`/`.stopped`.
     nonisolated static func initialStatus(for config: VMConfiguration, layout: VMBundleLayout) -> VMStatus {
-        if config.installContext != nil || config.linuxInstallContext != nil {
+        if config.hasPendingSetup {
             return .initialBoot
         }
         return layout.hasSaveFile ? .paused : .stopped
@@ -2548,16 +2548,22 @@ final class VMLibraryViewModel {
 
     /// The pass's move for one VM, decided from state alone.
     ///
-    /// `.initialBoot` satisfies ``VMStatus/canStart`` yet is skipped: its start
-    /// runs the macOS install or the Linux image download, neither of which may
-    /// begin unattended.
+    /// A VM that has yet to finish setup is skipped: its start runs the macOS
+    /// install or the Linux image download, neither of which may begin
+    /// unattended. ``VMConfiguration/hasPendingSetup`` is what decides that, not
+    /// the status — ``start(_:)`` dispatches on the surviving install context
+    /// too, so a failed install sitting at `.error` still routes into the
+    /// installer, and `.error` otherwise means "retry the boot".
     nonisolated static func autoStartStep(
         startsAutomaticallyOnLaunch: Bool,
         isPreparing: Bool,
+        hasPendingSetup: Bool,
         isColdPaused: Bool,
         status: VMStatus
     ) -> AutoStartStep {
-        guard startsAutomaticallyOnLaunch, !isPreparing, status != .initialBoot else { return .skip }
+        guard startsAutomaticallyOnLaunch, !isPreparing, !hasPendingSetup,
+            status != .initialBoot
+        else { return .skip }
         if isColdPaused { return .resume }
         return status.canStart ? .start : .skip
     }
@@ -2610,6 +2616,7 @@ final class VMLibraryViewModel {
             let step = Self.autoStartStep(
                 startsAutomaticallyOnLaunch: instance.configuration.startsAutomaticallyOnLaunch,
                 isPreparing: instance.isPreparing,
+                hasPendingSetup: instance.configuration.hasPendingSetup,
                 isColdPaused: instance.isColdPaused,
                 status: instance.status)
             switch step {

--- a/Kernova/ViewModels/VMLibraryViewModel.swift
+++ b/Kernova/ViewModels/VMLibraryViewModel.swift
@@ -2523,6 +2523,86 @@ final class VMLibraryViewModel {
             })
     }
 
+    // MARK: - Launch Auto-Start
+
+    /// What the launch auto-start pass does with one VM.
+    enum AutoStartStep: Equatable {
+        case start
+        case resume
+        case skip
+    }
+
+    /// The pass's move for one VM, decided from state alone.
+    ///
+    /// `.initialBoot` satisfies ``VMStatus/canStart`` yet is skipped: its start
+    /// runs the macOS install or the Linux image download, neither of which may
+    /// begin unattended.
+    nonisolated static func autoStartStep(
+        startsAutomaticallyOnLaunch: Bool,
+        isPreparing: Bool,
+        isColdPaused: Bool,
+        status: VMStatus
+    ) -> AutoStartStep {
+        guard startsAutomaticallyOnLaunch, !isPreparing, status != .initialBoot else { return .skip }
+        if isColdPaused { return .resume }
+        return status.canStart ? .start : .skip
+    }
+
+    /// Starts every VM marked to start automatically, one after another.
+    ///
+    /// Sequential on purpose: each guest commits its whole memory allocation at
+    /// start, and the duplicate machine-ID and MAC refusals inside ``start(_:)``
+    /// and ``resume(_:)`` compare against VMs that are already live, so they only
+    /// answer deterministically once the previous VM has settled.
+    ///
+    /// Per-VM failures are logged and surfaced by those two methods; the pass
+    /// carries on to the next VM either way.
+    func startAutomaticVMsForLaunch() async {
+        let marked = instances.filter { $0.configuration.startsAutomaticallyOnLaunch }
+        guard !marked.isEmpty else {
+            Self.logger.debug("Launch auto-start: no VMs are marked to start automatically")
+            return
+        }
+
+        Self.logger.notice("Launch auto-start: \(marked.count, privacy: .public) VM(s) marked")
+
+        var startedCount = 0
+        var skippedCount = 0
+        var failedCount = 0
+        for instance in marked {
+            // Re-read at the moment of acting rather than trusting the snapshot:
+            // the user can start a VM by hand while this pass runs, and the
+            // previous iteration's boot is what can make the next one a
+            // duplicate-identity conflict.
+            let step = Self.autoStartStep(
+                startsAutomaticallyOnLaunch: instance.configuration.startsAutomaticallyOnLaunch,
+                isPreparing: instance.isPreparing,
+                isColdPaused: instance.isColdPaused,
+                status: instance.status)
+            switch step {
+            case .start:
+                await start(instance)
+            case .resume:
+                await resume(instance)
+            case .skip:
+                Self.logger.debug(
+                    "Launch auto-start: skipped '\(instance.name, privacy: .public)' (\(instance.status.displayName, privacy: .public))"
+                )
+                skippedCount += 1
+                continue
+            }
+            if instance.status.isActive {
+                startedCount += 1
+            } else {
+                failedCount += 1
+            }
+        }
+
+        Self.logger.notice(
+            "Launch auto-start finished — \(startedCount, privacy: .public) running, \(failedCount, privacy: .public) failed, \(skippedCount, privacy: .public) skipped"
+        )
+    }
+
     // MARK: - Sleep/Wake
 
     /// Pauses all running VMs before system sleep, tracking which were auto-paused so

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -119,6 +119,9 @@ final class VMSettingsViewController: NSViewController {
 
     // Startup
     private var autoStartSwitch = NSSwitch()
+    /// Holds the banner naming how many macOS guests are marked to start at
+    /// launch, when that exceeds what macOS runs at once.
+    private var autoStartWarningContainer = NSStackView()
 
     // Resources
     private var cpuField = NSTextField()
@@ -249,6 +252,8 @@ final class VMSettingsViewController: NSViewController {
     /// The duplicate-MAC banner's rendered message, `nil` when no banner is
     /// shown, so a pass that changed nothing about it skips the rebuild.
     private var renderedNetworkMACWarning: String?
+    /// The Startup capacity banner's rendered message, on the same terms.
+    private var renderedAutoStartWarning: String?
     /// The Mode menu's rendered selection, so an `apply()` pass that changed
     /// nothing about networking skips a rebuild — which enumerates the host's
     /// bridgeable interfaces and queries the process signature.
@@ -391,6 +396,11 @@ final class VMSettingsViewController: NSViewController {
                 // duplicate-MAC banner follows a change made on the *other*
                 // holder, and library membership changing under it.
                 _ = self.viewModel.vmNamesSharingMACAddress(with: self.instance)
+                // Same reach for the Startup capacity banner, which counts the
+                // marked macOS guests across the whole library. Registered on
+                // its own rather than riding the read above, which is free to
+                // stop enumerating every configuration.
+                _ = self.viewModel.macOSVMNamesMarkedForAutoStart
             },
             apply: { [weak self] in self?.apply() }
         )
@@ -520,6 +530,7 @@ extension VMSettingsViewController {
         renderedSharedRows = nil
         renderedAudioWarning = nil
         renderedNetworkMACWarning = nil
+        renderedAutoStartWarning = nil
         renderedNetworkChoice = nil
         renderedPortForwardingRows = nil
 
@@ -724,7 +735,34 @@ extension VMSettingsViewController {
 
     // MARK: Startup
 
-    /// The Startup card's one toggle.
+    /// How many macOS guests macOS itself will run at the same time.
+    ///
+    /// The cap is the platform's, enforced by VZ — a start past it fails, which
+    /// is what ``VMLibraryViewModel/explainedFailure(for:on:)`` explains after
+    /// the fact. Here it is read ahead of time, off the marked set.
+    static let concurrentMacOSGuestLimit = 2
+
+    /// Caption under the Startup card: the launch pass walks the library in
+    /// sidebar order, so that is the order the marked VMs come up in.
+    static let autoStartOrderCaption =
+        "Virtual machines start in the order they appear in the sidebar."
+
+    /// Warning for a marked set macOS cannot run at once, or `nil` when it fits.
+    ///
+    /// Shown only on a macOS guest's own pane: it is the guests past the cap
+    /// that fail, and the pane a user is looking at is the one they can act on.
+    /// Linux guests do not count against the macOS cap and never see it.
+    static func autoStartCapacityWarning(
+        isMacOSGuest: Bool, markedMacOSVMCount: Int
+    ) -> String? {
+        guard isMacOSGuest, markedMacOSVMCount > concurrentMacOSGuestLimit else { return nil }
+        return "\(markedMacOSVMCount) macOS virtual machines are set to start when Kernova opens. "
+            + "macOS allows at most two macOS virtual machines to run at once, "
+            + "so the ones after the first two won't start."
+    }
+
+    /// The Startup card's one toggle, its ordering caption, and the capacity
+    /// banner's container.
     ///
     /// Not `lockable`, and `autoStartSwitch` stays out of
     /// `persistentLockableControls`: the flag is read once at app launch and
@@ -743,7 +781,18 @@ extension VMSettingsViewController {
                     ),
                 ])
         ])
-        return makeSection([makeHeader("Startup"), card])
+
+        autoStartWarningContainer = NSStackView()
+        autoStartWarningContainer.orientation = .vertical
+        autoStartWarningContainer.alignment = .leading
+        autoStartWarningContainer.spacing = Spacing.small
+        autoStartWarningContainer.translatesAutoresizingMaskIntoConstraints = false
+
+        return makeSection([
+            makeHeader("Startup"), card,
+            makeGroupedFormCaption(Self.autoStartOrderCaption),
+            autoStartWarningContainer,
+        ])
     }
 
     // MARK: Resources
@@ -1964,6 +2013,17 @@ extension VMSettingsViewController {
 
     private func refreshStartup() {
         autoStartSwitch.state = instance.configuration.startsAutomaticallyOnLaunch ? .on : .off
+
+        let message = Self.autoStartCapacityWarning(
+            isMacOSGuest: instance.configuration.guestOS == .macOS,
+            markedMacOSVMCount: viewModel.macOSVMNamesMarkedForAutoStart.count)
+        guard message != renderedAutoStartWarning else { return }
+        renderedAutoStartWarning = message
+        autoStartWarningContainer.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        guard let message else { return }
+        let banner = makeGroupedFormBanner(
+            symbolName: "exclamationmark.triangle.fill", tint: .systemYellow, message: message)
+        addFullWidth(banner, to: autoStartWarningContainer)
     }
 
     private func refreshResources() {

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -117,6 +117,9 @@ final class VMSettingsViewController: NSViewController {
     /// space, so without this the box would linger.
     private var nameOutsideClickMonitor: Any?
 
+    // Startup
+    private var autoStartSwitch = NSSwitch()
+
     // Resources
     private var cpuField = NSTextField()
     private var cpuStepper = NSStepper()
@@ -523,6 +526,7 @@ extension VMSettingsViewController {
         displayResolutionIsCustom = false
 
         addSection(buildGeneralSection())
+        addSection(buildStartupSection())
         addSection(buildResourcesSection())
         addSection(buildDisplaySection())
         addSection(buildStorageSection())
@@ -716,6 +720,30 @@ extension VMSettingsViewController {
                     instance.configuration.createdAt.formatted(date: .abbreviated, time: .shortened))),
         ]
         return makeSection([makeHeader("General"), makeGroupedFormCard(rows: rows)])
+    }
+
+    // MARK: Startup
+
+    /// The Startup card's one toggle.
+    ///
+    /// Not `lockable`, and `autoStartSwitch` stays out of
+    /// `persistentLockableControls`: the flag is read once at app launch and
+    /// reaches no `VZVirtualMachineConfiguration`, so it edits while the VM runs.
+    private func buildStartupSection() -> NSView {
+        autoStartSwitch = makeSwitch(action: #selector(autoStartToggled))
+        let card = makeGroupedFormCard(rows: [
+            makeToggleRowWithInfo(
+                "Start When Kernova Opens", control: autoStartSwitch,
+                paragraphs: [
+                    .body(
+                        "Starts this virtual machine each time Kernova opens. A suspended VM resumes from its saved state; one that has not finished its initial setup is left alone."
+                    ),
+                    .body(
+                        "Turn on Open at Login in Settings → General to have it running after you log in."
+                    ),
+                ])
+        ])
+        return makeSection([makeHeader("Startup"), card])
     }
 
     // MARK: Resources
@@ -1826,6 +1854,7 @@ extension VMSettingsViewController {
         persistentLockableControls.forEach { $0.isEnabled = !isReadOnly }
 
         refreshGeneral()
+        refreshStartup()
         refreshResources()
         refreshDisplay()
         refreshNetwork()
@@ -1931,6 +1960,10 @@ extension VMSettingsViewController {
         nameRowIsEditing = false
         nameDisplayRow.isHidden = false
         nameEditRow.isHidden = true
+    }
+
+    private func refreshStartup() {
+        autoStartSwitch.state = instance.configuration.startsAutomaticallyOnLaunch ? .on : .off
     }
 
     private func refreshResources() {
@@ -2655,6 +2688,10 @@ extension VMSettingsViewController: NSMenuItemValidation {
         // Routed through the view model's named accessor rather than the generic
         // `writeConfig` so every write of this flag shares one logged path.
         viewModel.setAgentInstallNudgeDismissed(installReminderSwitch.state != .on, for: instance)
+    }
+
+    @objc private func autoStartToggled() {
+        writeConfig { $0.startsAutomaticallyOnLaunch = autoStartSwitch.state == .on }
     }
 
     @objc private func serialRelayToggled() {

--- a/KernovaTests/VMConfigurationCloneTests.swift
+++ b/KernovaTests/VMConfigurationCloneTests.swift
@@ -190,6 +190,14 @@ struct VMConfigurationCloneTests {
         #expect(clone.agentInstallNudgeDismissed == false)
     }
 
+    @Test("Clone resets startsAutomaticallyOnLaunch to false")
+    func cloneResetsStartsAutomaticallyOnLaunch() {
+        var config = makeConfig()
+        config.startsAutomaticallyOnLaunch = true
+        let clone = config.clonedForNewInstance(existingNames: [])
+        #expect(clone.startsAutomaticallyOnLaunch == false)
+    }
+
     // MARK: - Shared Directories
 
     @Test("Clone regenerates shared directory IDs")

--- a/KernovaTests/VMConfigurationTests.swift
+++ b/KernovaTests/VMConfigurationTests.swift
@@ -360,6 +360,38 @@ struct VMConfigurationTests {
         #expect(config.serialSocketRelayEnabled == false)
     }
 
+    // MARK: - Launch Auto-Start
+
+    @Test("startsAutomaticallyOnLaunch round-trips through JSON")
+    func startsAutomaticallyOnLaunchRoundTrip() throws {
+        var original = VMConfiguration(name: "Auto VM", guestOS: .linux, bootMode: .efi)
+        original.startsAutomaticallyOnLaunch = true
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(VMConfiguration.self, from: try encoder.encode(original))
+
+        #expect(decoded.startsAutomaticallyOnLaunch == true)
+    }
+
+    @Test("Missing startsAutomaticallyOnLaunch decodes as false")
+    func missingStartsAutomaticallyOnLaunchDefaultsFalse() throws {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let config = try decoder.decode(VMConfiguration.self, from: Data(Self.makeBaseJSON().utf8))
+
+        #expect(config.startsAutomaticallyOnLaunch == false)
+    }
+
+    @Test("A new configuration does not start automatically")
+    func newConfigurationDoesNotStartAutomatically() {
+        let config = VMConfiguration(name: "Fresh VM", guestOS: .linux, bootMode: .efi)
+
+        #expect(config.startsAutomaticallyOnLaunch == false)
+    }
+
     // MARK: - Port Forwarding
 
     @Test("Port forwarding rules round-trip through JSON")
@@ -1352,6 +1384,7 @@ struct VMConfigurationTests {
             name: "Comprehensive VM",
             guestOS: .macOS,
             bootMode: .macOS,
+            startsAutomaticallyOnLaunch: true,
             cpuCount: 12,
             memorySizeInGB: 24,
             diskSizeInGB: 256,

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -4395,6 +4395,139 @@ struct VMLibraryViewModelTests {
         #expect(viewModel.activeRename == .sidebar(other.id))
     }
 
+    // MARK: - Launch Auto-Start
+
+    /// Marks the instance to start automatically, returning it for chaining.
+    @discardableResult
+    private func markAutoStart(_ instance: VMInstance) -> VMInstance {
+        instance.configuration.startsAutomaticallyOnLaunch = true
+        return instance
+    }
+
+    /// One row of the launch auto-start decision table.
+    struct AutoStartCase: Sendable, CustomStringConvertible {
+        let marked: Bool
+        let isPreparing: Bool
+        let isColdPaused: Bool
+        let status: VMStatus
+        let expected: VMLibraryViewModel.AutoStartStep
+
+        init(
+            marked: Bool, preparing: Bool = false, coldPaused: Bool = false, _ status: VMStatus,
+            _ expected: VMLibraryViewModel.AutoStartStep
+        ) {
+            self.marked = marked
+            self.isPreparing = preparing
+            self.isColdPaused = coldPaused
+            self.status = status
+            self.expected = expected
+        }
+
+        var description: String {
+            "marked \(marked), preparing \(isPreparing), coldPaused \(isColdPaused), "
+                + "\(status.displayName) → \(expected)"
+        }
+    }
+
+    @Test(
+        "autoStartStep decides start, resume, or skip from state",
+        arguments: [
+            AutoStartCase(marked: true, .stopped, .start),
+            AutoStartCase(marked: true, .error, .start),
+            AutoStartCase(marked: true, coldPaused: true, .paused, .resume),
+            // A VM that never finished setup would begin an unattended install
+            // or image download, so it is skipped despite passing `canStart`.
+            AutoStartCase(marked: true, .initialBoot, .skip),
+            AutoStartCase(marked: true, preparing: true, .stopped, .skip),
+            AutoStartCase(marked: true, .running, .skip),
+            AutoStartCase(marked: true, .starting, .skip),
+            AutoStartCase(marked: true, .saving, .skip),
+            AutoStartCase(marked: true, .restoring, .skip),
+            AutoStartCase(marked: true, .installing, .skip),
+            // Live-paused: the VZ object is already in memory, so the launch
+            // pass has nothing to bring up.
+            AutoStartCase(marked: true, .paused, .skip),
+            AutoStartCase(marked: false, .stopped, .skip),
+            AutoStartCase(marked: false, coldPaused: true, .paused, .skip),
+        ])
+    func autoStartStepMatrix(testCase: AutoStartCase) {
+        #expect(
+            VMLibraryViewModel.autoStartStep(
+                startsAutomaticallyOnLaunch: testCase.marked,
+                isPreparing: testCase.isPreparing,
+                isColdPaused: testCase.isColdPaused,
+                status: testCase.status) == testCase.expected)
+    }
+
+    @Test("startAutomaticVMsForLaunch starts only marked VMs")
+    func autoStartStartsOnlyMarked() async {
+        let (viewModel, _, _, virtService, _) = makeViewModel()
+        let marked1 = markAutoStart(makeInstance(name: "Marked 1"))
+        let marked2 = markAutoStart(makeInstance(name: "Marked 2"))
+        let unmarked = makeInstance(name: "Unmarked")
+        viewModel.instances = [marked1, marked2, unmarked]
+
+        await viewModel.startAutomaticVMsForLaunch()
+
+        #expect(virtService.startCallCount == 2)
+        #expect(marked1.status == .running)
+        #expect(marked2.status == .running)
+        #expect(unmarked.status == .stopped)
+    }
+
+    @Test("startAutomaticVMsForLaunch resumes a marked VM with saved state")
+    func autoStartResumesColdPaused() async {
+        let (viewModel, _, _, virtService, _) = makeViewModel()
+        let saved = markAutoStart(makeInstance(name: "Suspended"))
+        saved.status = .paused
+        viewModel.instances = [saved]
+
+        await viewModel.startAutomaticVMsForLaunch()
+
+        #expect(virtService.resumeCallCount == 1)
+        #expect(virtService.startCallCount == 0)
+        #expect(saved.status == .running)
+    }
+
+    @Test("startAutomaticVMsForLaunch leaves a marked VM awaiting initial boot alone")
+    func autoStartSkipsInitialBoot() async {
+        let (viewModel, _, _, virtService, _) = makeViewModel()
+        let fresh = markAutoStart(makeInstance(name: "Never Booted"))
+        fresh.status = .initialBoot
+        viewModel.instances = [fresh]
+
+        await viewModel.startAutomaticVMsForLaunch()
+
+        #expect(virtService.startCallCount == 0)
+        #expect(fresh.status == .initialBoot)
+    }
+
+    @Test("startAutomaticVMsForLaunch carries on past a VM that fails to start")
+    func autoStartContinuesAfterFailure() async {
+        let virtService = MockVirtualizationService()
+        virtService.startError = VirtualizationError.noVirtualMachine
+        let (viewModel, _, _, _, _) = makeViewModel(virtualizationService: virtService)
+        let failing = markAutoStart(makeInstance(name: "Failing"))
+        let following = markAutoStart(makeInstance(name: "Following"))
+        viewModel.instances = [failing, following]
+
+        await viewModel.startAutomaticVMsForLaunch()
+
+        #expect(virtService.startCallCount == 2)
+        #expect(presenter.showError == true)
+    }
+
+    @Test("startAutomaticVMsForLaunch does nothing when no VM is marked")
+    func autoStartNoOpWhenNothingMarked() async {
+        let (viewModel, _, _, virtService, _) = makeViewModel()
+        viewModel.instances = [makeInstance(name: "Unmarked")]
+
+        await viewModel.startAutomaticVMsForLaunch()
+
+        #expect(virtService.startCallCount == 0)
+        #expect(virtService.resumeCallCount == 0)
+    }
+
     // MARK: - Sleep/Wake
 
     @Test("pauseAllForSleep pauses only running VMs")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -4469,6 +4469,20 @@ struct VMLibraryViewModelTests {
                 status: testCase.status) == testCase.expected)
     }
 
+    @Test("macOSVMNamesMarkedForAutoStart lists marked macOS VMs in library order")
+    func markedMacOSVMNamesFollowLibraryOrder() {
+        let (viewModel, _, _, _, _) = makeViewModel()
+        let firstMac = markAutoStart(makeInstance(name: "Mac One", guestOS: .macOS))
+        let unmarkedMac = makeInstance(name: "Mac Unmarked", guestOS: .macOS)
+        let markedLinux = markAutoStart(makeInstance(name: "Linux Marked"))
+        let secondMac = markAutoStart(makeInstance(name: "Mac Two", guestOS: .macOS))
+        viewModel.instances = [firstMac, unmarkedMac, markedLinux, secondMac]
+
+        // Linux guests don't count against the macOS cap, and an unmarked macOS
+        // VM isn't coming up at launch.
+        #expect(viewModel.macOSVMNamesMarkedForAutoStart == ["Mac One", "Mac Two"])
+    }
+
     @Test("startAutomaticVMsForLaunch starts only marked VMs")
     func autoStartStartsOnlyMarked() async {
         let (viewModel, _, _, virtService, _) = makeViewModel()

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -4517,6 +4517,45 @@ struct VMLibraryViewModelTests {
         #expect(presenter.showError == true)
     }
 
+    @Test("startAutomaticVMsForLaunch stops between VMs once cancelled")
+    func autoStartHonorsCancellation() async {
+        let (viewModel, suspending) = makeSuspendingViewModel()
+        let first = markAutoStart(makeInstance(name: "First"))
+        let second = markAutoStart(makeInstance(name: "Second"))
+        viewModel.instances = [first, second]
+
+        let pass = Task { await viewModel.startAutomaticVMsForLaunch() }
+        // Suspended inside the first VM's start — the quit lands here.
+        await suspending.waitUntilSuspended()
+        pass.cancel()
+        suspending.shouldSuspendOnStart = false
+        suspending.resumeSuspended()
+        await pass.value
+
+        #expect(first.status == .running)
+        #expect(second.status == .stopped)
+    }
+
+    @Test("startAutomaticVMsForLaunch skips a VM that left the library mid-pass")
+    func autoStartSkipsInstanceRemovedMidPass() async {
+        let (viewModel, suspending) = makeSuspendingViewModel()
+        let first = markAutoStart(makeInstance(name: "First"))
+        let second = markAutoStart(makeInstance(name: "Second"))
+        viewModel.instances = [first, second]
+
+        let pass = Task { await viewModel.startAutomaticVMsForLaunch() }
+        // Deleted while the first VM is still booting, so the pass's snapshot
+        // holds an instance the library no longer has.
+        await suspending.waitUntilSuspended()
+        viewModel.instances = [first]
+        suspending.shouldSuspendOnStart = false
+        suspending.resumeSuspended()
+        await pass.value
+
+        #expect(first.status == .running)
+        #expect(second.status == .stopped)
+    }
+
     @Test("startAutomaticVMsForLaunch does nothing when no VM is marked")
     func autoStartNoOpWhenNothingMarked() async {
         let (viewModel, _, _, virtService, _) = makeViewModel()
@@ -4708,6 +4747,26 @@ struct VMLibraryViewModelTests {
             #expect(FileManager.default.fileExists(atPath: imported.bundleURL.path(percentEncoded: false)))
         }
         #expect(presenter.showError == false)
+    }
+
+    /// Auto-start runs a guest with no user action, so it is local intent rather
+    /// than something a bundle carries in from elsewhere.
+    @Test("Importing a bundle pre-marked to start automatically clears the flag")
+    func importClearsAutoStartFlag() async throws {
+        let (viewModel, storage, _, _, _) = makeViewModel()
+        let source = try makeImportSource(name: "Pre-marked VM", storage: storage)
+        defer { try? FileManager.default.removeItem(at: source.url.deletingLastPathComponent()) }
+        var marked = source.config
+        marked.startsAutomaticallyOnLaunch = true
+        storage.bundles[source.url] = marked
+
+        _ = viewModel.importVMs(fromDroppedURLs: [source.url])
+        await viewModel.awaitPreparingForTesting()
+
+        let imported = try #require(viewModel.instances.first)
+        #expect(imported.configuration.startsAutomaticallyOnLaunch == false)
+        // …and the cleared flag reached the imported bundle, not just the row.
+        #expect(storage.bundles[imported.bundleURL]?.startsAutomaticallyOnLaunch == false)
     }
 
     @Test("importVMs imports every bundle in a multi-select batch (#444)")

--- a/KernovaTests/VMLibraryViewModelTests.swift
+++ b/KernovaTests/VMLibraryViewModelTests.swift
@@ -4408,24 +4408,27 @@ struct VMLibraryViewModelTests {
     struct AutoStartCase: Sendable, CustomStringConvertible {
         let marked: Bool
         let isPreparing: Bool
+        let hasPendingSetup: Bool
         let isColdPaused: Bool
         let status: VMStatus
         let expected: VMLibraryViewModel.AutoStartStep
 
         init(
-            marked: Bool, preparing: Bool = false, coldPaused: Bool = false, _ status: VMStatus,
+            marked: Bool, preparing: Bool = false, pendingSetup: Bool = false,
+            coldPaused: Bool = false, _ status: VMStatus,
             _ expected: VMLibraryViewModel.AutoStartStep
         ) {
             self.marked = marked
             self.isPreparing = preparing
+            self.hasPendingSetup = pendingSetup
             self.isColdPaused = coldPaused
             self.status = status
             self.expected = expected
         }
 
         var description: String {
-            "marked \(marked), preparing \(isPreparing), coldPaused \(isColdPaused), "
-                + "\(status.displayName) → \(expected)"
+            "marked \(marked), preparing \(isPreparing), pendingSetup \(hasPendingSetup), "
+                + "coldPaused \(isColdPaused), \(status.displayName) → \(expected)"
         }
     }
 
@@ -4438,6 +4441,12 @@ struct VMLibraryViewModelTests {
             // A VM that never finished setup would begin an unattended install
             // or image download, so it is skipped despite passing `canStart`.
             AutoStartCase(marked: true, .initialBoot, .skip),
+            AutoStartCase(marked: true, pendingSetup: true, .initialBoot, .skip),
+            // A failed install leaves the context intact at `.error`, where
+            // `start(_:)` still routes into the installer — the status alone
+            // would read this as an ordinary boot retry.
+            AutoStartCase(marked: true, pendingSetup: true, .error, .skip),
+            AutoStartCase(marked: true, pendingSetup: true, .stopped, .skip),
             AutoStartCase(marked: true, preparing: true, .stopped, .skip),
             AutoStartCase(marked: true, .running, .skip),
             AutoStartCase(marked: true, .starting, .skip),
@@ -4455,6 +4464,7 @@ struct VMLibraryViewModelTests {
             VMLibraryViewModel.autoStartStep(
                 startsAutomaticallyOnLaunch: testCase.marked,
                 isPreparing: testCase.isPreparing,
+                hasPendingSetup: testCase.hasPendingSetup,
                 isColdPaused: testCase.isColdPaused,
                 status: testCase.status) == testCase.expected)
     }
@@ -4500,6 +4510,23 @@ struct VMLibraryViewModelTests {
 
         #expect(virtService.startCallCount == 0)
         #expect(fresh.status == .initialBoot)
+    }
+
+    /// The status reads `.error` — an ordinary boot retry — but the surviving
+    /// install context means `start(_:)` would route back into the installer.
+    @Test("startAutomaticVMsForLaunch leaves a marked VM whose setup failed alone")
+    func autoStartSkipsFailedSetup() async {
+        let (viewModel, _, _, virtService, _) = makeViewModel()
+        let stalled = markAutoStart(makeInstance(name: "Setup Failed"))
+        stalled.configuration.linuxInstallContext = LinuxInstallContext(
+            source: .catalogEntry(makeLinuxCatalogEntry()))
+        stalled.status = .error
+        viewModel.instances = [stalled]
+
+        await viewModel.startAutomaticVMsForLaunch()
+
+        #expect(virtService.startCallCount == 0)
+        #expect(stalled.status == .error)
     }
 
     @Test("startAutomaticVMsForLaunch carries on past a VM that fails to start")

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -334,6 +334,45 @@ struct VMSettingsViewControllerTests {
         #expect(instance.configuration.clipboardSharingEnabled == true)
     }
 
+    // MARK: - Launch auto-start
+
+    @Test("The Startup toggle reflects the configuration")
+    func autoStartSwitchReflectsConfiguration() {
+        let viewModel = makeViewModel()
+        let instance = makeInstance(guestOS: .linux)
+        instance.configuration.startsAutomaticallyOnLaunch = true
+        let vc = VMSettingsViewController(
+            instance: instance, viewModel: viewModel, isReadOnly: false)
+        vc.loadViewIfNeeded()
+        vc.viewDidAppear()
+
+        #expect(firstSwitch(action: "autoStartToggled", in: vc.view)?.state == .on)
+    }
+
+    @Test("Toggling the Startup switch writes back to the configuration")
+    func autoStartToggleWritesConfig() {
+        let (vc, instance, _) = makeController(guestOS: .linux, isReadOnly: false)
+        #expect(instance.configuration.startsAutomaticallyOnLaunch == false)
+
+        guard let autoStart = firstSwitch(action: "autoStartToggled", in: vc.view) else {
+            Issue.record("Expected a Startup switch")
+            return
+        }
+        autoStart.state = .on
+        autoStart.sendAction(autoStart.action, to: autoStart.target)
+
+        #expect(instance.configuration.startsAutomaticallyOnLaunch == true)
+    }
+
+    /// The flag is consumed once at app launch and reaches no
+    /// `VZVirtualMachineConfiguration`, so it must stay editable while the VM
+    /// runs — unlike every control the read-only banner locks.
+    @Test("The Startup toggle stays editable while the VM is running")
+    func autoStartSwitchStaysEnabledWhenReadOnly() {
+        let (vc, _, _) = makeController(guestOS: .linux, isReadOnly: true)
+        #expect(firstSwitch(action: "autoStartToggled", in: vc.view)?.isEnabled == true)
+    }
+
     // MARK: - Clipboard passthrough
 
     /// Builds a controller over a config with the given clipboard-sharing state,

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -373,6 +373,122 @@ struct VMSettingsViewControllerTests {
         #expect(firstSwitch(action: "autoStartToggled", in: vc.view)?.isEnabled == true)
     }
 
+    @Test("The Startup section says which order the marked VMs start in")
+    func startupSectionStatesTheStartOrder() {
+        let (vc, _, _) = makeController(guestOS: .linux, isReadOnly: false)
+        #expect(visibleLabel(VMSettingsViewController.autoStartOrderCaption, in: vc.view))
+    }
+
+    // MARK: - Startup capacity warning
+
+    /// Builds a controller over a library holding `markedMacOSVMs` macOS VMs
+    /// marked to start automatically — the VM under test among them when it is
+    /// itself a macOS guest.
+    private func makeStartupController(guestOS: VMGuestOS, markedMacOSVMs: Int) -> (
+        VMSettingsViewController, VMInstance
+    ) {
+        let viewModel = makeViewModel()
+        let instance = makeInstance(guestOS: guestOS)
+        var library = [instance]
+        var remaining = markedMacOSVMs
+        if guestOS == .macOS, remaining > 0 {
+            instance.configuration.startsAutomaticallyOnLaunch = true
+            remaining -= 1
+        }
+        for index in 0..<remaining {
+            let other = makeInstance(guestOS: .macOS)
+            other.configuration.name = "Marked \(index)"
+            other.configuration.startsAutomaticallyOnLaunch = true
+            library.append(other)
+        }
+        viewModel.instances = library
+        let vc = VMSettingsViewController(
+            instance: instance, viewModel: viewModel, isReadOnly: false)
+        vc.loadViewIfNeeded()
+        vc.viewDidAppear()
+        return (vc, instance)
+    }
+
+    @Test("Three marked macOS VMs warn that macOS won't run them all")
+    func startupWarnsOverTheMacOSLimit() throws {
+        let (vc, _) = makeStartupController(guestOS: .macOS, markedMacOSVMs: 3)
+        let warning = try #require(
+            VMSettingsViewController.autoStartCapacityWarning(
+                isMacOSGuest: true, markedMacOSVMCount: 3))
+
+        #expect(visibleLabel(warning, in: vc.view))
+    }
+
+    /// Whether any visible label carries the capacity warning's vendor sentence.
+    ///
+    /// Matched by substring rather than by whole string: the message leads with
+    /// the marked count, so the exact text is only known where a warning is
+    /// expected — and the absence assertions are exactly where it is not.
+    private func showsMacOSCapacityWarning(in view: NSView) -> Bool {
+        firstSubview(NSTextField.self, in: view) {
+            $0.stringValue.contains("macOS allows at most two macOS virtual machines to run at once")
+                && isVisible($0, within: view)
+        } != nil
+    }
+
+    @Test("Two marked macOS VMs are within the limit and warn about nothing")
+    func startupDoesNotWarnAtTheMacOSLimit() {
+        let (vc, _) = makeStartupController(guestOS: .macOS, markedMacOSVMs: 2)
+        #expect(!showsMacOSCapacityWarning(in: vc.view))
+    }
+
+    /// Linux guests don't count against the macOS cap, so the warning is not
+    /// theirs to show even while three macOS VMs are marked.
+    @Test("A Linux guest never shows the macOS capacity warning")
+    func startupNeverWarnsOnALinuxGuest() {
+        let (vc, _) = makeStartupController(guestOS: .linux, markedMacOSVMs: 3)
+        #expect(!showsMacOSCapacityWarning(in: vc.view))
+    }
+
+    /// One row of the capacity-warning decision table.
+    struct CapacityCase: Sendable, CustomStringConvertible {
+        let isMacOSGuest: Bool
+        let marked: Int
+        let warns: Bool
+
+        init(_ isMacOSGuest: Bool, _ marked: Int, _ warns: Bool) {
+            self.isMacOSGuest = isMacOSGuest
+            self.marked = marked
+            self.warns = warns
+        }
+
+        var description: String {
+            "\(isMacOSGuest ? "macOS" : "Linux") guest, \(marked) marked → "
+                + (warns ? "warns" : "silent")
+        }
+    }
+
+    @Test(
+        "autoStartCapacityWarning fires only for a macOS guest over the limit",
+        arguments: [
+            CapacityCase(true, 0, false),
+            CapacityCase(true, 1, false),
+            CapacityCase(true, 2, false),
+            CapacityCase(true, 3, true),
+            CapacityCase(true, 7, true),
+            // A Linux guest doesn't count against the macOS cap and can do
+            // nothing about it from its own pane.
+            CapacityCase(false, 3, false),
+            CapacityCase(false, 7, false),
+        ])
+    func autoStartCapacityWarningMatrix(testCase: CapacityCase) {
+        let warning = VMSettingsViewController.autoStartCapacityWarning(
+            isMacOSGuest: testCase.isMacOSGuest, markedMacOSVMCount: testCase.marked)
+
+        #expect((warning != nil) == testCase.warns)
+        if let warning {
+            // The vendor's claim, at the vendor's strength.
+            #expect(
+                warning.contains("macOS allows at most two macOS virtual machines to run at once"))
+            #expect(warning.contains("\(testCase.marked) macOS virtual machines"))
+        }
+    }
+
     // MARK: - Clipboard passthrough
 
     /// Builds a controller over a config with the given clipboard-sharing state,

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Requires macOS 26 (Tahoe) or later on Apple Silicon to run the app. macOS guests
 - **Full lifecycle** — start, stop, pause, resume, suspend, and restore, plus Force Stop for a hung VM and a one-shot Start in Recovery Mode for macOS guests
 - **Cloning and import** — clone a VM with a fresh machine identity, or keep it via a setting or the ⌥-alternate menu command; import `.kernova` bundles by double-click or drag-and-drop, which is also how you bring existing VMs into the sandboxed library (on the same volume it's an APFS clone: near-instant, no double disk usage)
 - **Keeps running in the background** — a resident menu-bar app, on by default and toggleable in Settings, with opt-in Open at Login, so closing the window can leave VMs running headless. Quitting save-suspends them; system sleep auto-pauses and wake resumes
+- **Starts chosen VMs on its own** — a per-VM opt-in that boots (or resumes from saved state) that guest whenever Kernova opens; paired with Open at Login, the machine comes up with those VMs already running
 
 <p align="center">
   <picture>


### PR DESCRIPTION
## Summary

An opt-in, per-VM setting that starts that VM whenever Kernova opens — resuming it from saved state when one exists, cold-booting it otherwise. Paired with *Open at Login*, a Mac comes up with the chosen guests already running and no interaction.

A new **Startup** section in the VM settings pane carries the *Start When Kernova Opens* toggle, a caption naming the order the marked VMs come up in (sidebar order — what the pass walks), and, on a macOS guest whose library has more macOS VMs marked than macOS runs at once, a warning banner.

Closes #797.

## The route taken

**The flag lives on `VMConfiguration`** (`startsAutomaticallyOnLaunch`, off by default, `decodeIfPresent ?? false`) rather than in `AppPreferences`, because the intent is per-VM. It is local intent rather than portable configuration, though: both cloning and importing clear it, so only the VM the local user marked ever starts on its own.

**The pass lives in `VMLibraryViewModel`, not `AppDelegate`.** The issue names `startResidentApp` as the location, and that is where the *trigger* goes — four lines that await the in-flight library read and call the view model. The decision and the loop sit where the existing mocks can exercise them, matching how every other `AppDelegate` decision (`residencyOutcome`, `terminationSaveStep`) is already factored into a `nonisolated static` pure function.

**"Boot" is implemented as boot-or-resume.** A VM with a save file loads as cold `.paused` and fails `canStart`, so a literal start would no-op for exactly the VMs a user most wants back after login. `autoStartStep` sends those through `resume(_:)` instead — the same thing a double-click in the sidebar does. The toggle's info copy says so rather than leaving it implicit.

**A VM that has never finished setup is skipped even when marked.** Its start kicks off an IPSW download or a macOS install, which must not begin unattended.

**The loop is sequential.** Each guest commits its whole memory allocation at start, and the duplicate machine-ID and MAC refusals inside `start(_:)`/`resume(_:)` compare against VMs that are *already* live — they only answer deterministically once the previous VM has settled. The step is re-read at the moment of acting, so a VM the user started by hand mid-pass, or one the previous boot just put into a conflict, is skipped rather than double-started. A per-VM failure is logged and surfaced by `start`/`resume` as usual; the pass carries on.

**The toggle stays editable while the VM runs.** The flag is read once at app launch and reaches no `VZVirtualMachineConfiguration`, so it is deliberately kept out of `persistentLockableControls`. A test pins that rather than a comment.

## Deviations from the issue

- **The issue's "the resident app comes up headless" premise is stale.** It was filed the day #800 shipped the `--login-launch` argv posture contract; #804 deleted that contract ~20 h later, and `LoginItemService` now wraps `SMAppService.mainApp`. A login launch is an ordinary windowed open, so there is exactly one launch path and no login-vs-double-click branch to write. `LoginItemService` is untouched.
- **The issue's crash-restart-is-out-of-scope reasoning is unchanged and still holds.**
- **Cloning clears the flag** rather than inheriting it. Duplicating a VM asks for a copy, not a second guest booting at every launch — and a clone taking the ⌥ "Clone (Keep Machine ID)" path would be refused by the duplicate-identity guard on every launch. This is a judgment call not covered by the issue; happy to flip it.

## Rejected alternatives

- **An app-wide "restore VMs that were running at quit" preference** — records state rather than intent, so a VM you happened to leave running once keeps coming back. The issue asks for an explicit per-VM opt-in.
- **Booting the marked VMs concurrently** — faster, but it makes the duplicate-identity refusals order-dependent and commits every guest's memory at once.
- **Aggregating failures into one alert** (the `SleepWakeError` shape) — each VM here carries an independent user-chosen intent, and `start`'s failure path already distinguishes a missing-attachment failure from a generic one, which an aggregate would flatten.

## Changes

- `Kernova/Models/VMConfiguration.swift` — the flag, its decode default, `hasPendingSetup`, and the clone reset
- `Kernova/ViewModels/VMLibraryViewModel.swift` — `AutoStartStep`, `autoStartStep(…)`, `startAutomaticVMsForLaunch()`, and the import sanitization
- `Kernova/App/AppDelegate.swift` — the trigger in `startResidentApp`, its cancellation on quit, and the corrected doc comment
- `Kernova/Views/Detail/VMSettingsViewController.swift` — the Startup section: the toggle, the start-order caption, and `autoStartCapacityWarning(isMacOSGuest:markedMacOSVMCount:)` behind the pane's standard warning banner
- `README.md` — the capability in the background-running feature list
- Tests across `VMConfigurationTests`, `VMConfigurationCloneTests`, `VMLibraryViewModelTests` (the decision matrix plus the pass's behavior, cancellation, mid-pass removal, and import sanitization), and `VMSettingsViewControllerTests`

## Test plan

- [x] `make build`
- [x] `make test` — full suite green
- [x] `make lint`
- [ ] Mark a stopped VM, quit and reopen Kernova: it boots
- [ ] Mark a suspended VM, quit and reopen: it resumes from saved state
- [ ] Mark a VM that has never finished setup: it stays untouched

## Notes

- No `RATIONALE:` comments added.
- No `docs/ARCHITECTURE.md` edit: no component boundary changed — one field on an existing `Codable`, one method on an existing view model, no new service, protocol, or actor-isolation change.

## Review round

Three findings held up and are fixed on the branch:

- **The pass outlived a quit.** It kept starting further guests behind the termination save pass. `AppDelegate` now retains the task and cancels it on both terminating paths, and the pass breaks between VMs. The VM already inside VZ still finishes — abandoning one mid-start is worse — and a quit still does not wait on a `.starting` VM, which is unchanged existing behavior.
- **A VM deleted mid-pass was still started.** The snapshot outlived the library; the loop now re-checks membership before acting, alongside the state re-read it already did.
- **An imported bundle could authorize its own unattended execution.** `reserveAndImport` clears the flag and writes the sanitized config back to the copied bundle, matching the clone reset.

One more, from the second pass: **the setup guard tested the wrong signal.** `.initialBoot` is *derived* from a surviving install context, and `start(_:)` dispatches on the context — so a failed install sitting at `.error` with its context intact would have been read as an ordinary boot retry and routed back into an unattended installer. `VMConfiguration.hasPendingSetup` now names the condition once, `initialStatus` derives `.initialBoot` from it, and `autoStartStep` gates on it.

Deferred, not fixed here: **#852** — `restoreOrColdBoot` deletes the save file and cold-boots on any restore failure, so a transient failure costs the suspended session with only a `.warning` logged. Pre-existing on the user-initiated resume path; this PR makes it reachable unattended, which is why it is filed rather than absorbed.

Dismissed: a `.kernova` bundle hand-placed in the VMs directory via *Open VMs Folder* bypasses the import sanitization. The only other enforcement point is the library scan, which cannot tell a newly-appeared bundle from one that has been marked all along — enforcing there would unmark every VM on load, breaking the feature.


## Maintainer follow-up: start order and the macOS limit

Two additions to the Startup section.

**Start order.** A caption under the card: "Virtual machines start in the order they appear in the sidebar." The pass filters `instances`, which is the persisted sidebar order, so this is what the code already does rather than a new guarantee.

**macOS capacity.** When the VM on screen is a macOS guest and the library has more than two macOS VMs marked, the section shows a yellow banner in the pane's existing warning style — the same `makeGroupedFormBanner` treatment as the duplicate-MAC disclosure. The copy carries the vendor claim at the vendor's strength, matching `explainedFailure`'s existing wording:

> 3 macOS virtual machines are set to start when Kernova opens. macOS allows at most two macOS virtual machines to run at once, so the ones after the first two won't start.

Only in the over-capacity state, never as a static line. It is scoped to macOS guests: a Linux guest doesn't count against the cap and can do nothing about it from its own pane.

**Live updates.** The banner follows a toggle flipped in *another* VM's settings. No new machinery — the pane's model observation loop already reaches cross-VM state for the duplicate-MAC banner, so this adds one tracked read of `macOSVMNamesMarkedForAutoStart` beside it. It is registered on its own rather than riding the MAC read, which is free to stop enumerating every configuration.

Tests follow the duplicate-MAC banner's precedent in `VMSettingsViewControllerTests` — build the controller against a pre-populated library and assert on the rendered label — plus a decision table for the pure warning function and an ordering test for the view model helper.
