### PR TITLE
perf: Drop the SH2 per-entry hash from the directory archive stream

### DIFF
--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -829,7 +829,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.62.0;
+				MARKETING_VERSION = 0.63.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
@@ -867,7 +867,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.62.0;
+				MARKETING_VERSION = 0.63.0;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;

--- a/KernovaKit/Sources/KernovaKit/ClipboardDirectoryArchive.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardDirectoryArchive.swift
@@ -25,12 +25,17 @@ public enum ClipboardDirectoryArchive {
     }
 
     /// Fidelity key set: type, path, link target, device id, data, uid, gid,
-    /// permissions, flags, mtime, ctime, and per-entry SHA-256.
+    /// permissions, flags, mtime, and ctime.
+    ///
+    /// No per-entry digest (`SH2`): AppleArchive writes it into the entry header,
+    /// so the encoder reads and hashes each file in full before its first
+    /// payload byte can leave, and the transfer's stream-level SHA-256 already
+    /// covers every payload byte (CLIPBOARD.md §7).
     ///
     /// RATIONALE: extended attributes (`XAT`) are deliberately omitted — the
     /// plain-file streaming path cannot carry them, and a folder carrying them
     /// alone would break CLIPBOARD.md §6's uniform xattr gap.
-    static let fieldKeys = "TYP,PAT,LNK,DEV,DAT,UID,GID,MOD,FLG,MTM,CTM,SH2"
+    static let fieldKeys = "TYP,PAT,LNK,DEV,DAT,UID,GID,MOD,FLG,MTM,CTM"
 }
 
 extension ClipboardDirectoryArchive {

--- a/KernovaKit/Sources/KernovaKit/ClipboardDirectoryArchive.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardDirectoryArchive.swift
@@ -24,13 +24,12 @@ public enum ClipboardDirectoryArchive {
         case invalidFieldKeySet
     }
 
-    /// Fidelity key set: type, path, link target, device id, data, uid, gid,
-    /// permissions, flags, mtime, and ctime.
+    /// The archive's fidelity key set — what a folder round trip preserves.
     ///
-    /// No per-entry digest (`SH2`): AppleArchive writes it into the entry header,
-    /// so the encoder reads and hashes each file in full before its first
-    /// payload byte can leave, and the transfer's stream-level SHA-256 already
-    /// covers every payload byte (CLIPBOARD.md §7).
+    /// AppleArchive writes a per-entry digest (`SH2`) into the entry *header*, so
+    /// carrying one makes the encoder read and hash each file in full before its
+    /// first payload byte can leave; the transfer's wire-level SHA-256
+    /// (CLIPBOARD.md §7) is the integrity check.
     ///
     /// RATIONALE: extended attributes (`XAT`) are deliberately omitted — the
     /// plain-file streaming path cannot carry them, and a folder carrying them

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardDirectoryStreamTests.swift
@@ -1,5 +1,7 @@
+import AppleArchive
 import Foundation
 import KernovaTestSupport
+import System
 import Testing
 
 @testable import KernovaKit
@@ -188,6 +190,39 @@ struct ClipboardDirectoryStreamTests {
             try String(
                 contentsOf: dest.appendingPathComponent("Ünïcødé 🎉/naïve — файл.txt"),
                 encoding: .utf8) == "ok")
+    }
+
+    @Test("archive entries carry no per-entry digest — the stream-level hash is the only one")
+    func entriesCarryNoDigest() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        try Data(repeating: 0xCD, count: 64 * 1024).write(to: source.appendingPathComponent("a.bin"))
+        try "b".write(to: source.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+
+        let archive = scratch.appendingPathComponent("tree.aar")
+        try archiveBytes(of: source).write(to: archive)
+
+        let file = try #require(
+            ArchiveByteStream.fileStream(
+                path: FilePath(archive.path), mode: .readOnly, options: [], permissions: []))
+        defer { try? file.close() }
+        let decompress = try #require(ArchiveByteStream.decompressionStream(readingFrom: file))
+        defer { try? decompress.close() }
+        let decode = try #require(ArchiveStream.decodeStream(readingFrom: decompress))
+        defer { try? decode.close() }
+
+        var paths: Set<String> = []
+        while let header = try decode.readHeader() {
+            #expect(header.field(forKey: ArchiveHeader.FieldKey("SH2")) == nil)
+            if case .string(_, let path)? = header.field(forKey: ArchiveHeader.FieldKey("PAT")) {
+                paths.insert(path)
+            }
+        }
+        #expect(paths.isSuperset(of: ["a.bin", "b.txt"]))
     }
 
     @Test("an empty directory streams real bytes and extracts to an empty tree")

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -148,9 +148,8 @@ defect; round-trip equality with a native copy/paste is the bar.
   marker suppressed is not a copy and releases nothing.
 - **Directory fidelity rides the archive's field-key set.** A folder crosses as an archive of its
   tree, and what survives the round trip is exactly what `ClipboardDirectoryArchive`'s key set
