### PR TITLE
feat: Drag files onto the VM display to send them to the guest's Downloads

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -829,7 +829,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.61.1;
+				MARKETING_VERSION = 0.62.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
@@ -867,7 +867,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.61.1;
+				MARKETING_VERSION = 0.62.0;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;

--- a/Kernova/App/DetailContainerViewController.swift
+++ b/Kernova/App/DetailContainerViewController.swift
@@ -156,6 +156,16 @@ final class DetailContainerViewController: NSViewController {
             else { return }
             Task { await viewModel.resume(target) }
         }
+        backing.dropAvailability = { [weak viewModel] in
+            viewModel?.instances.first(where: { $0.id == instanceID })?.displayDropAvailability
+                ?? .none
+        }
+        backing.onDropFiles = { [weak viewModel] urls in
+            guard let target = viewModel?.instances.first(where: { $0.id == instanceID })
+            else { return false }
+            return target.sendDroppedFilesToGuest(urls)
+        }
+        backing.applyDropRegistration()
 
         backing.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(backing)
@@ -217,6 +227,12 @@ final class DetailContainerViewController: NSViewController {
                         _ = inst.virtualMachine
                         _ = inst.displayMode
                         _ = inst.configuration.displayAutoResizes
+                        // Everything `displayDropAvailability` reads, so the
+                        // display registers and unregisters as a drag
+                        // destination when the guest agent comes and goes.
+                        _ = inst.configuration.lastSeenAgentVersion
+                        _ = inst.vsockDropService?.isConnected
+                        _ = inst.vsockControlService?.isConnected
                     }
                 }
             },
@@ -242,6 +258,7 @@ final class DetailContainerViewController: NSViewController {
             guard let instance = viewModel.instances.first(where: { $0.id == id }) else { continue }
             backing.apply(
                 automaticallyReconfiguresDisplay: instance.configuration.displayAutoResizes)
+            backing.applyDropRegistration()
         }
 
         // Evict backing views for VMs no longer running inline

--- a/Kernova/App/HostAgentStatusItemController.swift
+++ b/Kernova/App/HostAgentStatusItemController.swift
@@ -47,7 +47,8 @@ final class HostAgentStatusItemController: NSObject, NSMenuDelegate {
     /// reaches the reattached menu rather than the popover's dismissal handler.
     private lazy var pasteProgressPresenter = ClipboardProgressStatusItemPresenter(
         statusItem: statusItem, menu: menu,
-        willAutoOpen: { [weak self] in self?.transientPopover.dismiss() })
+        willAutoOpen: { [weak self] in self?.transientPopover.dismiss() },
+        onCancel: { ClipboardProgressCenter.shared.cancelCurrent() })
 
     /// The status item's one transient-popover slot, shared by the soft-quit
     /// reminder and the clipboard notice.

--- a/Kernova/App/VMDisplayWindowController.swift
+++ b/Kernova/App/VMDisplayWindowController.swift
@@ -64,6 +64,13 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
 
         let backing = VMDisplayBackingView()
         backing.onResume = onResume
+        backing.dropAvailability = { [weak instance] in
+            instance?.displayDropAvailability ?? .none
+        }
+        backing.onDropFiles = { [weak instance] urls in
+            instance?.sendDroppedFilesToGuest(urls) ?? false
+        }
+        backing.applyDropRegistration()
         backing.update(
             virtualMachine: instance.virtualMachine,
             isPaused: instance.status == .paused,
@@ -190,6 +197,12 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
                 _ = self.instance.displayMode
                 _ = self.instance.configuration.clipboardSharingEnabled
                 _ = self.instance.configuration.displayAutoResizes
+                // Everything `displayDropAvailability` reads, so the display
+                // registers and unregisters as a drag destination when the guest
+                // agent comes and goes.
+                _ = self.instance.configuration.lastSeenAgentVersion
+                _ = self.instance.vsockDropService?.isConnected
+                _ = self.instance.vsockControlService?.isConnected
             },
             apply: { [weak self] in
                 guard let self else { return }
@@ -204,6 +217,7 @@ final class VMDisplayWindowController: NSWindowController, NSWindowDelegate {
                         transitionText: status.transitionLabel,
                         automaticallyReconfiguresDisplay: self.instance.configuration.displayAutoResizes
                     )
+                    self.backingView.applyDropRegistration()
                     self.updateToolbarItems()
                 }
             }

