### PR TITLE
fix: Verify microphone-denied alerting and add a deep link to System Settings

### DIFF
--- a/Kernova/Services/SystemSettingsLink.swift
+++ b/Kernova/Services/SystemSettingsLink.swift
@@ -11,8 +11,6 @@ struct SystemSettingsLink {
     /// Observed 2026-08-14 on macOS 26: this URL lands System Settings on the
     /// Microphone sub-pane, not just the Privacy & Security root.
     static let microphonePrivacyURL = "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
-    /// Privacy & Security with no sub-pane anchor.
-    static let privacySecurityURL = "x-apple.systempreferences:com.apple.preference.security"
 
     private static let logger = Logger(subsystem: "app.kernova", category: "SystemSettingsLink")
 
@@ -22,19 +20,28 @@ struct SystemSettingsLink {
         self.open = open
     }
 
-    /// Opens System Settings on the Microphone privacy pane, falling back to the
-    /// unanchored Privacy & Security pane when the anchored URL does not open.
+    /// Opens System Settings on the Microphone privacy pane.
+    ///
+    /// Returns whether System Settings launched — not whether it reached the
+    /// Microphone sub-pane. The `?Privacy_Microphone` anchor is opaque to
+    /// Launch Services, which resolves only the scheme, so an anchor macOS
+    /// stops honoring still opens System Settings and still reports success.
+    /// That is the graceful degradation for a dropped anchor: the user lands in
+    /// System Settings, and the popover's written steps carry them the rest of
+    /// the way. A second, unanchored URL would share this one's scheme and pane
+    /// id, so it could never succeed where this one failed.
     @discardableResult
     func openMicrophonePrivacy() -> Bool {
-        for string in [Self.microphonePrivacyURL, Self.privacySecurityURL] {
-            guard let url = URL(string: string) else {
-                Self.logger.fault("Malformed System Settings URL '\(string, privacy: .public)'")
-                assertionFailure("Malformed System Settings URL: \(string)")
-                continue
-            }
-            if open(url) { return true }
+        guard let url = URL(string: Self.microphonePrivacyURL) else {
+            Self.logger.fault(
+                "Malformed System Settings URL '\(Self.microphonePrivacyURL, privacy: .public)'")
+            assertionFailure("Malformed System Settings URL: \(Self.microphonePrivacyURL)")
+            return false
         }
-        Self.logger.warning("System Settings did not open for microphone permission")
-        return false
+        guard open(url) else {
+            Self.logger.warning("System Settings did not open for microphone permission")
+            return false
+        }
+        return true
     }
 }

--- a/Kernova/Services/SystemSettingsLink.swift
+++ b/Kernova/Services/SystemSettingsLink.swift
@@ -1,0 +1,40 @@
+import AppKit
+import os
+
+/// Opens the System Settings panes Kernova sends users to.
+///
+/// The `open` closure is the seam tests substitute for `NSWorkspace`.
+@MainActor
+struct SystemSettingsLink {
+    /// Privacy & Security → Microphone.
+    ///
+    /// Observed 2026-08-14 on macOS 26: this URL lands System Settings on the
+    /// Microphone sub-pane, not just the Privacy & Security root.
+    static let microphonePrivacyURL = "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+    /// Privacy & Security with no sub-pane anchor.
+    static let privacySecurityURL = "x-apple.systempreferences:com.apple.preference.security"
+
+    private static let logger = Logger(subsystem: "app.kernova", category: "SystemSettingsLink")
+
+    private let open: @MainActor (URL) -> Bool
+
+    init(open: @escaping @MainActor (URL) -> Bool = { NSWorkspace.shared.open($0) }) {
+        self.open = open
+    }
+
+    /// Opens System Settings on the Microphone privacy pane, falling back to the
+    /// unanchored Privacy & Security pane when the anchored URL does not open.
+    @discardableResult
+    func openMicrophonePrivacy() -> Bool {
+        for string in [Self.microphonePrivacyURL, Self.privacySecurityURL] {
+            guard let url = URL(string: string) else {
+                Self.logger.fault("Malformed System Settings URL '\(string, privacy: .public)'")
+                assertionFailure("Malformed System Settings URL: \(string)")
+                continue
+            }
+            if open(url) { return true }
+        }
+        Self.logger.warning("System Settings did not open for microphone permission")
+        return false
+    }
+}

--- a/Kernova/Views/Detail/MicrophonePermissionPopoverContentViewController.swift
+++ b/Kernova/Views/Detail/MicrophonePermissionPopoverContentViewController.swift
@@ -7,7 +7,10 @@ import AppKit
 /// the steps to grant it via System Settings.
 @MainActor
 final class MicrophonePermissionPopoverContentViewController: NSViewController {
-    init() {
+    private let systemSettings: SystemSettingsLink
+
+    init(systemSettings: SystemSettingsLink = SystemSettingsLink()) {
+        self.systemSettings = systemSettings
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -17,53 +20,37 @@ final class MicrophonePermissionPopoverContentViewController: NSViewController {
     }
 
     override func loadView() {
-        let container = NSView()
-
-        let stack = NSStackView()
-        stack.orientation = .vertical
-        stack.alignment = .leading
-        stack.spacing = CalloutStyle.verticalSpacing
-        stack.translatesAutoresizingMaskIntoConstraints = false
-
-        stack.addArrangedSubview(makeCalloutHeadline("Microphone Permission"))
-        stack.addArrangedSubview(
+        installCalloutStack(rows: [
+            makeCalloutHeadline("Microphone Permission"),
             makeCalloutBody(
                 "Kernova needs microphone permission to pass your mic input to virtual machines.",
                 color: .labelColor
-            )
-        )
-        stack.addArrangedSubview(makeDivider())
-        stack.addArrangedSubview(makeSubheadline("How to enable"))
-        stack.addArrangedSubview(makeStep(number: 1, lead: "Open ", bold: "System Settings"))
-        stack.addArrangedSubview(
-            makeStep(number: 2, lead: "Go to ", bold: "Privacy & Security → Microphone")
-        )
-        stack.addArrangedSubview(
-            makeStep(number: 3, lead: "Enable the toggle for ", bold: "Kernova")
-        )
-        stack.addArrangedSubview(
-            makeCalloutBody("You will need to restart Kernova after granting permission.")
-        )
-
-        container.addSubview(stack)
-        let padding = CalloutStyle.padding
-        NSLayoutConstraint.activate([
-            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: padding),
-            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: padding),
-            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -padding),
-            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -padding),
-            container.widthAnchor.constraint(equalToConstant: CalloutStyle.width),
+            ),
+            makeOpenSettingsButton(),
+            makeDivider(),
+            makeSubheadline("How to enable"),
+            makeStep(number: 1, lead: "Open ", bold: "System Settings"),
+            makeStep(number: 2, lead: "Go to ", bold: "Privacy & Security → Microphone"),
+            makeStep(number: 3, lead: "Enable the toggle for ", bold: "Kernova"),
+            makeCalloutBody("You will need to restart Kernova after granting permission."),
         ])
-
-        view = container
     }
 
     override func viewDidLayout() {
         super.viewDidLayout()
-        let fittingSize = view.fittingSize
-        if preferredContentSize != fittingSize {
-            preferredContentSize = fittingSize
-        }
+        syncCalloutContentSize()
+    }
+
+    private func makeOpenSettingsButton() -> NSButton {
+        let button = NSButton(
+            title: "Open System Settings", target: self, action: #selector(openSettingsTapped))
+        button.bezelStyle = .push
+        button.keyEquivalent = "\r"
+        return button
+    }
+
+    @objc private func openSettingsTapped() {
+        systemSettings.openMicrophonePrivacy()
     }
 
     /// Full-width horizontal `NSBox` separator.

--- a/Kernova/Views/Detail/VMSettingsViewController.swift
+++ b/Kernova/Views/Detail/VMSettingsViewController.swift
@@ -43,7 +43,9 @@ final class VMSettingsViewController: NSViewController {
     /// `withObservationTracking` has no unregister) bails when its token no
     /// longer matches, so stale chains can't accumulate.
     private var fileMonitorObservationToken: UUID?
-    private var micPermission: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+    private var micPermission: AVAuthorizationStatus
+    private let micPermissionStatus: @MainActor () -> AVAuthorizationStatus
+    private let systemSettings: SystemSettingsLink
 
     // MARK: - Presenters & coordinators
 
@@ -265,7 +267,11 @@ final class VMSettingsViewController: NSViewController {
         isReadOnly: Bool,
         bridgedInterfaces: any BridgedInterfaceProviding = HostBridgedInterfaceProvider(),
         entitlements: EntitlementService = .shared,
-        vmnetNetworks: any VmnetNetworkProviding = VmnetNetworkService.shared
+        vmnetNetworks: any VmnetNetworkProviding = VmnetNetworkService.shared,
+        micPermissionStatus: @escaping @MainActor () -> AVAuthorizationStatus = {
+            AVCaptureDevice.authorizationStatus(for: .audio)
+        },
+        systemSettings: SystemSettingsLink = SystemSettingsLink()
     ) {
         self.instance = instance
         self.viewModel = viewModel
@@ -273,6 +279,9 @@ final class VMSettingsViewController: NSViewController {
         self.bridgedInterfaces = bridgedInterfaces
         self.entitlements = entitlements
         self.vmnetNetworks = vmnetNetworks
+        self.micPermissionStatus = micPermissionStatus
+        self.systemSettings = systemSettings
+        self.micPermission = micPermissionStatus()
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -2105,12 +2114,14 @@ extension VMSettingsViewController {
             info.isBordered = false
             info.imagePosition = .imageOnly
             info.contentTintColor = .secondaryLabelColor
+            let openSettings = NSButton(
+                title: "Open System Settings", target: self, action: #selector(openMicPermissionSettings))
             let banner = makeGroupedFormBanner(
                 symbolName: "exclamationmark.triangle.fill",
                 tint: .systemRed,
                 message:
                     "Microphone permission is denied. Enable it in System Settings for Kernova to pass your microphone to VMs.",
-                trailingButtons: [info])
+                trailingButtons: [openSettings, info])
             addFullWidth(banner, to: audioWarningContainer)
         }
     }
@@ -2415,7 +2426,7 @@ extension VMSettingsViewController {
     }
 
     private func refreshMicPermission() {
-        micPermission = AVCaptureDevice.authorizationStatus(for: .audio)
+        micPermission = micPermissionStatus()
     }
 
     private func makeSecondaryLabel(_ text: String) -> NSTextField {
@@ -2705,7 +2716,12 @@ extension VMSettingsViewController: NSMenuItemValidation {
 
     @objc private func showMicPermissionInfo(_ sender: NSButton) {
         micPermissionPresenter.show(
-            content: MicrophonePermissionPopoverContentViewController(), from: sender, preferredEdge: .minY)
+            content: MicrophonePermissionPopoverContentViewController(systemSettings: systemSettings),
+            from: sender, preferredEdge: .minY)
+    }
+
+    @objc private func openMicPermissionSettings() {
+        systemSettings.openMicrophonePrivacy()
     }
 
     @objc private func appDidBecomeActive() {

--- a/KernovaTests/MicrophonePermissionPopoverContentViewControllerTests.swift
+++ b/KernovaTests/MicrophonePermissionPopoverContentViewControllerTests.swift
@@ -71,6 +71,27 @@ struct MicrophonePermissionPopoverContentViewControllerTests {
         }
     }
 
+    @Test("offers an Open System Settings button alongside the manual steps")
+    func openSettingsButtonPresent() {
+        let vc = MicrophonePermissionPopoverContentViewController()
+        vc.loadViewIfNeeded()
+
+        #expect(findButton(titled: "Open System Settings", in: vc.view) != nil)
+    }
+
+    @Test("clicking Open System Settings opens the Microphone privacy pane")
+    func openSettingsButtonOpensMicrophonePane() throws {
+        let recorder = URLOpenRecorder(results: [true])
+        let vc = MicrophonePermissionPopoverContentViewController(
+            systemSettings: SystemSettingsLink(open: recorder.open))
+        vc.loadViewIfNeeded()
+
+        let button = try #require(findButton(titled: "Open System Settings", in: vc.view))
+        button.performClick(nil)
+
+        #expect(recorder.opened == [SystemSettingsLink.microphonePrivacyURL])
+    }
+
     // MARK: - Helpers
 
     /// Counts the number of distinct `.font`-attribute runs in `attributed`.

--- a/KernovaTests/Mocks/URLOpenRecorder.swift
+++ b/KernovaTests/Mocks/URLOpenRecorder.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Records the URLs handed to a `SystemSettingsLink`, answering each attempt
+/// with the next queued result (and `false` once the queue is spent).
+@MainActor
+final class URLOpenRecorder {
+    private(set) var opened: [String] = []
+    private var results: [Bool]
+
+    init(results: [Bool]) {
+        self.results = results
+    }
+
+    func open(_ url: URL) -> Bool {
+        opened.append(url.absoluteString)
+        return results.isEmpty ? false : results.removeFirst()
+    }
+}

--- a/KernovaTests/SystemSettingsLinkTests.swift
+++ b/KernovaTests/SystemSettingsLinkTests.swift
@@ -3,31 +3,13 @@ import Testing
 
 @testable import Kernova
 
-/// Records the URLs handed to `SystemSettingsLink`, answering each attempt with
-/// the next queued result.
-@MainActor
-final class URLOpenRecorder {
-    private(set) var opened: [String] = []
-    private var results: [Bool]
-
-    init(results: [Bool]) {
-        self.results = results
-    }
-
-    func open(_ url: URL) -> Bool {
-        opened.append(url.absoluteString)
-        return results.isEmpty ? false : results.removeFirst()
-    }
-}
-
 @Suite("SystemSettingsLink Tests")
 @MainActor
 struct SystemSettingsLinkTests {
     private let anchored = "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
-    private let unanchored = "x-apple.systempreferences:com.apple.preference.security"
 
-    @Test("The anchored Microphone URL is tried first, with no fallback when it opens")
-    func anchoredURLOpensAlone() {
+    @Test("Opening the microphone pane hands the anchored URL to the workspace")
+    func opensAnchoredMicrophoneURL() {
         let recorder = URLOpenRecorder(results: [true])
         let link = SystemSettingsLink(open: recorder.open)
 
@@ -35,27 +17,17 @@ struct SystemSettingsLinkTests {
         #expect(recorder.opened == [anchored])
     }
 
-    @Test("A failed anchored open falls back to the Privacy & Security pane")
-    func fallsBackToPrivacyPane() {
-        let recorder = URLOpenRecorder(results: [false, true])
-        let link = SystemSettingsLink(open: recorder.open)
-
-        #expect(link.openMicrophonePrivacy())
-        #expect(recorder.opened == [anchored, unanchored])
-    }
-
-    @Test("Both URLs failing reports failure after trying each once")
-    func bothURLsFailing() {
-        let recorder = URLOpenRecorder(results: [false, false])
+    @Test("A workspace that cannot open the URL reports failure without retrying")
+    func failedOpenReportsFailure() {
+        let recorder = URLOpenRecorder(results: [false])
         let link = SystemSettingsLink(open: recorder.open)
 
         #expect(!link.openMicrophonePrivacy())
-        #expect(recorder.opened == [anchored, unanchored])
+        #expect(recorder.opened == [anchored])
     }
 
-    @Test("The published URL constants match the panes the app links to")
-    func urlConstantsAreStable() {
+    @Test("The published URL constant matches the pane the app links to")
+    func urlConstantIsStable() {
         #expect(SystemSettingsLink.microphonePrivacyURL == anchored)
-        #expect(SystemSettingsLink.privacySecurityURL == unanchored)
     }
 }

--- a/KernovaTests/SystemSettingsLinkTests.swift
+++ b/KernovaTests/SystemSettingsLinkTests.swift
@@ -1,0 +1,61 @@
+import AppKit
+import Testing
+
+@testable import Kernova
+
+/// Records the URLs handed to `SystemSettingsLink`, answering each attempt with
+/// the next queued result.
+@MainActor
+final class URLOpenRecorder {
+    private(set) var opened: [String] = []
+    private var results: [Bool]
+
+    init(results: [Bool]) {
+        self.results = results
+    }
+
+    func open(_ url: URL) -> Bool {
+        opened.append(url.absoluteString)
+        return results.isEmpty ? false : results.removeFirst()
+    }
+}
+
+@Suite("SystemSettingsLink Tests")
+@MainActor
+struct SystemSettingsLinkTests {
+    private let anchored = "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+    private let unanchored = "x-apple.systempreferences:com.apple.preference.security"
+
+    @Test("The anchored Microphone URL is tried first, with no fallback when it opens")
+    func anchoredURLOpensAlone() {
+        let recorder = URLOpenRecorder(results: [true])
+        let link = SystemSettingsLink(open: recorder.open)
+
+        #expect(link.openMicrophonePrivacy())
+        #expect(recorder.opened == [anchored])
+    }
+
+    @Test("A failed anchored open falls back to the Privacy & Security pane")
+    func fallsBackToPrivacyPane() {
+        let recorder = URLOpenRecorder(results: [false, true])
+        let link = SystemSettingsLink(open: recorder.open)
+
+        #expect(link.openMicrophonePrivacy())
+        #expect(recorder.opened == [anchored, unanchored])
+    }
+
+    @Test("Both URLs failing reports failure after trying each once")
+    func bothURLsFailing() {
+        let recorder = URLOpenRecorder(results: [false, false])
+        let link = SystemSettingsLink(open: recorder.open)
+
+        #expect(!link.openMicrophonePrivacy())
+        #expect(recorder.opened == [anchored, unanchored])
+    }
+
+    @Test("The published URL constants match the panes the app links to")
+    func urlConstantsAreStable() {
+        #expect(SystemSettingsLink.microphonePrivacyURL == anchored)
+        #expect(SystemSettingsLink.privacySecurityURL == unanchored)
+    }
+}

--- a/KernovaTests/VMSettingsViewControllerTests.swift
+++ b/KernovaTests/VMSettingsViewControllerTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import AppKit
 import Testing
 import Virtualization
@@ -1623,6 +1624,63 @@ struct VMSettingsViewControllerTests {
 
     private func removeRuleButtons(in view: NSView) -> [NSButton] {
         allSubviews(NSButton.self, in: view) { $0.toolTip == "Remove Rule" }
+    }
+
+    // MARK: - Microphone permission
+
+    /// Builds a controller whose Audio section is driven by a pinned permission
+    /// status, so the denied banner does not depend on the test host's own TCC
+    /// state.
+    private func makeMicController(
+        _ status: AVAuthorizationStatus,
+        systemSettings: SystemSettingsLink = SystemSettingsLink()
+    ) -> VMSettingsViewController {
+        let instance = makeInstance(guestOS: .linux)
+        instance.configuration.audioInputEnabled = true
+        let vc = VMSettingsViewController(
+            instance: instance, viewModel: makeViewModel(), isReadOnly: false,
+            micPermissionStatus: { status }, systemSettings: systemSettings)
+        vc.loadViewIfNeeded()
+        vc.viewDidAppear()
+        return vc
+    }
+
+    @Test("Denied permission shows the warning banner with an Open System Settings button")
+    func deniedMicShowsBannerAndButton() {
+        let vc = makeMicController(.denied)
+
+        #expect(findLabel(containing: "Microphone permission is denied", in: vc.view) != nil)
+        #expect(findButton(titled: "Open System Settings", in: vc.view) != nil)
+    }
+
+    @Test("The banner's Open System Settings button opens the Microphone privacy pane")
+    func deniedMicBannerButtonOpensSettings() throws {
+        let recorder = URLOpenRecorder(results: [true])
+        let vc = makeMicController(.denied, systemSettings: SystemSettingsLink(open: recorder.open))
+
+        let button = try #require(findButton(titled: "Open System Settings", in: vc.view))
+        button.performClick(nil)
+
+        #expect(recorder.opened == [SystemSettingsLink.microphonePrivacyURL])
+    }
+
+    @Test("An undetermined permission explains the upcoming prompt instead of offering the link")
+    func undeterminedMicShowsCaptionOnly() {
+        let vc = makeMicController(.notDetermined)
+
+        #expect(
+            findLabel(
+                withText: "macOS will ask for microphone permission the first time a VM uses it.",
+                in: vc.view) != nil)
+        #expect(findButton(titled: "Open System Settings", in: vc.view) == nil)
+    }
+
+    @Test("Granted permission shows neither the banner nor the link")
+    func authorizedMicShowsNothing() {
+        let vc = makeMicController(.authorized)
+
+        #expect(findLabel(containing: "Microphone permission is denied", in: vc.view) == nil)
+        #expect(findButton(titled: "Open System Settings", in: vc.view) == nil)
     }
 
     // MARK: - Helpers (view-tree introspection)


### PR DESCRIPTION
Closes #301

## Summary

A denied microphone permission surfaced only written instructions. The warning banner in the Audio section and its info popover now both offer a one-click **Open System Settings** button that lands directly on Privacy & Security → Microphone, with the written steps kept as the manual fallback.

## Changes

- **`Kernova/Services/SystemSettingsLink.swift`** (new) — owns the pane URL `x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone` and states the return-value contract. The `NSWorkspace.shared.open` call sits behind an injectable `@MainActor (URL) -> Bool` closure so the call and the URL string are unit-testable. `URL(string:)` on the compile-time constant follows the repo's defensive-unwrapping convention (`fault` + `assertionFailure` + graceful `false`, never `!`).
- **`MicrophonePermissionPopoverContentViewController`** — button added below the explanation, above the divider, so the one-click route leads and the numbered steps remain the fallback. While in this `loadView`, its hand-rolled container/stack/padding/width block was replaced by the shared `installCalloutStack(rows:)` / `syncCalloutContentSize()` extensions in `CalloutStyle.swift` that it duplicated verbatim (−20 lines, identical geometry — the existing `fittingWidthMatchesStyle` test still passes unchanged).
- **`VMSettingsViewController`** — the denied banner gets the same button. `makeGroupedFormBanner` already takes `trailingButtons: [NSButton]` and styles each element, so this is a call-site array change with **no** change to the banner factory. The controller also gained two defaulted injected dependencies (`micPermissionStatus`, `systemSettings`) in the style of its existing three, so the Audio section's permission states are testable without depending on the test host's own TCC state.

## Verification of the full not-granted flow

The issue asked for the three states to be verified end-to-end, not just the deep link:

| State | Behavior | Status |
|---|---|---|
| `notDetermined` | Neutral caption "macOS will ask for microphone permission the first time a VM uses it."; the OS prompt fires on first VM use of the mic | Already correct — now covered by a regression test |
| `denied` / `restricted` | Red banner + info popover | Already correct; **this PR** adds the deep link to both |
| Revoked while running | macOS TCC forces a quit via the Privacy & Security settings extension; `classifyQuit` maps it to terminate-and-relaunch, VMs save-suspend, and `KernovaRelaunchHelper` relaunches | Already correct (`AppDelegateQuitClassificationTests`), generic to all TCC revocations |

So only the deep link was missing production code; the rest of the verification converted into regression tests rather than new alerting.

**URL confirmed on the current macOS (observed 2026-08-14):** the anchored URL lands System Settings on the Microphone sub-pane (window title "Microphone", pane id `com.apple.settings.PrivacySecurity.extension`). That dated observation is recorded on the constant.

## Deviations from the issue

- The issue hedged with "warning bar **and/or** popover" — both get the button, because the banner factory's `trailingButtons` array made the banner case free.
- **The issue's "fall back gracefully if the specific anchor stops resolving" is not implementable as a second URL, so it isn't one.** This PR first shipped an unanchored `…com.apple.preference.security` fallback; review showed it was dead code. `NSWorkspace.open`'s `Bool` reports that Launch Services resolved and launched a handler for the *scheme* — the `?Privacy_Microphone` query is opaque to it. Both URLs share a scheme and a pane id, so a macOS that stops honoring the anchor still opens System Settings and still returns `true` (fallback never runs), and a macOS that doesn't handle the scheme fails both identically. The graceful degradation is real but comes from macOS: an unhonored anchor lands the user in System Settings, and the popover's written steps carry them the rest of the way. That contract is now stated on the symbol rather than implied by an unreachable branch. An OS-version check was also rejected — it would be an environment-conditional shim with no deletion path.
- No VM-start-time alerting and no change to `ConfigurationBuilder.configureAudio` — surfacing denial in the Settings UI is the existing design and stays.

## Test plan

- [x] `make build`
- [x] `make test` — 2834 cases pass, 9 new
- [x] `make lint`
- [x] `SystemSettingsLinkTests`: the anchored URL is what reaches the workspace, a failed open reports failure without retrying, and the URL constant is pinned
- [x] Popover tests: button present; clicking it opens the Microphone pane
- [x] Audio-section tests: denied shows banner + button and the button opens the pane; `notDetermined` shows the caption and no button; `authorized` shows neither
