### PR TITLE
fix: Clear immutability on extract and bound the archive's trailing-byte window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,13 @@ guard let value = knownGoodAPI("compile-time-constant") else {
 
 Never force-unwrap (`!`) — it crashes end users — and never return a fallback silently, without `assertionFailure`; that masks bugs during development.
 
-### Persisted Data
+### Current-Only Surfaces
 
-Persisted formats are current-only — no migration code. Back-compat shims, decode-time back-fills, schema version flags, old-format fallbacks, and decode defaults that differ from what new instances get are all out. Adding a field to a persisted `Codable` type is `decodeIfPresent ?? default` with one uniform default, and nothing else. Migration code takes the maintainer's explicit sign-off, given only for old-shape data confirmed to exist (shipped in a release, or found on disk).
+No compatibility path is written for any shape that is not the current one.
+
+**Persisted formats** are current-only — no migration code. Back-compat shims, decode-time back-fills, schema version flags, old-format fallbacks, and decode defaults that differ from what new instances get are all out. Adding a field to a persisted `Codable` type is `decodeIfPresent ?? default` with one uniform default, and nothing else. Migration code takes the maintainer's explicit sign-off, given only for old-shape data confirmed to exist (shipped in a release, or found on disk).
+
+**The guest agent** the host bundles is the only supported one, so never write a path that keeps an older agent working — not on the host, and not in the shared KernovaKit code the agent compiles. The Hello exchange's capability strings gate *features*, never versions: an agent that advertises a capability but predates a change to it is out of date, not a peer to accommodate, and the `MARKETING_VERSION` bump is the whole remedy for that skew.
 
 ### File Operations
 

--- a/Kernova.xcodeproj/project.pbxproj
+++ b/Kernova.xcodeproj/project.pbxproj
@@ -829,7 +829,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.64.0;
+				MARKETING_VERSION = 0.65.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;
 				PRODUCT_NAME = "Kernova Guest Agent";
@@ -867,7 +867,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.64.0;
+				MARKETING_VERSION = 0.65.0;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = app.kernova.macosagent;
 				PRODUCT_MODULE_NAME = KernovaMacOSAgent;

