### PR TITLE
refactor: Replace the deprecated array String(cString:) in address formatting

### DIFF
--- a/Kernova/Services/VmnetNetworkService.swift
+++ b/Kernova/Services/VmnetNetworkService.swift
@@ -61,12 +61,25 @@ enum IPv4Value {
     }
 
     static func string(_ value: UInt32) -> String {
-        var address = in_addr(s_addr: value.bigEndian)
-        var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
-        guard inet_ntop(AF_INET, &address, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else {
-            return "?"
+        withUnsafeBytes(of: in_addr(s_addr: value.bigEndian)) {
+            presentationString($0, family: AF_INET, capacity: INET_ADDRSTRLEN)
         }
-        return String(cString: buffer)
+    }
+}
+
+/// The dotted-quad or colon-hex form of the socket address whose bytes are
+/// `address`, `"?"` when `inet_ntop` fails. `capacity` is the family's
+/// `INET*_ADDRSTRLEN`.
+private func presentationString(
+    _ address: UnsafeRawBufferPointer, family: Int32, capacity: Int32
+) -> String {
+    var buffer = [CChar](repeating: 0, count: Int(capacity))
+    return buffer.withUnsafeMutableBufferPointer { buffer in
+        guard
+            let text = inet_ntop(
+                family, address.baseAddress, buffer.baseAddress, socklen_t(buffer.count))
+        else { return "?" }
+        return String(cString: text)
     }
 }
 
@@ -280,12 +293,9 @@ struct HostVmnetNetworkOperator: VmnetNetworkOperating {
     }
 
     private static func ipv6String(_ address: in6_addr) -> String {
-        var address = address
-        var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
-        guard inet_ntop(AF_INET6, &address, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil else {
-            return "?"
+        withUnsafeBytes(of: address) {
+            presentationString($0, family: AF_INET6, capacity: INET6_ADDRSTRLEN)
         }
-        return String(cString: buffer)
     }
 }
 


### PR DESCRIPTION
## Summary

`String(cString: [CChar])` is deprecated in Swift 6, warning at both `inet_ntop` call sites in `VmnetNetworkService` — `IPv4Value.string` and `HostVmnetNetworkOperator.ipv6String`. The two were the same six lines differing only in address family and buffer size, so they now share one file-private helper rather than each growing its own fix.

The helper keeps `String(cString:)` on the `UnsafePointer<CChar>` that `inet_ntop` returns — that overload is not deprecated — and does the conversion inside `withUnsafeMutableBufferPointer`, so the pointer never outlives the buffer it points into. (The old code's `&buffer` conversion was scoped to the `inet_ntop` call itself, which is why it had to re-read the array afterwards.)

**Rejected alternative:** taking the address as a generic `<Address>` value reads better at the call sites but earns a fresh warning — "forming 'UnsafeRawPointer' to a variable of type 'Address'; this is likely incorrect because 'Address' may contain an object reference" — and the obvious silencer, constraining to `BitwiseCopyable`, does not compile: imported `in6_addr` does not conform. Passing raw bytes via `withUnsafeBytes(of:)` states the real requirement and warns nothing.

`String(decoding:as:)`, what the deprecation message suggests, would need the caller to truncate at the first NUL itself; the pointer overload already does that.

Behavior is unchanged — same buffer sizes, same `"?"` fallback — so no test changes.

## Changes

- `Kernova/Services/VmnetNetworkService.swift`: added `presentationString(_:family:capacity:)`; both call sites wrap their `in_addr`/`in6_addr` in `withUnsafeBytes(of:)` and delegate to it.

## Test plan

- [x] `make build` — exit 0, zero Swift warnings
- [x] `make test` — `** TEST SUCCEEDED **`, 159 tests in 9 suites