-  carries — entry kinds, permissions, ownership, flags, timestamps, link targets. Changing
-  directory fidelity means changing that key set, never bolting metadata on through a side
-  channel.
+  carries. Changing directory fidelity means changing that key set, never bolting metadata on
+  through a side channel.
 - **Accepted gap: extended attributes cross on *no* paste path** — Finder tags,
   `com.apple.quarantine`, `kMDItemWhereFroms`. A plain file streams content bytes into a freshly
   created destination file, which cannot carry them, and the directory archive deliberately omits

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -148,9 +148,9 @@ defect; round-trip equality with a native copy/paste is the bar.
   marker suppressed is not a copy and releases nothing.
 - **Directory fidelity rides the archive's field-key set.** A folder crosses as an archive of its
   tree, and what survives the round trip is exactly what `ClipboardDirectoryArchive`'s key set
-  carries — entry kinds, permissions, ownership, flags, timestamps, link targets, per-entry
-  digests. Changing directory fidelity means changing that key set, never bolting metadata on
-  through a side channel.
+  carries — entry kinds, permissions, ownership, flags, timestamps, link targets. Changing
+  directory fidelity means changing that key set, never bolting metadata on through a side
+  channel.
 - **Accepted gap: extended attributes cross on *no* paste path** — Finder tags,
   `com.apple.quarantine`, `kMDItemWhereFroms`. A plain file streams content bytes into a freshly
   created destination file, which cannot carry them, and the directory archive deliberately omits


### PR DESCRIPTION
## Summary
- Remove `SH2` from `ClipboardDirectoryArchive.fieldKeys`. AppleArchive writes the per-entry digest into the entry *header*, so the encoder read and hashed each file in full before its first payload byte could leave — the measured 2.27 s startup delay on a 4 GiB folder drop (`docs/research/2026-08-14-post-714-pipeline-baseline.md`) — and it was a second full-payload SHA-256 (22.7 % of the folder sender thread plus a worker) on top of the stream-level digest.
- The stream-level end-to-end SHA-256 (CLIPBOARD.md §7) covers every wire byte and is untouched; §7's own rule is "remove redundant work — re-hashing bytes already hashed — never the only correctness check", which is exactly this. Review probing confirmed `ArchiveStream.extractStream` never verified `SH2` on the receiving side either (a flipped payload byte extracts silently with or without it), so the field was pure encode-side cost.
- The extract side takes no key set (`ArchiveStream.extractStream(extractingTo:)`), so the encode-side string is the only pipeline change, and archives with or without the field decode identically — mixed host/agent versions interoperate.
- The guest agent compiles the same encoder, so guest→host folder copies only gain the change after a reinstall: agent `MARKETING_VERSION` 0.62.0 → 0.63.0 (both configurations).

## Changes
- `ClipboardDirectoryArchive.fieldKeys` and its `///` (states the header-placement fact, next to the existing `XAT` rationale)
- `docs/CLIPBOARD.md` §6: the fidelity bullet no longer enumerates the keys in prose (derivable from the constant)
- `Kernova.xcodeproj`: agent `MARKETING_VERSION` bump
- `ClipboardDirectoryStreamTests`: new test decodes an emitted archive's headers and asserts no entry carries `SH2` (and that the entry paths are present); the existing round-trip fidelity tests cover no regression

## Test plan
- [x] `make test` — 2960 cases pass, including `entriesCarryNoDigest`
- [x] `make lint`
- [ ] Not re-measured on a live guest: the research note's `duration − streamingDuration` gap on a large single-file folder drop should collapse to ~0

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013c3j8QyJCgJxABp9qLWKoH