--- a/Kernova/Models/VMInstance.swift
+++ b/Kernova/Models/VMInstance.swift
@@ -141,6 +141,16 @@ final class VMInstance {
 
     var vsockControlService: VsockControlService?
 
+    /// Listener for the guest's drop channel; installed for every guest with a
+    /// socket device while the VM has a live `VZVirtualMachine`.
+    ///
+    /// Ungated by any setting: dropping files on the display is the toggle.
+    var vsockDropListenerHost: VsockListenerHost?
+
+    /// Serves files dropped on this VM's display; populated once the guest
+    /// agent's drop client connects.
+    var vsockDropService: VsockDropService?
+
     /// `true` when this VM has reached `.running`, the host previously saw a
     /// guest agent connect (`configuration.lastSeenAgentVersion != nil`), and a
     /// grace period has elapsed without a `Hello` arriving over the control
@@ -760,6 +770,12 @@ final class VMInstance {
         controlHost.attach(to: socketDevice)
         vsockControlListenerHost = controlHost
 
+        // Unconditional, like control: there is no drop setting — the display
+        // simply refuses the gesture when the guest can't take it.
+        let dropHost = makeDropListenerHost()
+        dropHost.attach(to: socketDevice)
+        vsockDropListenerHost = dropHost
+
         if configuration.agentLogForwardingEnabled {
             let logHost = makeLogListenerHost()
             logHost.attach(to: socketDevice)
@@ -777,20 +793,47 @@ final class VMInstance {
 
     // MARK: - Vsock Feature-Channel Admission
 
-    /// Whether a feature vsock channel (log or clipboard) may be admitted right
-    /// now: a control channel whose `Hello` handshake completed must exist —
-    /// and, for the clipboard port, its `Hello` must have advertised
-    /// `clipboard.stream.v1`.
+    /// The guest capability a feature vsock channel needs before it may be
+    /// admitted, beyond the completed control handshake every one of them
+    /// requires.
+    enum FeatureChannelRequirement {
+        /// Log forwarding — the handshake alone.
+        case none
+        /// The clipboard channel: `clipboard.stream.v1`.
+        case clipboardStreaming
+        /// The drop channel: `drop.files.v1`.
+        case dropFiles
+
+        /// The capability tag a guest must advertise, or `nil` when none is
+        /// needed.
+        var capability: String? {
+            switch self {
+            case .none: return nil
+            case .clipboardStreaming: return KernovaCapability.clipboardStreamV1
+            case .dropFiles: return KernovaCapability.dropFilesV1
+            }
+        }
+    }
+
+    /// Whether a feature vsock channel may be admitted right now: a control
+    /// channel whose `Hello` handshake completed must exist, and its `Hello` must
+    /// have advertised whatever capability `requirement` names.
     ///
     /// Evaluated at accept time so it tracks reconnects.
-    func featureChannelAdmission(requiringClipboardStreaming: Bool) -> VsockAdmission {
+    func featureChannelAdmission(_ requirement: FeatureChannelRequirement) -> VsockAdmission {
         guard let control = vsockControlService, control.isConnected else {
             return .notReady(reason: "no control channel has completed its handshake")
         }
-        guard !requiringClipboardStreaming || control.guestSupportsClipboardStreaming else {
+        let advertised: Bool
+        switch requirement {
+        case .none: advertised = true
+        case .clipboardStreaming: advertised = control.guestSupportsClipboardStreaming
+        case .dropFiles: advertised = control.guestSupportsDropFiles
+        }
+        guard advertised else {
             return .denied(
                 reason:
-                    "the connected guest agent does not advertise \(KernovaCapability.clipboardStreamV1)"
+                    "the connected guest agent does not advertise \(requirement.capability ?? "")"
             )
         }
         return .admit
@@ -880,7 +923,7 @@ final class VMInstance {
         VsockListenerHost(
             port: KernovaVsockPort.log,
             shouldAdmit: { [weak self] in
-                self?.featureChannelAdmission(requiringClipboardStreaming: false)
+                self?.featureChannelAdmission(.none)
                     ?? .notReady(reason: "the VM instance is gone")
             }
         ) { [weak self] channel in
@@ -895,13 +938,38 @@ final class VMInstance {
         }
     }
 
+    /// Builds the drop-channel listener; each accepted channel replaces any prior
+    /// drop service.
+    private func makeDropListenerHost() -> VsockListenerHost {
+        VsockListenerHost(
+            port: KernovaVsockPort.drop,
+            shouldAdmit: { [weak self] in
+                self?.featureChannelAdmission(.dropFiles)
+                    ?? .notReady(reason: "the VM instance is gone")
+            }
+        ) { [weak self] channel in
+            guard let self else {
+                channel.close()
+                return
+            }
+            self.vsockDropService?.stop()
+            let service = VsockDropService(
+                channel: channel, label: self.name, instanceID: self.instanceID,
+                maxPasteBytes: { [weak self] in
+                    self?.effectiveClipboardMaxPasteBytes ?? ClipboardPasteLimit.defaultBytes
+                })
+            self.vsockDropService = service
+            service.start()
+        }
+    }
+
     /// Builds the clipboard-channel listener; each accepted channel replaces any
     /// prior clipboard service.
     private func makeClipboardListenerHost() -> VsockListenerHost {
         VsockListenerHost(
             port: KernovaVsockPort.clipboard,
             shouldAdmit: { [weak self] in
-                self?.featureChannelAdmission(requiringClipboardStreaming: true)
+                self?.featureChannelAdmission(.clipboardStreaming)
                     ?? .notReady(reason: "the VM instance is gone")
             }
         ) { [weak self] channel in
@@ -1062,6 +1130,10 @@ final class VMInstance {
         vsockLogService?.stop()
         vsockLogService = nil
         vsockLogListenerHost = nil
+
+        vsockDropService?.stop()
+        vsockDropService = nil
+        vsockDropListenerHost = nil
 
         if clipboardService is VsockClipboardService {
             clipboardService?.stop()

--- a/Kernova/Services/ClipboardProgressCenter.swift
+++ b/Kernova/Services/ClipboardProgressCenter.swift
@@ -5,6 +5,20 @@ import os
 
 /// App-level aggregate of every live clipboard service's transfer readout.
 ///
+/// A source of transfer progress whose currently-shown operation the user can
+/// stop.
+///
+/// Adopted by the services that publish to `ClipboardProgressCenter`, so a
+/// Cancel on the one aggregated readout reaches the VM whose transfer it shows
+/// rather than whichever service happens to be asked.
+@MainActor
+protocol TransferCancelling: AnyObject {
+    /// Cancels the operation this source is currently publishing progress for.
+    ///
+    /// Idempotent, and a no-op once that operation has finished.
+    func requestCancelOfShownOperation()
+}
+
 /// Clipboard services are per-VM, but the menu-bar status item renders one
 /// readout, so each service pushes its snapshot here and this republishes the
 /// most significant of them — a consumer never has to reason about individual
@@ -22,13 +36,29 @@ final class ClipboardProgressCenter {
     /// `nil` when none is.
     private(set) var materializationProgress: ClipboardProgressSnapshot?
 
+    /// One source's latest readout, alongside the source itself so a Cancel on
+    /// the aggregate can reach it.
+    ///
+    /// The reference is weak: a service that goes away without clearing its entry
+    /// would otherwise be kept alive by the aggregate, and a stopped VM's transfer
+    /// has nothing left to cancel anyway.
+    private struct Entry {
+        let snapshot: ClipboardProgressSnapshot
+        weak var source: AnyObject?
+    }
+
     /// The latest snapshot from each live service, keyed by its identity.
     ///
     /// Per service rather than a single slot, because two VMs can transfer at once
     /// and the readout must not flicker between them; a service drops its entry as
     /// it stops so a gone VM can't pin the ring.
     @ObservationIgnored
-    private var progressBySource: [ObjectIdentifier: ClipboardProgressSnapshot] = [:]
+    private var progressBySource: [ObjectIdentifier: Entry] = [:]
+
+    /// The source of the snapshot `materializationProgress` currently holds, so a
+    /// Cancel routes to the VM whose transfer is on screen.
+    @ObservationIgnored
+    private var publishedSource: ObjectIdentifier?
 
     /// Records a service's latest readout and republishes the most significant one
     /// across every live VM.
@@ -37,11 +67,13 @@ final class ClipboardProgressCenter {
     func progressChanged(from source: AnyObject, _ snapshot: ClipboardProgressSnapshot?) {
         let key = ObjectIdentifier(source)
         if let snapshot {
-            progressBySource[key] = snapshot
+            progressBySource[key] = Entry(snapshot: snapshot, source: source)
         } else {
             progressBySource.removeValue(forKey: key)
         }
-        materializationProgress = Self.mostSignificant(of: progressBySource)
+        let winner = Self.mostSignificant(of: progressBySource)
+        publishedSource = winner?.key
+        materializationProgress = winner?.entry.snapshot
         let sources = progressBySource.count
         guard let readout = materializationProgress else {
             Self.logger.debug("Aggregate readout cleared (\(sources, privacy: .public) source(s))")
@@ -52,22 +84,37 @@ final class ClipboardProgressCenter {
         )
     }
 
+    /// Cancels the operation behind the readout currently on screen.
+    ///
+    /// Routed to the publishing source rather than broadcast: another VM's
+    /// transfer is running under its own readout, and stopping it would cancel
+    /// something the user cannot even see.
+    func cancelCurrent() {
+        guard let key = publishedSource,
+            let source = progressBySource[key]?.source as? any TransferCancelling
+        else {
+            Self.logger.debug("Cancel requested with no cancellable source publishing")
+            return
+        }
+        source.requestCancelOfShownOperation()
+    }
+
     /// The snapshot with the most bytes left to move, or `nil` when none is live.
     ///
     /// Ties break on the source's identity — arbitrary, but *stable*, which
     /// dictionary iteration order is not: two VMs whose readouts are level would
     /// otherwise swap the status item's headline between them.
     private static func mostSignificant(
-        of snapshots: [ObjectIdentifier: ClipboardProgressSnapshot]
-    ) -> ClipboardProgressSnapshot? {
+        of entries: [ObjectIdentifier: Entry]
+    ) -> (key: ObjectIdentifier, entry: Entry)? {
         func remaining(_ snapshot: ClipboardProgressSnapshot) -> UInt64 {
             snapshot.totalBytes - min(snapshot.bytesTransferred, snapshot.totalBytes)
         }
-        return snapshots.max { lhs, rhs in
-            let lhsRemaining = remaining(lhs.value)
-            let rhsRemaining = remaining(rhs.value)
+        return entries.max { lhs, rhs in
+            let lhsRemaining = remaining(lhs.value.snapshot)
+            let rhsRemaining = remaining(rhs.value.snapshot)
             if lhsRemaining != rhsRemaining { return lhsRemaining < rhsRemaining }
             return lhs.key < rhs.key
-        }?.value
+        }.map { (key: $0.key, entry: $0.value) }
     }
 }

--- a/Kernova/Services/ClipboardTransferIssue.swift
+++ b/Kernova/Services/ClipboardTransferIssue.swift
@@ -187,22 +187,30 @@ extension ClipboardTransferIssue {
     /// Raised when the guest reports it could not put the dropped files in its
     /// Downloads folder.
     ///
-    /// Composed from the guest's machine-readable `code`, never from its
-    /// message text: the sentence a user reads is written on this side.
+    /// Composed from the guest's machine-readable `code`, never from its message
+    /// text: the sentence a user reads is written on this side. The code is
+    /// carried into the issue too, so every surface renders the same specific
+    /// outcome rather than the dropdown falling back to the generic line.
+    ///
+    /// The wording says the drop did not finish rather than that nothing was
+    /// saved: a batch that fails partway leaves the files it already moved in
+    /// Downloads, and a message claiming otherwise would send the user looking
+    /// for something that is there.
     static func dropFailed(code: ClipboardErrorCode?) -> ClipboardTransferIssue {
+        let resolved = code ?? .dropFailed
         let message: String
-        switch code {
+        switch resolved {
         case .dropDiskFull:
-            message = "The VM ran out of disk space, so the files weren't saved."
+            message = "The VM ran out of disk space, so the drop didn't finish."
         case .dropDownloadsDenied:
             message =
-                "The guest agent isn't allowed to use the VM's Downloads folder, so the files weren't saved."
+                "The guest agent isn't allowed to use the VM's Downloads folder, so the drop didn't finish."
         default:
-            message = "The files couldn't be saved in the VM's Downloads folder."
+            message =
+                "The drop didn't finish — some files may not be in the VM's Downloads folder."
         }
         return ClipboardTransferIssue(
-            kind: .localFailure(code: ClipboardErrorCode.dropFailed.rawValue, message: message),
-            date: Date())
+            kind: .localFailure(code: resolved.rawValue, message: message), date: Date())
     }
 
     /// Raised when a copied file's bytes arrived but could not be written to a

--- a/Kernova/Services/ClipboardTransferIssue.swift
+++ b/Kernova/Services/ClipboardTransferIssue.swift
@@ -154,6 +154,57 @@ extension ClipboardTransferIssue {
             date: Date())
     }
 
+    /// Raised when none of the items dropped on the VM display could be read, so
+    /// nothing was offered to the guest.
+    static func dropItemsUnreadable() -> ClipboardTransferIssue {
+        ClipboardTransferIssue(
+            kind: .localFailure(
+                code: ClipboardErrorCode.dropFailed.rawValue,
+                message: "Those items couldn't be read, so nothing was sent to the VM."),
+            date: Date())
+    }
+
+    /// Raised when the drop offer itself could not be sent to the guest.
+    static func dropSendFailed() -> ClipboardTransferIssue {
+        ClipboardTransferIssue(
+            kind: .localFailure(
+                code: ClipboardErrorCode.dropFailed.rawValue,
+                message: "The connection to the VM dropped, so the files weren't sent."),
+            date: Date())
+    }
+
+    /// Raised when the VM's drop connection ended while files were still on their
+    /// way, so the drop never finished.
+    static func dropInterrupted(fileCount: Int) -> ClipboardTransferIssue {
+        let subject = fileCount == 1 ? "The file" : "The files"
+        return ClipboardTransferIssue(
+            kind: .localFailure(
+                code: ClipboardErrorCode.dropFailed.rawValue,
+                message: "\(subject) stopped transferring when the VM disconnected."),
+            date: Date())
+    }
+
+    /// Raised when the guest reports it could not put the dropped files in its
+    /// Downloads folder.
+    ///
+    /// Composed from the guest's machine-readable `code`, never from its
+    /// message text: the sentence a user reads is written on this side.
+    static func dropFailed(code: ClipboardErrorCode?) -> ClipboardTransferIssue {
+        let message: String
+        switch code {
+        case .dropDiskFull:
+            message = "The VM ran out of disk space, so the files weren't saved."
+        case .dropDownloadsDenied:
+            message =
+                "The guest agent isn't allowed to use the VM's Downloads folder, so the files weren't saved."
+        default:
+            message = "The files couldn't be saved in the VM's Downloads folder."
+        }
+        return ClipboardTransferIssue(
+            kind: .localFailure(code: ClipboardErrorCode.dropFailed.rawValue, message: message),
+            date: Date())
+    }
+
     /// Raised when a copied file's bytes arrived but could not be written to a
     /// file on this Mac for the paste to serve.
     static func pasteFileStagingFailed() -> ClipboardTransferIssue {
@@ -196,7 +247,7 @@ extension ClipboardTransferIssue {
             case .pasteTimeout:
                 return "The clipboard transfer to the guest timed out"
             case .pasteFailed, .copyTooLarge, .pasteIncompleteSet, .forwardItemsSkipped,
-                .folderPeerOutdated, .none:
+                .folderPeerOutdated, .dropDiskFull, .dropDownloadsDenied, .dropFailed, .none:
                 return "Clipboard transfer failed on the guest side"
             }
         case .localFailure(_, let message):
@@ -224,6 +275,8 @@ extension ClipboardTransferIssue {
                 return "Clipboard not copied to \(Self.quoted(vmName))."
             case .pasteIncompleteSet, .pasteTimeout, .pasteFailed:
                 return "Clipboard not pasted from \(Self.quoted(vmName))."
+            case .dropFailed, .dropDiskFull, .dropDownloadsDenied:
+                return "Files not copied to \(Self.quoted(vmName))."
             case .pasteDiskFull, .pasteTooLarge, .none:
                 return "Clipboard issue with \(Self.quoted(vmName))."
             }
@@ -274,6 +327,9 @@ extension ClipboardTransferIssue {
             case .pasteIncompleteSet, .pasteFailed: return "Clipboard: paste from the guest failed"
             case .folderPeerOutdated: return "Clipboard: folder copy needs a guest agent update"
             case .forwardItemsSkipped: return "Clipboard: some items weren't forwarded"
+            case .dropDiskFull: return "Drop: the VM ran out of disk space"
+            case .dropDownloadsDenied: return "Drop: the VM's Downloads folder is off limits"
+            case .dropFailed: return "Drop: the files didn't reach the VM"
             case .pasteDiskFull, .pasteTooLarge, .none: return "Clipboard: transfer didn't complete"
             }
         }

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -160,6 +160,22 @@ final class VsockClipboardService: ClipboardServicing {
     /// the window can call `materializeForPreview()` freely without re-pulling.
     private var previewMaterializationStarted: UInt64 = 0
 
+    /// The inbound generation whose materialization loop the user cancelled.
+    ///
+    /// Cancelling aborts the transfer in flight, but the loop that started it has
+    /// a list of further representations to pull and would simply move to the
+    /// next one — so a multi-file operation would resume a beat after Cancel.
+    /// The latch is what ends the operation rather than one of its files.
+    /// Cleared by the next offer; a later paste or Copy to Mac is a fresh
+    /// gesture and pulls through its own path (docs/CLIPBOARD.md §9).
+    private var cancelledInboundGeneration: UInt64?
+
+    /// The outbound generation whose transfers the user cancelled, for the same
+    /// reason — the peer decides what it pulls, so without this it simply asks
+    /// for the next representation of a still-live offer and the readout comes
+    /// back.
+    private var cancelledOutboundGeneration: UInt64?
+
     /// Digest of the last content we successfully announced; suppresses
     /// redundant offers.
     private var lastGrabbedDigest: Data?
@@ -447,6 +463,7 @@ final class VsockClipboardService: ClipboardServicing {
     /// empty and nothing is reported as a failure on either side.
     private func cancelOutboundTransfers(generation: UInt64) {
         guard let sender else { return }
+        cancelledOutboundGeneration = generation
         sender.cancel(generation: generation)
         Self.logger.notice(
             "User cancelled the outbound clipboard transfer for '\(self.label, privacy: .public)' (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public))"
@@ -461,6 +478,7 @@ final class VsockClipboardService: ClipboardServicing {
     /// the benign `cancelled` code, so the loop ends without raising an issue.
     private func cancelInboundPulls(generation: UInt64) {
         guard let promise = inboundPromise, promise.generation == generation else { return }
+        cancelledInboundGeneration = generation
         for index in promise.inFlight.keys {
             let transferID = ClipboardTransferID.make(
                 generation: generation, repIndex: index, hostMinted: true)
@@ -809,6 +827,17 @@ final class VsockClipboardService: ClipboardServicing {
     // MARK: - Outbound (we are the sender)
 
     private func handleRequest(_ request: Kernova_V1_ClipboardRequest) {
+        guard cancelledOutboundGeneration != request.generation else {
+            Self.logger.debug(
+                "Clipboard request for cancelled gen=\(request.generation, privacy: .public) (conn=\(self.connectionTag, privacy: .public)) — refusing"
+            )
+            // Refused as stale, which the peer already retires quietly: its paste
+            // comes back empty and neither side reports a failure.
+            sender?.rejectRequest(
+                transferID: request.transferID, code: "request.stale",
+                message: "The transfer for generation \(request.generation) was cancelled")
+            return
+        }
         guard let pending = pendingOutbound, pending.generation == request.generation else {
             Self.logger.debug(
                 "Stale clipboard request gen=\(request.generation, privacy: .public) (pending=\(self.pendingOutbound?.generation ?? 0, privacy: .public), conn=\(self.connectionTag, privacy: .public))"
@@ -946,6 +975,8 @@ final class VsockClipboardService: ClipboardServicing {
                 "Clamped \(bounded.clampedCount, privacy: .public) implausible declared byte count(s) in the guest clipboard offer for '\(self.label, privacy: .public)' (conn=\(self.connectionTag, privacy: .public))"
             )
         }
+        // A new offer is a new operation; whatever the user cancelled is over.
+        cancelledInboundGeneration = nil
         let promise = InboundPromise(
             generation: offer.generation, reps: bounded.reps, isConcealed: offer.isConcealed)
         let placeholders = rebuiltReps(from: promise)
@@ -1119,6 +1150,9 @@ final class VsockClipboardService: ClipboardServicing {
         var allSucceeded = true
         for (index, info) in promise.reps.enumerated() {
             guard inboundPromise === promise else { return }  // superseded
+            // The user stopped the whole operation, not the one file that
+            // happened to be in flight when they clicked.
+            guard cancelledInboundGeneration != promise.generation else { return }
             guard Self.isEagerPreviewable(info), !Self.shouldSkip(info) else { continue }
             if await materialize(index: index, info: info, promise: promise, session: session) == nil {
                 allSucceeded = false

--- a/Kernova/Services/VsockClipboardService.swift
+++ b/Kernova/Services/VsockClipboardService.swift
@@ -429,9 +429,69 @@ final class VsockClipboardService: ClipboardServicing {
         }
         if let stale = outboundSession { progress.closeSession(stale.token, immediately: true) }
         let token = progress.openSession(
-            direction: .outbound, peerName: label, isPaste: true)
+            direction: .outbound, peerName: label, isPaste: true,
+            onCancelRequested: { [weak self] in
+                Self.onMainQueue { self?.cancelOutboundTransfers(generation: generation) }
+            })
         outboundSession = (generation: generation, token: token)
         return token
+    }
+
+    /// Stops streaming what the guest is pulling for `generation`, because the
+    /// user cancelled the readout.
+    ///
+    /// The offer itself survives: the guest can paste again and pull the same
+    /// representations, exactly as it can after any retired transfer
+    /// (docs/CLIPBOARD.md §9). The abort the sender emits carries `superseded`,
+    /// which the guest already treats as benign, so its paste simply comes back
+    /// empty and nothing is reported as a failure on either side.
+    private func cancelOutboundTransfers(generation: UInt64) {
+        guard let sender else { return }
+        sender.cancel(generation: generation)
+        Self.logger.notice(
+            "User cancelled the outbound clipboard transfer for '\(self.label, privacy: .public)' (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public))"
+        )
+    }
+
+    /// Stops the pulls the materialization loop has in flight for `generation`.
+    ///
+    /// Two halves, because the transfer spans both sides: an abort frame per
+    /// in-flight id tells the guest's sender to stop producing bytes, and the
+    /// local cancel deletes each partial temp file and wakes the parked pull with
+    /// the benign `cancelled` code, so the loop ends without raising an issue.
+    private func cancelInboundPulls(generation: UInt64) {
+        guard let promise = inboundPromise, promise.generation == generation else { return }
+        for index in promise.inFlight.keys {
+            let transferID = ClipboardTransferID.make(
+                generation: generation, repIndex: index, hostMinted: true)
+            sendStreamAbort(transferID: transferID, code: "user.cancelled")
+        }
+        receiver?.cancel(generation: generation)
+        Self.logger.notice(
+            "User cancelled the inbound clipboard transfer from '\(self.label, privacy: .public)' (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public))"
+        )
+    }
+
+    /// Tells the peer's sender to stop streaming a transfer this side is
+    /// abandoning.
+    private func sendStreamAbort(transferID: UInt64, code: String) {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.clipboardStreamAbort = .with {
+            $0.transferID = transferID
+            $0.code = code
+            $0.message = "Cancelled by the user"
+        }
+        try? channel.send(frame)
+    }
+
+    /// Runs `body` on the main actor on the next turn of the main queue.
+    ///
+    /// The hop is what makes a cancel closure safe to invoke from anywhere: the
+    /// tracker calls it outside its own lock, but on whichever thread noticed the
+    /// click.
+    nonisolated private static func onMainQueue(_ body: @escaping @MainActor () -> Void) {
+        DispatchQueue.main.async { MainActor.assumeIsolated { body() } }
     }
 
     // MARK: - Transfer issues
@@ -691,35 +751,12 @@ final class VsockClipboardService: ClipboardServicing {
     ) async {
         do {
             for try await frame in channel.incoming where frame.protocolVersion == 1 {
-                switch frame.payload {
-                case .clipboardStreamBegin(let begin):
-                    receiver.handleBegin(begin)
-                case .clipboardChunk(let chunk):
-                    receiver.handleChunk(chunk)
-                case .clipboardStreamEnd(let end):
-                    receiver.handleEnd(end)
-                case .clipboardStreamAck(let ack):
-                    sender.handleAck(
-                        transferID: ack.transferID, bytesConsumed: ack.bytesConsumed,
-                        windowBytes: ack.windowBytes)
-                case .clipboardStreamAbort(let abort):
-                    // Route by the direction bit so an abort reaches exactly the
-                    // engine that owns the id; the host receives ids that carry
-                    // the bit and sends those that don't. [H3]
-                    if ClipboardTransferID.hostReceives(abort.transferID) {
-                        receiver.handleAbort(abort)
-                    } else {
-                        // A sender-bound abort must not be handled off-main here:
-                        // `handleRequest` registers the transfer on main, so an
-                        // abort handled synchronously could race ahead of that
-                        // registration and no-op on an unregistered id — the
-                        // transfer would then stream despite being cancelled. The
-                        // shared main-queue dispatch preserves their order.
-                        onControlFrame(frame)
-                    }
-                default:
-                    onControlFrame(frame)
-                }
+                // `handleRequest` registers outbound transfers on the main actor,
+                // so a sender-bound abort rides the same hop rather than being
+                // handled here. [H3]
+                ClipboardStreamRouting.route(
+                    frame, role: .host, sender: sender, receiver: receiver,
+                    senderAbortDelivery: .viaControlFrame, onControlFrame: onControlFrame)
             }
             logger.info(
                 "Vsock clipboard channel closed for '\(label, privacy: .public)' (conn=\(connectionTag, privacy: .public))"
@@ -756,7 +793,8 @@ final class VsockClipboardService: ClipboardServicing {
         case .clipboardStreamBegin, .clipboardChunk, .clipboardStreamEnd, .clipboardStreamAck:
             // Routed off-main by the consume loop; never reaches here.
             break
-        case .hello, .heartbeat, .policyUpdate, .logRecord:
+        case .hello, .heartbeat, .policyUpdate, .logRecord, .dropOffer, .dropComplete,
+            .dropRelease:
             // Control-plane and log payloads belong on their own channels; a peer
             // sending them here crossed wires. A conformant agent reconnects.
             Self.logger.warning(
@@ -1049,7 +1087,12 @@ final class VsockClipboardService: ClipboardServicing {
                 id: UInt64(index), expectedBytes: info.byteCount,
                 name: info.filename.isEmpty ? nil : info.filename)
         }
-        return progress.openSession(direction: .inbound, peerName: label, units: units)
+        let generation = promise.generation
+        return progress.openSession(
+            direction: .inbound, peerName: label, units: units,
+            onCancelRequested: { [weak self] in
+                Self.onMainQueue { self?.cancelInboundPulls(generation: generation) }
+            })
     }
 
     /// Pulls the representations the window renders richly (text, inline RTF,
@@ -1461,7 +1504,7 @@ final class VsockClipboardService: ClipboardServicing {
     /// act on.
     // `nonisolated` so the blocking pull can read it off the main actor.
     nonisolated private static let retiringAbortCodes: Set<String> = [
-        "cancelled", "superseded", "request.stale",
+        "cancelled", "superseded", "request.stale", "user.cancelled",
     ]
 
     /// Records a user-visible issue for a paste-time fire that will serve
@@ -1644,6 +1687,16 @@ final class VsockClipboardService: ClipboardServicing {
     }
 }
 
+// MARK: - Cancelling the shown transfer
+
+extension VsockClipboardService: TransferCancelling {
+    /// Routes a Cancel on the app-wide readout to whichever of this VM's
+    /// operations that readout is showing.
+    func requestCancelOfShownOperation() {
+        progress.requestCancelOfPublishedSession()
+    }
+}
+
 // MARK: - Paste-time representation serving
 
 extension VsockClipboardService: ClipboardPasteboardRepProviding {
@@ -1697,6 +1750,11 @@ extension VsockClipboardService: ClipboardPasteboardRepProviding {
     /// Runs one paste-time blocking pull under its own single-transfer progress
     /// session (a paste has no other session to join), caching the delivered rep
     /// so the item's sibling flavors — and later fires — reuse it.
+    ///
+    /// The session is deliberately not cancellable: this pull parks the thread
+    /// the pasteboard fired it on, usually main, so the dropdown carrying the
+    /// Cancel button cannot repaint — let alone be clicked — until the pull is
+    /// already over.
     nonisolated private func pullWithOwnSession(
         _ snapshot: LazyPullSnapshot
     ) -> ClipboardContent.Representation? {

--- a/Kernova/Services/VsockControlService.swift
+++ b/Kernova/Services/VsockControlService.swift
@@ -200,6 +200,17 @@ final class VsockControlService {
     /// Whether the guest can honor a pushed `clipboard_max_paste_bytes`.
     var guestSupportsPasteLimit: Bool { guestSupportsPasteLimitStorage }
 
+    /// Whether the connected guest agent advertised `drop.files.v1` in its
+    /// `Hello`.
+    ///
+    /// Set on Hello, reset on stop. An agent without it runs no drop client, so
+    /// the display refuses the gesture rather than offering files nothing will
+    /// pull.
+    private var guestSupportsDropFilesStorage = false
+
+    /// Whether the guest can receive files dropped onto the VM display.
+    var guestSupportsDropFiles: Bool { guestSupportsDropFilesStorage }
+
     private static let logger = Logger(subsystem: "app.kernova", category: "VsockControlService")
 
     // MARK: - Init
@@ -319,6 +330,7 @@ final class VsockControlService {
         guestSupportsClipboardStreamingStorage = false
         guestSupportsDirectoryStreamingStorage = false
         guestSupportsPasteLimitStorage = false
+        guestSupportsDropFilesStorage = false
         Self.logger.info("Vsock control service stopped for '\(self.label, privacy: .public)'")
         // Last, so the owner observes fully-settled state — notably a nil
         // `agentVersion` — from inside the callback.
@@ -523,6 +535,8 @@ final class VsockControlService {
                 KernovaCapability.clipboardStreamDirectoryV1)
             guestSupportsPasteLimitStorage = hello.capabilities.contains(
                 KernovaCapability.clipboardPasteLimitV1)
+            guestSupportsDropFilesStorage = hello.capabilities.contains(
+                KernovaCapability.dropFilesV1)
             // Every peer-supplied piece of this line is filtered first — the
             // version by `boundedField`, the capability tags by
             // `logDescription` — so none of them can write arbitrary content
@@ -554,7 +568,8 @@ final class VsockControlService {
             )
         case .policyUpdate, .clipboardOffer, .clipboardRequest,
             .clipboardRelease, .clipboardStreamBegin, .clipboardChunk, .clipboardStreamEnd,
-            .clipboardStreamAck, .clipboardStreamAbort, .logRecord, .none:
+            .clipboardStreamAck, .clipboardStreamAbort, .logRecord, .dropOffer, .dropComplete,
+            .dropRelease, .none:
             // PolicyUpdate is host→guest and never arrives here; other payloads
             // belong on other channels. RATIONALE: the clipboard and log
             // channels close on a wrong-port payload, but this one stays up —

--- a/Kernova/Services/VsockDropService.swift
+++ b/Kernova/Services/VsockDropService.swift
@@ -164,6 +164,13 @@ final class VsockDropService {
                         MainActor.assumeIsolated { self?.handleControlFrame(frame) }
                     }
                 })
+            // The channel is gone — settle here rather than waiting for whatever
+            // replaces this service. `isConnected` is what the display reads to
+            // decide whether it may take a drop, and the guest closes this
+            // channel on every control reconnect (its client pauses until the
+            // next `Hello`), so a service left standing would keep advertising a
+            // drop it can no longer send.
+            await MainActor.run { self?.settle() }
         }
         Self.logger.notice(
             "Vsock drop service started for '\(self.label, privacy: .public)' (conn=\(self.connectionTag, privacy: .public))"
@@ -173,10 +180,20 @@ final class VsockDropService {
     func stop() {
         consumeTask?.cancel()
         consumeTask = nil
+        settle()
+    }
+
+    /// Tears the service down once its channel is over, whether the owner asked
+    /// or the channel simply ended.
+    ///
+    /// Idempotent: the consume loop's own settle and an owner's `stop()` race by
+    /// construction, and the first one through does the work.
+    private func settle() {
+        channel.close()
+        guard isConnected else { return }
+        isConnected = false
         sender?.cancelAll()
         sender = nil
-        channel.close()
-        isConnected = false
         // A job still open when the channel goes is a drop whose files never
         // landed, and the gesture was made on this Mac — so it is owed an answer
         // here. One already called off is not: the user knows.
@@ -184,7 +201,9 @@ final class VsockDropService {
         for job in abandoned { job.liveGeneration.set(0) }
         jobs.removeAll()
         if !abandoned.isEmpty {
-            raiseIssue(.dropInterrupted(fileCount: abandoned.reduce(0) { $0 + $1.content.representations.count }))
+            raiseIssue(
+                .dropInterrupted(
+                    fileCount: abandoned.reduce(0) { $0 + $1.content.representations.count }))
         }
         progress.clearAll()
         // Synchronously, not via the tracker's emission hop: a readout still
@@ -281,7 +300,14 @@ final class VsockDropService {
             DispatchQueue.main.async {
                 guard let self else { return }
                 MainActor.assumeIsolated {
-                    guard self.isConnected else { return }
+                    guard self.isConnected else {
+                        // The channel went away while the folder was being
+                        // sized. The drop was accepted, so its disappearance is
+                        // owed the same answer an interrupted transfer gets —
+                        // there is no job yet for `settle()` to have reported.
+                        self.raiseIssue(.dropInterrupted(fileCount: dropped.count))
+                        return
+                    }
                     self.offer(
                         generation: generation,
                         reps: Self.representations(for: dropped, sizes: measured))

--- a/Kernova/Services/VsockDropService.swift
+++ b/Kernova/Services/VsockDropService.swift
@@ -1,0 +1,572 @@
+import Foundation
+import KernovaKit
+import UniformTypeIdentifiers
+import os
+
+/// Streams files dropped on the VM display to the guest agent, which writes them
+/// into the guest's Downloads folder.
+///
+/// One instance serves one accepted channel on `KernovaVsockPort.drop`. It is
+/// send-only and rides the clipboard streaming engine unchanged: a drop is
+/// announced as a `DropOffer` carrying metadata, the guest pulls each
+/// representation with a `ClipboardRequest`, and the bytes cross on the same
+/// `Begin`/`Chunk`/`End` path a paste uses.
+///
+/// Drops are **independent jobs**, not a supersession chain: dropping a second
+/// batch while the first is still streaming leaves both running under their own
+/// generations, because the user asked for both sets of files.
+@MainActor
+@Observable
+final class VsockDropService {
+    // MARK: - Observable state
+
+    /// `true` between `start()` and `stop()`.
+    private(set) var isConnected: Bool = false
+
+    /// The drop currently being shown (most-significant in-flight session past
+    /// the reveal delay), or `nil`.
+    private(set) var transferProgress: ClipboardProgressSnapshot?
+
+    // MARK: - Private state
+
+    private let channel: VsockChannel
+    private let label: String
+    private let instanceID: UUID
+
+    /// Log coordinate for this connection: generations and transfer ids restart
+    /// with every accepted channel, and one instance serves exactly one.
+    private let connectionTag = ClipboardConnectionTag.nextHost()
+
+    private let progressCenter: ClipboardProgressCenter
+    private let issueCenter: ClipboardIssueCenter
+
+    /// The paste ceiling in force, recorded on any issue this service raises so
+    /// every surface renders one VM's notices the same way.
+    private let maxPasteBytes: @MainActor () -> Int
+
+    /// Sizes a dropped folder's tree without reading it.
+    ///
+    /// Injected so a test can drop a folder without building one on disk, and so
+    /// the walk can be driven synchronously.
+    private let directoryByteCount: @Sendable (URL) -> Int
+
+    /// Runs a payload-scaled folder walk off the main actor and calls back on it.
+    ///
+    /// A tree of any size would otherwise freeze the app for the length of the
+    /// walk (docs/CLIPBOARD.md §8). Injected so a test can run it inline.
+    private let runOffMainActor: (@escaping @Sendable () -> Void) -> Void
+
+    @ObservationIgnored private var progress = ClipboardProgressTracker { _ in }
+
+    private var sender: ClipboardStreamSender?
+    private var consumeTask: Task<Void, Never>?
+
+    /// Generation for the next drop; starts at 1 so 0 is the "no drop" sentinel.
+    private var nextGeneration: UInt64 = 1
+
+    /// Every drop still being served, keyed by its generation.
+    private var jobs: [UInt64: DropJob] = [:]
+
+    // `nonisolated` so the off-main consume loop can log; `Logger` is Sendable.
+    nonisolated private static let logger = Logger(
+        subsystem: "app.kernova", category: "VsockDropService")
+
+    /// One drop gesture: the files it carries and the readout measuring them.
+    private final class DropJob {
+        let generation: UInt64
+        let content: ClipboardContent
+        let session: ClipboardProgressTracker.SessionToken
+        /// Read from the sender's transfer queues to decide whether the job is
+        /// still wanted; zeroed by a cancel, which aborts every transfer under it.
+        let liveGeneration = AtomicGeneration()
+        /// Whether the user (or a teardown) called this job off, so its silent
+        /// end is not reported as a failure.
+        var isCancelled = false
+
+        init(
+            generation: UInt64, content: ClipboardContent,
+            session: ClipboardProgressTracker.SessionToken
+        ) {
+            self.generation = generation
+            self.content = content
+            self.session = session
+            liveGeneration.set(generation)
+        }
+    }
+
+    /// One dropped item's cheap metadata, gathered on the main actor before any
+    /// payload-scaled work.
+    private struct DropCandidate: Sendable {
+        let url: URL
+        let uti: String
+        let filename: String
+        /// A file's stat'd size; `nil` until a folder's walk fills it in.
+        let byteCount: Int?
+        let isDirectory: Bool
+    }
+
+    // MARK: - Init
+
+    init(
+        channel: VsockChannel, label: String, instanceID: UUID,
+        maxPasteBytes: @escaping @MainActor () -> Int = { ClipboardPasteLimit.defaultBytes },
+        progressRevealDelay: TimeInterval = ClipboardProgressTracker.defaultRevealDelay,
+        progressIdleLinger: TimeInterval = ClipboardProgressTracker.defaultIdleLinger,
+        directoryByteCount: @escaping @Sendable (URL) -> Int = {
+            ClipboardDirectoryArchive.estimatedByteCount(at: $0)
+        },
+        runOffMainActor: @escaping (@escaping @Sendable () -> Void) -> Void = { work in
+            DispatchQueue.global(qos: .userInitiated).async(execute: work)
+        },
+        progressCenter: ClipboardProgressCenter = .shared,
+        issueCenter: ClipboardIssueCenter = .shared
+    ) {
+        self.channel = channel
+        self.label = label
+        self.instanceID = instanceID
+        self.maxPasteBytes = maxPasteBytes
+        self.directoryByteCount = directoryByteCount
+        self.runOffMainActor = runOffMainActor
+        self.progressCenter = progressCenter
+        self.issueCenter = issueCenter
+        // Emissions hop to main on a serial (FIFO) queue, not an unordered
+        // `Task { @MainActor }`: two snapshots arriving out of order would make
+        // the progress bar jump backwards.
+        progress = ClipboardProgressTracker(
+            revealDelay: progressRevealDelay, idleLinger: progressIdleLinger
+        ) { [weak self] snapshot in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                MainActor.assumeIsolated { self.publishProgress(snapshot) }
+            }
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard consumeTask == nil else { return }
+        isConnected = true
+
+        let sender = ClipboardStreamSender(channel: channel)
+        self.sender = sender
+
+        let channel = self.channel
+        let label = self.label
+        let connectionTag = self.connectionTag
+        consumeTask = Task { [weak self] in
+            await Self.consume(
+                channel: channel, label: label, connectionTag: connectionTag, sender: sender,
+                onControlFrame: { [weak self] frame in
+                    // Fire-and-forget on the serial main queue, which preserves
+                    // control-frame FIFO order; a per-frame Task would not.
+                    DispatchQueue.main.async {
+                        MainActor.assumeIsolated { self?.handleControlFrame(frame) }
+                    }
+                })
+        }
+        Self.logger.notice(
+            "Vsock drop service started for '\(self.label, privacy: .public)' (conn=\(self.connectionTag, privacy: .public))"
+        )
+    }
+
+    func stop() {
+        consumeTask?.cancel()
+        consumeTask = nil
+        sender?.cancelAll()
+        sender = nil
+        channel.close()
+        isConnected = false
+        // A job still open when the channel goes is a drop whose files never
+        // landed, and the gesture was made on this Mac — so it is owed an answer
+        // here. One already called off is not: the user knows.
+        let abandoned = jobs.values.filter { !$0.isCancelled }
+        for job in abandoned { job.liveGeneration.set(0) }
+        jobs.removeAll()
+        if !abandoned.isEmpty {
+            raiseIssue(.dropInterrupted(fileCount: abandoned.reduce(0) { $0 + $1.content.representations.count }))
+        }
+        progress.clearAll()
+        // Synchronously, not via the tracker's emission hop: a readout still
+        // standing for a VM that has gone is the stuck indicator §13 forbids.
+        publishProgress(nil)
+        // Unconditional, unlike `publishProgress`'s change-guarded push: a stopped
+        // VM's last snapshot would otherwise pin the status item's readout.
+        progressCenter.progressChanged(from: self, nil)
+        Self.logger.notice(
+            "Vsock drop service stopped for '\(self.label, privacy: .public)' (conn=\(self.connectionTag, privacy: .public))"
+        )
+    }
+
+    // MARK: - Progress and issues
+
+    private func publishProgress(_ snapshot: ClipboardProgressSnapshot?) {
+        // A stopped service shows nothing: emissions reach here through a queue
+        // hop, so one dispatched just before teardown can land just after it.
+        let next = isConnected ? snapshot : nil
+        guard next != transferProgress else { return }
+        transferProgress = next
+        progressCenter.progressChanged(from: self, next)
+    }
+
+    private func raiseIssue(_ issue: ClipboardTransferIssue) {
+        issueCenter.report(
+            issue, instanceID: instanceID, vmName: label, pasteLimitBytes: maxPasteBytes())
+    }
+
+    // MARK: - Starting a drop
+
+    /// Offers the dropped `urls` to the guest, reporting whether the drop was
+    /// taken up.
+    ///
+    /// Returns as soon as the items' metadata has been read, so the drag session
+    /// ends promptly: a folder's size walk and the offer itself follow off the
+    /// main actor. `false` means nothing was offered — the channel is gone, or
+    /// none of the items could be read.
+    @discardableResult
+    func startDrop(urls: [URL]) -> Bool {
+        guard isConnected, sender != nil else { return false }
+        var candidates: [DropCandidate] = []
+        var unreadable = 0
+        for url in urls {
+            guard
+                let values = try? url.resourceValues(forKeys: [
+                    .contentTypeKey, .isDirectoryKey, .fileSizeKey,
+                ])
+            else {
+                unreadable += 1
+                continue
+            }
+            if values.isDirectory == true {
+                candidates.append(
+                    DropCandidate(
+                        url: url, uti: (values.contentType ?? .folder).identifier,
+                        filename: url.lastPathComponent, byteCount: nil, isDirectory: true))
+            } else if let type = values.contentType, let size = values.fileSize {
+                candidates.append(
+                    DropCandidate(
+                        url: url, uti: type.identifier, filename: url.lastPathComponent,
+                        byteCount: size, isDirectory: false))
+            } else {
+                unreadable += 1
+            }
+        }
+        if unreadable > 0 {
+            Self.logger.warning(
+                "Skipped \(unreadable, privacy: .public) unreadable dropped item(s) for '\(self.label, privacy: .public)' (conn=\(self.connectionTag, privacy: .public))"
+            )
+        }
+        guard !candidates.isEmpty else {
+            // The gesture happened on this Mac and produced nothing, so the
+            // silence has to be explained here.
+            raiseIssue(.dropItemsUnreadable())
+            return false
+        }
+
+        let generation = nextGeneration
+        nextGeneration += 1
+        let dropped = candidates
+        guard dropped.contains(where: \.isDirectory) else {
+            offer(generation: generation, reps: Self.representations(for: dropped, sizes: [:]))
+            return true
+        }
+        // A folder's stat-walk estimate is payload-scaled, so it never runs on
+        // the main actor. The offer follows once it lands.
+        let folders = dropped.filter(\.isDirectory).map(\.url)
+        let sizeOf = directoryByteCount
+        runOffMainActor { [weak self] in
+            var sizes: [URL: Int] = [:]
+            for folder in folders { sizes[folder] = sizeOf(folder) }
+            let measured = sizes
+            DispatchQueue.main.async {
+                guard let self else { return }
+                MainActor.assumeIsolated {
+                    guard self.isConnected else { return }
+                    self.offer(
+                        generation: generation,
+                        reps: Self.representations(for: dropped, sizes: measured))
+                }
+            }
+        }
+        return true
+    }
+
+    /// Builds one representation per dropped item, taking a folder's size from
+    /// the completed walk.
+    private static func representations(
+        for candidates: [DropCandidate], sizes: [URL: Int]
+    ) -> [ClipboardContent.Representation] {
+        candidates.map { candidate in
+            guard candidate.isDirectory else {
+                return ClipboardContent.Representation(
+                    uti: candidate.uti, fileURL: candidate.url,
+                    byteCount: candidate.byteCount ?? 0, filename: candidate.filename)
+            }
+            return ClipboardContent.Representation(
+                directorySourceURL: candidate.url, estimatedByteCount: sizes[candidate.url] ?? 0,
+                filename: candidate.filename, uti: candidate.uti)
+        }
+    }
+
+    /// Registers the job and announces it, opening the readout that spans every
+    /// file in the drop.
+    private func offer(generation: UInt64, reps: [ClipboardContent.Representation]) {
+        // Cap to the 16-bit rep-index limit a transfer id can address.
+        let capped = ClipboardContent(representations: reps).cappedToOfferLimit()
+        if let originalCount = capped.truncatedFrom {
+            Self.logger.warning(
+                "Drop truncated from \(originalCount, privacy: .public) to \(ClipboardContent.maxOfferableRepresentations, privacy: .public) items (16-bit transfer-id limit)"
+            )
+        }
+        let content = capped.content
+        guard !content.representations.isEmpty else { return }
+
+        // One session for the whole drop, declared up front, so the bar's
+        // denominator is every dropped file rather than each in turn (§13).
+        let units = content.representations.enumerated().map { index, rep in
+            ClipboardProgressTracker.PlannedUnit(
+                id: ClipboardTransferID.make(
+                    generation: generation, repIndex: index, hostMinted: false),
+                expectedBytes: UInt64(max(0, rep.byteCount)), name: rep.filename)
+        }
+        let session = progress.openSession(
+            direction: .outbound, peerName: label, units: units,
+            onCancelRequested: { [weak self] in
+                DispatchQueue.main.async {
+                    MainActor.assumeIsolated { self?.cancelDrop(generation: generation) }
+                }
+            })
+
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.dropOffer = Kernova_V1_DropOffer.with {
+            $0.generation = generation
+            $0.repInfo = content.representations.map(\.offerRepresentationInfo)
+        }
+        do {
+            try channel.send(frame)
+        } catch {
+            progress.closeSession(session, immediately: true)
+            Self.logger.error(
+                "Failed to offer a drop to '\(self.label, privacy: .public)': \(error.localizedDescription, privacy: .public)"
+            )
+            raiseIssue(.dropSendFailed())
+            return
+        }
+        jobs[generation] = DropJob(generation: generation, content: content, session: session)
+        Self.logger.notice(
+            "Offered a drop to '\(self.label, privacy: .public)' (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public), \(content.representations.count, privacy: .public) item(s), \(content.totalByteCount, privacy: .public) bytes)"
+        )
+    }
+
+    // MARK: - Cancelling
+
+    /// Calls off the drop for `generation`: the guest keeps whatever already
+    /// landed in Downloads and drops the rest.
+    func cancelDrop(generation: UInt64) {
+        guard let job = jobs[generation] else { return }
+        job.isCancelled = true
+        // Zeroed first, so a transfer between chunks sees the job is gone and
+        // aborts itself rather than racing the explicit cancel below.
+        job.liveGeneration.set(0)
+        sender?.cancel(generation: generation)
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.dropRelease = Kernova_V1_DropRelease.with { $0.generation = generation }
+        try? channel.send(frame)
+        // Not `immediately`: the linger is what leaves the readout on screen at
+        // the fraction it stopped on, so the cancel is visibly what happened.
+        progress.closeSession(job.session)
+        jobs[generation] = nil
+        Self.logger.notice(
+            "User cancelled the drop to '\(self.label, privacy: .public)' (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public))"
+        )
+    }
+
+    // MARK: - Frame consumer
+
+    /// Drains the channel, routing high-frequency stream frames off the main
+    /// actor.
+    nonisolated private static func consume(
+        channel: VsockChannel,
+        label: String,
+        connectionTag: ClipboardConnectionTag,
+        sender: ClipboardStreamSender,
+        onControlFrame: @Sendable @escaping (Frame) -> Void
+    ) async {
+        do {
+            for try await frame in channel.incoming where frame.protocolVersion == 1 {
+                // `handleRequest` registers outbound transfers on the main actor,
+                // so a sender-bound abort rides the same hop rather than being
+                // handled here.
+                ClipboardStreamRouting.route(
+                    frame, role: .host, sender: sender, receiver: nil,
+                    senderAbortDelivery: .viaControlFrame, onControlFrame: onControlFrame)
+            }
+            logger.info(
+                "Vsock drop channel closed for '\(label, privacy: .public)' (conn=\(connectionTag, privacy: .public))"
+            )
+        } catch {
+            logger.warning(
+                "Vsock drop channel ended with error for '\(label, privacy: .public)' (conn=\(connectionTag, privacy: .public)): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    private func handleControlFrame(_ frame: Frame) {
+        switch frame.payload {
+        case .clipboardRequest(let request):
+            handleRequest(request)
+        case .dropComplete(let complete):
+            handleDropComplete(complete)
+        case .clipboardStreamAbort(let abort):
+            // Only a sender-bound abort reaches here; see the routing in `consume`.
+            sender?.handleAbort(transferID: abort.transferID)
+        case .error(let error):
+            Self.logger.warning(
+                "Guest drop error for '\(self.label, privacy: .public)': \(error.code, privacy: .public) — \(error.message, privacy: .public)"
+            )
+        case .clipboardStreamBegin, .clipboardChunk, .clipboardStreamEnd, .clipboardStreamAck:
+            // Routed off-main by the consume loop; never reaches here.
+            break
+        case .hello, .heartbeat, .policyUpdate, .logRecord, .clipboardOffer, .clipboardRelease,
+            .dropOffer, .dropRelease:
+            // Control-plane, clipboard and host→guest drop payloads belong
+            // elsewhere; a peer sending them here crossed wires.
+            Self.logger.warning(
+                "Unexpected payload on the drop channel for '\(self.label, privacy: .public)' — wrong port; closing the channel"
+            )
+            channel.close()
+        case .none:
+            Self.logger.debug("Frame with no payload for '\(self.label, privacy: .public)'")
+        }
+    }
+
+    // MARK: - Serving the guest's pulls
+
+    private func handleRequest(_ request: Kernova_V1_ClipboardRequest) {
+        guard let job = jobs[request.generation] else {
+            Self.logger.debug(
+                "Drop request for an unknown generation \(request.generation, privacy: .public) (conn=\(self.connectionTag, privacy: .public))"
+            )
+            // Abort every dropped request so the guest's parked pull wakes
+            // immediately instead of stalling to its backstop timeout.
+            sender?.rejectRequest(
+                transferID: request.transferID, code: "request.stale",
+                message: "No live drop for generation \(request.generation)")
+            return
+        }
+        let repIndex = Int(request.transferID & 0xFFFF)
+        guard repIndex < job.content.representations.count else {
+            Self.logger.warning(
+                "Drop request transfer_id \(request.transferID, privacy: .public) out of range for gen=\(request.generation, privacy: .public) (conn=\(self.connectionTag, privacy: .public))"
+            )
+            sender?.rejectRequest(
+                transferID: request.transferID, code: "request.range",
+                message: "Item index \(repIndex) out of range")
+            return
+        }
+        let representation = job.content.representations[repIndex]
+        guard representation.uti == request.uti else {
+            Self.logger.warning(
+                "Drop request uti '\(request.uti, privacy: .public)' doesn't match offered item \(repIndex, privacy: .public) (conn=\(self.connectionTag, privacy: .public))"
+            )
+            sender?.rejectRequest(
+                transferID: request.transferID, code: "request.uti",
+                message: "Requested UTI '\(request.uti)' does not match the dropped item")
+            return
+        }
+        // Ahead of the session bookkeeping: with no sender nothing streams, so a
+        // transfer announced here would never see a terminal and its readout
+        // would stick on screen.
+        guard let sender else { return }
+
+        let xid = request.transferID
+        let session = job.session
+        let tracker = progress
+        let live = job.liveGeneration
+        tracker.unitBegan(
+            session: session, id: xid, expectedBytes: UInt64(max(0, representation.byteCount)),
+            name: representation.filename)
+        if case .directory(let sourceURL, let estimatedByteCount) = representation.source {
+            Self.logger.notice(
+                "Streaming dropped folder '\(representation.filename, privacy: .public)' to '\(self.label, privacy: .public)' (gen=\(request.generation, privacy: .public), conn=\(self.connectionTag, privacy: .public), estimate \(estimatedByteCount, privacy: .public) bytes)"
+            )
+            sender.startDirectoryTransfer(
+                transferID: xid,
+                generation: request.generation,
+                sourceDirectoryURL: sourceURL,
+                folderName: representation.filename,
+                uti: representation.uti,
+                maxAcceptByteCount: request.maxAcceptByteCount,
+                isCurrent: { live.isCurrent($0) },
+                onProgress: { sent, total in
+                    tracker.unitProgressed(
+                        session: session, id: xid, bytesTransferred: UInt64(max(0, sent)),
+                        totalBytes: UInt64(max(0, total)))
+                },
+                onComplete: { success in
+                    tracker.unitEnded(session: session, id: xid, succeeded: success)
+                })
+            return
+        }
+        sender.startTransfer(
+            transferID: xid,
+            generation: request.generation,
+            representation: representation,
+            maxAcceptByteCount: request.maxAcceptByteCount,
+            // A drop always lands as a file in Downloads; nothing about it is
+            // pasteboard-inline.
+            isInline: false,
+            isCurrent: { live.isCurrent($0) },
+            onProgress: { sent, total in
+                tracker.unitProgressed(
+                    session: session, id: xid, bytesTransferred: UInt64(max(0, sent)),
+                    totalBytes: UInt64(max(0, total)))
+            },
+            onComplete: { success in
+                tracker.unitEnded(session: session, id: xid, succeeded: success)
+            })
+        Self.logger.debug(
+            "Streaming dropped file \(repIndex, privacy: .public) to '\(self.label, privacy: .public)' (gen=\(request.generation, privacy: .public), conn=\(self.connectionTag, privacy: .public), \(representation.byteCount, privacy: .public) bytes)"
+        )
+    }
+
+    // MARK: - The guest's verdict
+
+    private func handleDropComplete(_ complete: Kernova_V1_DropComplete) {
+        guard let job = jobs.removeValue(forKey: complete.generation) else { return }
+        job.liveGeneration.set(0)
+        switch complete.outcome {
+        case .completed:
+            progress.closeSession(job.session)
+            Self.logger.notice(
+                "Drop to '\(self.label, privacy: .public)' completed (gen=\(complete.generation, privacy: .public), conn=\(self.connectionTag, privacy: .public), \(job.content.representations.count, privacy: .public) item(s))"
+            )
+        case .cancelled:
+            progress.closeSession(job.session)
+            Self.logger.notice(
+                "Drop to '\(self.label, privacy: .public)' cancelled (gen=\(complete.generation, privacy: .public), conn=\(self.connectionTag, privacy: .public))"
+            )
+        case .failed, .unspecified, .UNRECOGNIZED:
+            progress.closeSession(job.session)
+            // The code is matched, never the message: `message` is guest-supplied
+            // text and the sentence the user reads is composed here.
+            let code = ClipboardErrorCode(rawValue: complete.code)
+            Self.logger.error(
+                "Drop to '\(self.label, privacy: .public)' failed (gen=\(complete.generation, privacy: .public), conn=\(self.connectionTag, privacy: .public), code=\(complete.code, privacy: .public)): \(complete.message, privacy: .public)"
+            )
+            raiseIssue(.dropFailed(code: code))
+        }
+    }
+}
+
+// MARK: - Cancelling the shown transfer
+
+extension VsockDropService: TransferCancelling {
+    /// Routes a Cancel on the app-wide readout to whichever drop that readout is
+    /// showing.
+    func requestCancelOfShownOperation() {
+        progress.requestCancelOfPublishedSession()
+    }
+}

--- a/Kernova/Services/VsockGuestLogService.swift
+++ b/Kernova/Services/VsockGuestLogService.swift
@@ -99,9 +99,11 @@ final class VsockGuestLogService {
             return true
         case .hello, .heartbeat, .policyUpdate, .clipboardOffer, .clipboardRequest,
             .clipboardRelease, .clipboardStreamBegin, .clipboardChunk,
-            .clipboardStreamEnd, .clipboardStreamAck, .clipboardStreamAbort:
+            .clipboardStreamEnd, .clipboardStreamAck, .clipboardStreamAbort,
+            .dropOffer, .dropComplete, .dropRelease:
             // Hello, Heartbeat, and PolicyUpdate belong on the control channel;
-            // clipboard payloads belong on the clipboard channel.
+            // clipboard payloads belong on the clipboard channel, drop payloads
+            // on the drop channel.
             logger.warning(
                 "Unexpected payload on log channel for '\(label, privacy: .public)' — wrong port; closing the channel"
             )

--- a/Kernova/Services/VsockPorts.swift
+++ b/Kernova/Services/VsockPorts.swift
@@ -14,4 +14,7 @@ enum KernovaVsockPort {
 
     /// Guest agent log forwarding.
     static let log: UInt32 = 49153
+
+    /// Files dragged onto the VM display, streamed host→guest into Downloads.
+    static let drop: UInt32 = 49155
 }

--- a/Kernova/Views/Console/VMDisplayBackingView.swift
+++ b/Kernova/Views/Console/VMDisplayBackingView.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import Virtualization
+import os
 
 /// Pure AppKit view containing a `VZVirtualMachineView` with built-in pause and transition overlays.
 ///
@@ -16,6 +17,30 @@ final class VMDisplayBackingView: NSView {
 
     /// Called when the user taps the resume button on the pause overlay.
     var onResume: (() -> Void)?
+
+    /// Whether this VM can take files dropped on its display right now.
+    ///
+    /// Read at every drag event rather than cached, so a drag that outlives the
+    /// guest agent's connection stops being accepted mid-gesture.
+    var dropAvailability: () -> DisplayDropAvailability = { .none }
+
+    /// Sends dropped file URLs to the guest, reporting whether they were taken.
+    var onDropFiles: ([URL]) -> Bool = { _ in false }
+
+    /// Whether `registerForDraggedTypes` is currently in effect, so
+    /// ``applyDropRegistration()`` can be called on every observation tick
+    /// without churning AppKit's registration.
+    private var isDropRegistered = false
+
+    private static let logger = Logger(subsystem: "app.kernova", category: "VMDisplayBackingView")
+
+    /// The only pasteboard reading options a display drop ever uses: concrete
+    /// file URLs, never a file promise. A Finder drag carries these; a
+    /// promise-only drag never enters, because `.fileURL` is the sole registered
+    /// type.
+    private static let fileURLReadingOptions: [NSPasteboard.ReadingOptionKey: Any] = [
+        .urlReadingFileURLsOnly: true
+    ]
 
     /// Mirrors `machineView.automaticallyReconfiguresDisplay`, so ``apply(automaticallyReconfiguresDisplay:)``
     /// writes the framework property only when it actually changes.
@@ -108,6 +133,66 @@ final class VMDisplayBackingView: NSView {
         }
         self.automaticallyReconfiguresDisplay = automaticallyReconfiguresDisplay
         machineView.automaticallyReconfiguresDisplay = automaticallyReconfiguresDisplay
+    }
+
+    // MARK: - File Drop
+
+    /// Registers (or unregisters) the display as a drag destination to match the
+    /// VM's current availability.
+    ///
+    /// Registration is what separates the two refusals the issue asks for: a VM
+    /// that has never run the agent is *not* a destination, so a drag over it is
+    /// as if Kernova weren't there, while a registered-but-disconnected one takes
+    /// part and returns an empty operation. Idempotent — hosts call it on every
+    /// observation tick.
+    func applyDropRegistration() {
+        let shouldRegister = dropAvailability() != .none
+        guard shouldRegister != isDropRegistered else { return }
+        isDropRegistered = shouldRegister
+        if shouldRegister {
+            registerForDraggedTypes([.fileURL])
+            // A `VZVirtualMachineView` covering this view would take the drag
+            // first if it registered types of its own. It does not today, and
+            // this is the line that says so if that ever changes.
+            if !machineView.registeredDraggedTypes.isEmpty {
+                Self.logger.fault(
+                    "VZVirtualMachineView registers dragged types — display drops will not reach Kernova"
+                )
+                assertionFailure("VZVirtualMachineView registers dragged types")
+            }
+        } else {
+            unregisterDraggedTypes()
+        }
+    }
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        dragOperation(for: sender)
+    }
+
+    override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        dragOperation(for: sender)
+    }
+
+    /// `.copy` when this drag can be sent to the guest, else the empty operation
+    /// AppKit renders as "no" — no accept badge, and a release springs back.
+    private func dragOperation(for sender: any NSDraggingInfo) -> NSDragOperation {
+        guard dropAvailability() == .available,
+            sender.draggingPasteboard.canReadObject(
+                forClasses: [NSURL.self], options: Self.fileURLReadingOptions)
+        else { return [] }
+        return .copy
+    }
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        guard
+            let urls = sender.draggingPasteboard.readObjects(
+                forClasses: [NSURL.self], options: Self.fileURLReadingOptions) as? [URL],
+            !urls.isEmpty
+        else { return false }
+        // Re-checked here rather than trusted from `draggingUpdated`: the guest
+        // agent can go away between the last pointer move and the release.
+        guard dropAvailability() == .available else { return false }
+        return onDropFiles(urls)
     }
 
     // MARK: - Overlay Animation

--- a/Kernova/Views/VMInstance+Display.swift
+++ b/Kernova/Views/VMInstance+Display.swift
@@ -1,8 +1,50 @@
 import AppKit
 import KernovaKit
 
+/// Whether the VM display takes files dragged onto it, and if not, why.
+enum DisplayDropAvailability {
+    /// This VM has never run a guest agent, so the display is not a drag
+    /// destination at all — a drag over it behaves as if Kernova were not there.
+    case none
+    /// The agent has connected before but is not reachable now. The display takes
+    /// part in the drag and refuses it, which is what makes the pointer show no
+    /// accept badge and a release spring back.
+    case disconnected
+    /// Files dropped now will be sent to the guest.
+    case available
+}
+
 /// Display-layer properties derived from a VM's status.
 extension VMInstance {
+    /// Whether files dragged onto this VM's display can be sent to the guest.
+    ///
+    /// The single read site for the gesture's three states. `.none` is decided
+    /// from persisted state (`lastSeenAgentVersion`), so it survives restarts and
+    /// a VM that has never had an agent never advertises a drop it cannot do;
+    /// the live channel decides the rest, so an agent that goes away mid-session
+    /// downgrades to a refusal on the next observation tick.
+    var displayDropAvailability: DisplayDropAvailability {
+        guard configuration.guestOS == .macOS, configuration.lastSeenAgentVersion != nil else {
+            return .none
+        }
+        guard let drop = vsockDropService, drop.isConnected,
+            vsockControlService?.guestSupportsDropFiles == true
+        else { return .disconnected }
+        return .available
+    }
+
+    /// Sends `urls` to the guest's Downloads folder, reporting whether the drop
+    /// was taken up.
+    ///
+    /// Re-checks availability itself: a drag can outlive the channel it was
+    /// started over, and a drop the service can no longer serve must spring back
+    /// rather than silently vanish.
+    func sendDroppedFilesToGuest(_ urls: [URL]) -> Bool {
+        guard displayDropAvailability == .available, let service = vsockDropService else {
+            return false
+        }
+        return service.startDrop(urls: urls)
+    }
     /// Display name that distinguishes preparing, cold-paused ("Suspended"), and live-paused ("Paused").
     var statusDisplayName: String {
         if let state = preparingState { return state.displayLabel }

--- a/KernovaKit/Proto/kernova.proto
+++ b/KernovaKit/Proto/kernova.proto
@@ -409,8 +409,9 @@ message Error {
 // Metadata only, exactly like `ClipboardOffer`: the guest pulls each
 // representation with a `ClipboardRequest` on the drop channel and receives it
 // through the same `ClipboardStreamBegin`/`Chunk`/`End` path a paste uses. Every
-// representation carries a non-empty `filename` and `is_inline = false` — a drop
-// always lands as a file — and the guest writes each into its Downloads folder.
+// representation carries a non-empty `filename`, and the guest writes each into
+// its Downloads folder as a file — `is_inline` is meaningless here and is
+// ignored, since a drop never reaches a pasteboard.
 message DropOffer {
   // Per-connection counter, starting at 1. Each drop gesture is an independent
   // job under its own generation; a second drop does not supersede the first.

--- a/KernovaKit/Proto/kernova.proto
+++ b/KernovaKit/Proto/kernova.proto
@@ -62,6 +62,10 @@ message Frame {
     // 29 retired (see `reserved` above).
 
     LogRecord log_record = 30;
+
+    DropOffer drop_offer = 40;
+    DropComplete drop_complete = 41;
+    DropRelease drop_release = 42;
   }
 }
 
@@ -398,4 +402,53 @@ message Error {
   // e.g. "clipboard.request". Populated when the error is causally linked
   // to a specific incoming message.
   optional string in_reply_to = 3;
+}
+
+// Host->guest: the files of one drag-and-drop gesture onto the VM display.
+//
+// Metadata only, exactly like `ClipboardOffer`: the guest pulls each
+// representation with a `ClipboardRequest` on the drop channel and receives it
+// through the same `ClipboardStreamBegin`/`Chunk`/`End` path a paste uses. Every
+// representation carries a non-empty `filename` and `is_inline = false` — a drop
+// always lands as a file — and the guest writes each into its Downloads folder.
+message DropOffer {
+  // Per-connection counter, starting at 1. Each drop gesture is an independent
+  // job under its own generation; a second drop does not supersede the first.
+  uint64 generation = 1;
+
+  // Metadata for each dropped item, in the order the drop delivered them.
+  repeated ClipboardRepresentationInfo rep_info = 2;
+}
+
+// Guest->host: the drop job for `generation` has finished.
+message DropComplete {
+  uint64 generation = 1;
+
+  enum Outcome {
+    OUTCOME_UNSPECIFIED = 0;
+    // Every representation landed in the guest's Downloads folder.
+    OUTCOME_COMPLETED = 1;
+    // Cancelled from either side. Files already landed are kept; the in-flight
+    // partial is deleted by the stream layer's abort path.
+    OUTCOME_CANCELLED = 2;
+    // The drop could not be completed — see `code`.
+    OUTCOME_FAILED = 3;
+  }
+  Outcome outcome = 2;
+
+  // Stable machine-readable code for `OUTCOME_FAILED`, from
+  // `ClipboardErrorCode` (e.g. "clipboard.drop.disk.full"); empty otherwise.
+  // The host renders its own sentence from this rather than from `message`.
+  string code = 3;
+
+  // Human-readable detail for logs. Never rendered in host UI.
+  string message = 4;
+}
+
+// Host->guest: the host abandons the drop for `generation` (the user cancelled,
+// or the session is going away). The guest aborts the in-flight pull, drops the
+// representations it has not requested yet, keeps whatever already landed in
+// Downloads, and replies `DropComplete{OUTCOME_CANCELLED}`.
+message DropRelease {
+  uint64 generation = 1;
 }

--- a/KernovaKit/Sources/KernovaKit/ClipboardErrorCode.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardErrorCode.swift
@@ -44,4 +44,15 @@ public enum ClipboardErrorCode: String, CaseIterable, Sendable {
     /// A copied folder was not offered because the peer's agent cannot receive a
     /// folder streamed with no declared size.
     case folderPeerOutdated = "clipboard.folder.peer.outdated"
+
+    /// The guest has no room to write a dropped file into its Downloads folder.
+    case dropDiskFull = "clipboard.drop.disk.full"
+
+    /// The guest could not write into its Downloads folder — the guest user has
+    /// not granted the agent access to it.
+    case dropDownloadsDenied = "clipboard.drop.downloads.denied"
+
+    /// A dropped file did not reach the guest's Downloads folder, for a reason
+    /// with no more specific code.
+    case dropFailed = "clipboard.drop.failed"
 }

--- a/KernovaKit/Sources/KernovaKit/ClipboardFileStaging.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardFileStaging.swift
@@ -238,7 +238,8 @@ public final class ClipboardFileStaging: @unchecked Sendable {
         defer { lock.unlock() }
         let dir = try directory(for: generation)
         let parent = dir.appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let url = parent.appendingPathComponent(Self.sanitize(name), isDirectory: true)
+        let url = parent.appendingPathComponent(
+            FinderStyleUniquing.sanitizedComponent(name), isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
     }
@@ -332,7 +333,7 @@ public final class ClipboardFileStaging: @unchecked Sendable {
     /// this the second sink in the generation reuses the first's path and the
     /// two files collapse into one. Caller holds the lock.
     private static func uniqueDestination(in dir: URL, filename: String) -> URL {
-        let sanitized = sanitize(filename)
+        let sanitized = FinderStyleUniquing.sanitizedComponent(filename)
         let candidate = dir.appendingPathComponent(sanitized)
         guard FileManager.default.fileExists(atPath: candidate.path) else { return candidate }
         let name = sanitized as NSString
@@ -345,15 +346,6 @@ public final class ClipboardFileStaging: @unchecked Sendable {
             if !FileManager.default.fileExists(atPath: url.path) { return url }
             counter += 1
         }
-    }
-
-    /// Reduces a suggested filename to a single safe path component so a
-    /// crafted name (`"../escape"`, `"a/b"`) can't write outside the
-    /// generation directory.
-    private static func sanitize(_ filename: String) -> String {
-        let base = (filename as NSString).lastPathComponent
-        let cleaned = base.replacingOccurrences(of: "/", with: "_")
-        return cleaned.isEmpty || cleaned == "." || cleaned == ".." ? "clipboard-file" : cleaned
     }
 
     /// Default free-space query: `volumeAvailableCapacityForImportantUsageKey`

--- a/KernovaKit/Sources/KernovaKit/ClipboardProgressMenuItemView.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardProgressMenuItemView.swift
@@ -5,8 +5,9 @@ import AppKit
 ///
 /// Every label must stay single-line and truncate rather than wrap: a menu item
 /// that changed height while its menu was open would re-lay-out the dropdown
-/// under the user's cursor. Non-actionable — the menu item carrying it is
-/// disabled.
+/// under the user's cursor. The Cancel button is the view's only control; the
+/// menu item carrying it is disabled, and a custom view's own subviews track
+/// mouse events regardless of that.
 @MainActor
 public final class ClipboardProgressMenuItemView: NSView {
     /// Content width — fits a headline naming a VM plus the byte-progress line
@@ -20,6 +21,7 @@ public final class ClipboardProgressMenuItemView: NSView {
     private static let rowSpacing: CGFloat = 4
 
     private let headline = NSTextField(labelWithString: "")
+    private let cancelButton = NSButton(title: "Cancel", target: nil, action: nil)
     private let bar = NSProgressIndicator()
     /// The fraction the bar should show, committed to it only while the view is
     /// on screen — see `viewDidMoveToWindow`.
@@ -27,6 +29,15 @@ public final class ClipboardProgressMenuItemView: NSView {
     private let byteProgress = NSTextField(labelWithString: "")
     private let itemCounter = NSTextField(labelWithString: "")
     private let timeRemaining = NSTextField(labelWithString: "")
+
+    /// Stops the transfer the readout is showing.
+    ///
+    /// `nil` hides the Cancel button, for a readout of something that cannot be
+    /// stopped. Set it before the view is shown; it is read at click time, so a
+    /// later change takes effect without a rebuild.
+    public var onCancel: (() -> Void)? {
+        didSet { cancelButton.isHidden = onCancel == nil }
+    }
 
     /// Creates the readout, sized to its content.
     public init() {
@@ -38,6 +49,11 @@ public final class ClipboardProgressMenuItemView: NSView {
         frame.size = NSSize(
             width: Self.contentWidth,
             height: stack.fittingSize.height + Self.verticalInset * 2)
+        // Measured with the button in place, then hidden: `NSStackView` drops a
+        // hidden view from layout, so measuring without it would size the item
+        // too short for the first readout that *can* be cancelled — and an
+        // `NSMenu` takes a custom item's height from the frame, once.
+        cancelButton.isHidden = true
     }
 
     @available(*, unavailable)
@@ -51,6 +67,15 @@ public final class ClipboardProgressMenuItemView: NSView {
         headline.font = .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold)
         headline.textColor = .labelColor
         headline.lineBreakMode = .byTruncatingTail
+        headline.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        cancelButton.bezelStyle = .rounded
+        cancelButton.controlSize = .small
+        cancelButton.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        cancelButton.target = self
+        cancelButton.action = #selector(cancelTapped)
+        cancelButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        cancelButton.setContentHuggingPriority(.required, for: .horizontal)
 
         bar.style = .bar
         bar.isIndeterminate = false
@@ -78,7 +103,13 @@ public final class ClipboardProgressMenuItemView: NSView {
         byteRow.distribution = .fill
         byteRow.spacing = 8
 
-        let stack = NSStackView(views: [headline, bar, byteRow, timeRemaining])
+        let headlineRow = NSStackView(views: [headline, cancelButton])
+        headlineRow.orientation = .horizontal
+        headlineRow.alignment = .centerY
+        headlineRow.distribution = .fill
+        headlineRow.spacing = 8
+
+        let stack = NSStackView(views: [headlineRow, bar, byteRow, timeRemaining])
         stack.orientation = .vertical
         stack.alignment = .leading
         stack.spacing = Self.rowSpacing
@@ -90,6 +121,7 @@ public final class ClipboardProgressMenuItemView: NSView {
             stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.verticalInset),
             stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.leadingInset),
             stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Self.trailingInset),
+            headlineRow.widthAnchor.constraint(equalTo: stack.widthAnchor),
             byteRow.widthAnchor.constraint(equalTo: stack.widthAnchor),
             bar.widthAnchor.constraint(equalTo: stack.widthAnchor),
             // Pin the content width so the rows lay out (and the height measures)
@@ -139,4 +171,18 @@ public final class ClipboardProgressMenuItemView: NSView {
             ClipboardProgressFormat.timeRemaining(seconds: snapshot.secondsRemaining) ?? ""
         setAccessibilityLabel(ClipboardProgressFormat.summary(snapshot))
     }
+
+    /// Runs the cancel handler for whatever the readout is currently showing.
+    ///
+    /// Read at click time rather than captured, so a handler replaced between two
+    /// operations cancels the live one.
+    @objc private func cancelTapped() {
+        onCancel?()
+    }
+
+    #if DEBUG
+    /// Test seam: the Cancel button, so a test can assert its visibility and
+    /// drive its action without a live menu.
+    public var cancelButtonForTesting: NSButton { cancelButton }
+    #endif
 }

--- a/KernovaKit/Sources/KernovaKit/ClipboardProgressSnapshot.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardProgressSnapshot.swift
@@ -43,12 +43,17 @@ public struct ClipboardProgressSnapshot: Equatable, Sendable {
     public let isPasteSession: Bool
     /// How long this operation has been running.
     public let elapsedSeconds: TimeInterval
+    /// Whether the user can stop this operation — what puts a Cancel affordance
+    /// on the readout. A surface must not offer one otherwise: the transfers
+    /// behind an operation with nothing to cancel would keep running.
+    public let isCancellable: Bool
 
     /// Creates a snapshot of one clipboard operation in flight.
     public init(
         direction: Direction, peerName: String, currentItemName: String?, filesCompleted: Int,
         fileCount: Int, bytesTransferred: UInt64, totalBytes: UInt64, bytesPerSecond: Double?,
-        secondsRemaining: Double?, isPasteSession: Bool, elapsedSeconds: TimeInterval
+        secondsRemaining: Double?, isPasteSession: Bool, elapsedSeconds: TimeInterval,
+        isCancellable: Bool = false
     ) {
         self.direction = direction
         self.peerName = peerName
@@ -61,6 +66,7 @@ public struct ClipboardProgressSnapshot: Equatable, Sendable {
         self.secondsRemaining = secondsRemaining
         self.isPasteSession = isPasteSession
         self.elapsedSeconds = elapsedSeconds
+        self.isCancellable = isCancellable
     }
 
     /// Progress as a `0...1` fraction, clamped (a zero/unknown total reads as 0).

--- a/KernovaKit/Sources/KernovaKit/ClipboardProgressStatusItemPresenter.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardProgressStatusItemPresenter.swift
@@ -20,6 +20,10 @@ public final class ClipboardProgressStatusItemPresenter {
     /// the reminder's dismissal handler instead of opening the menu.
     private let willAutoOpen: (() -> Void)?
 
+    /// Stops the operation the readout is showing, for a readout that reports
+    /// itself cancellable. `nil` leaves every readout without a Cancel button.
+    private let onCancel: (() -> Void)?
+
     /// The paste currently materializing, or `nil` when none is.
     public private(set) var snapshot: ClipboardProgressSnapshot?
 
@@ -43,19 +47,45 @@ public final class ClipboardProgressStatusItemPresenter {
     private var pendingAutoOpen = false
 
     /// Creates a presenter bound to a status item and its dropdown.
-    public init(statusItem: NSStatusItem, menu: NSMenu, willAutoOpen: (() -> Void)? = nil) {
+    ///
+    /// `onCancel` stops whichever operation the readout is currently showing; the
+    /// button appears only while that readout reports itself cancellable.
+    public init(
+        statusItem: NSStatusItem, menu: NSMenu, willAutoOpen: (() -> Void)? = nil,
+        onCancel: (() -> Void)? = nil
+    ) {
         self.statusItem = statusItem
         self.menu = menu
         self.willAutoOpen = willAutoOpen
+        self.onCancel = onCancel
     }
 
     /// Applies the readout the domain host just published — a snapshot to render,
     /// or `nil` to clear it.
     public func apply(_ snapshot: ClipboardProgressSnapshot?) {
         self.snapshot = snapshot
-        if let snapshot { view.apply(snapshot) }
+        if let snapshot {
+            view.apply(snapshot)
+            view.onCancel = snapshot.isCancellable ? cancelHandler() : nil
+        }
         syncItems()
         applyAutoOpen(snapshot)
+    }
+
+    /// The click handler installed on the readout: dismiss the dropdown the user
+    /// clicked in, then cancel.
+    ///
+    /// The dropdown goes first because the cancel's own effect on the readout
+    /// arrives asynchronously — the transfers abort, the session ends below
+    /// 100 %, and the linger clears it — so leaving the menu up would strand the
+    /// user in front of a row that keeps ticking for a moment after they stopped
+    /// it.
+    private func cancelHandler() -> (() -> Void)? {
+        guard let onCancel else { return nil }
+        return { [weak self] in
+            self?.menu.cancelTracking()
+            onCancel()
+        }
     }
 
     /// Inserts the readout rows at the top of a dropdown being rebuilt, when a

--- a/KernovaKit/Sources/KernovaKit/ClipboardProgressTracker.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardProgressTracker.swift
@@ -85,6 +85,9 @@ public final class ClipboardProgressTracker: @unchecked Sendable {
         let peerName: String
         let isPaste: Bool
         let startedAt: TimeInterval
+        /// Stops what this session is measuring, when the operation can be
+        /// cancelled. `nil` for one that cannot.
+        let onCancelRequested: (@Sendable () -> Void)?
         /// Whether the reveal gate has been passed — once true, the readout is on
         /// screen and every terminal must clear it.
         var revealed = false
@@ -118,7 +121,8 @@ public final class ClipboardProgressTracker: @unchecked Sendable {
 
         init(
             token: SessionToken, direction: ClipboardProgressSnapshot.Direction, peerName: String,
-            isPaste: Bool, startedAt: TimeInterval, units: [Unit: UnitState]
+            isPaste: Bool, startedAt: TimeInterval, units: [Unit: UnitState],
+            onCancelRequested: (@Sendable () -> Void)?
         ) {
             self.token = token
             self.direction = direction
@@ -126,6 +130,7 @@ public final class ClipboardProgressTracker: @unchecked Sendable {
             self.isPaste = isPaste
             self.startedAt = startedAt
             self.units = units
+            self.onCancelRequested = onCancelRequested
             for state in units.values {
                 totalBytes &+= state.expected
                 transferredBytes &+= state.observed
@@ -206,6 +211,9 @@ public final class ClipboardProgressTracker: @unchecked Sendable {
     /// Whether the last emission put something on screen, so a clear is only sent
     /// when there is something to clear.
     private var showing = false
+    /// The session backing the snapshot last emitted, so a Cancel on the readout
+    /// reaches the operation the user is actually looking at.
+    private var publishedSession: SessionToken?
 
     private let revealDelay: TimeInterval
     private let idleLinger: TimeInterval
@@ -256,9 +264,15 @@ public final class ClipboardProgressTracker: @unchecked Sendable {
     /// nothing else explains the wait. A paste *this* side performs never sets
     /// it: that paste parks this process's main thread, so no readout of it can
     /// repaint before it is over.
+    ///
+    /// `onCancelRequested` stops what the session measures — the transfers, not
+    /// the offer behind them — and is what puts a Cancel button on the readout.
+    /// It is invoked outside the tracker's lock, may fire more than once, and may
+    /// fire after the session has ended, so it must be idempotent. Leave it `nil`
+    /// for an operation with nothing to cancel.
     public func openSession(
         direction: ClipboardProgressSnapshot.Direction, peerName: String, isPaste: Bool = false,
-        units: [PlannedUnit] = []
+        units: [PlannedUnit] = [], onCancelRequested: (@Sendable () -> Void)? = nil
     ) -> SessionToken {
         let opened: (token: SessionToken, unitCount: Int, plannedBytes: UInt64) = lock.withLock {
             let token = SessionToken(value: nextToken)
@@ -269,7 +283,7 @@ public final class ClipboardProgressTracker: @unchecked Sendable {
             }
             let session = Session(
                 token: token, direction: direction, peerName: peerName, isPaste: isPaste,
-                startedAt: now(), units: table)
+                startedAt: now(), units: table, onCancelRequested: onCancelRequested)
             sessions[token] = session
             return (token, session.units.count, session.totalBytes)
         }
@@ -277,6 +291,25 @@ public final class ClipboardProgressTracker: @unchecked Sendable {
             "Progress session \(opened.token.value, privacy: .public) opened — \(direction, privacy: .public) '\(peerName, privacy: .public)' isPaste=\(isPaste, privacy: .public), \(opened.unitCount, privacy: .public) unit(s), \(opened.plannedBytes, privacy: .public) bytes"
         )
         return opened.token
+    }
+
+    /// Cancels the operation behind the snapshot last emitted.
+    ///
+    /// The readout is the only handle the user has on a transfer, so a Cancel on
+    /// it must reach *that* operation and no other — a second VM's transfer
+    /// running at the same time is a different session and is left alone. A no-op
+    /// when nothing is published, when the published session has since ended, or
+    /// when its operation is not cancellable.
+    public func requestCancelOfPublishedSession() {
+        // Resolved under the lock, invoked outside it: a cancel closure aborts
+        // transfers whose terminals re-enter this tracker.
+        let cancel: (@Sendable () -> Void)? = lock.withLock {
+            guard let token = publishedSession else { return nil }
+            return sessions[token]?.onCancelRequested
+        }
+        guard let cancel else { return }
+        Self.logger.notice("Cancel requested for the published progress session")
+        cancel()
     }
 
     /// Whether `token` still addresses a live session.
@@ -409,6 +442,7 @@ public final class ClipboardProgressTracker: @unchecked Sendable {
             let logs = sessions.values.map { endedLocked($0) }
             sessions.removeAll()
             showing = false
+            publishedSession = nil
             return Outcome(wasShowing ? .emit(nil, session: nil) : .none, logs: logs)
         }
         deliver(outcome)
@@ -570,6 +604,7 @@ public final class ClipboardProgressTracker: @unchecked Sendable {
         let projection = projectionLocked()
         guard projection != nil || showing else { return .none }
         showing = projection != nil
+        publishedSession = projection?.token
         return .emit(projection?.snapshot, session: projection?.token)
     }
 
@@ -607,7 +642,8 @@ public final class ClipboardProgressTracker: @unchecked Sendable {
             bytesPerSecond: session.rate.bytesPerSecond,
             secondsRemaining: session.rate.secondsRemaining(bytes: transferred, total: total),
             isPasteSession: session.isPaste,
-            elapsedSeconds: max(0, now() - session.startedAt))
+            elapsedSeconds: max(0, now() - session.startedAt),
+            isCancellable: session.onCancelRequested != nil)
         return (session.token, snapshot)
     }
 }

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamRouting.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamRouting.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Routes the frames of a chunk-streamed channel between the streaming engine
+/// and the owner's control-frame handler.
+///
+/// Every channel carrying `ClipboardStreamBegin`/`Chunk`/`End`/`Ack`/`Abort` —
+/// the clipboard channel on both sides, the drop channel on both sides — has the
+/// same routing rule, and it is a rule with two subtleties that must not be
+/// restated per channel: which engine owns an abort (decided by the transfer
+/// id's direction bit, read from the routing side's point of view), and whether
+/// a sender-bound abort may be delivered off the owner's actor at all.
+///
+/// The high-frequency payloads go straight to the thread-safe engine so a
+/// multi-GB transfer's chunk and ack traffic never reaches the owner's actor.
+public enum ClipboardStreamRouting {
+    /// Which end of the wire the routing side is, which is what makes the
+    /// transfer id's direction bit readable: the host receives on ids that carry
+    /// it and sends on ids that do not, and the guest is the mirror.
+    public enum Role: Sendable {
+        case host
+        case guest
+    }
+
+    /// How an abort naming a transfer this side is *sending* is delivered.
+    ///
+    /// `.viaControlFrame` when the owner registers outbound transfers on its own
+    /// actor: an abort handled synchronously here can otherwise overtake that
+    /// registration and no-op on an id the engine does not know yet, leaving a
+    /// cancelled transfer streaming. Routing it through the same hop the
+    /// registering frame takes preserves their order.
+    public enum SenderAbortDelivery: Sendable {
+        case direct
+        case viaControlFrame
+    }
+
+    /// Hands `frame` to `sender`/`receiver` when it is a stream payload, and to
+    /// `onControlFrame` otherwise.
+    ///
+    /// `onControlFrame` is called on the routing thread; an owner confined to an
+    /// actor hops inside it.
+    public static func route(
+        _ frame: Frame,
+        role: Role,
+        sender: ClipboardStreamSender?,
+        receiver: ClipboardStreamReceiver?,
+        senderAbortDelivery: SenderAbortDelivery,
+        onControlFrame: (Frame) -> Void
+    ) {
+        switch frame.payload {
+        case .clipboardStreamBegin(let begin):
+            receiver?.handleBegin(begin)
+        case .clipboardChunk(let chunk):
+            receiver?.handleChunk(chunk)
+        case .clipboardStreamEnd(let end):
+            receiver?.handleEnd(end)
+        case .clipboardStreamAck(let ack):
+            sender?.handleAck(
+                transferID: ack.transferID, bytesConsumed: ack.bytesConsumed,
+                windowBytes: ack.windowBytes)
+        case .clipboardStreamAbort(let abort):
+            if receiverOwns(abort.transferID, role: role) {
+                receiver?.handleAbort(abort)
+            } else {
+                switch senderAbortDelivery {
+                case .direct: sender?.handleAbort(transferID: abort.transferID)
+                case .viaControlFrame: onControlFrame(frame)
+                }
+            }
+        default:
+            onControlFrame(frame)
+        }
+    }
+
+    /// Whether `transferID` names a transfer this side is receiving, so an abort
+    /// for it belongs to the receiver rather than the sender.
+    public static func receiverOwns(_ transferID: UInt64, role: Role) -> Bool {
+        ClipboardTransferID.hostReceives(transferID) == (role == .host)
+    }
+}

--- a/KernovaKit/Sources/KernovaKit/FinderStyleUniquing.swift
+++ b/KernovaKit/Sources/KernovaKit/FinderStyleUniquing.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Names an arriving file inside a folder the user browses, using Finder's own
+/// "Keep Both" convention: `report.pdf` → `report 2.pdf` → `report 3.pdf`, and
+/// `Photos` → `Photos 2` for an extensionless name or a folder.
+///
+/// Distinct from `ClipboardFileStaging`'s internal ` (n)` suffixing, which names
+/// files inside an invisible staging root that no one reads: a dropped file lands
+/// in the guest's Downloads folder and the drop ends in a Finder window, so its
+/// name has to be the one Finder itself would have produced.
+public enum FinderStyleUniquing {
+    /// Reduces a peer-supplied filename to a single safe path component, so a
+    /// crafted name (`"../escape"`, `"a/b"`) cannot write outside the destination
+    /// directory.
+    ///
+    /// An empty, `.`, or `..` result falls back to `fallback`.
+    public static func sanitizedComponent(
+        _ filename: String, fallback: String = "clipboard-file"
+    ) -> String {
+        let base = (filename as NSString).lastPathComponent
+        let cleaned = base.replacingOccurrences(of: "/", with: "_")
+        return cleaned.isEmpty || cleaned == "." || cleaned == ".." ? fallback : cleaned
+    }
+
+    /// A URL under `directory` for `filename`, suffixed ` 2`, ` 3`, … before the
+    /// extension until nothing exists at that path.
+    ///
+    /// The existence probe is inherently racy against another writer in the same
+    /// directory; the caller's move is the operation that has to fail safe.
+    /// `fileExists` follows a symlink's target, so a dangling symlink is treated
+    /// as free and the move replaces it — which is what the user asked for.
+    public static func uniqueDestination(
+        in directory: URL, filename: String, fileManager: FileManager = .default
+    ) -> URL {
+        let sanitized = sanitizedComponent(filename)
+        let candidate = directory.appendingPathComponent(sanitized)
+        guard fileManager.fileExists(atPath: candidate.path) else { return candidate }
+        let name = sanitized as NSString
+        let base = name.deletingPathExtension
+        let ext = name.pathExtension
+        var counter = 2
+        while true {
+            let suffixed = ext.isEmpty ? "\(base) \(counter)" : "\(base) \(counter).\(ext)"
+            let url = directory.appendingPathComponent(suffixed)
+            if !fileManager.fileExists(atPath: url.path) { return url }
+            counter += 1
+        }
+    }
+}

--- a/KernovaKit/Sources/KernovaKit/Generated/kernova.pb.swift
+++ b/KernovaKit/Sources/KernovaKit/Generated/kernova.pb.swift
@@ -737,8 +737,9 @@ public nonisolated struct Kernova_V1_Error: Sendable {
 /// Metadata only, exactly like `ClipboardOffer`: the guest pulls each
 /// representation with a `ClipboardRequest` on the drop channel and receives it
 /// through the same `ClipboardStreamBegin`/`Chunk`/`End` path a paste uses. Every
-/// representation carries a non-empty `filename` and `is_inline = false` — a drop
-/// always lands as a file — and the guest writes each into its Downloads folder.
+/// representation carries a non-empty `filename`, and the guest writes each into
+/// its Downloads folder as a file — `is_inline` is meaningless here and is
+/// ignored, since a drop never reaches a pasteboard.
 public nonisolated struct Kernova_V1_DropOffer: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for

--- a/KernovaKit/Sources/KernovaKit/Generated/kernova.pb.swift
+++ b/KernovaKit/Sources/KernovaKit/Generated/kernova.pb.swift
@@ -161,6 +161,30 @@ public nonisolated struct Kernova_V1_Frame: Sendable {
     set {payload = .logRecord(newValue)}
   }
 
+  public var dropOffer: Kernova_V1_DropOffer {
+    get {
+      if case .dropOffer(let v)? = payload {return v}
+      return Kernova_V1_DropOffer()
+    }
+    set {payload = .dropOffer(newValue)}
+  }
+
+  public var dropComplete: Kernova_V1_DropComplete {
+    get {
+      if case .dropComplete(let v)? = payload {return v}
+      return Kernova_V1_DropComplete()
+    }
+    set {payload = .dropComplete(newValue)}
+  }
+
+  public var dropRelease: Kernova_V1_DropRelease {
+    get {
+      if case .dropRelease(let v)? = payload {return v}
+      return Kernova_V1_DropRelease()
+    }
+    set {payload = .dropRelease(newValue)}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public nonisolated enum OneOf_Payload: Equatable, Sendable {
@@ -187,6 +211,9 @@ public nonisolated struct Kernova_V1_Frame: Sendable {
     case clipboardStreamAck(Kernova_V1_ClipboardStreamAck)
     case clipboardStreamAbort(Kernova_V1_ClipboardStreamAbort)
     case logRecord(Kernova_V1_LogRecord)
+    case dropOffer(Kernova_V1_DropOffer)
+    case dropComplete(Kernova_V1_DropComplete)
+    case dropRelease(Kernova_V1_DropRelease)
 
   }
 
@@ -705,13 +732,125 @@ public nonisolated struct Kernova_V1_Error: Sendable {
   fileprivate var _inReplyTo: String? = nil
 }
 
+/// Host->guest: the files of one drag-and-drop gesture onto the VM display.
+///
+/// Metadata only, exactly like `ClipboardOffer`: the guest pulls each
+/// representation with a `ClipboardRequest` on the drop channel and receives it
+/// through the same `ClipboardStreamBegin`/`Chunk`/`End` path a paste uses. Every
+/// representation carries a non-empty `filename` and `is_inline = false` — a drop
+/// always lands as a file — and the guest writes each into its Downloads folder.
+public nonisolated struct Kernova_V1_DropOffer: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Per-connection counter, starting at 1. Each drop gesture is an independent
+  /// job under its own generation; a second drop does not supersede the first.
+  public var generation: UInt64 = 0
+
+  /// Metadata for each dropped item, in the order the drop delivered them.
+  public var repInfo: [Kernova_V1_ClipboardRepresentationInfo] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Guest->host: the drop job for `generation` has finished.
+public nonisolated struct Kernova_V1_DropComplete: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var generation: UInt64 = 0
+
+  public var outcome: Kernova_V1_DropComplete.Outcome = .unspecified
+
+  /// Stable machine-readable code for `OUTCOME_FAILED`, from
+  /// `ClipboardErrorCode` (e.g. "clipboard.drop.disk.full"); empty otherwise.
+  /// The host renders its own sentence from this rather than from `message`.
+  public var code: String = String()
+
+  /// Human-readable detail for logs. Never rendered in host UI.
+  public var message: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public nonisolated enum Outcome: SwiftProtobuf.Enum, Swift.CaseIterable {
+    public typealias RawValue = Int
+    case unspecified // = 0
+
+    /// Every representation landed in the guest's Downloads folder.
+    case completed // = 1
+
+    /// Cancelled from either side. Files already landed are kept; the in-flight
+    /// partial is deleted by the stream layer's abort path.
+    case cancelled // = 2
+
+    /// The drop could not be completed — see `code`.
+    case failed // = 3
+    case UNRECOGNIZED(Int)
+
+    public init() {
+      self = .unspecified
+    }
+
+    public init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .unspecified
+      case 1: self = .completed
+      case 2: self = .cancelled
+      case 3: self = .failed
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    public var rawValue: Int {
+      switch self {
+      case .unspecified: return 0
+      case .completed: return 1
+      case .cancelled: return 2
+      case .failed: return 3
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [Kernova_V1_DropComplete.Outcome] = [
+      .unspecified,
+      .completed,
+      .cancelled,
+      .failed,
+    ]
+
+  }
+
+  public init() {}
+}
+
+/// Host->guest: the host abandons the drop for `generation` (the user cancelled,
+/// or the session is going away). The guest aborts the in-flight pull, drops the
+/// representations it has not requested yet, keeps whatever already landed in
+/// Downloads, and replies `DropComplete{OUTCOME_CANCELLED}`.
+public nonisolated struct Kernova_V1_DropRelease: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var generation: UInt64 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate nonisolated let _protobuf_package = "kernova.v1"
 
 nonisolated extension Kernova_V1_Frame: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Frame"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}protocol_version\0\u{2}\u{9}hello\0\u{1}error\0\u{1}heartbeat\0\u{3}policy_update\0\u{4}\u{7}clipboard_offer\0\u{3}clipboard_request\0\u{4}\u{2}clipboard_release\0\u{3}clipboard_stream_begin\0\u{3}clipboard_chunk\0\u{3}clipboard_stream_end\0\u{3}clipboard_stream_ack\0\u{3}clipboard_stream_abort\0\u{4}\u{2}log_record\0\u{c}\u{16}\u{1}\u{c}\u{1d}\u{1}")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}protocol_version\0\u{2}\u{9}hello\0\u{1}error\0\u{1}heartbeat\0\u{3}policy_update\0\u{4}\u{7}clipboard_offer\0\u{3}clipboard_request\0\u{4}\u{2}clipboard_release\0\u{3}clipboard_stream_begin\0\u{3}clipboard_chunk\0\u{3}clipboard_stream_end\0\u{3}clipboard_stream_ack\0\u{3}clipboard_stream_abort\0\u{4}\u{2}log_record\0\u{4}\u{a}drop_offer\0\u{3}drop_complete\0\u{3}drop_release\0\u{c}\u{16}\u{1}\u{c}\u{1d}\u{1}")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -889,6 +1028,45 @@ nonisolated extension Kernova_V1_Frame: SwiftProtobuf.Message, SwiftProtobuf._Me
           self.payload = .logRecord(v)
         }
       }()
+      case 40: try {
+        var v: Kernova_V1_DropOffer?
+        var hadOneofValue = false
+        if let current = self.payload {
+          hadOneofValue = true
+          if case .dropOffer(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payload = .dropOffer(v)
+        }
+      }()
+      case 41: try {
+        var v: Kernova_V1_DropComplete?
+        var hadOneofValue = false
+        if let current = self.payload {
+          hadOneofValue = true
+          if case .dropComplete(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payload = .dropComplete(v)
+        }
+      }()
+      case 42: try {
+        var v: Kernova_V1_DropRelease?
+        var hadOneofValue = false
+        if let current = self.payload {
+          hadOneofValue = true
+          if case .dropRelease(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payload = .dropRelease(v)
+        }
+      }()
       default: break
       }
     }
@@ -954,6 +1132,18 @@ nonisolated extension Kernova_V1_Frame: SwiftProtobuf.Message, SwiftProtobuf._Me
     case .logRecord?: try {
       guard case .logRecord(let v)? = self.payload else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 30)
+    }()
+    case .dropOffer?: try {
+      guard case .dropOffer(let v)? = self.payload else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 40)
+    }()
+    case .dropComplete?: try {
+      guard case .dropComplete(let v)? = self.payload else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 41)
+    }()
+    case .dropRelease?: try {
+      guard case .dropRelease(let v)? = self.payload else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 42)
     }()
     case nil: break
     }
@@ -1600,6 +1790,120 @@ nonisolated extension Kernova_V1_Error: SwiftProtobuf.Message, SwiftProtobuf._Me
     if lhs.code != rhs.code {return false}
     if lhs.message != rhs.message {return false}
     if lhs._inReplyTo != rhs._inReplyTo {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Kernova_V1_DropOffer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DropOffer"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}generation\0\u{3}rep_info\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt64Field(value: &self.generation) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.repInfo) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.generation != 0 {
+      try visitor.visitSingularUInt64Field(value: self.generation, fieldNumber: 1)
+    }
+    if !self.repInfo.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repInfo, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Kernova_V1_DropOffer, rhs: Kernova_V1_DropOffer) -> Bool {
+    if lhs.generation != rhs.generation {return false}
+    if lhs.repInfo != rhs.repInfo {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Kernova_V1_DropComplete: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DropComplete"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}generation\0\u{1}outcome\0\u{1}code\0\u{1}message\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt64Field(value: &self.generation) }()
+      case 2: try { try decoder.decodeSingularEnumField(value: &self.outcome) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.code) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.message) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.generation != 0 {
+      try visitor.visitSingularUInt64Field(value: self.generation, fieldNumber: 1)
+    }
+    if self.outcome != .unspecified {
+      try visitor.visitSingularEnumField(value: self.outcome, fieldNumber: 2)
+    }
+    if !self.code.isEmpty {
+      try visitor.visitSingularStringField(value: self.code, fieldNumber: 3)
+    }
+    if !self.message.isEmpty {
+      try visitor.visitSingularStringField(value: self.message, fieldNumber: 4)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Kernova_V1_DropComplete, rhs: Kernova_V1_DropComplete) -> Bool {
+    if lhs.generation != rhs.generation {return false}
+    if lhs.outcome != rhs.outcome {return false}
+    if lhs.code != rhs.code {return false}
+    if lhs.message != rhs.message {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Kernova_V1_DropComplete.Outcome: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OUTCOME_UNSPECIFIED\0\u{1}OUTCOME_COMPLETED\0\u{1}OUTCOME_CANCELLED\0\u{1}OUTCOME_FAILED\0")
+}
+
+nonisolated extension Kernova_V1_DropRelease: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DropRelease"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}generation\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt64Field(value: &self.generation) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.generation != 0 {
+      try visitor.visitSingularUInt64Field(value: self.generation, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Kernova_V1_DropRelease, rhs: Kernova_V1_DropRelease) -> Bool {
+    if lhs.generation != rhs.generation {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/KernovaKit/Sources/KernovaKit/KernovaCapability.swift
+++ b/KernovaKit/Sources/KernovaKit/KernovaCapability.swift
@@ -35,11 +35,20 @@ public enum KernovaCapability {
     /// to `ClipboardPasteLimit.defaultBytes` and stay in agreement.
     public static let clipboardPasteLimitV1 = "clipboard.paste.limit.v1"
 
+    /// Files dragged onto the VM display, streamed on their own vsock channel
+    /// and written into the guest's Downloads folder.
+    ///
+    /// Independent of clipboard sharing: the drop channel carries its own offer
+    /// and never touches a pasteboard. A peer without it has no drop listener or
+    /// drop client at all, so the display refuses the gesture rather than
+    /// starting a transfer nothing will answer.
+    public static let dropFilesV1 = "drop.files.v1"
+
     /// The capabilities advertised by both the host control service and the
     /// guest control agent today.
     public static let controlChannelDefaults = [
         controlV1, controlHeartbeatV1, clipboardStreamV1, clipboardStreamDirectoryV1,
-        clipboardPasteLimitV1,
+        clipboardPasteLimitV1, dropFilesV1,
     ]
 
     /// Every capability tag this build recognizes — the allowlist for

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardProgressMenuItemViewTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardProgressMenuItemViewTests.swift
@@ -1,0 +1,69 @@
+import AppKit
+import Testing
+
+@testable import KernovaKit
+
+/// Unit tests for the Cancel affordance on the dropdown's transfer readout.
+@Suite("ClipboardProgressMenuItemView")
+@MainActor
+struct ClipboardProgressMenuItemViewTests {
+    private func makeSnapshot(isCancellable: Bool) -> ClipboardProgressSnapshot {
+        ClipboardProgressSnapshot(
+            direction: .outbound, peerName: "VM", currentItemName: "a.bin", filesCompleted: 0,
+            fileCount: 1, bytesTransferred: 10, totalBytes: 100, bytesPerSecond: nil,
+            secondsRemaining: nil, isPasteSession: false, elapsedSeconds: 1,
+            isCancellable: isCancellable)
+    }
+
+    @Test("the button is hidden until a cancel handler is installed")
+    func hidesTheButtonWithoutAHandler() {
+        let view = ClipboardProgressMenuItemView()
+        #expect(view.cancelButtonForTesting.isHidden)
+
+        view.onCancel = {}
+        #expect(!view.cancelButtonForTesting.isHidden)
+
+        view.onCancel = nil
+        #expect(view.cancelButtonForTesting.isHidden)
+    }
+
+    @Test("clicking the button runs the handler installed at click time")
+    func clickRunsTheCurrentHandler() {
+        let view = ClipboardProgressMenuItemView()
+        var first = 0
+        var second = 0
+        view.onCancel = { first += 1 }
+        view.cancelButtonForTesting.performClick(nil)
+        #expect(first == 1)
+
+        // Replaced between two operations: the click must stop the live one.
+        view.onCancel = { second += 1 }
+        view.cancelButtonForTesting.performClick(nil)
+        #expect(first == 1)
+        #expect(second == 1)
+    }
+
+    @Test("the item is tall enough for the row that carries the button")
+    func measuresWithTheButtonInPlace() {
+        // `NSMenu` takes a custom item's height from the frame once, so the
+        // measurement has to include a button the first cancellable readout will
+        // reveal.
+        let view = ClipboardProgressMenuItemView()
+        let withoutButton = view.fittingSize.height
+        view.onCancel = {}
+        view.layoutSubtreeIfNeeded()
+
+        #expect(view.frame.height >= withoutButton)
+        #expect(view.frame.height >= view.cancelButtonForTesting.fittingSize.height)
+    }
+
+    @Test("applying a snapshot renders it without disturbing the handler")
+    func applyKeepsTheHandler() {
+        let view = ClipboardProgressMenuItemView()
+        view.onCancel = {}
+        view.apply(makeSnapshot(isCancellable: true))
+
+        #expect(!view.cancelButtonForTesting.isHidden)
+        #expect(view.accessibilityLabel()?.isEmpty == false)
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardProgressTrackerTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardProgressTrackerTests.swift
@@ -698,4 +698,114 @@ struct ClipboardProgressTrackerTests {
 
         #expect(harness.emissions.isEmpty)
     }
+
+    // MARK: - Cancel
+
+    /// Counts cancel invocations for a session, so a test can tell "the right
+    /// one fired" from "both did".
+    private final class CancelCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = 0
+        var count: Int { lock.withLock { value } }
+        var handler: @Sendable () -> Void {
+            { self.lock.withLock { self.value += 1 } }
+        }
+    }
+
+    /// Reveals `session` by driving one unit past the reveal delay.
+    private func reveal(
+        _ harness: Harness, _ session: ClipboardProgressTracker.SessionToken, bytes: UInt64,
+        at time: TimeInterval
+    ) {
+        harness.tracker.unitBegan(session: session, id: 0, expectedBytes: bytes, name: "f.bin")
+        harness.now = time
+        harness.tracker.unitProgressed(session: session, id: 0, bytesTransferred: 1)
+    }
+
+    @Test("a cancellable session says so on its snapshot, and a plain one does not")
+    func snapshotReportsCancellability() throws {
+        let harness = Harness(revealDelay: 1)
+        let cancellable = harness.tracker.openSession(
+            direction: .outbound, peerName: "VM", onCancelRequested: {})
+        reveal(harness, cancellable, bytes: 1_000, at: 2)
+        #expect(try #require(harness.latest).isCancellable)
+
+        let plain = Harness(revealDelay: 1)
+        let session = plain.tracker.openSession(direction: .outbound, peerName: "VM")
+        reveal(plain, session, bytes: 1_000, at: 2)
+        #expect(try #require(plain.latest).isCancellable == false)
+    }
+
+    @Test("a cancel reaches the session backing the readout, and no other")
+    func cancelsOnlyThePublishedSession() {
+        let harness = Harness(revealDelay: 1)
+        let shownCancel = CancelCounter()
+        let hiddenCancel = CancelCounter()
+
+        // The bigger remaining payload wins the readout, so the smaller session
+        // is live but not shown — and must not be what a Cancel stops.
+        let hidden = harness.tracker.openSession(
+            direction: .outbound, peerName: "VM", onCancelRequested: hiddenCancel.handler)
+        harness.tracker.unitBegan(session: hidden, id: 0, expectedBytes: 1_000, name: "small.bin")
+        let shown = harness.tracker.openSession(
+            direction: .outbound, peerName: "VM", onCancelRequested: shownCancel.handler)
+        harness.tracker.unitBegan(session: shown, id: 0, expectedBytes: 500_000, name: "big.bin")
+        harness.now = 2
+        harness.tracker.unitProgressed(session: shown, id: 0, bytesTransferred: 1_000)
+        #expect(harness.latest?.currentItemName == "big.bin")
+
+        harness.tracker.requestCancelOfPublishedSession()
+
+        #expect(shownCancel.count == 1)
+        #expect(hiddenCancel.count == 0)
+    }
+
+    @Test("a repeated cancel fires the handler again — idempotency is the handler's job")
+    func repeatedCancelIsForwarded() {
+        let harness = Harness(revealDelay: 1)
+        let counter = CancelCounter()
+        let session = harness.tracker.openSession(
+            direction: .outbound, peerName: "VM", onCancelRequested: counter.handler)
+        reveal(harness, session, bytes: 1_000, at: 2)
+
+        harness.tracker.requestCancelOfPublishedSession()
+        harness.tracker.requestCancelOfPublishedSession()
+
+        // The tracker deliberately does not latch: it cannot know whether a
+        // second click means "stop the next file too".
+        #expect(counter.count == 2)
+    }
+
+    @Test("a cancel with nothing on screen, or after the session ended, does nothing")
+    func cancelIsANoOpWithoutAPublishedSession() {
+        let harness = Harness(revealDelay: 1, idleLinger: 2)
+        let counter = CancelCounter()
+
+        // Nothing revealed yet.
+        harness.tracker.requestCancelOfPublishedSession()
+        #expect(counter.count == 0)
+
+        let session = harness.tracker.openSession(
+            direction: .outbound, peerName: "VM", onCancelRequested: counter.handler)
+        reveal(harness, session, bytes: 1_000, at: 2)
+        harness.tracker.unitEnded(session: session, id: 0, succeeded: true)
+        harness.fireScheduledWork()
+
+        harness.tracker.requestCancelOfPublishedSession()
+        #expect(counter.count == 0)
+    }
+
+    @Test("clearing every session leaves nothing for a cancel to reach")
+    func clearAllDropsThePublishedSession() {
+        let harness = Harness(revealDelay: 1)
+        let counter = CancelCounter()
+        let session = harness.tracker.openSession(
+            direction: .outbound, peerName: "VM", onCancelRequested: counter.handler)
+        reveal(harness, session, bytes: 1_000, at: 2)
+
+        harness.tracker.clearAll()
+        harness.tracker.requestCancelOfPublishedSession()
+
+        #expect(counter.count == 0)
+    }
 }

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardStreamRoutingTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardStreamRoutingTests.swift
@@ -1,0 +1,107 @@
+import Testing
+
+@testable import KernovaKit
+
+/// Unit tests for the one routing rule every chunk-streamed channel shares —
+/// which engine owns an abort, and whether a sender-bound one may be delivered
+/// off the owner's actor.
+@Suite("ClipboardStreamRouting")
+struct ClipboardStreamRoutingTests {
+    /// A transfer id the host receives (direction bit set) — one the guest is
+    /// therefore sending.
+    private let hostReceivedID = ClipboardTransferID.make(
+        generation: 3, repIndex: 1, hostMinted: true)
+    /// A transfer id the guest receives — one the host is sending.
+    private let guestReceivedID = ClipboardTransferID.make(
+        generation: 3, repIndex: 1, hostMinted: false)
+
+    private func abortFrame(_ transferID: UInt64) -> Frame {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.clipboardStreamAbort = .with {
+            $0.transferID = transferID
+            $0.code = "superseded"
+        }
+        return frame
+    }
+
+    // MARK: - Abort ownership
+
+    @Test("the host's receiver owns an abort for an id the host receives")
+    func hostReceiverOwnsHostReceivedIDs() {
+        #expect(ClipboardStreamRouting.receiverOwns(hostReceivedID, role: .host))
+        #expect(!ClipboardStreamRouting.receiverOwns(guestReceivedID, role: .host))
+    }
+
+    @Test("the guest's receiver owns the mirror set")
+    func guestReceiverOwnsGuestReceivedIDs() {
+        #expect(ClipboardStreamRouting.receiverOwns(guestReceivedID, role: .guest))
+        #expect(!ClipboardStreamRouting.receiverOwns(hostReceivedID, role: .guest))
+    }
+
+    // MARK: - Delivery
+
+    @Test("a sender-bound abort rides the control hop when the owner asks it to")
+    func routesSenderAbortsAsControlFrames() {
+        var control: [Frame] = []
+        ClipboardStreamRouting.route(
+            abortFrame(guestReceivedID), role: .host, sender: nil, receiver: nil,
+            senderAbortDelivery: .viaControlFrame, onControlFrame: { control.append($0) })
+
+        #expect(control.count == 1)
+        if case .clipboardStreamAbort(let abort) = control.first?.payload {
+            #expect(abort.transferID == guestReceivedID)
+        } else {
+            Issue.record("Expected the abort to reach the control-frame handler")
+        }
+    }
+
+    @Test("a receiver-bound abort never reaches the control hop")
+    func keepsReceiverAbortsOffTheControlHop() {
+        var control: [Frame] = []
+        ClipboardStreamRouting.route(
+            abortFrame(hostReceivedID), role: .host, sender: nil, receiver: nil,
+            senderAbortDelivery: .viaControlFrame, onControlFrame: { control.append($0) })
+
+        #expect(control.isEmpty)
+    }
+
+    @Test("a sender-bound abort is delivered directly when the owner allows it")
+    func routesSenderAbortsDirectly() {
+        var control: [Frame] = []
+        ClipboardStreamRouting.route(
+            abortFrame(hostReceivedID), role: .guest, sender: nil, receiver: nil,
+            senderAbortDelivery: .direct, onControlFrame: { control.append($0) })
+
+        #expect(control.isEmpty)
+    }
+
+    @Test("stream payloads never reach the control hop, and everything else does")
+    func separatesStreamPayloadsFromControlFrames() {
+        var control: [Frame] = []
+        let record: (Frame) -> Void = { control.append($0) }
+
+        for payload in [
+            Frame.OneOf_Payload.clipboardStreamBegin(Kernova_V1_ClipboardStreamBegin()),
+            .clipboardChunk(Kernova_V1_ClipboardChunk()),
+            .clipboardStreamEnd(Kernova_V1_ClipboardStreamEnd()),
+            .clipboardStreamAck(Kernova_V1_ClipboardStreamAck()),
+        ] {
+            var frame = Frame()
+            frame.protocolVersion = 1
+            frame.payload = payload
+            ClipboardStreamRouting.route(
+                frame, role: .host, sender: nil, receiver: nil,
+                senderAbortDelivery: .viaControlFrame, onControlFrame: record)
+        }
+        #expect(control.isEmpty)
+
+        var offer = Frame()
+        offer.protocolVersion = 1
+        offer.dropOffer = Kernova_V1_DropOffer()
+        ClipboardStreamRouting.route(
+            offer, role: .host, sender: nil, receiver: nil,
+            senderAbortDelivery: .viaControlFrame, onControlFrame: record)
+        #expect(control.count == 1)
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/DropFrameTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/DropFrameTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+
+@testable import KernovaKit
+
+/// Wire round-trip for the drag-and-drop frames, so a field number or type that
+/// changes shape is caught here rather than by a guest that silently reads
+/// nothing.
+@Suite("Drop frames")
+struct DropFrameTests {
+    private func roundTrip(_ frame: Frame) throws -> Frame {
+        try Frame(serializedBytes: frame.serializedData())
+    }
+
+    @Test("a drop offer round-trips its generation and every item's metadata")
+    func offerRoundTrips() throws {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.dropOffer = Kernova_V1_DropOffer.with {
+            $0.generation = 7
+            $0.repInfo = [
+                Kernova_V1_ClipboardRepresentationInfo.with {
+                    $0.uti = "public.png"
+                    $0.byteCount = 4_096
+                    $0.filename = "shot.png"
+                },
+                Kernova_V1_ClipboardRepresentationInfo.with {
+                    $0.uti = "public.folder"
+                    $0.byteCount = 1_000_000
+                    $0.filename = "Photos"
+                    $0.isDirectory = true
+                },
+            ]
+        }
+
+        let decoded = try roundTrip(frame)
+        guard case .dropOffer(let offer) = decoded.payload else {
+            Issue.record("Expected a drop offer payload")
+            return
+        }
+        #expect(offer.generation == 7)
+        #expect(offer.repInfo.count == 2)
+        #expect(offer.repInfo[0].filename == "shot.png")
+        #expect(offer.repInfo[0].byteCount == 4_096)
+        #expect(offer.repInfo[1].isDirectory)
+        #expect(offer.repInfo[1].uti == "public.folder")
+    }
+
+    @Test("every completion outcome round-trips, carrying its code only when it failed")
+    func completeRoundTrips() throws {
+        for outcome in [
+            Kernova_V1_DropComplete.Outcome.completed, .cancelled, .failed,
+        ] {
+            var frame = Frame()
+            frame.protocolVersion = 1
+            frame.dropComplete = Kernova_V1_DropComplete.with {
+                $0.generation = 3
+                $0.outcome = outcome
+                if outcome == .failed {
+                    $0.code = ClipboardErrorCode.dropDiskFull.rawValue
+                    $0.message = "no room"
+                }
+            }
+
+            let decoded = try roundTrip(frame)
+            guard case .dropComplete(let complete) = decoded.payload else {
+                Issue.record("Expected a drop completion payload")
+                return
+            }
+            #expect(complete.generation == 3)
+            #expect(complete.outcome == outcome)
+            #expect(
+                complete.code
+                    == (outcome == .failed ? ClipboardErrorCode.dropDiskFull.rawValue : ""))
+        }
+    }
+
+    @Test("a drop release round-trips its generation")
+    func releaseRoundTrips() throws {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.dropRelease = Kernova_V1_DropRelease.with { $0.generation = 11 }
+
+        let decoded = try roundTrip(frame)
+        guard case .dropRelease(let release) = decoded.payload else {
+            Issue.record("Expected a drop release payload")
+            return
+        }
+        #expect(release.generation == 11)
+    }
+
+    @Test("the drop payloads occupy the field numbers the proto reserves for them")
+    func usesTheReservedFieldNumbers() throws {
+        // A renumbering would decode as an unknown field on a peer built from
+        // the previous proto — silently, which is what this pins.
+        var offer = Frame()
+        offer.dropOffer = Kernova_V1_DropOffer()
+        var complete = Frame()
+        complete.dropComplete = Kernova_V1_DropComplete()
+        var release = Frame()
+        release.dropRelease = Kernova_V1_DropRelease()
+
+        // Field 40/41/42 with wire type 2 encodes as the tag byte pair below.
+        #expect(Array(try offer.serializedData()).prefix(2) == [0xC2, 0x02])
+        #expect(Array(try complete.serializedData()).prefix(2) == [0xCA, 0x02])
+        #expect(Array(try release.serializedData()).prefix(2) == [0xD2, 0x02])
+    }
+}

--- a/KernovaKit/Tests/KernovaKitTests/FinderStyleUniquingTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/FinderStyleUniquingTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+
+@testable import KernovaKit
+
+/// Unit tests for the naming a dropped file gets in the guest's Downloads
+/// folder — Finder's own "Keep Both" convention, not staging's invisible ` (n)`
+/// style.
+@Suite("FinderStyleUniquing")
+struct FinderStyleUniquingTests {
+    /// A fresh empty directory, plus the files named in `seeded`.
+    private func makeDirectory(seeded: [String] = []) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FinderStyleUniquingTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for name in seeded {
+            FileManager.default.createFile(
+                atPath: root.appendingPathComponent(name).path, contents: Data())
+        }
+        return root
+    }
+
+    // MARK: - Uniquing
+
+    @Test("a free name is used as-is")
+    func keepsAFreeName() throws {
+        let dir = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        #expect(
+            FinderStyleUniquing.uniqueDestination(in: dir, filename: "report.pdf").lastPathComponent
+                == "report.pdf")
+    }
+
+    @Test("a taken name counts up before the extension, Finder-style")
+    func countsUpBeforeTheExtension() throws {
+        let dir = try makeDirectory(seeded: ["report.pdf"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let second = FinderStyleUniquing.uniqueDestination(in: dir, filename: "report.pdf")
+        #expect(second.lastPathComponent == "report 2.pdf")
+
+        FileManager.default.createFile(atPath: second.path, contents: Data())
+        #expect(
+            FinderStyleUniquing.uniqueDestination(in: dir, filename: "report.pdf")
+                .lastPathComponent == "report 3.pdf")
+    }
+
+    @Test("an extensionless name — a folder's, say — takes a bare counter")
+    func countsUpWithoutAnExtension() throws {
+        let dir = try makeDirectory(seeded: ["Photos"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        #expect(
+            FinderStyleUniquing.uniqueDestination(in: dir, filename: "Photos").lastPathComponent
+                == "Photos 2")
+    }
+
+    @Test("a multi-dot name counts up before the last extension only")
+    func treatsOnlyTheLastComponentAsAnExtension() throws {
+        let dir = try makeDirectory(seeded: ["archive.tar.gz"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        #expect(
+            FinderStyleUniquing.uniqueDestination(in: dir, filename: "archive.tar.gz")
+                .lastPathComponent == "archive.tar 2.gz")
+    }
+
+    // MARK: - Sanitization
+
+    @Test("a peer-supplied name cannot escape the destination directory")
+    func sanitizesTraversal() throws {
+        let dir = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let escaped = FinderStyleUniquing.uniqueDestination(in: dir, filename: "../escape.txt")
+        #expect(escaped.lastPathComponent == "escape.txt")
+        #expect(escaped.deletingLastPathComponent().standardizedFileURL == dir.standardizedFileURL)
+
+        let nested = FinderStyleUniquing.uniqueDestination(in: dir, filename: "a/b.txt")
+        #expect(nested.lastPathComponent == "b.txt")
+        #expect(nested.deletingLastPathComponent().standardizedFileURL == dir.standardizedFileURL)
+    }
+
+    @Test("an empty or dot-only name falls back rather than naming the directory")
+    func sanitizesDegenerateNames() {
+        #expect(FinderStyleUniquing.sanitizedComponent("") == "clipboard-file")
+        #expect(FinderStyleUniquing.sanitizedComponent(".") == "clipboard-file")
+        #expect(FinderStyleUniquing.sanitizedComponent("..") == "clipboard-file")
+        // A bare separator survives as a placeholder character rather than the
+        // fallback — still one harmless component, which is the whole contract.
+        #expect(FinderStyleUniquing.sanitizedComponent("/") == "_")
+    }
+
+    @Test("an ordinary name passes through sanitization untouched")
+    func keepsOrdinaryNames() {
+        #expect(FinderStyleUniquing.sanitizedComponent("Some File.txt") == "Some File.txt")
+        #expect(FinderStyleUniquing.sanitizedComponent(".hidden") == ".hidden")
+    }
+}

--- a/KernovaMacOSAgent/AgentAppDelegate.swift
+++ b/KernovaMacOSAgent/AgentAppDelegate.swift
@@ -3,8 +3,8 @@ import Foundation
 import KernovaKit
 
 // Guest-side agent for macOS VMs managed by Kernova: an `.accessory` menu-bar
-// app holding three long-lived, self-reconnecting vsock connections to the host
-// — control, clipboard, and log forwarding.
+// app holding four long-lived, self-reconnecting vsock connections to the host
+// — control, clipboard, drop, and log forwarding.
 
 @main
 @MainActor
@@ -43,8 +43,14 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
 
     private var vsockConnection: VsockHostConnection?
     private var clipboardAgent: VsockGuestClipboardAgent?
+    private var dropAgent: VsockGuestDropAgent?
     private var controlAgent: VsockGuestControlAgent?
     private var statusItemController: AgentStatusItemController?
+
+    /// This side's single transfer-readout authority, shared by every agent that
+    /// moves files, so the one status item never has two sources deciding what it
+    /// shows.
+    private var progressTracker: ClipboardProgressTracker?
 
     /// Retained so the signal sources stay armed for the process lifetime.
     private var sigintSource: DispatchSourceSignal?
@@ -96,20 +102,23 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
         // Progress emissions arrive off-main and hop via `DispatchQueue.main`,
         // not a `Task` — two independently scheduled hops carrying immutable
         // snapshots have no ordering guarantee, and the ring would jump backwards.
+        let progressTracker = ClipboardProgressTracker { [weak self] snapshot in
+            DispatchQueue.main.async {
+                self?.statusItemController?.materializationProgressChanged(snapshot)
+            }
+        }
         let clipboardAgent = VsockGuestClipboardAgent(
-            onProgress: { [weak self] snapshot in
-                DispatchQueue.main.async {
-                    self?.statusItemController?.materializationProgressChanged(snapshot)
-                }
-            },
+            progressTracker: progressTracker,
             onClipboardNotice: { [weak self] in
                 DispatchQueue.main.async {
                     self?.statusItemController?.clipboardNoticeRaised()
                 }
             })
+        let dropAgent = VsockGuestDropAgent(progressTracker: progressTracker)
 
         // `onPolicy` gates the log + clipboard capabilities; `onStateChange`
-        // drives the status-item icon.
+        // drives the status-item icon; `onHostCapabilitiesChanged` is what tells
+        // the drop client whether this host has a drop listener at all.
         let controlAgent = VsockGuestControlAgent(
             onPolicy: { [weak self] policy in
                 vsockConnection.setEnabled(policy.logForwardingEnabled)
@@ -125,6 +134,9 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
                 Task { @MainActor in
                     self?.statusItemController?.connectionStateChanged()
                 }
+            },
+            onHostCapabilitiesChanged: { [weak dropAgent] in
+                dropAgent?.syncEnablement()
             }
         )
 
@@ -132,7 +144,12 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
         clipboardAgent.hostStreamsDirectories = { [weak controlAgent] in
             controlAgent?.hostSupportsDirectoryStreaming ?? false
         }
+        dropAgent.hostSupportsDrop = { [weak controlAgent] in
+            controlAgent?.hostSupportsDropFiles ?? false
+        }
+        self.progressTracker = progressTracker
         self.clipboardAgent = clipboardAgent
+        self.dropAgent = dropAgent
         self.controlAgent = controlAgent
 
         self.statusItemController = AgentStatusItemController(
@@ -143,25 +160,31 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
                 vsockConnection?.isLogForwardingEnabled ?? false
             },
             clipboardActivity: { [weak clipboardAgent] in clipboardAgent?.clipboardActivity ?? .disabled },
+            onCancelTransfer: { [weak progressTracker] in
+                progressTracker?.requestCancelOfPublishedSession()
+            },
             onQuit: { NSApp.terminate(nil) }
         )
 
         installSignalHandlers(
             vsockConnection: vsockConnection,
             clipboardAgent: clipboardAgent,
+            dropAgent: dropAgent,
             controlAgent: controlAgent
         )
 
         vsockConnection.start()
         clipboardAgent.start()
+        dropAgent.start()
         controlAgent.start()
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         // Stop control first so heartbeat cessation is the cleanest going-away
-        // signal to the host; clipboard and log follow.
+        // signal to the host; clipboard, drop and log follow.
         controlAgent?.stop()
         clipboardAgent?.stop()
+        dropAgent?.stop()
         vsockConnection?.stop()
         // Balance any held App-Nap activity so begin/end stays paired.
         updateAppNap(clipboardEnabled: false)
@@ -185,6 +208,7 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
     private func installSignalHandlers(
         vsockConnection: VsockHostConnection,
         clipboardAgent: VsockGuestClipboardAgent,
+        dropAgent: VsockGuestDropAgent,
         controlAgent: VsockGuestControlAgent
     ) {
         signal(SIGINT, SIG_IGN)
@@ -200,6 +224,7 @@ final class AgentAppDelegate: NSObject, NSApplicationDelegate {
             Self.logger.notice("Received termination signal, shutting down")
             controlAgent.stop()
             clipboardAgent.stop()
+            dropAgent.stop()
             vsockConnection.stop()
             exit(0)
         }

--- a/KernovaMacOSAgent/AgentMenuText.swift
+++ b/KernovaMacOSAgent/AgentMenuText.swift
@@ -44,9 +44,9 @@ enum AgentMenuText {
 
     /// Why a paste of the host's clipboard did not happen, per failure code.
     ///
-    /// `copyTooLarge`, `pasteIncompleteSet`, `forwardItemsSkipped` and
-    /// `folderPeerOutdated` are host-only outcomes that never reach the guest, so
-    /// they read as the generic failure.
+    /// `copyTooLarge`, `pasteIncompleteSet`, `forwardItemsSkipped`,
+    /// `folderPeerOutdated` and the three drop codes are outcomes the guest
+    /// reports rather than receives, so they read as the generic failure.
     private static func pasteRefusalDetail(
         _ code: ClipboardErrorCode, pasteLimitBytes: Int?
     ) -> String {
@@ -58,7 +58,7 @@ enum AgentMenuText {
         case .pasteDiskFull: return "not enough disk space to paste"
         case .pasteTimeout: return "paste timed out"
         case .pasteFailed, .copyTooLarge, .pasteIncompleteSet, .forwardItemsSkipped,
-            .folderPeerOutdated:
+            .folderPeerOutdated, .dropDiskFull, .dropDownloadsDenied, .dropFailed:
             return "paste failed"
         }
     }

--- a/KernovaMacOSAgent/AgentStatusItemController.swift
+++ b/KernovaMacOSAgent/AgentStatusItemController.swift
@@ -20,11 +20,13 @@ final class AgentStatusItemController: NSObject, NSMenuDelegate {
     private let hostBundledVersion: () -> String
     private let logForwardingEnabled: () -> Bool
     private let clipboardActivity: () -> ClipboardActivity
+    private let onCancelTransfer: () -> Void
     private let onQuit: () -> Void
 
     /// Built lazily, since most sessions never reveal a paste readout.
     private lazy var pasteProgressPresenter = ClipboardProgressStatusItemPresenter(
-        statusItem: statusItem, menu: menu)
+        statusItem: statusItem, menu: menu,
+        onCancel: { [weak self] in self?.onCancelTransfer() })
 
     init(
         version: String,
@@ -32,6 +34,7 @@ final class AgentStatusItemController: NSObject, NSMenuDelegate {
         hostBundledVersion: @escaping () -> String,
         logForwardingEnabled: @escaping () -> Bool,
         clipboardActivity: @escaping () -> ClipboardActivity,
+        onCancelTransfer: @escaping () -> Void = {},
         onQuit: @escaping () -> Void
     ) {
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -40,6 +43,7 @@ final class AgentStatusItemController: NSObject, NSMenuDelegate {
         self.hostBundledVersion = hostBundledVersion
         self.logForwardingEnabled = logForwardingEnabled
         self.clipboardActivity = clipboardActivity
+        self.onCancelTransfer = onCancelTransfer
         self.onQuit = onQuit
         super.init()
 

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -260,16 +260,16 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     // MARK: - Init
 
     /// Production init — uses real `NSPasteboard.general` on the clipboard port,
-    /// publishing transfer progress through `onProgress` and clipboard refusals
-    /// through `onClipboardNotice`.
+    /// reporting progress through the agent-wide `progressTracker` and clipboard
+    /// refusals through `onClipboardNotice`.
     convenience init(
-        onProgress: @escaping @Sendable (ClipboardProgressSnapshot?) -> Void,
+        progressTracker: ClipboardProgressTracker,
         onClipboardNotice: @escaping @Sendable () -> Void
     ) {
         self.init(
             pasteboard: NSPasteboard.general,
             client: VsockGuestClient(port: KernovaVsockPort.clipboard, label: "clipboard"),
-            onProgress: onProgress,
+            progressTracker: progressTracker,
             onClipboardNotice: onClipboardNotice
         )
     }
@@ -281,11 +281,18 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// parallel tests, an `onProgress` sink to observe the readout the status
     /// item renders, an `onClipboardNotice` sink to observe refusals, and zeroed
     /// reveal/linger delays so a test transfer surfaces while in flight.
+    ///
+    /// `progressTracker` is the agent's single readout authority, shared with
+    /// every other agent that transfers files, so one status item never has two
+    /// sources deciding what it shows. A test that only cares about the clipboard
+    /// leaves it out and gets one built from `progressRevealDelay` /
+    /// `progressIdleLinger` / `onProgress`.
     init(
         pasteboard: Pasteboard, client: VsockGuestClient,
         clock: any EngineClock = makePlatformEngineClock(),
         freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
         stagingTempRoot: URL = FileManager.default.temporaryDirectory,
+        progressTracker: ClipboardProgressTracker? = nil,
         progressRevealDelay: TimeInterval = ClipboardProgressTracker.defaultRevealDelay,
         progressIdleLinger: TimeInterval = ClipboardProgressTracker.defaultIdleLinger,
         onProgress: @escaping @Sendable (ClipboardProgressSnapshot?) -> Void = { _ in },
@@ -295,8 +302,10 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         self.client = client
         self.clock = clock
         self.onClipboardNotice = onClipboardNotice
-        self.progressTracker = ClipboardProgressTracker(
-            revealDelay: progressRevealDelay, idleLinger: progressIdleLinger, emit: onProgress)
+        self.progressTracker =
+            progressTracker
+            ?? ClipboardProgressTracker(
+                revealDelay: progressRevealDelay, idleLinger: progressIdleLinger, emit: onProgress)
         self.staging = ClipboardFileStaging(
             label: "agent", tempRoot: stagingTempRoot, freeSpaceProvider: freeSpaceProvider)
         self.lastPasteboardChangeCount = pasteboard.changeCount
@@ -380,9 +389,28 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         }
         if let stale = outboundSession { progressTracker.closeSession(stale.token, immediately: true) }
         let token = progressTracker.openSession(
-            direction: .outbound, peerName: Self.pasteSourceName)
+            direction: .outbound, peerName: Self.pasteSourceName,
+            onCancelRequested: { [weak self] in
+                DispatchQueue.main.async { self?.cancelOutboundTransfers(generation: generation) }
+            })
         outboundSession = (generation: generation, token: token)
         return token
+    }
+
+    /// Stops streaming what the host is pulling for `generation`, because the
+    /// user cancelled the readout in this guest.
+    ///
+    /// The offer stands: the host can paste again and pull the same
+    /// representations. The sender's abort carries `superseded`, which the host
+    /// already retires quietly, so the host's paste comes back empty without
+    /// either side reporting a failure.
+    private func cancelOutboundTransfers(generation: UInt64) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let sender else { return }
+        sender.cancel(generation: generation)
+        Self.logger.notice(
+            "User cancelled the outbound clipboard transfer (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public))"
+        )
     }
 
     /// Clears per-connection streaming + pending state on the main queue.
@@ -397,8 +425,14 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
         pendingOutbound = nil
         currentOutboundGeneration.set(0)
         inboundPromise = nil
+        // Only this agent's own session is retired, never `clearAll()`: the
+        // tracker is the whole agent's readout authority and another agent's
+        // transfer may be live on it, which a clipboard teardown has no business
+        // wiping off the status item.
+        if let session = outboundSession {
+            progressTracker.closeSession(session.token, immediately: true)
+        }
         outboundSession = nil
-        progressTracker.clearAll()
         // A stale in-flight estimate walk's completion checks `liveChannel` and
         // drops itself; clear the flag now so the next connection can walk again.
         estimateInFlight = false
@@ -467,33 +501,18 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             for try await frame in channel.incoming where frame.protocolVersion == 1 {
                 // High-frequency stream frames go straight to the thread-safe
                 // engine off the main queue; only control frames hop to main.
-                switch frame.payload {
-                case .clipboardStreamBegin(let begin):
-                    receiver.handleBegin(begin)
-                case .clipboardChunk(let chunk):
-                    receiver.handleChunk(chunk)
-                case .clipboardStreamEnd(let end):
-                    receiver.handleEnd(end)
-                case .clipboardStreamAck(let ack):
-                    sender.handleAck(
-                        transferID: ack.transferID, bytesConsumed: ack.bytesConsumed,
-                        windowBytes: ack.windowBytes)
-                case .clipboardStreamAbort(let abort):
-                    // Route by the direction bit: a host-received id (bit set) is
-                    // one this guest sends; otherwise this guest receives it.
-                    if ClipboardTransferID.hostReceives(abort.transferID) {
-                        sender.handleAbort(transferID: abort.transferID)
-                    } else {
-                        receiver.handleAbort(abort)
-                    }
-                default:
-                    // Control frames are serialized on the main queue, so while a
-                    // synchronous `provideData` pull blocks main they queue behind
-                    // it; a pull is woken by its off-main Abort, not by these.
-                    DispatchQueue.main.async { [weak self] in
-                        self?.handleControlFrame(frame)
-                    }
-                }
+                ClipboardStreamRouting.route(
+                    frame, role: .guest, sender: sender, receiver: receiver,
+                    senderAbortDelivery: .direct,
+                    onControlFrame: { frame in
+                        // Control frames are serialized on the main queue, so
+                        // while a synchronous `provideData` pull blocks main they
+                        // queue behind it; a pull is woken by its off-main Abort,
+                        // not by these.
+                        DispatchQueue.main.async { [weak self] in
+                            self?.handleControlFrame(frame)
+                        }
+                    })
             }
             Self.logger.notice(
                 "Vsock clipboard channel closed by host (conn=\(connectionTag, privacy: .public))")
@@ -915,7 +934,8 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
             .clipboardStreamAbort:
             // Routed off-main by the consume loop; never reaches here.
             break
-        case .hello, .heartbeat, .policyUpdate, .logRecord, .none:
+        case .hello, .heartbeat, .policyUpdate, .logRecord, .dropOffer, .dropComplete,
+            .dropRelease, .none:
             Self.logger.warning("Unexpected payload on clipboard channel — wrong port")
         }
     }
@@ -1366,7 +1386,9 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
 
     /// Abort codes that are a normal supersession/teardown, not a failure worth
     /// surfacing to the user.
-    private static let benignAbortCodes: Set<String> = ["superseded", "cancelled", "request.stale"]
+    private static let benignAbortCodes: Set<String> = [
+        "superseded", "cancelled", "request.stale", "user.cancelled",
+    ]
 
     /// Maps a receiver/peer abort code to the user-facing paste code the host
     /// renders.

--- a/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestClipboardAgent.swift
@@ -139,6 +139,15 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     /// off-queue supersession check.
     private let currentOutboundGeneration = AtomicGeneration()
 
+    /// The outbound generation whose transfers the user cancelled.
+    ///
+    /// Cancelling aborts what is streaming, but the host decides what it pulls
+    /// and would simply request the next representation of a still-live offer,
+    /// bringing the readout back a beat later. The latch is what ends the
+    /// operation rather than one of its files; a later paste is a fresh gesture
+    /// against a fresh generation.
+    private var cancelledOutboundGeneration: UInt64?
+
     /// The host offer currently promised on the guest pasteboard, with its
     /// per-representation materialization cache.
     private var inboundPromise: InboundPromise?
@@ -407,6 +416,7 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     private func cancelOutboundTransfers(generation: UInt64) {
         dispatchPrecondition(condition: .onQueue(.main))
         guard let sender else { return }
+        cancelledOutboundGeneration = generation
         sender.cancel(generation: generation)
         Self.logger.notice(
             "User cancelled the outbound clipboard transfer (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public))"
@@ -943,6 +953,17 @@ final class VsockGuestClipboardAgent: @unchecked Sendable {
     // MARK: - Outbound (we are the sender)
 
     private func handleRequest(_ request: Kernova_V1_ClipboardRequest) {
+        guard cancelledOutboundGeneration != request.generation else {
+            Self.logger.debug(
+                "Clipboard request for cancelled gen=\(request.generation, privacy: .public) (conn=\(self.connectionTag, privacy: .public)) — refusing"
+            )
+            // Refused as stale, which the host already retires quietly: its paste
+            // comes back empty and neither side reports a failure.
+            sender?.rejectRequest(
+                transferID: request.transferID, code: "request.stale",
+                message: "The transfer for generation \(request.generation) was cancelled")
+            return
+        }
         guard let pending = pendingOutbound, pending.generation == request.generation else {
             Self.logger.debug(
                 "Stale clipboard request gen=\(request.generation, privacy: .public) (pending=\(self.pendingOutbound?.generation ?? 0, privacy: .public), conn=\(self.connectionTag, privacy: .public))"

--- a/KernovaMacOSAgent/VsockGuestControlAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestControlAgent.swift
@@ -58,6 +58,21 @@ final class VsockGuestControlAgent: @unchecked Sendable {
     /// offer one.
     private var hostSupportsDirectoryStreamingStorage = false
 
+    /// Whether the host advertised the display-drop capability.
+    ///
+    /// Guarded by `lock` and reset per connection; a host without it runs no drop
+    /// listener, so the guest's drop client stays paused rather than redialling a
+    /// port nothing is bound to.
+    private var hostSupportsDropFilesStorage = false
+
+    /// Invoked whenever the host's advertised capabilities change — on each
+    /// `Hello`, and on each connection teardown that clears them.
+    ///
+    /// Separate from `onStateChange`, which is change-gated on a state already
+    /// set to `.connected` before any `Hello` arrives and so never fires for the
+    /// capabilities themselves. Called off the main thread.
+    private let onHostCapabilitiesChanged: (@Sendable () -> Void)?
+
     /// Creates the control agent; tests inject a socketpair-backed client and
     /// small cadences.
     init(
@@ -68,7 +83,8 @@ final class VsockGuestControlAgent: @unchecked Sendable {
         unresponsiveAfter: TimeInterval = 15,
         terminateAfter: TimeInterval = 30,
         onPolicy: (@Sendable (Kernova_V1_PolicyUpdate) -> Void)? = nil,
-        onStateChange: (@Sendable (HostConnectionState) -> Void)? = nil
+        onStateChange: (@Sendable (HostConnectionState) -> Void)? = nil,
+        onHostCapabilitiesChanged: (@Sendable () -> Void)? = nil
     ) {
         precondition(
             unresponsiveAfter < terminateAfter,
@@ -84,6 +100,7 @@ final class VsockGuestControlAgent: @unchecked Sendable {
         self.livenessTickInterval = min(heartbeatInterval, unresponsiveAfter / 3)
         self.onPolicy = onPolicy
         self.onStateChange = onStateChange
+        self.onHostCapabilitiesChanged = onHostCapabilitiesChanged
     }
 
     // MARK: - UI state accessors
@@ -102,6 +119,12 @@ final class VsockGuestControlAgent: @unchecked Sendable {
     /// straight onto the wire.
     var hostSupportsDirectoryStreaming: Bool {
         lock.withLock { hostSupportsDirectoryStreamingStorage }
+    }
+
+    /// Thread-safe read of whether the host takes files dropped on the VM
+    /// display.
+    var hostSupportsDropFiles: Bool {
+        lock.withLock { hostSupportsDropFilesStorage }
     }
 
     /// Transitions `connectionState`, firing `onStateChange` only on a real
@@ -143,7 +166,11 @@ final class VsockGuestControlAgent: @unchecked Sendable {
             unresponsiveLogged = false
             hostSupportsClipboardStreaming = false
             hostSupportsDirectoryStreamingStorage = false
+            hostSupportsDropFilesStorage = false
         }
+        // The clearing is a capability change like any other: a client enabled by
+        // the previous host's Hello has to stand down until this one says Hello.
+        onHostCapabilitiesChanged?()
         updateConnectionState(.connected)
 
         sendHello(on: channel)
@@ -213,11 +240,14 @@ final class VsockGuestControlAgent: @unchecked Sendable {
             let hostStreams = hello.capabilities.contains(KernovaCapability.clipboardStreamV1)
             let hostStreamsDirectories = hello.capabilities.contains(
                 KernovaCapability.clipboardStreamDirectoryV1)
+            let hostTakesDrops = hello.capabilities.contains(KernovaCapability.dropFilesV1)
             lock.withLock {
                 hostSupportsClipboardStreaming = hostStreams
                 hostSupportsDirectoryStreamingStorage = hostStreamsDirectories
+                hostSupportsDropFilesStorage = hostTakesDrops
                 hostBundledAgentVersionStorage = hello.bundledAgentVersion
             }
+            onHostCapabilitiesChanged?()
             // `logDescription` bounds the peer-supplied capability strings; these
             // records can be forwarded into the host's log store.
             Self.logger.notice(
@@ -247,7 +277,7 @@ final class VsockGuestControlAgent: @unchecked Sendable {
             onPolicy?(effective)
         case .clipboardOffer, .clipboardRequest, .clipboardRelease,
             .clipboardStreamBegin, .clipboardChunk, .clipboardStreamEnd, .clipboardStreamAck,
-            .clipboardStreamAbort, .logRecord, .none:
+            .clipboardStreamAbort, .logRecord, .dropOffer, .dropComplete, .dropRelease, .none:
             Self.logger.warning("Unexpected payload on control channel — wrong port")
         }
     }

--- a/KernovaMacOSAgent/VsockGuestDropAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestDropAgent.swift
@@ -423,6 +423,11 @@ final class VsockGuestDropAgent: @unchecked Sendable {
         let generation = job.generation
         send(completion: outcome, generation: generation, on: channel)
         DispatchQueue.main.async { [weak self] in
+            // Identity-checked, not just keyed: generations restart at 1 with
+            // every accepted channel, so a worker that outlived a teardown would
+            // otherwise clear the *next* connection's job of the same number —
+            // leaving it unreachable by a release or a Cancel.
+            guard self?.jobs[generation] === job else { return }
             self?.jobs[generation] = nil
         }
         Self.logger.notice(

--- a/KernovaMacOSAgent/VsockGuestDropAgent.swift
+++ b/KernovaMacOSAgent/VsockGuestDropAgent.swift
@@ -1,0 +1,640 @@
+import AppKit
+import Foundation
+import KernovaKit
+
+/// Guest-side agent for files dropped on the VM display, talking to the host's
+/// `VsockDropService` on `KernovaVsockPort.drop`.
+///
+/// Receive-only, and independent of clipboard sharing: a drop never touches the
+/// pasteboard. Each `DropOffer` becomes one job, pulled representation by
+/// representation on a dedicated worker queue and landed in the guest's
+/// Downloads folder with Finder's own "Keep Both" naming, then revealed in a
+/// Finder window.
+///
+/// Published state is confined to the main dispatch queue; the worker queue is
+/// what the blocking pulls park on, so no pull ever holds the main thread.
+final class VsockGuestDropAgent: @unchecked Sendable {
+    private static let logger = KernovaLogger(
+        subsystem: "app.kernova.macosagent", category: "VsockGuestDropAgent")
+
+    /// What the drop readout calls the machine the files come from — the guest
+    /// cannot learn the host's actual computer name over the handshake.
+    private static let dropSourceName = "Mac"
+
+    private let client: VsockGuestClient
+    private let progressTracker: ClipboardProgressTracker
+    private let downloadsDirectory: URL
+    private let staging: ClipboardFileStaging
+    private let pullTimeout: TimeInterval
+    private let revealInFinder: @Sendable ([URL]) -> Void
+
+    /// Whether the host advertised `drop.files.v1`, so the reconnect loop only
+    /// dials a host that has a drop listener.
+    var hostSupportsDrop: @Sendable () -> Bool = { false }
+
+    /// Bridges each blocking pull on the worker queue to the off-main stream
+    /// receive.
+    private let coordinator = LazyPullCoordinator()
+
+    /// Runs one drop job at a time, in offer order.
+    ///
+    /// Serial and separate from main: `LazyPullCoordinator.pull` blocks its
+    /// caller, and a drop has no pasteboard deadline to race, so one file streams
+    /// at a time on a thread nothing else needs.
+    private let jobQueue = DispatchQueue(
+        label: "app.kernova.macosagent.drop-jobs", qos: .userInitiated)
+
+    // MARK: - Main-queue state
+
+    private var liveChannel: VsockChannel?
+    private var receiver: ClipboardStreamReceiver?
+    private var connectionTag = ClipboardConnectionTag.guestUnconnected
+
+    /// Every job the host has offered and this side has not finished, by
+    /// generation.
+    private var jobs: [UInt64: DropJob] = [:]
+
+    #if DEBUG
+    /// Test seam.
+    var liveChannelForTesting: VsockChannel? { liveChannel }
+    #endif
+
+    /// One drop gesture's files, and the transfer of it that is in flight.
+    ///
+    /// `@unchecked Sendable`: `lock` guards everything the worker queue and the
+    /// main queue both touch.
+    private final class DropJob: @unchecked Sendable {
+        let generation: UInt64
+        let reps: [Kernova_V1_ClipboardRepresentationInfo]
+        let session: ClipboardProgressTracker.SessionToken
+
+        private let lock = NSLock()
+        private var cancelledStorage = false
+        private var inFlightTransferID: UInt64?
+
+        init(
+            generation: UInt64, reps: [Kernova_V1_ClipboardRepresentationInfo],
+            session: ClipboardProgressTracker.SessionToken
+        ) {
+            self.generation = generation
+            self.reps = reps
+            self.session = session
+        }
+
+        var isCancelled: Bool { lock.withLock { cancelledStorage } }
+
+        /// Marks the job cancelled, returning the transfer to abort if one is in
+        /// flight.
+        ///
+        /// Idempotent: a second cancel finds nothing in flight and returns `nil`.
+        func cancel() -> UInt64? {
+            lock.withLock {
+                cancelledStorage = true
+                defer { inFlightTransferID = nil }
+                return inFlightTransferID
+            }
+        }
+
+        /// Claims the job for one transfer, reporting `false` when a cancel has
+        /// already landed and the transfer must not start.
+        func beginTransfer(_ transferID: UInt64) -> Bool {
+            lock.withLock {
+                guard !cancelledStorage else { return false }
+                inFlightTransferID = transferID
+                return true
+            }
+        }
+
+        func endTransfer() {
+            lock.withLock { inFlightTransferID = nil }
+        }
+    }
+
+    /// How one job ended.
+    private enum JobOutcome {
+        case completed
+        case cancelled
+        case failed(ClipboardErrorCode, String)
+    }
+
+    // MARK: - Init
+
+    /// Production init — the real drop port and the guest user's Downloads
+    /// folder.
+    convenience init(progressTracker: ClipboardProgressTracker) {
+        self.init(
+            client: VsockGuestClient(port: KernovaVsockPort.drop, label: "drop"),
+            progressTracker: progressTracker)
+    }
+
+    /// Designated init; tests inject a socketpair-backed client, a Downloads
+    /// directory under a temp root, an isolated staging root, a
+    /// `freeSpaceProvider` to simulate a full disk, and a `revealInFinder` sink
+    /// in place of opening a real Finder window.
+    ///
+    /// The agent runs unsandboxed inside the guest, so `.downloadsDirectory`
+    /// resolves to the real `~/Downloads`.
+    init(
+        client: VsockGuestClient,
+        progressTracker: ClipboardProgressTracker,
+        downloadsDirectory: URL = FileManager.default.urls(
+            for: .downloadsDirectory, in: .userDomainMask
+        ).first
+            ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Downloads", isDirectory: true),
+        stagingTempRoot: URL = FileManager.default.temporaryDirectory,
+        freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil,
+        pullTimeout: TimeInterval = ClipboardStreamTuning.lazyPullTimeout,
+        revealInFinder: @escaping @Sendable ([URL]) -> Void = { urls in
+            DispatchQueue.main.async { NSWorkspace.shared.activateFileViewerSelecting(urls) }
+        }
+    ) {
+        self.client = client
+        self.progressTracker = progressTracker
+        self.downloadsDirectory = downloadsDirectory
+        self.pullTimeout = pullTimeout
+        self.revealInFinder = revealInFinder
+        self.staging = ClipboardFileStaging(
+            label: "agent-drop", tempRoot: stagingTempRoot, freeSpaceProvider: freeSpaceProvider)
+        // Default-paused: nothing dials until the host's `Hello` says it has a
+        // drop listener.
+        client.pause()
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        client.start { [weak self] channel in
+            await self?.serve(channel: channel)
+        }
+        Self.logger.notice("Vsock drop agent started")
+    }
+
+    /// Matches the reconnect loop to what the host advertises.
+    ///
+    /// Called whenever the control agent learns the host's capabilities — its
+    /// `Hello`, and the clearing that precedes the next one — so a host without a
+    /// drop listener is never redialled every retry interval.
+    func syncEnablement() {
+        if hostSupportsDrop() {
+            client.resume()
+        } else {
+            client.pause()
+        }
+    }
+
+    func stop() {
+        client.stop()
+        DispatchQueue.main.async { [weak self] in
+            self?.teardownConnectionState()
+        }
+        Self.logger.notice("Vsock drop agent stopped")
+    }
+
+    /// Clears per-connection state on the main queue.
+    private func teardownConnectionState() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        receiver?.cancelAll()
+        // Unblock any worker parked on a pull (it returns cancelled).
+        coordinator.failAll()
+        receiver = nil
+        liveChannel = nil
+        for job in jobs.values {
+            _ = job.cancel()
+            // Immediate: the transport measuring these is gone, so there is
+            // nothing left for the linger to show finishing.
+            progressTracker.closeSession(job.session, immediately: true)
+        }
+        jobs.removeAll()
+    }
+
+    private func teardownIfCurrent(_ channel: VsockChannel) {
+        if liveChannel === channel { teardownConnectionState() }
+    }
+
+    #if DEBUG
+    /// Test seam for `teardownIfCurrent`.
+    func teardownIfCurrentForTesting(_ channel: VsockChannel) {
+        teardownIfCurrent(channel)
+    }
+    #endif
+
+    // MARK: - Per-connection serve
+
+    private func serve(channel: VsockChannel) async {
+        let connectionTag = ClipboardConnectionTag.nextGuest()
+        // Built off-main (its callbacks hop themselves); only the published
+        // reference is assigned on the main queue.
+        let receiver = ClipboardStreamReceiver(
+            channel: channel, staging: staging,
+            onTransferTimed: { metrics in
+                Self.logger.notice(
+                    "Dropped file \(metrics.transferID, privacy: .public) (conn=\(connectionTag, privacy: .public)) received: \(metrics.logSummary, privacy: .public)"
+                )
+            },
+            onComplete: { transferID, _ in
+                Self.logger.warning(
+                    "Unawaited dropped file \(transferID, privacy: .public) (conn=\(connectionTag, privacy: .public)) completed — dropped"
+                )
+            },
+            onAbort: { info in
+                Self.logger.debug(
+                    "Unawaited dropped file \(info.transferID, privacy: .public) (conn=\(connectionTag, privacy: .public)) aborted (\(info.code, privacy: .public))"
+                )
+            })
+        await MainActor.run {
+            self.connectionTag = connectionTag
+            self.liveChannel = channel
+            self.receiver = receiver
+        }
+        Self.logger.notice(
+            "Vsock drop connected to host (conn=\(connectionTag, privacy: .public))")
+
+        do {
+            for try await frame in channel.incoming where frame.protocolVersion == 1 {
+                ClipboardStreamRouting.route(
+                    frame, role: .guest, sender: nil, receiver: receiver,
+                    senderAbortDelivery: .direct,
+                    onControlFrame: { frame in
+                        DispatchQueue.main.async { [weak self] in
+                            self?.handleControlFrame(frame, on: channel)
+                        }
+                    })
+            }
+            Self.logger.notice(
+                "Vsock drop channel closed by host (conn=\(connectionTag, privacy: .public))")
+        } catch {
+            Self.logger.warning(
+                "Vsock drop channel ended with error (conn=\(connectionTag, privacy: .public)): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+
+        // Wake any worker blocked on a now-dead transfer immediately, off-main —
+        // `teardownConnectionState` runs on main, which the worker does not hold
+        // but the ordering keeps identical to the clipboard agent's.
+        coordinator.failAll()
+        await MainActor.run {
+            self.teardownIfCurrent(channel)
+        }
+    }
+
+    // MARK: - Frame handlers (main queue)
+
+    private func handleControlFrame(_ frame: Frame, on channel: VsockChannel) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard liveChannel === channel else { return }
+        switch frame.payload {
+        case .dropOffer(let offer):
+            handleDropOffer(offer, on: channel)
+        case .dropRelease(let release):
+            cancelJob(generation: release.generation)
+        case .error(let error):
+            Self.logger.warning(
+                "Host drop error: \(error.code, privacy: .public) — \(error.message, privacy: .public)"
+            )
+        case .clipboardStreamBegin, .clipboardChunk, .clipboardStreamEnd, .clipboardStreamAck,
+            .clipboardStreamAbort:
+            // Routed off-main by the serve loop; never reaches here.
+            break
+        case .hello, .heartbeat, .policyUpdate, .logRecord, .clipboardOffer, .clipboardRequest,
+            .clipboardRelease, .dropComplete, .none:
+            Self.logger.warning("Unexpected payload on the drop channel — wrong port")
+        }
+    }
+
+    /// Takes on one drop gesture: opens its readout and queues its files behind
+    /// whatever is already running.
+    private func handleDropOffer(_ offer: Kernova_V1_DropOffer, on channel: VsockChannel) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard jobs[offer.generation] == nil else {
+            Self.logger.warning(
+                "Duplicate drop offer for gen=\(offer.generation, privacy: .public) (conn=\(self.connectionTag, privacy: .public)) — ignored"
+            )
+            return
+        }
+        // Every field of the offer is host-supplied. Bound the count and each
+        // declared size once, here at intake, so no capacity or progress
+        // arithmetic downstream reasons about a value that can't be real.
+        let bounded = ClipboardOfferBounds.bounded(offer.repInfo)
+        if let truncatedFrom = bounded.truncatedFrom {
+            Self.logger.warning(
+                "Drop offer (gen=\(offer.generation, privacy: .public), conn=\(self.connectionTag, privacy: .public)) declared \(truncatedFrom, privacy: .public) items — truncated to \(bounded.reps.count, privacy: .public)"
+            )
+        }
+        guard !bounded.reps.isEmpty else {
+            send(
+                completion: .failed(.dropFailed, "The drop carried no files"),
+                generation: offer.generation, on: channel)
+            return
+        }
+
+        let units = bounded.reps.enumerated().map { index, info in
+            ClipboardProgressTracker.PlannedUnit(
+                id: ClipboardTransferID.make(
+                    generation: offer.generation, repIndex: index, hostMinted: false),
+                expectedBytes: info.byteCount,
+                name: info.filename.isEmpty ? nil : info.filename)
+        }
+        let generation = offer.generation
+        let session = progressTracker.openSession(
+            direction: .inbound, peerName: Self.dropSourceName, units: units,
+            onCancelRequested: { [weak self] in
+                DispatchQueue.main.async { self?.cancelJob(generation: generation) }
+            })
+        let job = DropJob(generation: generation, reps: bounded.reps, session: session)
+        jobs[generation] = job
+        Self.logger.notice(
+            "Accepted a drop of \(bounded.reps.count, privacy: .public) item(s) (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public))"
+        )
+        jobQueue.async { [weak self] in
+            self?.run(job: job, on: channel)
+        }
+    }
+
+    /// Calls off the drop for `generation`, keeping what already landed.
+    ///
+    /// The same body serves a host `DropRelease` and a Cancel on this guest's own
+    /// readout: both mean the user stopped it, and the files already written to
+    /// Downloads are complete and stay — Finder's own cancel keeps them too.
+    private func cancelJob(generation: UInt64) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let job = jobs[generation] else { return }
+        guard let transferID = job.cancel() else { return }
+        // Order matters: deregister the awaiter, stop the host producing bytes,
+        // then wake the parked worker. Waking it first would let it start the
+        // next file before the cancel is visible.
+        receiver?.cancelAwait(transferID)
+        sendStreamAbort(transferID: transferID)
+        coordinator.abort(
+            transferID,
+            ClipboardStreamAbortInfo(
+                transferID: transferID, code: "cancelled", message: "Cancelled by the user",
+                neededBytes: nil, availableBytes: nil))
+        Self.logger.notice(
+            "Drop cancelled (gen=\(generation, privacy: .public), conn=\(self.connectionTag, privacy: .public))"
+        )
+    }
+
+    /// Tells the host's sender to stop streaming a transfer this side has
+    /// abandoned.
+    private func sendStreamAbort(transferID: UInt64) {
+        guard let channel = liveChannel else { return }
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.clipboardStreamAbort = .with {
+            $0.transferID = transferID
+            $0.code = "user.cancelled"
+            $0.message = "Cancelled by the user"
+        }
+        try? channel.send(frame)
+    }
+
+    // MARK: - Job execution (worker queue)
+
+    /// Pulls each of the job's files in order and lands it in Downloads.
+    private func run(job: DropJob, on channel: VsockChannel) {
+        dispatchPrecondition(condition: .notOnQueue(.main))
+        var landed: [URL] = []
+        var outcome: JobOutcome = .completed
+
+        for (index, info) in job.reps.enumerated() {
+            if job.isCancelled {
+                outcome = .cancelled
+                break
+            }
+            switch pull(index: index, info: info, job: job, on: channel) {
+            case .success(let url):
+                landed.append(url)
+            case .cancelled:
+                outcome = .cancelled
+            case .failure(let code, let message):
+                outcome = .failed(code, message)
+            }
+            if case .completed = outcome { continue }
+            break
+        }
+
+        // The readout ends where it stopped: a cancelled or failed drop finishes
+        // below 100 %, which is the whole of how those two read on screen.
+        progressTracker.closeSession(job.session)
+        if case .completed = outcome, !landed.isEmpty {
+            revealInFinder(landed)
+        }
+        let generation = job.generation
+        send(completion: outcome, generation: generation, on: channel)
+        DispatchQueue.main.async { [weak self] in
+            self?.jobs[generation] = nil
+        }
+        Self.logger.notice(
+            "Drop job finished (gen=\(generation, privacy: .public), \(landed.count, privacy: .public) file(s) in Downloads)"
+        )
+    }
+
+    /// One representation's outcome.
+    private enum PullOutcome {
+        case success(URL)
+        case cancelled
+        case failure(ClipboardErrorCode, String)
+    }
+
+    /// Requests one representation, blocks until it lands, and moves it into
+    /// Downloads.
+    private func pull(
+        index: Int, info: Kernova_V1_ClipboardRepresentationInfo, job: DropJob,
+        on channel: VsockChannel
+    ) -> PullOutcome {
+        let byteCount = Int(clamping: info.byteCount)
+        guard staging.hasCapacity(forByteCount: byteCount) else {
+            Self.logger.warning(
+                "Not enough disk space to receive dropped file '\(info.filename, privacy: .public)' (\(info.byteCount, privacy: .public) bytes)"
+            )
+            return .failure(
+                .dropDiskFull, "Not enough disk space in the guest for \(info.byteCount) bytes")
+        }
+        // The guest is the receiver here, so it does not set the direction bit.
+        let transferID = ClipboardTransferID.make(
+            generation: job.generation, repIndex: index, hostMinted: false)
+        guard job.beginTransfer(transferID) else { return .cancelled }
+        defer { job.endTransfer() }
+
+        let maxAccept =
+            staging.availableCapacity().map { UInt64(clamping: $0) }
+            ?? ClipboardStreamTuning.unlimitedAcceptByteCount
+        let coordinator = self.coordinator
+        let tracker = progressTracker
+        let session = job.session
+        guard let receiver = mainQueue({ self.receiver }) else { return .cancelled }
+        receiver.awaitTransfer(
+            transferID,
+            // A folder's bytes are an archive of its tree, extracted as they
+            // arrive. Directory-ness rides the offer this side already read, so
+            // nothing on the wire has to repeat it.
+            extractsDirectoryNamed: info.isDirectory ? info.filename : nil,
+            advertisedByteCount: byteCount,
+            onComplete: { rep in coordinator.deliver(transferID, rep) },
+            onAbort: { abort in coordinator.abort(transferID, abort) },
+            onProgress: { bytes, total in
+                // Re-arms the inactivity backstop so a large still-streaming file
+                // is never cut off mid-transfer.
+                coordinator.heartbeat(transferID)
+                tracker.unitProgressed(
+                    session: session, id: transferID, bytesTransferred: UInt64(max(0, bytes)),
+                    totalBytes: UInt64(max(0, total)))
+            })
+        tracker.unitBegan(
+            session: session, id: transferID, expectedBytes: info.byteCount,
+            name: info.filename.isEmpty ? nil : info.filename)
+
+        let uti = info.uti
+        let generation = job.generation
+        let outcome = coordinator.pull(transferID: transferID, timeout: pullTimeout) {
+            var request = Frame()
+            request.protocolVersion = 1
+            request.clipboardRequest = Kernova_V1_ClipboardRequest.with {
+                $0.generation = generation
+                $0.transferID = transferID
+                $0.uti = uti
+                $0.maxAcceptByteCount = maxAccept
+            }
+            do {
+                try channel.send(request)
+            } catch {
+                // No request went out, so no reply will arrive — resolve the pull
+                // now instead of blocking to the backstop timeout.
+                receiver.cancelAwait(transferID)
+                coordinator.abort(
+                    transferID,
+                    ClipboardStreamAbortInfo(
+                        transferID: transferID, code: "send.failed",
+                        message: "Failed to request the dropped file", neededBytes: nil,
+                        availableBytes: nil))
+            }
+        }
+
+        switch outcome {
+        case .delivered(let representation):
+            do {
+                let url = try land(representation, named: info.filename)
+                tracker.unitEnded(session: session, id: transferID, succeeded: true)
+                return .success(url)
+            } catch {
+                tracker.unitEnded(session: session, id: transferID, succeeded: false)
+                let failure = Self.classify(error)
+                Self.logger.error(
+                    "Failed to save a dropped file into Downloads: \(error.localizedDescription, privacy: .public)"
+                )
+                return .failure(failure.0, failure.1)
+            }
+        case .aborted(let abort):
+            tracker.unitEnded(session: session, id: transferID, succeeded: false)
+            if job.isCancelled { return .cancelled }
+            Self.logger.warning(
+                "Dropped file \(transferID, privacy: .public) aborted (\(abort.code, privacy: .public))"
+            )
+            return .failure(
+                abort.code == "disk.full" ? .dropDiskFull : .dropFailed, abort.message)
+        case .timedOut:
+            receiver.cancelAwait(transferID)
+            tracker.unitEnded(session: session, id: transferID, succeeded: false)
+            sendStreamAbortFromWorker(transferID: transferID, on: channel)
+            Self.logger.warning("Dropped file \(transferID, privacy: .public) timed out")
+            return .failure(.dropFailed, "The transfer stopped making progress")
+        case .cancelled:
+            receiver.cancelAwait(transferID)
+            tracker.unitEnded(session: session, id: transferID, succeeded: false)
+            return .cancelled
+        case .superseded:
+            // A newer pull owns this id now; touch nothing keyed by it.
+            tracker.unitEnded(session: session, id: transferID, succeeded: false)
+            return .cancelled
+        }
+    }
+
+    /// Sends a stall abort from the worker queue, where `liveChannel` is not
+    /// readable.
+    private func sendStreamAbortFromWorker(transferID: UInt64, on channel: VsockChannel) {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.clipboardStreamAbort = .with {
+            $0.transferID = transferID
+            $0.code = "stall.timeout"
+            $0.message = "Receiver gave up waiting for the dropped file"
+        }
+        try? channel.send(frame)
+    }
+
+    // MARK: - Landing files in Downloads
+
+    /// Moves a delivered representation out of staging and into the Downloads
+    /// folder, naming it the way Finder would.
+    ///
+    /// A rename, not a copy: staging and Downloads share the guest's data volume,
+    /// so nothing payload-scaled happens here. A cross-device move falls back to
+    /// copy-and-delete, which is the only case where it can.
+    private func land(_ representation: ClipboardContent.Representation, named filename: String)
+        throws -> URL
+    {
+        guard let source = representation.fileURL else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(
+            at: downloadsDirectory, withIntermediateDirectories: true)
+        let destination = FinderStyleUniquing.uniqueDestination(
+            in: downloadsDirectory,
+            filename: filename.isEmpty ? source.lastPathComponent : filename)
+        do {
+            try fileManager.moveItem(at: source, to: destination)
+        } catch let error as NSError where Self.isCrossDevice(error) {
+            try fileManager.copyItem(at: source, to: destination)
+            try? fileManager.removeItem(at: source)
+        }
+        return destination
+    }
+
+    private static func isCrossDevice(_ error: NSError) -> Bool {
+        (error.userInfo[NSUnderlyingErrorKey] as? NSError)?.code == Int(EXDEV)
+            || error.code == Int(EXDEV)
+    }
+
+    /// Maps a filesystem failure to the code the host renders a sentence from.
+    private static func classify(_ error: any Error) -> (ClipboardErrorCode, String) {
+        let nsError = error as NSError
+        let posix =
+            (nsError.userInfo[NSUnderlyingErrorKey] as? NSError).map(\.code) ?? nsError.code
+        switch Int32(truncatingIfNeeded: posix) {
+        case EACCES, EPERM:
+            return (.dropDownloadsDenied, "The guest agent cannot write to Downloads")
+        case ENOSPC, EDQUOT:
+            return (.dropDiskFull, "The guest volume is full")
+        default:
+            return (.dropFailed, nsError.localizedDescription)
+        }
+    }
+
+    // MARK: - Reporting the outcome
+
+    private func send(completion: JobOutcome, generation: UInt64, on channel: VsockChannel) {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.dropComplete = Kernova_V1_DropComplete.with {
+            $0.generation = generation
+            switch completion {
+            case .completed:
+                $0.outcome = .completed
+            case .cancelled:
+                $0.outcome = .cancelled
+            case .failed(let code, let message):
+                $0.outcome = .failed
+                $0.code = code.rawValue
+                $0.message = message
+            }
+        }
+        try? channel.send(frame)
+    }
+
+    /// Reads main-queue-confined state from the worker queue.
+    private func mainQueue<T>(_ body: () -> T) -> T {
+        Thread.isMainThread ? body() : DispatchQueue.main.sync(execute: body)
+    }
+}

--- a/KernovaMacOSAgent/VsockPorts.swift
+++ b/KernovaMacOSAgent/VsockPorts.swift
@@ -12,4 +12,7 @@ enum KernovaVsockPort {
 
     /// Guest agent log forwarding.
     static let log: UInt32 = 49153
+
+    /// Files dragged onto the VM display, streamed host→guest into Downloads.
+    static let drop: UInt32 = 49155
 }

--- a/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestControlAgentTests.swift
@@ -73,7 +73,8 @@ struct VsockGuestControlAgentTests {
         unresponsiveAfter: TimeInterval? = nil,
         terminateAfter: TimeInterval? = nil,
         onPolicy: (@Sendable (Kernova_V1_PolicyUpdate) -> Void)? = nil,
-        onStateChange: (@Sendable (HostConnectionState) -> Void)? = nil
+        onStateChange: (@Sendable (HostConnectionState) -> Void)? = nil,
+        onHostCapabilitiesChanged: (@Sendable () -> Void)? = nil
     ) -> VsockGuestControlAgent {
         let provided = AtomicInt()
         let provider: VsockSocketProvider = { _, _ in
@@ -92,7 +93,8 @@ struct VsockGuestControlAgentTests {
             unresponsiveAfter: unresponsiveAfter ?? Self.watchdogDisabledUnresponsive,
             terminateAfter: terminateAfter ?? Self.watchdogDisabledTerminate,
             onPolicy: onPolicy,
-            onStateChange: onStateChange
+            onStateChange: onStateChange,
+            onHostCapabilitiesChanged: onHostCapabilitiesChanged
         )
     }
 
@@ -517,6 +519,50 @@ struct VsockGuestControlAgentTests {
         // Log forwarding passes through; clipboard is forced off by the gate.
         #expect(policy.logForwardingEnabled == true)
         #expect(policy.clipboardSharingEnabled == false)
+    }
+
+    // MARK: - Display drops
+
+    @Test("the host's drop capability is recorded from its Hello")
+    func hostDropCapabilityObservedFromHello() async throws {
+        let (agentFd, hostFd) = try makeRawSocketPair()
+        let host = VsockChannel(fileDescriptor: hostFd)
+        host.start()
+        defer { host.close() }
+
+        let notified = AtomicInt()
+        let agent = makeAgent(agentFd: agentFd, onHostCapabilitiesChanged: { notified.increment() })
+        agent.start()
+        defer { agent.stop() }
+
+        _ = try await nextFrame(from: host)  // drain outbound Hello
+        // The connection itself clears the previous host's capabilities, which
+        // is a change the drop client has to hear about too.
+        try await notified.changed.wait { notified.value >= 1 }
+        #expect(agent.hostSupportsDropFiles == false)
+
+        try host.send(makeHostHelloFrame())
+        try await notified.changed.wait { notified.value >= 2 }
+        #expect(agent.hostSupportsDropFiles)
+    }
+
+    @Test("a host that advertises no drop capability leaves it off")
+    func hostWithoutDropCapability() async throws {
+        let (agentFd, hostFd) = try makeRawSocketPair()
+        let host = VsockChannel(fileDescriptor: hostFd)
+        host.start()
+        defer { host.close() }
+
+        let notified = AtomicInt()
+        let agent = makeAgent(agentFd: agentFd, onHostCapabilitiesChanged: { notified.increment() })
+        agent.start()
+        defer { agent.stop() }
+
+        _ = try await nextFrame(from: host)  // drain outbound Hello
+        try host.send(makeHostHelloFrame(streamingCapable: false))
+        try await notified.changed.wait { notified.value >= 2 }
+
+        #expect(agent.hostSupportsDropFiles == false)
     }
 
     @Test("stop() halts the connection without throwing")

--- a/KernovaMacOSAgentTests/VsockGuestDropAgentTests.swift
+++ b/KernovaMacOSAgentTests/VsockGuestDropAgentTests.swift
@@ -1,0 +1,366 @@
+import CryptoKit
+import Foundation
+import KernovaKit
+import KernovaTestSupport
+import Testing
+import UniformTypeIdentifiers
+
+/// Unit tests for the guest side of a display drop: pulling each offered file,
+/// landing it in Downloads with Finder's own naming, revealing the result, and
+/// what it reports when the drop is cancelled or cannot be written.
+@Suite("VsockGuestDropAgent")
+struct VsockGuestDropAgentTests {
+    // MARK: - Harness
+
+    /// The agent under test, the host end of its channel, and the fake Downloads
+    /// folder it writes into.
+    private final class Harness {
+        let agent: VsockGuestDropAgent
+        let host: VsockChannel
+        let downloads: URL
+        let root: URL
+        /// Every set of URLs handed to the Finder reveal, in order.
+        let revealed = AtomicBox<[URL]>()
+        let tracker: ClipboardProgressTracker
+
+        init(freeSpaceProvider: ClipboardFileStaging.FreeSpaceProvider? = nil) throws {
+            root = FileManager.default.temporaryDirectory
+                .appendingPathComponent(
+                    "VsockGuestDropAgentTests-\(UUID().uuidString)",
+                    isDirectory: true)
+            downloads = root.appendingPathComponent("Downloads", isDirectory: true)
+            try FileManager.default.createDirectory(at: downloads, withIntermediateDirectories: true)
+
+            let (agentFd, hostFd) = try makeRawSocketPair()
+            host = VsockChannel(fileDescriptor: hostFd)
+            host.start()
+
+            let provided = AtomicInt()
+            let client = VsockGuestClient(
+                port: KernovaVsockPort.drop, label: "drop-test",
+                clock: MonotonicEngineClock(), retryInterval: 0.05
+            ) { _, _ in
+                provided.increment() == 1 ? .success(agentFd) : .failure(.transient("test: no fd"))
+            }
+            // Zeroed delays so a live transfer's readout is observable.
+            tracker = ClipboardProgressTracker(revealDelay: 0, idleLinger: 0, emit: { _ in })
+            let revealed = self.revealed
+            agent = VsockGuestDropAgent(
+                client: client, progressTracker: tracker, downloadsDirectory: downloads,
+                stagingTempRoot: root.appendingPathComponent("staging", isDirectory: true),
+                freeSpaceProvider: freeSpaceProvider,
+                revealInFinder: { urls in revealed.set(urls) })
+            agent.hostSupportsDrop = { true }
+        }
+
+        /// Starts the agent, enables it the way the control agent's capability
+        /// hook does, and waits for the channel to land.
+        func start() async throws {
+            agent.start()
+            agent.syncEnablement()
+            // RATIONALE: sanctioned no-signal poll (docs/TESTING.md) — the
+            // lifecycle read is SUT-internal state with nothing to await on.
+            try await waitUntil { agent.liveChannelForTesting != nil }
+        }
+
+        func tearDown() {
+            agent.stop()
+            host.close()
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        /// Names of the entries in the fake Downloads folder, sorted.
+        var downloadNames: [String] {
+            ((try? FileManager.default.contentsOfDirectory(atPath: downloads.path)) ?? []).sorted()
+        }
+
+        func downloadContents(_ name: String) -> Data? {
+            try? Data(contentsOf: downloads.appendingPathComponent(name))
+        }
+    }
+
+    // MARK: - Frame factories
+
+    private func makeDropOffer(generation: UInt64, reps: [RepInfo]) -> Frame {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.dropOffer = Kernova_V1_DropOffer.with {
+            $0.generation = generation
+            $0.repInfo = reps.map { rep in
+                Kernova_V1_ClipboardRepresentationInfo.with {
+                    $0.uti = rep.uti
+                    $0.byteCount = rep.byteCount
+                    $0.filename = rep.filename
+                    $0.isInline = rep.isInline
+                    $0.isDirectory = rep.isDirectory
+                }
+            }
+        }
+        return frame
+    }
+
+    private func makeDropRelease(generation: UInt64) -> Frame {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.dropRelease = Kernova_V1_DropRelease.with { $0.generation = generation }
+        return frame
+    }
+
+    /// One dropped file's metadata, as the host would offer it.
+    private func fileRep(_ name: String, bytes: Data) -> RepInfo {
+        RepInfo(
+            uti: UTType(filenameExtension: (name as NSString).pathExtension)?.identifier
+                ?? UTType.data.identifier,
+            byteCount: UInt64(bytes.count), filename: name, isInline: false)
+    }
+
+    /// The id the guest mints for representation `index` of `generation`.
+    private func transferID(generation: UInt64, repIndex: Int) -> UInt64 {
+        ClipboardTransferID.make(generation: generation, repIndex: repIndex, hostMinted: false)
+    }
+
+    /// Reads frames until the agent's request for `transferID` arrives, then
+    /// streams `payload` back to it.
+    ///
+    /// Returns the frames seen along the way, so a caller can assert on request
+    /// ordering.
+    @discardableResult
+    private func serveRequest(
+        on channel: VsockChannel, generation: UInt64, repIndex: Int, payload: Data
+    ) async throws -> Kernova_V1_ClipboardRequest {
+        let expected = transferID(generation: generation, repIndex: repIndex)
+        while true {
+            let frame = try await nextFrame(from: channel)
+            guard case .clipboardRequest(let request) = frame.payload,
+                request.transferID == expected
+            else { continue }
+            try channel.send(
+                makeBeginFrame(
+                    generation: generation, transferID: expected, uti: request.uti,
+                    totalBytes: payload.count, filename: "", isInline: false))
+            try channel.send(makeChunkFrame(transferID: expected, offset: 0, data: payload))
+            try channel.send(makeEndFrame(transferID: expected, payload: payload))
+            return request
+        }
+    }
+
+    /// Reads frames until a `DropComplete` arrives.
+    private func awaitCompletion(
+        on channel: VsockChannel
+    ) async throws -> Kernova_V1_DropComplete {
+        while true {
+            let frame = try await nextFrame(from: channel)
+            if case .dropComplete(let complete) = frame.payload { return complete }
+        }
+    }
+
+    // MARK: - Happy path
+
+    @Test("every offered file is requested in order and lands in Downloads")
+    func landsEveryDroppedFile() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        try await harness.start()
+
+        let first = Data("first file".utf8)
+        let second = Data(repeating: 0x7F, count: 4_096)
+        try harness.host.send(
+            makeDropOffer(
+                generation: 1,
+                reps: [fileRep("notes.txt", bytes: first), fileRep("blob.bin", bytes: second)]))
+
+        try await serveRequest(on: harness.host, generation: 1, repIndex: 0, payload: first)
+        try await serveRequest(on: harness.host, generation: 1, repIndex: 1, payload: second)
+        let complete = try await awaitCompletion(on: harness.host)
+
+        #expect(complete.generation == 1)
+        #expect(complete.outcome == .completed)
+        #expect(harness.downloadNames == ["blob.bin", "notes.txt"])
+        #expect(harness.downloadContents("notes.txt") == first)
+        #expect(harness.downloadContents("blob.bin") == second)
+    }
+
+    @Test("a completed drop reveals exactly the files it landed")
+    func revealsTheLandedFiles() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        try await harness.start()
+
+        let payload = Data("reveal me".utf8)
+        try harness.host.send(
+            makeDropOffer(generation: 1, reps: [fileRep("shown.txt", bytes: payload)]))
+        try await serveRequest(on: harness.host, generation: 1, repIndex: 0, payload: payload)
+        _ = try await awaitCompletion(on: harness.host)
+
+        try await harness.revealed.changed.wait { harness.revealed.value != nil }
+        #expect(harness.revealed.value?.map(\.lastPathComponent) == ["shown.txt"])
+    }
+
+    @Test("a name already taken in Downloads counts up the way Finder does")
+    func uniquesAgainstAnExistingName() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        try Data("existing".utf8).write(
+            to: harness.downloads.appendingPathComponent("report.pdf"))
+        try await harness.start()
+
+        let payload = Data("arriving".utf8)
+        try harness.host.send(
+            makeDropOffer(generation: 1, reps: [fileRep("report.pdf", bytes: payload)]))
+        try await serveRequest(on: harness.host, generation: 1, repIndex: 0, payload: payload)
+        _ = try await awaitCompletion(on: harness.host)
+
+        #expect(harness.downloadNames == ["report 2.pdf", "report.pdf"])
+        // The file that was already there is untouched.
+        #expect(harness.downloadContents("report.pdf") == Data("existing".utf8))
+        #expect(harness.downloadContents("report 2.pdf") == payload)
+    }
+
+    // MARK: - Cancelling
+
+    @Test("a release keeps what already landed and stops the rest")
+    func releaseKeepsCompletedFiles() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        try await harness.start()
+
+        let landed = Data("already here".utf8)
+        let never = Data(repeating: 0x11, count: 64)
+        try harness.host.send(
+            makeDropOffer(
+                generation: 1,
+                reps: [fileRep("kept.txt", bytes: landed), fileRep("dropped.bin", bytes: never)]))
+        try await serveRequest(on: harness.host, generation: 1, repIndex: 0, payload: landed)
+
+        // The second file's request arrives, and is answered with a release
+        // instead of bytes.
+        while true {
+            let frame = try await nextFrame(from: harness.host)
+            if case .clipboardRequest(let request) = frame.payload,
+                request.transferID == transferID(generation: 1, repIndex: 1)
+            {
+                break
+            }
+        }
+        try harness.host.send(makeDropRelease(generation: 1))
+        let complete = try await awaitCompletion(on: harness.host)
+
+        #expect(complete.outcome == .cancelled)
+        // Finder's own cancel keeps what it already copied, and so does this.
+        #expect(harness.downloadNames == ["kept.txt"])
+        #expect(harness.downloadContents("kept.txt") == landed)
+        // Nothing is revealed for a drop the user called off.
+        #expect(harness.revealed.value == nil)
+    }
+
+    @Test("a cancel on this guest's readout aborts the transfer and reports it")
+    func guestCancelAbortsAndReports() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        try await harness.start()
+
+        let payload = Data(repeating: 0x22, count: 128)
+        try harness.host.send(
+            makeDropOffer(generation: 1, reps: [fileRep("pending.bin", bytes: payload)]))
+        // Wait for the request, then cancel without ever answering it — the
+        // worker is parked on the pull, which is where a cancel has to reach it.
+        while true {
+            let frame = try await nextFrame(from: harness.host)
+            if case .clipboardRequest = frame.payload { break }
+        }
+        harness.tracker.requestCancelOfPublishedSession()
+
+        var sawAbort = false
+        var complete: Kernova_V1_DropComplete?
+        while complete == nil {
+            let frame = try await nextFrame(from: harness.host)
+            switch frame.payload {
+            case .clipboardStreamAbort(let abort):
+                #expect(abort.code == "user.cancelled")
+                sawAbort = true
+            case .dropComplete(let value):
+                complete = value
+            default:
+                continue
+            }
+        }
+        #expect(sawAbort)
+        #expect(complete?.outcome == .cancelled)
+        #expect(harness.downloadNames.isEmpty)
+    }
+
+    // MARK: - Failures
+
+    @Test("a Downloads folder that cannot be written fails the drop with a code")
+    func unwritableDownloadsFailsTheDrop() async throws {
+        let harness = try Harness()
+        defer {
+            // Restore write permission so the temp tree can be removed.
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: harness.downloads.path)
+            harness.tearDown()
+        }
+        try await harness.start()
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o500], ofItemAtPath: harness.downloads.path)
+
+        let payload = Data("nowhere to go".utf8)
+        try harness.host.send(
+            makeDropOffer(generation: 1, reps: [fileRep("blocked.txt", bytes: payload)]))
+        try await serveRequest(on: harness.host, generation: 1, repIndex: 0, payload: payload)
+        let complete = try await awaitCompletion(on: harness.host)
+
+        #expect(complete.outcome == .failed)
+        #expect(complete.code == ClipboardErrorCode.dropDownloadsDenied.rawValue)
+        #expect(harness.revealed.value == nil)
+    }
+
+    @Test("a volume with no room refuses the file before requesting a byte")
+    func refusesWhenTheVolumeIsFull() async throws {
+        let harness = try Harness(freeSpaceProvider: { _ in 0 })
+        defer { harness.tearDown() }
+        try await harness.start()
+
+        try harness.host.send(
+            makeDropOffer(
+                generation: 1, reps: [fileRep("huge.bin", bytes: Data(repeating: 0, count: 1_024))]))
+        let complete = try await awaitCompletion(on: harness.host)
+
+        #expect(complete.outcome == .failed)
+        #expect(complete.code == ClipboardErrorCode.dropDiskFull.rawValue)
+        #expect(harness.downloadNames.isEmpty)
+    }
+
+    @Test("an offer with no items is failed rather than left open")
+    func emptyOfferIsFailed() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        try await harness.start()
+
+        try harness.host.send(makeDropOffer(generation: 1, reps: []))
+        let complete = try await awaitCompletion(on: harness.host)
+
+        #expect(complete.outcome == .failed)
+    }
+
+    // MARK: - Enablement
+
+    @Test("the client stays paused until the host advertises the capability")
+    func staysPausedWithoutTheCapability() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        harness.agent.hostSupportsDrop = { false }
+
+        harness.agent.start()
+        harness.agent.syncEnablement()
+        // A host with no drop listener is never redialled, so no channel lands.
+        // Several retry intervals' worth of silence is the assertion.
+        try await MonotonicEngineClock().sleep(for: 0.2)
+        #expect(harness.agent.liveChannelForTesting == nil)
+
+        // The capability arriving is what starts the client.
+        harness.agent.hostSupportsDrop = { true }
+        harness.agent.syncEnablement()
+        try await waitUntil { harness.agent.liveChannelForTesting != nil }
+    }
+}

--- a/KernovaTests/ClipboardProgressCenterTests.swift
+++ b/KernovaTests/ClipboardProgressCenterTests.swift
@@ -15,6 +15,13 @@ struct ClipboardProgressCenterTests {
     /// Stands in for a clipboard service: the center keys purely on identity.
     private final class Source {}
 
+    /// A source whose shown operation can be stopped, counting the requests it
+    /// receives.
+    private final class CancellableSource: TransferCancelling {
+        private(set) var cancels = 0
+        func requestCancelOfShownOperation() { cancels += 1 }
+    }
+
     private func makeSnapshot(
         peerName: String, bytesTransferred: UInt64, totalBytes: UInt64
     ) -> ClipboardProgressSnapshot {
@@ -101,5 +108,78 @@ struct ClipboardProgressCenterTests {
 
         // No underflow trap, and the clamped remainder (0) loses to the real one.
         #expect(center.materializationProgress?.peerName == "Ordinary")
+    }
+
+    // MARK: - Cancel routing
+
+    @Test("Cancel reaches the source publishing the shown readout, not another")
+    func cancelRoutesToThePublishedSource() {
+        let center = ClipboardProgressCenter()
+        let shown = CancellableSource()
+        let hidden = CancellableSource()
+
+        center.progressChanged(
+            from: hidden, makeSnapshot(peerName: "Hidden", bytesTransferred: 0, totalBytes: 100))
+        center.progressChanged(
+            from: shown, makeSnapshot(peerName: "Shown", bytesTransferred: 0, totalBytes: 10_000))
+        #expect(center.materializationProgress?.peerName == "Shown")
+
+        center.cancelCurrent()
+
+        // The other VM's transfer is running under a readout nobody is looking
+        // at; stopping it would cancel something the user cannot see.
+        #expect(shown.cancels == 1)
+        #expect(hidden.cancels == 0)
+    }
+
+    @Test("Cancel follows the readout when the winner changes")
+    func cancelFollowsTheWinner() {
+        let center = ClipboardProgressCenter()
+        let first = CancellableSource()
+        let second = CancellableSource()
+
+        center.progressChanged(
+            from: first, makeSnapshot(peerName: "First", bytesTransferred: 0, totalBytes: 10_000))
+        center.progressChanged(
+            from: second, makeSnapshot(peerName: "Second", bytesTransferred: 0, totalBytes: 100))
+        center.cancelCurrent()
+        #expect(first.cancels == 1)
+
+        // The first VM finishes; the second one's remainder takes the readout.
+        center.progressChanged(
+            from: first,
+            makeSnapshot(peerName: "First", bytesTransferred: 10_000, totalBytes: 10_000))
+        center.cancelCurrent()
+        #expect(second.cancels == 1)
+        #expect(first.cancels == 1)
+    }
+
+    @Test("Cancel with nothing published, or from a source that can't cancel, does nothing")
+    func cancelIsANoOpWithoutACancellableSource() {
+        let center = ClipboardProgressCenter()
+        center.cancelCurrent()
+
+        let plain = Source()
+        center.progressChanged(
+            from: plain, makeSnapshot(peerName: "Plain", bytesTransferred: 0, totalBytes: 100))
+        // A source that never adopted `TransferCancelling` publishes readouts
+        // that report themselves non-cancellable, so no surface offers the
+        // button — and routing to it is a no-op rather than a crash.
+        center.cancelCurrent()
+        #expect(center.materializationProgress?.peerName == "Plain")
+    }
+
+    @Test("A source that stopped publishing is no longer the cancel target")
+    func cancelDropsWithTheSource() {
+        let center = ClipboardProgressCenter()
+        let stopping = CancellableSource()
+
+        center.progressChanged(
+            from: stopping,
+            makeSnapshot(peerName: "Stopping", bytesTransferred: 0, totalBytes: 10_000))
+        center.progressChanged(from: stopping, nil)
+        center.cancelCurrent()
+
+        #expect(stopping.cancels == 0)
     }
 }

--- a/KernovaTests/VMDisplayBackingViewTests.swift
+++ b/KernovaTests/VMDisplayBackingViewTests.swift
@@ -47,4 +47,156 @@ struct VMDisplayBackingViewTests {
         #expect(backing.machineView.virtualMachine == nil)
         #expect(backing.machineView.automaticallyReconfiguresDisplay == false)
     }
+
+    // MARK: - File drop
+
+    /// A dragging info carrying whatever `pasteboard` holds; only the pasteboard
+    /// is read by the drop path.
+    private final class StubDraggingInfo: NSObject, @unchecked Sendable, NSDraggingInfo {
+        // `nonisolated` so the conformance stays outside the main actor:
+        // `NSDraggingInfo` is a nonisolated protocol, and only the drop path's
+        // reads of `draggingPasteboard` matter here. The stub is immutable
+        // apart from the two settable properties AppKit requires, which nothing
+        // in these tests writes.
+        nonisolated(unsafe) let draggingPasteboard: NSPasteboard
+        init(pasteboard: NSPasteboard) { self.draggingPasteboard = pasteboard }
+
+        var draggingDestinationWindow: NSWindow? { nil }
+        var draggingSourceOperationMask: NSDragOperation { .copy }
+        var draggingLocation: NSPoint { .zero }
+        var draggedImageLocation: NSPoint { .zero }
+        var draggedImage: NSImage? { nil }
+        var draggingSource: Any? { nil }
+        var draggingSequenceNumber: Int { 0 }
+        var animatesToDestination: Bool = false
+        var numberOfValidItemsForDrop: Int = 0
+        var draggingFormation: NSDraggingFormation = .default
+        var springLoadingHighlight: NSSpringLoadingHighlight { .none }
+        func slideDraggedImage(to screenPoint: NSPoint) {}
+        func enumerateDraggingItems(
+            options enumOpts: NSDraggingItemEnumerationOptions, for view: NSView?,
+            classes classArray: [AnyClass], searchOptions: [NSPasteboard.ReadingOptionKey: Any],
+            using block: (NSDraggingItem, Int, UnsafeMutablePointer<ObjCBool>) -> Void
+        ) {}
+        func resetSpringLoading() {}
+    }
+
+    /// A uniquely-named pasteboard holding `urls` as file URLs.
+    private func makeFileDrag(_ urls: [URL]) -> StubDraggingInfo {
+        let pasteboard = NSPasteboard(name: .init("VMDisplayBackingViewTests-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.writeObjects(urls as [NSURL])
+        return StubDraggingInfo(pasteboard: pasteboard)
+    }
+
+    private func makeTextDrag(_ text: String) -> StubDraggingInfo {
+        let pasteboard = NSPasteboard(name: .init("VMDisplayBackingViewTests-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+        return StubDraggingInfo(pasteboard: pasteboard)
+    }
+
+    @Test("a VM that never ran the agent is not a drag destination at all")
+    func neverConnectedRegistersNothing() {
+        let backing = VMDisplayBackingView(frame: .zero)
+        backing.dropAvailability = { .none }
+
+        backing.applyDropRegistration()
+
+        #expect(backing.registeredDraggedTypes.isEmpty)
+    }
+
+    @Test("a VM whose agent has connected before registers, even while disconnected")
+    func disconnectedStillRegisters() {
+        let backing = VMDisplayBackingView(frame: .zero)
+        var availability = DisplayDropAvailability.disconnected
+        backing.dropAvailability = { availability }
+
+        backing.applyDropRegistration()
+        #expect(backing.registeredDraggedTypes == [.fileURL])
+
+        // Registration is idempotent, and follows availability back down.
+        backing.applyDropRegistration()
+        #expect(backing.registeredDraggedTypes == [.fileURL])
+
+        availability = .none
+        backing.applyDropRegistration()
+        #expect(backing.registeredDraggedTypes.isEmpty)
+    }
+
+    @Test("a disconnected agent refuses the drag with the empty operation")
+    func disconnectedRefusesTheDrag() {
+        let backing = VMDisplayBackingView(frame: .zero)
+        backing.dropAvailability = { .disconnected }
+        backing.applyDropRegistration()
+        let drag = makeFileDrag([URL(fileURLWithPath: "/tmp/a.txt")])
+
+        // The empty operation is what makes the pointer show no accept badge and
+        // a release spring back — no custom rejection UI.
+        #expect(backing.draggingEntered(drag) == [])
+        #expect(backing.draggingUpdated(drag) == [])
+    }
+
+    @Test("a reachable agent accepts a file drag with .copy")
+    func availableAcceptsFileURLs() {
+        let backing = VMDisplayBackingView(frame: .zero)
+        backing.dropAvailability = { .available }
+        backing.applyDropRegistration()
+        let drag = makeFileDrag([URL(fileURLWithPath: "/tmp/a.txt")])
+
+        #expect(backing.draggingEntered(drag) == .copy)
+        #expect(backing.draggingUpdated(drag) == .copy)
+    }
+
+    @Test("a drag carrying no file URL is refused even when the agent is reachable")
+    func refusesNonFileDrags() {
+        let backing = VMDisplayBackingView(frame: .zero)
+        backing.dropAvailability = { .available }
+        backing.applyDropRegistration()
+
+        #expect(backing.draggingEntered(makeTextDrag("hello")) == [])
+    }
+
+    @Test("a drop forwards every dragged file URL")
+    func dropForwardsTheURLs() {
+        let backing = VMDisplayBackingView(frame: .zero)
+        backing.dropAvailability = { .available }
+        var received: [URL] = []
+        backing.onDropFiles = { urls in
+            received = urls
+            return true
+        }
+        let dropped = [URL(fileURLWithPath: "/tmp/a.txt"), URL(fileURLWithPath: "/tmp/b.txt")]
+
+        #expect(backing.performDragOperation(makeFileDrag(dropped)))
+        #expect(received.map(\.lastPathComponent) == ["a.txt", "b.txt"])
+    }
+
+    @Test("a drop re-checks availability, so a session lost mid-drag springs back")
+    func dropRechecksAvailability() {
+        let backing = VMDisplayBackingView(frame: .zero)
+        var availability = DisplayDropAvailability.available
+        backing.dropAvailability = { availability }
+        var forwarded = false
+        backing.onDropFiles = { _ in
+            forwarded = true
+            return true
+        }
+        let drag = makeFileDrag([URL(fileURLWithPath: "/tmp/a.txt")])
+        #expect(backing.draggingUpdated(drag) == .copy)
+
+        // The guest agent goes away between the last pointer move and the release.
+        availability = .disconnected
+        #expect(!backing.performDragOperation(drag))
+        #expect(!forwarded)
+    }
+
+    @Test("a refused send reports the drop as not taken")
+    func reportsARefusedSend() {
+        let backing = VMDisplayBackingView(frame: .zero)
+        backing.dropAvailability = { .available }
+        backing.onDropFiles = { _ in false }
+
+        #expect(!backing.performDragOperation(makeFileDrag([URL(fileURLWithPath: "/tmp/a.txt")])))
+    }
 }

--- a/KernovaTests/VMInstanceDisplayDropTests.swift
+++ b/KernovaTests/VMInstanceDisplayDropTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import KernovaKit
+import Testing
+
+@testable import Kernova
+
+/// The three-state gate on dragging files onto a VM display: a VM that has never
+/// run the agent is not a drag destination at all, one whose agent is away takes
+/// part and refuses, and a reachable one accepts.
+@Suite("VMInstance display drop availability")
+@MainActor
+struct VMInstanceDisplayDropTests {
+    /// A VM instance plus the socket pairs its control and drop services run on.
+    private final class Harness {
+        let instance: VMInstance
+        private var channels: [VsockChannel] = []
+
+        @MainActor
+        init(guestOS: VMGuestOS = .macOS, lastSeenAgentVersion: String? = "1.0.0") {
+            var config = VMConfiguration(
+                name: "Drop VM", guestOS: guestOS,
+                bootMode: guestOS == .macOS ? .macOS : .efi)
+            config.lastSeenAgentVersion = lastSeenAgentVersion
+            let bundleURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(config.id.uuidString, isDirectory: true)
+            instance = VMInstance(configuration: config, bundleURL: bundleURL)
+        }
+
+        /// Installs a started control service and hands back the guest end, so a
+        /// test can drive the `Hello` that carries the capability.
+        @MainActor
+        func attachControl() throws -> VsockChannel {
+            let (guest, host) = try makePair()
+            let control = VsockControlService(channel: host, label: "drop-test")
+            instance.vsockControlService = control
+            control.start()
+            return guest
+        }
+
+        /// Installs a started drop service.
+        @MainActor
+        func attachDrop() throws {
+            let (_, host) = try makePair()
+            let service = VsockDropService(
+                channel: host, label: "Drop VM", instanceID: instance.instanceID,
+                progressCenter: ClipboardProgressCenter(), issueCenter: ClipboardIssueCenter())
+            instance.vsockDropService = service
+            service.start()
+        }
+
+        @MainActor
+        private func makePair() throws -> (guest: VsockChannel, host: VsockChannel) {
+            let (guestFd, hostFd) = try makeRawSocketPair()
+            let guest = VsockChannel(fileDescriptor: guestFd)
+            let host = VsockChannel(fileDescriptor: hostFd)
+            guest.start()
+            host.start()
+            channels.append(contentsOf: [guest, host])
+            return (guest, host)
+        }
+
+        @MainActor
+        func tearDown() {
+            instance.vsockDropService?.stop()
+            instance.vsockControlService?.stop()
+            for channel in channels { channel.close() }
+        }
+    }
+
+    private func makeHello(capabilities: [String]) -> Frame {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.hello = Kernova_V1_Hello.with {
+            $0.serviceVersion = 1
+            $0.capabilities = capabilities
+            $0.agentInfo = Kernova_V1_AgentInfo.with {
+                $0.os = "macOS"
+                $0.agentVersion = "1.0.0"
+            }
+        }
+        return frame
+    }
+
+    @Test("a VM that has never seen an agent is not a drag destination")
+    func neverConnectedIsNotADestination() {
+        let harness = Harness(lastSeenAgentVersion: nil)
+        defer { harness.tearDown() }
+
+        #expect(harness.instance.displayDropAvailability == .none)
+    }
+
+    @Test("a Linux guest is never a drag destination — the agent is macOS-only")
+    func linuxIsNotADestination() {
+        // A Linux guest never records an agent version, so this is belt and
+        // braces; the guest-OS check is what makes it explicit.
+        let harness = Harness(guestOS: .linux, lastSeenAgentVersion: "1.0.0")
+        defer { harness.tearDown() }
+
+        #expect(harness.instance.displayDropAvailability == .none)
+    }
+
+    @Test("a VM whose agent has connected before, but isn't now, refuses the drag")
+    func previouslyConnectedRefuses() {
+        let harness = Harness()
+        defer { harness.tearDown() }
+
+        // Registered as a destination (not `.none`), so the drag participates and
+        // springs back rather than passing through to whatever is behind.
+        #expect(harness.instance.displayDropAvailability == .disconnected)
+    }
+
+    @Test("a live drop channel without the capability still refuses")
+    func requiresTheCapability() async throws {
+        let harness = Harness()
+        defer { harness.tearDown() }
+        let guest = try harness.attachControl()
+        try harness.attachDrop()
+
+        try guest.send(
+            makeHello(capabilities: [
+                KernovaCapability.controlV1, KernovaCapability.clipboardStreamV1,
+            ]))
+        try await waitForChange { harness.instance.vsockControlService?.isConnected == true }
+
+        #expect(harness.instance.displayDropAvailability == .disconnected)
+    }
+
+    @Test("a live drop channel from a capable agent accepts the drag")
+    func liveAndCapableAccepts() async throws {
+        let harness = Harness()
+        defer { harness.tearDown() }
+        let guest = try harness.attachControl()
+        try harness.attachDrop()
+
+        try guest.send(makeHello(capabilities: KernovaCapability.controlChannelDefaults))
+        try await waitForChange { harness.instance.displayDropAvailability == .available }
+    }
+
+    @Test("a stopped drop service downgrades an available VM back to a refusal")
+    func stoppingTheServiceRefusesAgain() async throws {
+        let harness = Harness()
+        defer { harness.tearDown() }
+        let guest = try harness.attachControl()
+        try harness.attachDrop()
+        try guest.send(makeHello(capabilities: KernovaCapability.controlChannelDefaults))
+        try await waitForChange { harness.instance.displayDropAvailability == .available }
+
+        harness.instance.vsockDropService?.stop()
+
+        #expect(harness.instance.displayDropAvailability == .disconnected)
+        // And a drop attempted in that state is refused rather than swallowed.
+        #expect(!harness.instance.sendDroppedFilesToGuest([URL(fileURLWithPath: "/tmp/a.txt")]))
+    }
+}

--- a/KernovaTests/VMInstanceVsockAdmissionTests.swift
+++ b/KernovaTests/VMInstanceVsockAdmissionTests.swift
@@ -21,14 +21,18 @@ struct VMInstanceVsockAdmissionTests {
     }
 
     private func makeGuestHello(streamingCapable: Bool) -> Frame {
+        makeGuestHello(
+            capabilities: streamingCapable
+                ? KernovaCapability.controlChannelDefaults
+                : [KernovaCapability.controlV1, KernovaCapability.controlHeartbeatV1])
+    }
+
+    private func makeGuestHello(capabilities: [String]) -> Frame {
         var frame = Frame()
         frame.protocolVersion = 1
         frame.hello = Kernova_V1_Hello.with {
             $0.serviceVersion = 1
-            $0.capabilities =
-                streamingCapable
-                ? KernovaCapability.controlChannelDefaults
-                : [KernovaCapability.controlV1, KernovaCapability.controlHeartbeatV1]
+            $0.capabilities = capabilities
             $0.agentInfo = Kernova_V1_AgentInfo.with {
                 $0.os = "macOS"
                 $0.osVersion = "26.0"
@@ -41,7 +45,7 @@ struct VMInstanceVsockAdmissionTests {
     /// The verdict as the listener acts on it, for the assertions that only care
     /// whether the channel gets in.
     private func admits(_ instance: VMInstance, clipboard: Bool) -> Bool {
-        instance.featureChannelAdmission(requiringClipboardStreaming: clipboard) == .admit
+        instance.featureChannelAdmission(clipboard ? .clipboardStreaming : .none) == .admit
     }
 
     /// Whether the refusal is the routine "handshake hasn't landed" one, which
@@ -65,7 +69,8 @@ struct VMInstanceVsockAdmissionTests {
     func refusedWithoutControlService(clipboard: Bool) {
         let instance = makeInstance()
         #expect(
-            isNotReady(instance.featureChannelAdmission(requiringClipboardStreaming: clipboard)))
+            isNotReady(
+                instance.featureChannelAdmission(clipboard ? .clipboardStreaming : .none)))
     }
 
     @Test("Admission follows the control Hello handshake and its capabilities")
@@ -85,14 +90,14 @@ struct VMInstanceVsockAdmissionTests {
 
         // Channel accepted but no guest Hello yet — still refused, and as the
         // routine "too early" verdict rather than a peer that overstepped.
-        #expect(isNotReady(instance.featureChannelAdmission(requiringClipboardStreaming: false)))
+        #expect(isNotReady(instance.featureChannelAdmission(.none)))
 
         // A Hello without the streaming capability admits the log channel; the
         // clipboard channel is refused against a *completed* handshake, so that
         // refusal names the peer.
         try guest.send(makeGuestHello(streamingCapable: false))
         try await waitForChange { admits(instance, clipboard: false) }
-        #expect(isDenied(instance.featureChannelAdmission(requiringClipboardStreaming: true)))
+        #expect(isDenied(instance.featureChannelAdmission(.clipboardStreaming)))
 
         // A Hello advertising streaming flips clipboard admission too.
         try guest.send(makeGuestHello(streamingCapable: true))
@@ -166,5 +171,59 @@ struct VMInstanceVsockAdmissionTests {
         try secondGuest.send(makeGuestHello(streamingCapable: true))
         try await waitForChange { admits(instance, clipboard: true) }
         #expect(instance.vsockControlService !== first)
+    }
+
+    // MARK: - Drop channel
+
+    @Test("The drop channel is refused before the handshake, and without drop.files.v1")
+    func dropAdmissionFollowsItsOwnCapability() async throws {
+        let instance = makeInstance()
+        let (guestFd, hostFd) = try makeRawSocketPair()
+        let guest = VsockChannel(fileDescriptor: guestFd)
+        let host = VsockChannel(fileDescriptor: hostFd)
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        #expect(isNotReady(instance.featureChannelAdmission(.dropFiles)))
+
+        let control = VsockControlService(channel: host, label: "admission-test")
+        instance.vsockControlService = control
+        control.start()
+        defer { control.stop() }
+
+        // An agent that streams the clipboard but predates display drops gets
+        // the log and clipboard channels and not this one.
+        try guest.send(
+            makeGuestHello(capabilities: [
+                KernovaCapability.controlV1, KernovaCapability.controlHeartbeatV1,
+                KernovaCapability.clipboardStreamV1,
+            ]))
+        try await waitForChange { admits(instance, clipboard: true) }
+        #expect(isDenied(instance.featureChannelAdmission(.dropFiles)))
+
+        try guest.send(makeGuestHello(capabilities: KernovaCapability.controlChannelDefaults))
+        try await waitForChange { instance.featureChannelAdmission(.dropFiles) == .admit }
+    }
+
+    @Test("Stopping the control service withdraws drop admission too")
+    func stopWithdrawsDropAdmission() async throws {
+        let instance = makeInstance()
+        let (guestFd, hostFd) = try makeRawSocketPair()
+        let guest = VsockChannel(fileDescriptor: guestFd)
+        let host = VsockChannel(fileDescriptor: hostFd)
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let control = VsockControlService(channel: host, label: "admission-test")
+        instance.vsockControlService = control
+        control.start()
+
+        try guest.send(makeGuestHello(streamingCapable: true))
+        try await waitForChange { instance.featureChannelAdmission(.dropFiles) == .admit }
+
+        control.stop()
+        #expect(instance.featureChannelAdmission(.dropFiles) != .admit)
     }
 }

--- a/KernovaTests/VsockClipboardServiceTests.swift
+++ b/KernovaTests/VsockClipboardServiceTests.swift
@@ -4708,6 +4708,69 @@ struct VsockClipboardServiceTests {
         responder.releaseEnd()
         await previewTask.value
     }
+
+    // MARK: - Cancelling a shown transfer
+
+    @Test("cancelling an outbound paste refuses the rest of the guest's pulls")
+    func cancelStopsTheWholeOutboundOperation() async throws {
+        let (guest, host) = try makePair()
+        guest.start()
+        host.start()
+        defer { guest.close() }
+
+        let center = ClipboardProgressCenter()
+        let service = VsockClipboardService(
+            channel: host, label: "test-\(UUID().uuidString)", instanceID: UUID(),
+            progressRevealDelay: 0, progressIdleLinger: 0, progressCenter: center)
+        service.start()
+        defer { service.stop() }
+
+        // Two representations, so there is a "next file" for the cancel to have
+        // to stop as well as the one in flight.
+        let first = String(repeating: "A", count: 200 * 1024)
+        service.clipboardContent = ClipboardContent(
+            representations: [
+                ClipboardContent.Representation(
+                    uti: ClipboardContent.utf8TextUTI, data: Data(first.utf8)),
+                ClipboardContent.Representation(uti: "public.html", data: Data("<p>b</p>".utf8)),
+            ])
+        service.grabIfChanged()
+
+        let offerFrame = try await nextFrame(from: guest)
+        guard case .clipboardOffer(let offer) = offerFrame.payload else {
+            Issue.record("Expected an offer, got \(String(describing: offerFrame.payload))")
+            return
+        }
+        let firstInfo = try #require(offer.repInfo.first)
+        let firstID = transferID(generation: offer.generation, repIndex: 0)
+        try guest.send(makeRequest(generation: offer.generation, repIndex: 0, uti: firstInfo.uti))
+        _ = try await nextFrame(from: guest)  // Begin
+        // A one-chunk window parks the sender mid-transfer, with the readout up.
+        try sendAck(from: guest, transferID: firstID, bytesConsumed: 0, windowBytes: 64 * 1024)
+        try await waitForChange { service.transferProgress != nil }
+        #expect(service.transferProgress?.isCancellable == true)
+
+        center.cancelCurrent()
+
+        // The guest's paste walks to the next representation regardless — the
+        // peer decides what it pulls — so the cancel has to refuse that too, or
+        // the operation the user stopped simply resumes a beat later.
+        let secondInfo = offer.repInfo[1]
+        try guest.send(makeRequest(generation: offer.generation, repIndex: 1, uti: secondInfo.uti))
+        let secondID = transferID(generation: offer.generation, repIndex: 1)
+        while true {
+            let frame = try await nextFrame(from: guest)
+            if case .clipboardStreamAbort(let abort) = frame.payload, abort.transferID == secondID {
+                // Refused as stale, which the guest already retires quietly.
+                #expect(abort.code == "request.stale")
+                break
+            }
+            if case .clipboardStreamBegin(let begin) = frame.payload, begin.transferID == secondID {
+                Issue.record("The cancelled operation streamed its next representation")
+                break
+            }
+        }
+    }
 }
 
 extension [CopyToMacItem] {

--- a/KernovaTests/VsockDropServiceTests.swift
+++ b/KernovaTests/VsockDropServiceTests.swift
@@ -1,0 +1,480 @@
+import Foundation
+import KernovaKit
+import KernovaTestSupport
+import Testing
+import UniformTypeIdentifiers
+
+@testable import Kernova
+
+/// Unit tests for the host side of dragging files onto the VM display: the offer
+/// it announces, the bytes it streams when the guest pulls, and what it reports
+/// when a drop is cancelled or the guest cannot finish it.
+@Suite("VsockDropService")
+@MainActor
+struct VsockDropServiceTests {
+    // MARK: - Harness
+
+    /// A socketpair, the service under test on one end, and a frame recorder
+    /// standing in for the guest agent on the other.
+    @MainActor
+    private final class Harness {
+        let service: VsockDropService
+        let guest: VsockChannel
+        let issueCenter = ClipboardIssueCenter()
+        let progressCenter = ClipboardProgressCenter()
+        let instanceID = UUID()
+        let recorder: FrameRecorder
+        private let host: VsockChannel
+
+        init(directoryByteCount: @escaping @Sendable (URL) -> Int = { _ in 0 }) throws {
+            let (hostFd, guestFd) = try makeRawSocketPair()
+            host = VsockChannel(fileDescriptor: hostFd)
+            guest = VsockChannel(fileDescriptor: guestFd)
+            host.start()
+            guest.start()
+            recorder = FrameRecorder(channel: guest)
+            service = VsockDropService(
+                channel: host, label: "Drop VM", instanceID: instanceID,
+                // Zeroed so a transfer's readout is on screen while it runs.
+                progressRevealDelay: 0, progressIdleLinger: 0,
+                directoryByteCount: directoryByteCount,
+                // Inline, so the folder walk needs no cross-thread wait.
+                runOffMainActor: { work in work() },
+                progressCenter: progressCenter, issueCenter: issueCenter)
+            service.start()
+        }
+
+        func tearDown() {
+            recorder.cancel()
+            service.stop()
+            guest.close()
+        }
+
+        var issue: ClipboardTransferIssue? { issueCenter.latestByInstance[instanceID]?.issue }
+    }
+
+    /// Collects frames arriving on the guest end, with a gate to await them.
+    @MainActor
+    private final class FrameRecorder {
+        var frames: [Frame] = []
+        let recorded = AsyncGate()
+        private var consumeTask: Task<Void, Never>?
+
+        init(channel: VsockChannel) {
+            consumeTask = Task { @MainActor [weak self] in
+                do {
+                    for try await frame in channel.incoming {
+                        self?.frames.append(frame)
+                        self?.recorded.notify()
+                    }
+                } catch {
+                    // Stream ended; tests assert on what was recorded.
+                }
+            }
+        }
+
+        func cancel() { consumeTask?.cancel() }
+        deinit { consumeTask?.cancel() }
+
+        var offers: [Kernova_V1_DropOffer] {
+            frames.compactMap {
+                if case .dropOffer(let offer) = $0.payload { return offer }
+                return nil
+            }
+        }
+
+        var releases: [Kernova_V1_DropRelease] {
+            frames.compactMap {
+                if case .dropRelease(let release) = $0.payload { return release }
+                return nil
+            }
+        }
+
+        var begins: [Kernova_V1_ClipboardStreamBegin] {
+            frames.compactMap {
+                if case .clipboardStreamBegin(let begin) = $0.payload { return begin }
+                return nil
+            }
+        }
+
+        var aborts: [Kernova_V1_ClipboardStreamAbort] {
+            frames.compactMap {
+                if case .clipboardStreamAbort(let abort) = $0.payload { return abort }
+                return nil
+            }
+        }
+
+        func chunkBytes(for transferID: UInt64) -> Data {
+            var data = Data()
+            for frame in frames {
+                if case .clipboardChunk(let chunk) = frame.payload, chunk.transferID == transferID {
+                    data.append(chunk.data)
+                }
+            }
+            return data
+        }
+
+        func end(for transferID: UInt64) -> Kernova_V1_ClipboardStreamEnd? {
+            for frame in frames {
+                if case .clipboardStreamEnd(let end) = frame.payload, end.transferID == transferID {
+                    return end
+                }
+            }
+            return nil
+        }
+
+        func wait(until predicate: @escaping () -> Bool) async throws {
+            try await recorded.wait(until: predicate)
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// A fresh directory under the temp root, removed by the caller.
+    private func makeScratchDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VsockDropServiceTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makeFile(in directory: URL, named name: String, bytes: Data) throws -> URL {
+        let url = directory.appendingPathComponent(name)
+        try bytes.write(to: url)
+        return url
+    }
+
+    /// The id the guest mints for representation `index` of `generation` — the
+    /// guest is the receiver, so the direction bit stays clear.
+    private func transferID(generation: UInt64, repIndex: Int) -> UInt64 {
+        ClipboardTransferID.make(
+            generation: generation, repIndex: repIndex, hostMinted: false)
+    }
+
+    private func makeRequest(generation: UInt64, transferID: UInt64, uti: String) -> Frame {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.clipboardRequest = Kernova_V1_ClipboardRequest.with {
+            $0.generation = generation
+            $0.transferID = transferID
+            $0.uti = uti
+            $0.maxAcceptByteCount = ClipboardStreamTuning.unlimitedAcceptByteCount
+        }
+        return frame
+    }
+
+    /// The receiver's go-signal plus credit for the whole payload.
+    private func makeAck(transferID: UInt64, consumed: UInt64 = 0) -> Frame {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.clipboardStreamAck = Kernova_V1_ClipboardStreamAck.with {
+            $0.transferID = transferID
+            $0.bytesConsumed = consumed
+            $0.windowBytes = UInt64(ClipboardStreamTuning.defaultWindowBytes)
+        }
+        return frame
+    }
+
+    private func makeComplete(
+        generation: UInt64, outcome: Kernova_V1_DropComplete.Outcome,
+        code: ClipboardErrorCode? = nil
+    ) -> Frame {
+        var frame = Frame()
+        frame.protocolVersion = 1
+        frame.dropComplete = Kernova_V1_DropComplete.with {
+            $0.generation = generation
+            $0.outcome = outcome
+            if let code {
+                $0.code = code.rawValue
+                $0.message = "detail the host must not render"
+            }
+        }
+        return frame
+    }
+
+    // MARK: - Offering
+
+    @Test("a drop offers one item per file, with the name and stat'd size")
+    func offersEveryDroppedFile() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let first = try makeFile(in: scratch, named: "notes.txt", bytes: Data(repeating: 0x41, count: 12))
+        let second = try makeFile(in: scratch, named: "data.bin", bytes: Data(repeating: 0x42, count: 34))
+
+        #expect(harness.service.startDrop(urls: [first, second]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+
+        let offer = try #require(harness.recorder.offers.first)
+        #expect(offer.generation == 1)
+        #expect(offer.repInfo.map(\.filename) == ["notes.txt", "data.bin"])
+        #expect(offer.repInfo.map(\.byteCount) == [12, 34])
+        // A drop always lands as a file; nothing about it is pasteboard-inline.
+        #expect(offer.repInfo.allSatisfy { !$0.isInline })
+        #expect(offer.repInfo.allSatisfy { !$0.isDirectory })
+    }
+
+    @Test("a dropped folder is offered as a directory carrying its stat-walk estimate")
+    func offersAFolderWithItsEstimate() async throws {
+        let harness = try Harness(directoryByteCount: { _ in 4_096 })
+        defer { harness.tearDown() }
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let folder = scratch.appendingPathComponent("Photos", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+
+        #expect(harness.service.startDrop(urls: [folder]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+
+        let rep = try #require(harness.recorder.offers.first?.repInfo.first)
+        #expect(rep.filename == "Photos")
+        #expect(rep.isDirectory)
+        #expect(rep.byteCount == 4_096)
+    }
+
+    @Test("two drops are independent jobs under their own generations")
+    func secondDropDoesNotSupersedeTheFirst() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = try makeFile(in: scratch, named: "a.txt", bytes: Data("a".utf8))
+
+        #expect(harness.service.startDrop(urls: [file]))
+        #expect(harness.service.startDrop(urls: [file]))
+        try await harness.recorder.wait { harness.recorder.offers.count == 2 }
+
+        #expect(harness.recorder.offers.map(\.generation) == [1, 2])
+        // Nothing retires the first drop: the user asked for both sets of files.
+        #expect(harness.recorder.releases.isEmpty)
+    }
+
+    @Test("a drop of items that cannot be read is refused, and says so")
+    func refusesUnreadableItems() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID().uuidString)")
+
+        #expect(!harness.service.startDrop(urls: [missing]))
+        #expect(harness.recorder.offers.isEmpty)
+        // The gesture happened on this Mac and produced nothing, so the silence
+        // is explained here.
+        #expect(harness.issue != nil)
+    }
+
+    // MARK: - Serving the guest's pulls
+
+    @Test("the guest's request streams the dropped file's bytes end to end")
+    func streamsTheRequestedFile() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let payload = Data((0..<2_048).map { UInt8($0 & 0xFF) })
+        let file = try makeFile(in: scratch, named: "blob.bin", bytes: payload)
+
+        #expect(harness.service.startDrop(urls: [file]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+
+        let xid = transferID(generation: 1, repIndex: 0)
+        let uti = try #require(harness.recorder.offers.first?.repInfo.first?.uti)
+        try harness.guest.send(makeRequest(generation: 1, transferID: xid, uti: uti))
+        try await harness.recorder.wait { !harness.recorder.begins.isEmpty }
+
+        let begin = try #require(harness.recorder.begins.first)
+        #expect(begin.transferID == xid)
+        #expect(begin.filename == "blob.bin")
+        #expect(begin.totalBytes == UInt64(payload.count))
+        #expect(!begin.isInline)
+
+        // The first ack is the sender's go-signal.
+        try harness.guest.send(makeAck(transferID: xid))
+        try await harness.recorder.wait { harness.recorder.end(for: xid) != nil }
+
+        #expect(harness.recorder.chunkBytes(for: xid) == payload)
+        #expect(harness.recorder.end(for: xid)?.totalBytes == UInt64(payload.count))
+    }
+
+    @Test("a request naming an unknown drop, index, or type is rejected rather than served")
+    func rejectsMalformedRequests() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = try makeFile(in: scratch, named: "a.txt", bytes: Data("a".utf8))
+
+        #expect(harness.service.startDrop(urls: [file]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+        let uti = try #require(harness.recorder.offers.first?.repInfo.first?.uti)
+
+        // A generation no drop was ever offered under.
+        try harness.guest.send(
+            makeRequest(
+                generation: 99, transferID: transferID(generation: 99, repIndex: 0), uti: uti))
+        try await harness.recorder.wait { !harness.recorder.aborts.isEmpty }
+        #expect(harness.recorder.aborts.first?.code == "request.stale")
+
+        // An index past the offer's items.
+        try harness.guest.send(
+            makeRequest(
+                generation: 1, transferID: transferID(generation: 1, repIndex: 5), uti: uti))
+        try await harness.recorder.wait { harness.recorder.aborts.count >= 2 }
+        #expect(harness.recorder.aborts[1].code == "request.range")
+
+        // The right item, the wrong type.
+        try harness.guest.send(
+            makeRequest(
+                generation: 1, transferID: transferID(generation: 1, repIndex: 0),
+                uti: "public.mpeg-4"))
+        try await harness.recorder.wait { harness.recorder.aborts.count >= 3 }
+        #expect(harness.recorder.aborts[2].code == "request.uti")
+        // Nothing was streamed for any of them.
+        #expect(harness.recorder.begins.isEmpty)
+    }
+
+    // MARK: - Cancelling
+
+    @Test("cancelling releases the drop and stops the transfer in flight")
+    func cancelReleasesAndAborts() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = try makeFile(
+            in: scratch, named: "big.bin", bytes: Data(repeating: 0x5A, count: 512 * 1_024))
+
+        #expect(harness.service.startDrop(urls: [file]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+        let xid = transferID(generation: 1, repIndex: 0)
+        let uti = try #require(harness.recorder.offers.first?.repInfo.first?.uti)
+        try harness.guest.send(makeRequest(generation: 1, transferID: xid, uti: uti))
+        try await harness.recorder.wait { !harness.recorder.begins.isEmpty }
+        // Deliberately never acked: the transfer parks on credit, which is where
+        // a cancel has to reach it.
+
+        harness.service.cancelDrop(generation: 1)
+
+        try await harness.recorder.wait { !harness.recorder.releases.isEmpty }
+        #expect(harness.recorder.releases.first?.generation == 1)
+        try await harness.recorder.wait { harness.recorder.aborts.contains { $0.code == "superseded" } }
+        // A cancel is not a failure: nothing is raised on either surface.
+        #expect(harness.issue == nil)
+    }
+
+    @Test("cancelling a drop that is already over does nothing")
+    func cancelAfterCompletionIsANoOp() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = try makeFile(in: scratch, named: "a.txt", bytes: Data("a".utf8))
+
+        #expect(harness.service.startDrop(urls: [file]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+        try harness.guest.send(makeComplete(generation: 1, outcome: .completed))
+        try await Task.sleep(for: .milliseconds(50))
+
+        harness.service.cancelDrop(generation: 1)
+        harness.service.cancelDrop(generation: 1)
+
+        #expect(harness.recorder.releases.isEmpty)
+        #expect(harness.issue == nil)
+    }
+
+    // MARK: - The guest's verdict
+
+    @Test("a completed drop raises nothing")
+    func completionIsSilent() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = try makeFile(in: scratch, named: "a.txt", bytes: Data("a".utf8))
+
+        #expect(harness.service.startDrop(urls: [file]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+        try harness.guest.send(makeComplete(generation: 1, outcome: .completed))
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(harness.issue == nil)
+    }
+
+    @Test("a failed drop raises an issue whose sentence the host composes")
+    func failureRaisesAHostComposedIssue() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = try makeFile(in: scratch, named: "a.txt", bytes: Data("a".utf8))
+
+        #expect(harness.service.startDrop(urls: [file]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+        try harness.guest.send(
+            makeComplete(generation: 1, outcome: .failed, code: .dropDownloadsDenied))
+        try await waitUntil { harness.issue != nil }
+
+        let issue = try #require(harness.issue)
+        let message = issue.displayMessage(pasteLimitBytes: ClipboardPasteLimit.defaultBytes)
+        #expect(message.contains("Downloads"))
+        // The guest's own message text never reaches a surface.
+        #expect(!message.contains("detail the host must not render"))
+    }
+
+    // MARK: - Teardown
+
+    @Test("stopping clears the readout and answers for a drop still in flight")
+    func stopReportsAbandonedDrops() async throws {
+        let harness = try Harness()
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = try makeFile(in: scratch, named: "a.txt", bytes: Data("a".utf8))
+
+        #expect(harness.service.startDrop(urls: [file]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+
+        harness.recorder.cancel()
+        harness.service.stop()
+        harness.guest.close()
+
+        #expect(!harness.service.isConnected)
+        #expect(harness.service.transferProgress == nil)
+        #expect(harness.progressCenter.materializationProgress == nil)
+        // The files never landed and the gesture was made here, so the silence
+        // is owed an answer.
+        #expect(harness.issue != nil)
+    }
+
+    @Test("stopping after a cancelled drop reports nothing — the user already knows")
+    func stopIsSilentAfterACancel() async throws {
+        let harness = try Harness()
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = try makeFile(in: scratch, named: "a.txt", bytes: Data("a".utf8))
+
+        #expect(harness.service.startDrop(urls: [file]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+        harness.service.cancelDrop(generation: 1)
+
+        harness.recorder.cancel()
+        harness.service.stop()
+        harness.guest.close()
+
+        #expect(harness.issue == nil)
+    }
+
+    @Test("a drop is refused once the service has stopped")
+    func refusesADropAfterStop() async throws {
+        let harness = try Harness()
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = try makeFile(in: scratch, named: "a.txt", bytes: Data("a".utf8))
+
+        harness.recorder.cancel()
+        harness.service.stop()
+        harness.guest.close()
+
+        #expect(!harness.service.startDrop(urls: [file]))
+    }
+}

--- a/KernovaTests/VsockDropServiceTests.swift
+++ b/KernovaTests/VsockDropServiceTests.swift
@@ -420,6 +420,31 @@ struct VsockDropServiceTests {
         #expect(message.contains("Downloads"))
         // The guest's own message text never reaches a surface.
         #expect(!message.contains("detail the host must not render"))
+        // The specific code reaches every surface, so the dropdown line names
+        // the same outcome the notice body does rather than the generic one.
+        #expect(issue.menuLineText == "Drop: the VM's Downloads folder is off limits")
+    }
+
+    @Test("a drop that fails partway never claims the files it already moved weren't saved")
+    func failureCopyDoesNotDenyPartialProgress() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = try makeFile(in: scratch, named: "a.txt", bytes: Data("a".utf8))
+
+        #expect(harness.service.startDrop(urls: [file]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+        try harness.guest.send(makeComplete(generation: 1, outcome: .failed, code: .dropDiskFull))
+        try await waitUntil { harness.issue != nil }
+
+        // The guest moves each file as it lands, so a batch that fails on file 3
+        // leaves 1 and 2 in Downloads. A message saying nothing was saved would
+        // send the user looking for files that are there.
+        let message = try #require(harness.issue).displayMessage(
+            pasteLimitBytes: ClipboardPasteLimit.defaultBytes)
+        #expect(message.contains("disk space"))
+        #expect(!message.contains("weren't saved"))
     }
 
     // MARK: - Teardown
@@ -462,6 +487,52 @@ struct VsockDropServiceTests {
         harness.guest.close()
 
         #expect(harness.issue == nil)
+    }
+
+    @Test("the channel ending settles the service, so the display stops offering drops")
+    func channelEndSettlesTheService() async throws {
+        let harness = try Harness()
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = try makeFile(in: scratch, named: "a.txt", bytes: Data("a".utf8))
+
+        #expect(harness.service.startDrop(urls: [file]))
+        try await harness.recorder.wait { !harness.recorder.offers.isEmpty }
+
+        // The guest's drop client closes this channel on every control
+        // reconnect. Nothing calls `stop()` for that, so the service has to
+        // settle itself or it keeps advertising a drop it cannot send.
+        harness.recorder.cancel()
+        harness.guest.close()
+
+        try await waitForChange { !harness.service.isConnected }
+        #expect(!harness.service.startDrop(urls: [file]))
+        #expect(harness.service.transferProgress == nil)
+        #expect(harness.progressCenter.materializationProgress == nil)
+        // The drop in flight when the channel went is owed an answer.
+        #expect(harness.issue != nil)
+    }
+
+    @Test("a folder still being sized when the channel goes reports the interruption")
+    func pendingFolderWalkReportsInterruption() async throws {
+        let harness = try Harness(directoryByteCount: { _ in 4_096 })
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let folder = scratch.appendingPathComponent("Photos", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+
+        // The drop is accepted and its offer deferred behind the size walk. This
+        // test is main-actor bound, so the walk's completion hop cannot run
+        // until the awaits below — the same window a slow real walk opens.
+        #expect(harness.service.startDrop(urls: [folder]))
+        harness.recorder.cancel()
+        harness.service.stop()
+        harness.guest.close()
+
+        // No job was ever registered, so `settle()` had nothing to report: only
+        // the discarded walk can account for the drop the user made.
+        try await waitForChange { harness.issue != nil }
+        #expect(harness.recorder.offers.isEmpty)
     }
 
     @Test("a drop is refused once the service has stopped")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -166,8 +166,9 @@ The vsock stack (macOS guests only):
   mirrors the same assignments guest-side.
 - `VsockListenerHost` — one `VZVirtioSocketListener` per port, bridging an accepted connection to a
   `VsockChannel`. Its `shouldAdmit` predicate refuses a connection before any channel is built;
-  `VMInstance` wires the log and clipboard listeners to `featureChannelAdmission`, so no feature
-  channel is accepted before the control handshake completes. Socket-buffer sizing and its
+  `VMInstance` wires the log, clipboard and drop listeners to `featureChannelAdmission`, so no
+  feature channel is accepted before the control handshake completes, and each names the guest
+  capability it additionally requires. Socket-buffer sizing and its
   measurements: [research/2026-07-13-vsock-transport-throughput.md](research/2026-07-13-vsock-transport-throughput.md).
 - `VsockControlService` — `@MainActor` `@Observable` owner of the always-on control channel:
   `Hello`/`Heartbeat` exchange, a liveness watchdog, the observed `agentVersion`, and `PolicyUpdate`
@@ -178,10 +179,17 @@ The vsock stack (macOS guests only):
   notification that re-arms `VMInstance`'s agent-arrival watchdog. Installed for every macOS guest
   with a socket device, independent of clipboard sharing.
 - `VsockGuestLogService` — forwards guest `LogRecord` frames into the `app.kernova.guest` subsystem.
+- `VsockDropService` — `@MainActor` `@Observable` owner of the drop channel, send-only. Files
+  dragged onto `VMDisplayBackingView` become a `DropOffer` the guest pulls representation by
+  representation over the same streaming engine the clipboard uses; the guest writes them into its
+  Downloads folder and replies `DropComplete`. Installed for every guest with a socket device,
+  gated only on the guest's `drop.files.v1`. `VMInstance.displayDropAvailability` is the single
+  read site deciding whether the display registers as a drag destination at all.
 
 The log and clipboard listeners are gated on their configuration toggles and re-evaluated at
-runtime through `VMInstance.applyLivePolicy(oldConfig:newConfig:)`. Linux clipboard sharing is
-restart-only — its SPICE port must be declared at config-build time.
+runtime through `VMInstance.applyLivePolicy(oldConfig:newConfig:)`; the control and drop listeners
+have no toggle to track. Linux clipboard sharing is restart-only — its SPICE port must be declared
+at config-build time.
 
 Clipboard (principles and trade-off rules: [CLIPBOARD.md](CLIPBOARD.md)):
 
@@ -396,8 +404,8 @@ kernel resources until relaunch — hence one owner (`RuntimeFileAccess`) and on
   `NSWorkspace`. Sandboxed with `app-sandbox` + `inherit`.
 
 - **KernovaMacOSAgent** — `Kernova Guest Agent.app`, the `.accessory` menu-bar app that runs inside
-  macOS guests, holding three independent vsock connections to the host (control, log forwarding,
-  clipboard). It is not embedded as a bundle: the `Package Guest Agent DMG` build phase produces
+  macOS guests, holding four independent vsock connections to the host (control, log forwarding,
+  clipboard, drop). It is not embedded as a bundle: the `Package Guest Agent DMG` build phase produces
   `Contents/Resources/KernovaMacOSAgent.dmg`, so it must already carry its final Developer ID
   signature when the DMG is baked — export-time re-signing cannot reach inside a DMG resource
   ([RELEASING.md](RELEASING.md)); version bumps are in [BUILD.md](BUILD.md).


### PR DESCRIPTION
Closes #298

## Summary

Dragging files from Finder onto a running macOS VM's display transfers them into the guest's Downloads folder, uniqued the way Finder itself would, and reveals them selected in a Finder window when the drop finishes.

## The route taken

**A dedicated vsock channel, the same streaming engine.** The drop rides `KernovaVsockPort.drop` (49155) rather than the clipboard channel, because the clipboard listener only exists while clipboard sharing is on, its admission requires `clipboard.stream.v1`, and everything it delivers lands on the guest pasteboard. A drop has to work with sharing off and must not disturb either clipboard. The *byte plane* is reused wholesale: `DropOffer` is metadata only, the guest pulls each item with an ordinary `ClipboardRequest`, and the bytes cross on the existing `Begin`/`Chunk`/`End`/`Ack`/`Abort` path — so there is one streaming implementation, not two.

**Three availability states, decided in one place.** `VMInstance.displayDropAvailability`:

| State | Signal | Behavior |
|---|---|---|
| `.none` | `lastSeenAgentVersion == nil` (persisted) | the display is not a drag destination at all |
| `.disconnected` | agent seen before, channel or capability missing now | registered, returns the empty `NSDragOperation` — no accept badge, release springs back |
| `.available` | live drop channel + `drop.files.v1` | `.copy` |

**Cancel, everywhere or nowhere.** The issue asked whether a Cancel button should extend beyond drops. It does: `ClipboardProgressTracker.openSession(onCancelRequested:)` puts it on the readout itself, so the host's status item and the guest agent's both get it, for drops and clipboard transfers alike. `ClipboardProgressCenter.cancelCurrent()` routes a host Cancel to the VM whose transfer is actually on screen rather than broadcasting. Completed files stay in Downloads; the in-flight partial is deleted by the existing abort path; the offer survives, so a paste can pull again.

**Guest-side landing.** Files stage to temp and are *renamed* into `~/Downloads` (same volume, so nothing payload-scaled happens), named by a new `FinderStyleUniquing` (`report 2.pdf`, not staging's invisible `report (2).pdf`). Jobs run FIFO on a dedicated serial queue, so a blocking pull never holds the agent's main thread.

## Rejected alternatives

- **Carrying drops on the clipboard channel** — would make the feature depend on a clipboard toggle it has nothing to do with, and would have to keep drop payloads off the pasteboard by convention rather than by construction.
- **Copying the consume loop per channel.** The design note called for copying `VsockClipboardService`'s frame-routing switch (including its abort-ordering fix) into the drop service. That is four copies of one rule; `ClipboardStreamRouting` now holds it once and all four endpoints use it, with the host/guest difference in sender-abort delivery an explicit parameter rather than a silently divergent copy.
- **A new `ClipboardTransferIssue.Kind` case for drop failures** — every other flow uses a factory over `.localFailure`, and a new case would have forced changes into an exhaustive `switch` that has nothing to do with drops.
- **A drop-only Cancel** — see above.

## Deviations from the design note

Verified against HEAD before implementing; these are where the note's factual claims did not hold:

1. **Guest enablement hook.** The note reused `VsockGuestControlAgent.onStateChange` to wake the drop client on `Hello`. That callback is change-gated on a state already set to `.connected` *before* any `Hello` arrives, so it never fires for the capabilities — the drop client would have stayed paused forever. Added an explicit `onHostCapabilitiesChanged` hook, fired on `Hello` and on the per-connection reset.
2. **`ClipboardProgressCenter` held no source reference.** The note assumed `progressBySource` already kept one; it keyed bare `ObjectIdentifier`s with no reference at all. Added a weak-source entry plus winner tracking.
3. **Guest-inbound clipboard cancel does not exist to wire.** The guest agent opens no inbound progress session (an inbound paste blocks its main thread, so no readout could repaint or be clicked). The same reasoning applies to the host's paste-time blocking pull, so neither gets a cancel closure; the sessions that *can* be cancelled are the two outbound ones plus both drop directions.
4. **One shared guest tracker required a teardown fix.** Sharing a tracker between the clipboard and drop agents made `clearAll()` on a clipboard teardown wipe a live drop's readout. The clipboard agent now closes only its own session.
5. **Peer-supplied text is not rendered.** `DropComplete` carries a machine-readable `code` alongside its message; the host maps the code to a sentence it composes itself, and the guest's message is logged only.
6. **No pbxproj source-list edits.** The targets use synchronized folder groups, so new files are picked up automatically.
7. `featureChannelAdmission` was refactored to take a `FeatureChannelRequirement` (existing two call sites migrated), and `startVsockServices()` needed no OS branch — `ConfigurationBuilder` only creates a socket device for macOS guests.

## Changes

- `KernovaKit/Proto/kernova.proto` — `DropOffer`/`DropComplete`/`DropRelease` at 40-42; regenerated bindings.
- `KernovaCapability.dropFilesV1`, `KernovaVsockPort.drop` (host + agent mirrors), three `ClipboardErrorCode` drop codes.
- New: `ClipboardStreamRouting`, `FinderStyleUniquing` (KernovaKit); `VsockDropService` (host); `VsockGuestDropAgent` (agent).
- Cancel plumbing across `ClipboardProgressTracker`, `ClipboardProgressSnapshot`, `ClipboardProgressMenuItemView`, `ClipboardProgressStatusItemPresenter`, `ClipboardProgressCenter`, both status-item controllers, and both clipboard endpoints.
- `VMDisplayBackingView` drag destination + wiring in `DetailContainerViewController` and `VMDisplayWindowController`.
- Agent `MARKETING_VERSION` 0.61.1 → 0.62.0 (both configurations) — the guest needs a reinstall for the new client.
- `docs/ARCHITECTURE.md` — drop service in the vsock stack; the agent now holds four connections.

## Test plan

- [x] `make test` — 2955 host + 170 agent + 408 package tests, all green
- [x] `make lint`
- [ ] Drag files and a folder onto a running macOS guest's display; confirm they land in Downloads, unique Finder-style against existing names, and are revealed selected
- [ ] Drag onto a VM whose guest agent is stopped; confirm no accept badge and a spring-back
- [ ] Cancel a large drop from the menu-bar readout; confirm completed files stay and the partial does not

## Notes

New coverage: `FinderStyleUniquingTests`, `ClipboardStreamRoutingTests`, `DropFrameTests`, `ClipboardProgressMenuItemViewTests`, `VsockDropServiceTests`, `VMInstanceDisplayDropTests`, `VsockGuestDropAgentTests`, plus additions to the progress-tracker, progress-center, display-backing-view, admission and control-agent suites.

### Maintenance Notes

- ✅ **ARCHITECTURE.md** — updated: a new service and a new guest agent are component boundaries; the vsock stack list and the agent's connection count now say so.
- ✅ **Tests** — every new public type and both new endpoints are covered, including the cancel paths and the three-state availability matrix.
- ⚠️ **AGENTS.md** — skipped: no rule stated there changed.
- ✅ **Follow-up filed** — the wire abort codes are still bare string literals matched across four files; typing them is out of scope here and is filed separately.