--- a/KernovaKit/Sources/KernovaKit/ClipboardArchiveStream.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardArchiveStream.swift
@@ -42,8 +42,9 @@ enum ClipboardArchiveStreamError: Error, Equatable {
 /// an archive pipeline parked in a callback that has no timeout of its own:
 /// `finish()` declares a clean end of stream from the writing side, `fail(_:)`
 /// abandons the pipe, and `complete()` reports that the reading side has finished
-/// its work — after which further writes are accepted and dropped rather than
-/// refused, since there is no longer anything they could break.
+/// its work — after which one capacity's worth of further writes is accepted and
+/// dropped rather than refused, since a straggling tail can break nothing, and
+/// anything past that is refused.
 ///
 /// `@unchecked Sendable`: every field is guarded by `condition`.
 final class ClipboardArchiveBytePipe: @unchecked Sendable {
@@ -60,6 +61,8 @@ final class ClipboardArchiveBytePipe: @unchecked Sendable {
     ///
     /// Implies `finished`.
     private var completed = false
+    /// Bytes written since `complete()` and discarded, which `capacity` bounds.
+    private var droppedBytes = 0
     private var failure: Error?
 
     /// - Parameter capacity: how many undelivered bytes park the writer. A single
@@ -72,10 +75,13 @@ final class ClipboardArchiveBytePipe: @unchecked Sendable {
 
     /// Appends `data`, parking while the pipe is at capacity.
     ///
-    /// Accepted and discarded once `complete()` has been called.
+    /// Discarded once `complete()` has been called, up to `capacity` bytes in
+    /// total; past that the writer is feeding a reader that finished long ago
+    /// and is refused.
     ///
     /// - Throws: the failure that ended the pipe, or
-    ///   ``ClipboardArchiveStreamError/streamClosed`` after `finish()`.
+    ///   ``ClipboardArchiveStreamError/streamClosed`` after `finish()` and past
+    ///   the drop bound.
     func write(_ data: Data) throws {
         guard !data.isEmpty else { return }
         condition.lock()
@@ -84,7 +90,19 @@ final class ClipboardArchiveBytePipe: @unchecked Sendable {
             condition.wait()
         }
         if let failure { throw failure }
-        guard !completed else { return }
+        if completed {
+            // The tail a completed reader legitimately leaves unread is the
+            // codec's own trailer — bytes, not a window's worth — so a peer
+            // still streaming this far past a finished extract is sending
+            // payload that no longer has anywhere to go. Counting cumulatively
+            // keeps every write past the bound refused, not just the one that
+            // crossed it.
+            droppedBytes += data.count
+            guard droppedBytes <= capacity else {
+                throw ClipboardArchiveStreamError.streamClosed
+            }
+            return
+        }
         guard !finished else { throw ClipboardArchiveStreamError.streamClosed }
         chunks.append(data)
         pendingBytes += data.count
@@ -176,8 +194,8 @@ final class ClipboardArchiveBytePipe: @unchecked Sendable {
     }
 
     /// Ends the stream from the *reading* side, which has finished successfully:
-    /// a parked writer wakes, and every write from here on is accepted and
-    /// dropped instead of refused.
+    /// a parked writer wakes, and the next `capacity` bytes written are dropped
+    /// instead of refused.
     ///
     /// Distinct from `fail(_:)`, which reports that the pipeline gave up and so
     /// must keep refusing writes.
@@ -624,11 +642,7 @@ public final class ClipboardArchiveReader: @unchecked Sendable {
         header.append(.uint(key: .init("UID"), value: UInt64(status.st_uid)))
         header.append(.uint(key: .init("GID"), value: UInt64(status.st_gid)))
         header.append(.uint(key: .init("MOD"), value: UInt64(status.st_mode & 0o7777)))
-        // Immutability stays behind: a Finder-locked source would otherwise
-        // extract as a locked staging file that neither a move into its final
-        // destination nor generation cleanup can touch.
-        let flags = UInt64(status.st_flags & ~UInt32(UF_IMMUTABLE | SF_IMMUTABLE | UF_APPEND | SF_APPEND))
-        header.append(.uint(key: .init("FLG"), value: flags))
+        header.append(.uint(key: .init("FLG"), value: UInt64(status.st_flags)))
         header.append(.timespec(key: .init("MTM"), value: status.st_mtimespec))
         // `CTM` is the entry's creation time (AADefs.h), not the inode change time.
         header.append(.timespec(key: .init("CTM"), value: status.st_birthtimespec))
@@ -772,10 +786,12 @@ public final class ClipboardArchiveExtractSink: StagingSink, @unchecked Sendable
             // Both endings wake a writer parked on a pipeline that has stopped
             // consuming, and differ in what a *later* write means: after a
             // failure it must be refused, but after a complete extract the
-            // archive is already unpacked, so trailing bytes are dropped rather
-            // than made to fail a good transfer. Dropping them loses no integrity
-            // check — the receiver takes the digest over what arrives on the
-            // wire, outside this sink.
+            // archive is already unpacked, so a trailing tail is dropped rather
+            // than made to fail a good transfer — bounded by the pipe's capacity,
+            // since a peer streaming past that is holding the transfer open
+            // rather than finishing one. Dropping the tail loses no integrity
+            // check: the receiver takes the digest over what arrives on the wire,
+            // outside this sink.
             if let failure {
                 pipe.fail(failure)
             } else {
@@ -788,7 +804,9 @@ public final class ClipboardArchiveExtractSink: StagingSink, @unchecked Sendable
     /// Hands `data` to the extract pipeline, parking while it is a window behind.
     ///
     /// Bytes offered after the pipeline has unpacked the whole archive are
-    /// accepted and dropped, not refused.
+    /// dropped rather than refused, up to one window of them; past that the
+    /// write is refused, so a peer cannot keep a finished transfer alive by
+    /// streaming into it.
     ///
     /// - Throws: whatever failed the pipeline, so the transfer aborts on the
     ///   receiver's own write lane instead of running to completion over output
@@ -910,7 +928,8 @@ public final class ClipboardArchiveExtractSink: StagingSink, @unchecked Sendable
             // one — `/etc/hosts`, another user's document — must still extract.
             guard
                 let extractStream = ArchiveStream.extractStream(
-                    extractingTo: FilePath(destinationURL.path), flags: .ignoreOperationNotPermitted)
+                    extractingTo: FilePath(destinationURL.path),
+                    selectUsing: Self.clearImmutability, flags: .ignoreOperationNotPermitted)
             else { throw ClipboardArchive.ArchiveError.openExtractStream }
             defer { closes.close { try extractStream.close() } }
 
@@ -919,5 +938,29 @@ public final class ClipboardArchiveExtractSink: StagingSink, @unchecked Sendable
             failure = error
         }
         return failure ?? closes.failure
+    }
+
+    /// Clears the immutable and append-only bits from each entry's flags as the
+    /// extract applies them.
+    ///
+    /// Either bit blocks `unlink` on the entry *and* on every directory above
+    /// it, so one locked entry makes `removeItem` fail for the whole extracted
+    /// tree — taking out the generation sweep with it, and, since
+    /// `ClipboardFileStaging.reclaimAll` is a single `removeItem` on the shared
+    /// staging parent, every later reclaim of that parent too. The peer chooses
+    /// what an entry's `FLG` carries, so the receiver is the only place the
+    /// guarantee can hold; the sender writes the source's flags unaltered.
+    ///
+    /// Cleared here rather than off a walk of the finished tree because an
+    /// extract that stops part-way removes its output immediately, leaving no
+    /// point at which a walk could run.
+    private static func clearImmutability(
+        _: ArchiveHeader.EntryMessage, _: FilePath, _ data: ArchiveHeader.EntryFilterData?
+    ) -> ArchiveHeader.EntryMessageStatus {
+        if case .entryAttributes(let attributes)? = data, let flags = attributes.flg {
+            attributes.flg =
+                flags & ~UInt32(UF_IMMUTABLE | SF_IMMUTABLE | UF_APPEND | SF_APPEND)
+        }
+        return .ok
     }
 }

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
@@ -917,6 +917,16 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
             }
             return
         }
+        // The extract unpacked a whole archive and the peer kept streaming past
+        // the tail a finished decoder leaves unread: more payload than the
+        // archive it already completed, so it is named as the overrun it is
+        // rather than as a failure of the extract, which succeeded.
+        if case ClipboardArchiveStreamError.streamClosed = error {
+            fail(
+                transfer, code: "size.overrun",
+                message: "The peer streamed past the end of a complete archive")
+            return
+        }
         guard staging.hasCapacity(forByteCount: 0) else {
             failDiskFull(transfer)
             return

--- a/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
+++ b/KernovaKit/Sources/KernovaKit/ClipboardStreamReceiver.swift
@@ -309,6 +309,18 @@ public final class ClipboardStreamReceiver: @unchecked Sendable {
                     message: "Out-of-order chunk at \(offset), expected \(transfer.receivedBytes)")
                 return
             }
+            // A chunk carrying nothing advances no counter — not the byte
+            // total, not the digest, not the extract's drop budget — while
+            // still refreshing the stall clock and the lazy pull's inactivity
+            // backstop below, so a stream of them holds a transfer open for
+            // free past every bound there is. A sender emits none: it breaks
+            // out of its read loop on an empty read, so a zero-byte transfer is
+            // a Begin and an End with no chunk between them.
+            guard !chunk.data.isEmpty else {
+                self.fail(
+                    transfer, code: "chunk.empty", message: "Chunk carries no bytes")
+                return
+            }
             // Bound a single chunk — a frame can carry up to 128 MiB, but the
             // negotiated chunk is 64 KiB. [M3]
             guard chunk.data.count <= ClipboardStreamTuning.maxChunkBytes else {

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardArchiveStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardArchiveStreamTests.swift
@@ -431,6 +431,38 @@ struct ClipboardArchiveStreamTests {
         #expect(!fm.fileExists(atPath: dest.path))
     }
 
+    @Test("a locked directory extracts unlocked, so its children can still be swept")
+    func lockedDirectoryExtractsUnlocked() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        let locked = source.appendingPathComponent("locked", isDirectory: true)
+        try fm.createDirectory(at: locked, withIntermediateDirectories: true)
+        try "inside".write(
+            to: locked.appendingPathComponent("child.txt"), atomically: true, encoding: .utf8)
+        // Locked last: an immutable directory takes no new entries.
+        try fm.setAttributes([.immutable: true], ofItemAtPath: locked.path)
+        defer { try? fm.setAttributes([.immutable: false], ofItemAtPath: locked.path) }
+
+        let dest = try makeDestination(in: scratch)
+        try stream(from: source, into: dest)
+
+        // The peer authors every entry's flags, and a locked *directory* is the
+        // damaging shape: it blocks `unlink` of everything inside it, so one in
+        // a staged tree is what makes the shared staging parent's reclaim fail
+        // for good.
+        let extracted = dest.appendingPathComponent("locked")
+        let immutable = try fm.attributesOfItem(atPath: extracted.path)[.immutable] as? Bool
+        #expect(immutable != true)
+        #expect(
+            try String(contentsOf: extracted.appendingPathComponent("child.txt"), encoding: .utf8)
+                == "inside")
+        try fm.removeItem(at: dest)
+        #expect(!fm.fileExists(atPath: dest.path))
+    }
+
     @Test("a blob source round-trips as one entry")
     func blobSourceRoundTrips() throws {
         let fm = FileManager.default

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardArchiveStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardArchiveStreamTests.swift
@@ -399,6 +399,38 @@ struct ClipboardArchiveStreamTests {
         try fm.removeItem(at: moved)
     }
 
+    @Test("a locked file inside a folder extracts unlocked, so the whole tree can be swept")
+    func lockedFileInsideAFolderExtractsUnlocked() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        let nested = source.appendingPathComponent("sub", isDirectory: true)
+        try fm.createDirectory(at: nested, withIntermediateDirectories: true)
+        let locked = nested.appendingPathComponent("locked.bin")
+        try Data(repeating: 0x2A, count: 1024).write(to: locked)
+        try "plain".write(
+            to: source.appendingPathComponent("plain.txt"), atomically: true, encoding: .utf8)
+        try fm.setAttributes([.immutable: true], ofItemAtPath: locked.path)
+        defer { try? fm.setAttributes([.immutable: false], ofItemAtPath: locked.path) }
+
+        let dest = try makeDestination(in: scratch)
+        try stream(from: source, into: dest)
+
+        let entry = dest.appendingPathComponent("sub/locked.bin")
+        let immutable =
+            try fm.attributesOfItem(atPath: entry.path)[.immutable] as? Bool
+        #expect(immutable != true)
+        #expect(try Data(contentsOf: entry) == Data(repeating: 0x2A, count: 1024))
+        // The proof that matters: a locked entry blocks `unlink` on itself and on
+        // every directory above it, so an undeleted tree here is a staging
+        // generation — and the shared staging parent behind it — that no sweep
+        // can ever reclaim.
+        try fm.removeItem(at: dest)
+        #expect(!fm.fileExists(atPath: dest.path))
+    }
+
     @Test("a blob source round-trips as one entry")
     func blobSourceRoundTrips() throws {
         let fm = FileManager.default
@@ -566,6 +598,38 @@ struct ClipboardArchiveStreamTests {
         #expect(
             try String(contentsOf: url.appendingPathComponent("sub/a.txt"), encoding: .utf8)
                 == "hello")
+    }
+
+    @Test("writes past the drop bound are refused rather than dropped forever")
+    func writesPastTheDropBoundAreRefused() throws {
+        let fm = FileManager.default
+        let scratch = try makeScratch()
+        defer { try? fm.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("source", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        try "hello".write(
+            to: source.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let capacity = 64 << 10
+        let dest = try makeDestination(in: scratch)
+        let sink = ClipboardArchiveExtractSink(
+            destinationURL: dest, label: "test", capacityBytes: capacity)
+        try sink.write(try archiveBytes(of: source))
+        _ = try sink.commit()
+
+        // A peer that never sends End keeps a transfer alive for as long as its
+        // writes are taken, so the accept-and-drop window has to end somewhere.
+        let block = Data(repeating: 0, count: 4096)
+        var accepted = 0
+        #expect(throws: (any Error).self) {
+            while accepted <= capacity * 2 {
+                try sink.write(block)
+                accepted += block.count
+            }
+        }
+        #expect(accepted > 0)
+        #expect(accepted <= capacity)
     }
 
     @Test("a write after the pipeline failed is still refused")

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
@@ -806,6 +806,44 @@ struct ClipboardStreamTests {
         try await waitUntil { materializedFiles(under: harness.stagingTempRoot).isEmpty }
     }
 
+    @Test("an extract refusing bytes past its drop bound aborts the transfer as an overrun")
+    func writeRefusedPastTheDropBoundAborts() async throws {
+        // Where a peer that streams a whole valid archive and then keeps sending
+        // chunks without an End frame lands: the extract has already unpacked
+        // everything, drops the tail up to its bound, and refuses past it. The
+        // refusal is injected rather than streamed, because how much of that
+        // tail AppleArchive's decompressor buffers before the pipeline exits is
+        // its business, not this receiver's — the bound itself is covered by
+        // `ClipboardArchiveStreamTests`.
+        let harness = try StreamHarness(
+            chunkSize: Self.chunk, windowBytes: Self.window,
+            freeSpaceProvider: { _ in 100 << 30 },
+            sinkFactory: { destination, label, onOutputAdvanced in
+                FailingSink(
+                    wrapping: makeExtractSink(
+                        destinationURL: destination, label: label, windowBytes: Self.window,
+                        onOutputAdvanced: onOutputAdvanced),
+                    failingWrite: 2, throwing: ClipboardArchiveStreamError.streamClosed)
+            })
+        defer { harness.tearDown() }
+        let id: UInt64 = 605
+
+        let payload = randomBytes(Self.chunk * 3)
+        let source = try tempFile(bytes: payload)
+        defer { try? FileManager.default.removeItem(at: source) }
+        let wire = try clipboardArchiveBytes(ofFileAt: source, named: "overrun.bin")
+
+        prime(harness, id: id, advertised: payload.count)
+        try await openArchivedTransfer(harness, id: id, filename: "overrun.bin")
+        feed(harness, id: id, bytes: wire)
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        // Named as the overrun it is: the extract itself succeeded, so
+        // `extract.error` would send the user off retrying a good transfer.
+        #expect(harness.collector.abortInfos.contains { $0.code == "size.overrun" })
+        #expect(harness.collector.representation(id) == nil)
+    }
+
     @Test("a sink that silently drops archive bytes fails the extract instead of delivering a truncated payload")
     func droppedArchiveBytesAreCaughtAtCommit() async throws {
         // The digest is taken over the bytes that *arrive*, so a sink that

--- a/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
+++ b/KernovaKit/Tests/KernovaKitTests/ClipboardStreamTests.swift
@@ -1083,6 +1083,32 @@ struct ClipboardStreamTests {
         #expect(harness.collector.representation(99)?.inMemoryData == all)
     }
 
+    @Test("a chunk carrying no bytes aborts the transfer")
+    func emptyChunkAborts() async throws {
+        let harness = try roomyHarness()
+        defer { harness.tearDown() }
+
+        harness.receiver.handleBegin(
+            .with {
+                $0.generation = 1
+                $0.transferID = 8
+                $0.uti = "public.data"
+                $0.totalBytes = 8192
+                $0.isInline = true
+            })
+        // Accepted, it would refresh the stall clock and the pull's backstop
+        // while advancing nothing — the one way to hold a transfer open that
+        // costs the peer no bytes at all.
+        harness.receiver.handleChunk(
+            .with {
+                $0.transferID = 8; $0.offset = 0; $0.data = Data()
+            })
+
+        try await harness.collector.gate.wait { harness.collector.abortCount > 0 }
+        #expect(harness.collector.representation(8) == nil)
+        #expect(harness.collector.abortInfos.contains { $0.code == "chunk.empty" })
+    }
+
     @Test("an out-of-order (gapped) chunk aborts the transfer")
     func gappedChunkAborts() async throws {
         let harness = try roomyHarness()

--- a/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
+++ b/KernovaKit/Tests/KernovaKitTests/StreamTestSupport.swift
@@ -177,15 +177,21 @@ final class SilentlyDroppingSink: StagingSink, @unchecked Sendable {
 /// A `StagingSink` that throws on its `failingWrite`-th write (1-based),
 /// wrapping a real staging sink otherwise — models a volume that fails an
 /// append mid-stream.
+///
+/// `throwing` names the failure, so a test can inject one the receiver reads as
+/// something other than a plain write error — a
+/// ``ClipboardArchiveStreamError`` the extract raises on its own terms.
 final class FailingSink: StagingSink, @unchecked Sendable {
     private let wrapped: any StagingSink
     private let failingWrite: Int
+    private let injected: (any Error)?
     private let lock = NSLock()
     private var attempts = 0
 
-    init(wrapping sink: any StagingSink, failingWrite: Int) {
+    init(wrapping sink: any StagingSink, failingWrite: Int, throwing error: (any Error)? = nil) {
         wrapped = sink
         self.failingWrite = failingWrite
+        injected = error
     }
 
     func write(_ data: Data) throws {
@@ -194,7 +200,8 @@ final class FailingSink: StagingSink, @unchecked Sendable {
             return attempts
         }
         guard attempt != failingWrite else {
-            throw StreamTestFailure("Injected staging write failure on write \(attempt)")
+            throw injected
+                ?? StreamTestFailure("Injected staging write failure on write \(attempt)")
         }
         try wrapped.write(data)
     }

--- a/docs/CLIPBOARD.md
+++ b/docs/CLIPBOARD.md
@@ -286,8 +286,7 @@ Non-negotiable mechanics for how clipboard changes ship:
 - **Verify at the seam.** Protocol and stream changes get deterministic, transport-level tests
   (socketpair round-trips through the real sender and receiver) covering inline and file paths,
   backpressure, abort, and digest/size mismatch. Use event-driven waits, never sleeps.
-- **Evolve by capability negotiation, not legacy shims.** Protocol changes are gated by the Hello
+- **Gate protocol changes on capability, not on version.** Protocol changes are gated by the Hello
   exchange's `capabilities` list; frames carrying an unsupported `Frame.protocol_version` are
-  dropped silently. There is **no legacy fallback**, and any behavior change requiring a guest
-  reinstall **bumps the guest agent version**. Do not add back-compat decode paths for data that
-  does not exist.
+  dropped silently. That list says which features a peer speaks, never which agent build it is —
+  what a change may assume about the agent on the other end is AGENTS.md's current-only rule.


### PR DESCRIPTION
Closes #867

## Summary

Two receiver-side findings from #866's review, both on the archive extract path.

**Locked entries inside a folder.** The archive key set carries `FLG`, so a Finder-locked file inside a copied or dropped folder extracted locked. `UF_IMMUTABLE` blocks `unlink` on the entry *and* on every directory above it, so the whole extracted tree became undeletable — verified directly: `FileManager.removeItem` fails `EPERM` and aborts the walk, leaving the locked child, its unlocked siblings, and the parent chain on disk.

That is worse than an orphaned generation. `ClipboardFileStaging.reclaimAll` — the launch-time reclaim — is a single `removeItem` on the shared staging parent, so one locked descendant anywhere under it makes that call fail permanently, and every later session's leftovers accumulate under a parent Kernova can no longer reclaim. A peer chooses what each entry's `FLG` carries, so a hostile guest can plant one per folder paste the user performs.

**Trailing bytes after the archive completes.** `ClipboardArchiveBytePipe.complete()` accepted and dropped every later write. A peer that sent a valid archive followed by endless chunks and no End kept the transfer alive indefinitely: each accepted byte re-acked, refreshed the stall clock and re-armed the lazy pull's inactivity backstop, while the extract ceiling saw nothing because dropped bytes are not counted.

Review then surfaced a third hole in the same shape, and it made the second fix incomplete: a **zero-length chunk** advanced no counter at all — not the byte total, not the digest, not the new drop budget — yet still refreshed the stall clock and the pull's backstop. An endless run of them held a transfer, its staging output and a blocked paste open at no byte cost, straight past the bound. The receiver refuses one outright; a sender emits none, breaking out of its read loop on an empty read.

## Route taken

The receiver clears the immutable and append-only bits through an `ArchiveHeader.EntryFilter` passed to `ArchiveStream.extractStream`, which hands each entry's `EntryAttributes` over with a settable `flg` on the `extractAttributes` message. Verified: one callback per entry including directories, the mutation is honored, extracted flags are `0`, and removal succeeds. Directory attributes are applied after the children are written, so a locked directory entry round-trips with its contents intact.

Rejected: clearing immutability by walking the finished tree, as the issue suggested. An extract that stops part-way removes its output immediately, so there is no point at which such a walk could run — the partial tree would still be orphaned. Filtering during extract closes that hole because nothing locked ever lands.

The sender-side mask #866 added to `writeFileEntry` is removed rather than kept alongside it. The rule now lives once, on the receiver, where it covers files and folders alike and holds against a peer this side does not control.

That removal is only safe because older agents are not supported, which had never been written down — the Hello exchange's capability strings read like the compatibility story, and they are not. AGENTS.md now states it: the bundled agent is the only supported one, and capability strings gate features, never versions. `KernovaMacOSAgent`'s `MARKETING_VERSION` moves 0.64.0 → 0.65.0, so an installed 0.64.0 agent reports as outdated and the update affordance appears. Nothing yet *enforces* that update — admission still asks only whether the capability is advertised — which is #869.

This drops locked-ness on **both** paths rather than preserving it on one. Re-locking at the final destination is only possible on the guest-drop path — a paste has no final destination, since Finder copies out of staging itself — so preserving fidelity would buy a capability on one path and not the other.

For the trailing bytes, the pipe counts what it drops after `complete()` and refuses past `capacity`. The tail a finished decoder legitimately leaves unread is the codec's own trailer, so one credit window is generous. The receiver reports that refusal as `size.overrun` rather than `extract.error`: the extract succeeded, and naming it an extract failure would send the user off retrying a good transfer.

## Changes

- `ClipboardArchiveExtractSink`: `clearImmutability` entry filter on the extract stream.
- `ClipboardArchiveReader.writeFileEntry`: writes `st_flags` unaltered.
- `ClipboardArchiveBytePipe`: bounded drop window after `complete()`.
- `ClipboardStreamReceiver`: maps that refusal to `size.overrun`; refuses a zero-length chunk as `chunk.empty`.
- `KernovaMacOSAgent` `MARKETING_VERSION` 0.64.0 → 0.65.0, Debug and Release together.
- AGENTS.md: `Persisted Data` becomes `Current-Only Surfaces`, covering the guest agent alongside persisted formats. docs/CLIPBOARD.md keeps the clipboard mechanism and drops the general rule it restated.
- `FailingSink` takes the error it throws.

## Test plan

- [x] `make test` — 3155 passed, 0 failed, 0 skipped
- [x] `make lint`
- [x] A locked file inside an archived folder extracts unlocked and the tree removes cleanly
- [x] A locked *directory* extracts unlocked and its children sweep
- [x] A completed extract drops its tail up to the bound and refuses past it
- [x] A receiver whose extract refuses past the bound aborts as `size.overrun`
- [x] An empty chunk aborts the transfer

## Notes

No `RATIONALE:` comments added.

**Review findings not taken.**

*Restoring the sender-side flag mask for pre-0.65.0 agents.* Declined: older agents are not supported, so the version bump is the whole answer to skew rather than a compatibility path kept in the encoder. Enforcement of that policy is #869.

*Widening the drop bound to `capacity + maxChunkBytes` to match `maxBacklogBytes`.* Declined: it takes the window from 1 MiB to 17 MiB and weakens the bound this PR exists to add. The two look alike but express different limits — `maxBacklogBytes` caps transient RAM on the write lane, which drains, while the drop bound caps how long a peer keeps a finished transfer alive. Reaching it needs a sender whose chunk size exceeds the window the receiver itself advertises, which no sender here does.

**Test shape that was not used.** #867 asked the trailing-byte test to stream a valid archive plus trailing chunks and no End. That proved timing-dependent: AppleArchive's decompressor buffers the trailing bytes into its own block buffer before the pipeline exits, so they are absorbed rather than counted, and the transfer ends on the 30 s stall timeout instead. Escaping that buffering needs more trailing data than the receiver's backlog bound allows in a single continuous feed, so no such test is deterministic. The bound is covered at the sink and the receiver's handling of the refusal with an injected one — together the same ground, without depending on AppleArchive's buffering. The absorption is itself bounded (the decompressor's block buffer, then one credit window of drops), so the fix still terminates the transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zinXb8LYfsJGpHGc5p2hF